### PR TITLE
Canonicalize shampoo eligibility pairs

### DIFF
--- a/scripts/ingest-products.ts
+++ b/scripts/ingest-products.ts
@@ -30,6 +30,14 @@ import {
   isMaskCategory,
   type ProductMaskSpecs,
 } from "../src/lib/mask/constants"
+import {
+  isShampooCategory,
+  type ShampooBucketPair,
+} from "../src/lib/shampoo/constants"
+import {
+  type ShampooBucketPairInput,
+  normalizeShampooBucketPairs,
+} from "../src/lib/shampoo/eligibility"
 
 // Load .env.local for standalone script execution
 const envPath = path.join(process.cwd(), ".env.local")
@@ -84,7 +92,9 @@ interface ProductInput {
   price_eur?: number
   tags?: string[]
   suitable_thicknesses?: string[]
+  suitable_hair_textures?: string[]
   suitable_concerns?: string[]
+  shampoo_bucket_pairs?: ShampooBucketPairInput[]
   is_active?: boolean
   sort_order?: number
   leave_in_specs?: Omit<ProductLeaveInSpecs, "product_id" | "created_at" | "updated_at">
@@ -102,6 +112,69 @@ const MASK_WEIGHT_SET = new Set<string>(MASK_WEIGHTS)
 const MASK_CONCENTRATION_SET = new Set<string>(MASK_CONCENTRATIONS)
 const MASK_BENEFIT_SET = new Set<string>(MASK_BENEFITS)
 const MASK_INGREDIENT_SET = new Set<string>(MASK_INGREDIENT_FLAGS)
+
+function normalizeProductInput(product: ProductInput, fallbackSortOrder: number): ProductInput {
+  const suitable_thicknesses = product.suitable_thicknesses?.length
+    ? product.suitable_thicknesses
+    : product.suitable_hair_textures?.map((value) => value.trim()).filter(Boolean) ?? []
+
+  return {
+    ...product,
+    tags: product.tags?.map((value) => value.trim()).filter(Boolean) ?? [],
+    suitable_thicknesses,
+    suitable_concerns: product.suitable_concerns?.map((value) => value.trim()).filter(Boolean) ?? [],
+    shampoo_bucket_pairs: product.shampoo_bucket_pairs?.map((pair) => ({
+      thickness: pair.thickness.trim(),
+      shampoo_bucket: pair.shampoo_bucket?.trim(),
+      concern: pair.concern?.trim(),
+    })),
+    sort_order: product.sort_order ?? fallbackSortOrder,
+  }
+}
+
+async function replaceCanonicalShampooPairs(
+  productId: string,
+  product: ProductInput,
+): Promise<void> {
+  const canonicalPairs = normalizeShampooBucketPairs(product)
+
+  const { error: deleteError } = await supabase
+    .from("product_shampoo_specs")
+    .delete()
+    .eq("product_id", productId)
+
+  if (deleteError) {
+    throw new Error(`Failed to clear shampoo pairs: ${deleteError.message}`)
+  }
+
+  if (canonicalPairs.length === 0) {
+    throw new Error("Shampoo braucht mindestens ein kanonisches Eligibility-Paar.")
+  }
+
+  const rows = canonicalPairs.map((pair: ShampooBucketPair) => ({
+    product_id: productId,
+    thickness: pair.thickness,
+    shampoo_bucket: pair.shampoo_bucket,
+  }))
+
+  const { error: insertError } = await supabase
+    .from("product_shampoo_specs")
+    .insert(rows)
+
+  if (insertError) {
+    throw new Error(`Failed to write canonical shampoo pairs: ${insertError.message}`)
+  }
+}
+
+function parseProductNamesFilter(rawValue?: string): Set<string> | null {
+  if (!rawValue?.trim()) return null
+  const names = rawValue
+    .split("|")
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  return names.length > 0 ? new Set(names) : null
+}
 
 function parseCSV(content: string): ProductInput[] {
   const lines = content.split("\n").filter((l) => l.trim())
@@ -424,6 +497,19 @@ async function main() {
     process.exit(1)
   }
 
+  products = products.map((product, index) => normalizeProductInput(product, index))
+
+  const requestedNames = parseProductNamesFilter(process.env.PRODUCT_NAMES)
+  if (requestedNames) {
+    products = products.filter((product) => requestedNames.has(product.name))
+    console.log(`Filtered to ${products.length} products via PRODUCT_NAMES`)
+  }
+
+  if (products.length === 0) {
+    console.error("Error: No products left after filtering.")
+    process.exit(1)
+  }
+
   console.log(`Found ${products.length} products`)
 
   for (let i = 0; i < products.length; i++) {
@@ -454,7 +540,7 @@ async function main() {
         sort_order: product.sort_order ?? i,
         embedding: JSON.stringify(embedding),
       },
-      { onConflict: "name" }
+      { onConflict: "name,category" }
     )
       .select("id, category")
       .single()
@@ -462,6 +548,16 @@ async function main() {
     if (error) {
       console.error(`  Error upserting ${product.name}:`, error.message)
       continue
+    }
+
+    if (upsertedProduct && isShampooCategory(upsertedProduct.category || product.category)) {
+      try {
+        await replaceCanonicalShampooPairs(upsertedProduct.id, product)
+      } catch (shampooError) {
+        const message = shampooError instanceof Error ? shampooError.message : String(shampooError)
+        console.error(`  Error syncing shampoo pairs for ${product.name}:`, message)
+        throw shampooError
+      }
     }
 
     if (upsertedProduct && isLeaveInCategory(upsertedProduct.category || product.category)) {

--- a/scripts/research-shampoo-specs.ts
+++ b/scripts/research-shampoo-specs.ts
@@ -1,0 +1,214 @@
+import { createClient } from "@supabase/supabase-js"
+import fs from "fs"
+import path from "path"
+import { normalizeShampooBucketPairs, type ShampooBucketPairInput } from "../src/lib/shampoo/eligibility"
+
+type Thickness = "fine" | "normal" | "coarse"
+type ShampooBucket = "schuppen" | "irritationen" | "normal" | "dehydriert-fettig" | "trocken"
+
+interface DbProduct {
+  id: string
+  name: string
+  brand: string | null
+  category: string | null
+}
+
+interface SourceProduct {
+  name: string
+  brand?: string
+  category?: string
+  suitable_thicknesses?: string[]
+  suitable_hair_textures?: string[]
+  suitable_concerns?: string[]
+  shampoo_bucket_pairs?: ShampooBucketPairInput[]
+  tags?: string[]
+}
+
+interface ReviewRow {
+  product_id: string
+  product_name: string
+  brand: string
+  thickness: Thickness
+  shampoo_bucket: ShampooBucket
+  anti_dandruff_active: "yes" | "none"
+  use_pattern: string
+  verification_status: string
+  team_notes: string
+  verified_by: string
+  verified_on: string
+  source_index: number
+}
+
+const THICKNESS_ORDER: Thickness[] = ["fine", "normal", "coarse"]
+const BUCKET_ORDER: ShampooBucket[] = [
+  "schuppen",
+  "irritationen",
+  "normal",
+  "dehydriert-fettig",
+  "trocken",
+]
+
+const SHAMPOO_CATEGORIES = ["Shampoo", "Shampoo Profi"]
+
+const NAME_ALIASES: Record<string, string> = {
+  "pntene hydra glow": "pantene hydra glow shampoo",
+  "shampoo curl care": "hask curl care shampoo",
+  "laghaarmadchen beautiful curls": "langhaarmadchen beautiful curls shampoo",
+  "head shoulder derma x pro sensitive": "head shoulders derma x pro sensitive",
+}
+
+function loadEnvLocal(): void {
+  const envPath = path.join(process.cwd(), ".env.local")
+  if (!fs.existsSync(envPath)) return
+
+  for (const rawLine of fs.readFileSync(envPath, "utf-8").replace(/\r/g, "").split("\n")) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith("#")) continue
+    const match = line.match(/^([^=]+)=(.*)$/)
+    if (!match) continue
+    const key = match[1].trim()
+    const value = match[2].trim()
+    if (!process.env[key]) process.env[key] = value
+  }
+}
+
+function normalizeProductName(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/&/g, " ")
+    .replace(/[’']/g, "")
+    .replace(/[()]/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+function escapeCsvValue(value: string): string {
+  if (!/[",\n]/.test(value)) return value
+  return `"${value.replace(/"/g, "\"\"")}"`
+}
+
+function resolveDbProduct(sourceProduct: SourceProduct, dbProducts: DbProduct[]): DbProduct {
+  const normalizedSourceName = normalizeProductName(sourceProduct.name)
+  const normalizedAlias = NAME_ALIASES[normalizedSourceName] ?? normalizedSourceName
+
+  const exactMatch = dbProducts.find(
+    (product) => normalizeProductName(product.name) === normalizedAlias
+  )
+  if (exactMatch) return exactMatch
+
+  const fuzzyMatches = dbProducts.filter((product) => {
+    const normalizedDbName = normalizeProductName(product.name)
+    return normalizedDbName.includes(normalizedAlias) || normalizedAlias.includes(normalizedDbName)
+  })
+
+  if (fuzzyMatches.length === 1) {
+    return fuzzyMatches[0]
+  }
+
+  throw new Error(`Unable to resolve shampoo product "${sourceProduct.name}" to a catalog entry.`)
+}
+
+async function main(): Promise<void> {
+  loadEnvLocal()
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  const sourcePath = path.join(process.cwd(), "data/products-from-excel/shampoo.json")
+  const outputPath = path.join(process.cwd(), "data/research/shampoo-specs-review-table.csv")
+  const sourceProducts = JSON.parse(fs.readFileSync(sourcePath, "utf-8")) as SourceProduct[]
+
+  const { data: dbProducts, error } = await supabase
+    .from("products")
+    .select("id, name, brand, category")
+    .in("category", SHAMPOO_CATEGORIES)
+    .order("name", { ascending: true })
+
+  if (error) {
+    throw new Error(`Failed to load shampoo products: ${error.message}`)
+  }
+
+  const rows: ReviewRow[] = []
+
+  for (const [sourceIndex, sourceProduct] of sourceProducts.entries()) {
+    const matchedProduct = resolveDbProduct(sourceProduct, (dbProducts ?? []) as DbProduct[])
+    const resolvedPairs = normalizeShampooBucketPairs(sourceProduct)
+    const antiDandruffActive = resolvedPairs.some((pair) => pair.shampoo_bucket === "schuppen")
+      ? "yes"
+      : "none"
+
+    for (const pair of resolvedPairs) {
+      rows.push({
+        product_id: matchedProduct.id,
+        product_name: matchedProduct.name,
+        brand: matchedProduct.brand ?? "",
+        thickness: pair.thickness,
+        shampoo_bucket: pair.shampoo_bucket,
+        anti_dandruff_active: antiDandruffActive,
+        use_pattern: "",
+        verification_status: "PRELIMINARY",
+        team_notes: "",
+        verified_by: "",
+        verified_on: "",
+        source_index: sourceIndex,
+      })
+    }
+  }
+
+  rows.sort((a, b) => {
+    const thicknessDiff = THICKNESS_ORDER.indexOf(a.thickness) - THICKNESS_ORDER.indexOf(b.thickness)
+    if (thicknessDiff !== 0) return thicknessDiff
+
+    const bucketDiff = BUCKET_ORDER.indexOf(a.shampoo_bucket) - BUCKET_ORDER.indexOf(b.shampoo_bucket)
+    if (bucketDiff !== 0) return bucketDiff
+
+    return a.source_index - b.source_index
+  })
+
+  const header = [
+    "product_id",
+    "product_name",
+    "brand",
+    "thickness",
+    "shampoo_bucket",
+    "anti_dandruff_active",
+    "use_pattern",
+    "verification_status",
+    "team_notes",
+    "verified_by",
+    "verified_on",
+  ]
+
+  const lines = [
+    header.join(","),
+    ...rows.map((row) =>
+      [
+        row.product_id,
+        row.product_name,
+        row.brand,
+        row.thickness,
+        row.shampoo_bucket,
+        row.anti_dandruff_active,
+        row.use_pattern,
+        row.verification_status,
+        row.team_notes,
+        row.verified_by,
+        row.verified_on,
+      ]
+        .map((value) => escapeCsvValue(value))
+        .join(",")
+    ),
+  ]
+
+  fs.writeFileSync(outputPath, lines.join("\n") + "\n", "utf-8")
+  console.log(`Wrote ${rows.length} shampoo review rows to ${outputPath}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useToast } from "@/providers/toast-provider"
-import type { Product } from "@/lib/types"
+import type { Product, ShampooBucketPair } from "@/lib/types"
 import { HAIR_THICKNESS_OPTIONS, CONCERN_OPTIONS } from "@/lib/types"
 import { fehler } from "@/lib/vocabulary"
 import {
@@ -27,6 +27,11 @@ import {
   MASK_INGREDIENT_FLAGS,
   isMaskCategory,
 } from "@/lib/mask/constants"
+import {
+  SHAMPOO_BUCKET_LABELS,
+  SHAMPOO_SOURCE_MANAGED_MESSAGE,
+  isShampooCategory,
+} from "@/lib/shampoo/constants"
 
 interface LeaveInSpecForm {
   format: string
@@ -65,6 +70,7 @@ interface ProductForm {
   tags: string
   suitable_thicknesses: string[]
   suitable_concerns: string[]
+  shampoo_bucket_pairs: ShampooBucketPair[]
   is_active: boolean
   sort_order: number
   conditioner_specs: ConditionerSpecForm | null
@@ -109,6 +115,7 @@ const emptyForm: ProductForm = {
   tags: "",
   suitable_thicknesses: [],
   suitable_concerns: [],
+  shampoo_bucket_pairs: [],
   is_active: true,
   sort_order: 0,
   conditioner_specs: null,
@@ -124,6 +131,11 @@ export default function AdminProductsPage() {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [form, setForm] = useState<ProductForm>(emptyForm)
   const { toast } = useToast()
+  const editingProduct = editingId
+    ? products.find((product) => product.id === editingId) ?? null
+    : null
+  const isSourceManagedShampoo = isShampooCategory(form.category)
+  const isExistingSourceManagedShampoo = isShampooCategory(editingProduct?.category)
 
   async function loadProducts() {
     try {
@@ -208,6 +220,7 @@ export default function AdminProductsPage() {
       tags: (product.tags || []).join(", "),
       suitable_thicknesses: product.suitable_thicknesses || [],
       suitable_concerns: product.suitable_concerns || [],
+      shampoo_bucket_pairs: product.shampoo_bucket_pairs || [],
       is_active: product.is_active,
       sort_order: product.sort_order,
       conditioner_specs: conditionerSpecs,
@@ -290,6 +303,11 @@ export default function AdminProductsPage() {
     e.preventDefault()
     if (!form.name.trim()) {
       toast({ title: "Produktname ist erforderlich", variant: "destructive" })
+      return
+    }
+
+    if (isSourceManagedShampoo) {
+      toast({ title: SHAMPOO_SOURCE_MANAGED_MESSAGE, variant: "destructive" })
       return
     }
 
@@ -402,6 +420,12 @@ export default function AdminProductsPage() {
   }
 
   async function handleDelete(id: string) {
+    const product = products.find((entry) => entry.id === id)
+    if (product && isShampooCategory(product.category)) {
+      toast({ title: SHAMPOO_SOURCE_MANAGED_MESSAGE, variant: "destructive" })
+      return
+    }
+
     if (!window.confirm("Dieses Produkt wirklich löschen?")) return
 
     try {
@@ -424,6 +448,13 @@ export default function AdminProductsPage() {
       style: "currency",
       currency: "EUR",
     }).format(price)
+  }
+
+  function formatShampooPair(pair: ShampooBucketPair): string {
+    const thicknessLabel =
+      HAIR_THICKNESS_OPTIONS.find((option) => option.value === pair.thickness)?.label ?? pair.thickness
+    const bucketLabel = SHAMPOO_BUCKET_LABELS[pair.shampoo_bucket] ?? pair.shampoo_bucket
+    return `${thicknessLabel}: ${bucketLabel}`
   }
 
   return (
@@ -449,7 +480,32 @@ export default function AdminProductsPage() {
             {editingId ? "Produkt bearbeiten" : "Neues Produkt erstellen"}
           </h2>
 
-          <div className="space-y-4">
+          {isSourceManagedShampoo && (
+            <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+              <h3 className="text-sm font-semibold text-foreground">Shampoo ist quellenverwaltet</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {SHAMPOO_SOURCE_MANAGED_MESSAGE} Bitte Quelldaten aktualisieren und den Ingest erneut laufen
+                lassen.
+              </p>
+              {form.shampoo_bucket_pairs.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {form.shampoo_bucket_pairs.map((pair) => (
+                    <span
+                      key={`${pair.thickness}-${pair.shampoo_bucket}`}
+                      className="rounded-full bg-background/80 px-3 py-1 text-xs font-medium text-foreground"
+                    >
+                      {formatShampooPair(pair)}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          <fieldset
+            disabled={isExistingSourceManagedShampoo}
+            className="space-y-4 disabled:cursor-not-allowed disabled:opacity-60"
+          >
             <div className="grid gap-4 sm:grid-cols-2">
               <div>
                 <label className="mb-1 block text-sm font-medium text-foreground">
@@ -574,55 +630,59 @@ export default function AdminProductsPage() {
               />
             </div>
 
-            <div>
-              <label className="mb-2 block text-sm font-medium text-foreground">
-                Geeignete Haardicke
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {HAIR_THICKNESS_OPTIONS.map(({ value, label }) => {
-                  const selected = form.suitable_thicknesses.includes(value)
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      onClick={() => toggleChip("suitable_thicknesses", value)}
-                      className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                        selected
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted text-muted-foreground hover:bg-muted/80"
-                      }`}
-                    >
-                      {label}
-                    </button>
-                  )
-                })}
+            {!isSourceManagedShampoo && (
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  Geeignete Haardicke
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {HAIR_THICKNESS_OPTIONS.map(({ value, label }) => {
+                    const selected = form.suitable_thicknesses.includes(value)
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => toggleChip("suitable_thicknesses", value)}
+                        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                          selected
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-muted-foreground hover:bg-muted/80"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    )
+                  })}
+                </div>
               </div>
-            </div>
+            )}
 
-            <div>
-              <label className="mb-2 block text-sm font-medium text-foreground">
-                Geeignet bei Problemen
-              </label>
-              <div className="flex flex-wrap gap-2">
-                {CONCERN_OPTIONS.map(({ value, label }) => {
-                  const selected = form.suitable_concerns.includes(value)
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      onClick={() => toggleChip("suitable_concerns", value)}
-                      className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                        selected
-                          ? "bg-primary text-primary-foreground"
-                          : "bg-muted text-muted-foreground hover:bg-muted/80"
-                      }`}
-                    >
-                      {label}
-                    </button>
-                  )
-                })}
+            {!isSourceManagedShampoo && (
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  Geeignet bei Problemen
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {CONCERN_OPTIONS.map(({ value, label }) => {
+                    const selected = form.suitable_concerns.includes(value)
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => toggleChip("suitable_concerns", value)}
+                        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                          selected
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-muted-foreground hover:bg-muted/80"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    )
+                  })}
+                </div>
               </div>
-            </div>
+            )}
 
             {isConditionerCategory(form.category) && form.conditioner_specs && (
               <div className="rounded-lg border border-input/70 bg-muted/20 p-4 space-y-4">
@@ -1076,15 +1136,22 @@ export default function AdminProductsPage() {
                 Aktiv
               </label>
             </div>
-          </div>
+
+          </fieldset>
 
           <div className="mt-6 flex gap-3">
             <button
               type="submit"
-              disabled={saving}
+              disabled={saving || isSourceManagedShampoo}
               className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
             >
-              {saving ? "Speichern..." : editingId ? "Aktualisieren" : "Erstellen"}
+              {isSourceManagedShampoo
+                ? "Nur ueber Quelldaten"
+                : saving
+                  ? "Speichern..."
+                  : editingId
+                    ? "Aktualisieren"
+                    : "Erstellen"}
             </button>
             <button
               type="button"
@@ -1128,7 +1195,12 @@ export default function AdminProductsPage() {
                     {product.brand || "—"}
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">
-                    {product.category || "—"}
+                    <div>{product.category || "—"}</div>
+                    {isShampooCategory(product.category) && (
+                      <div className="mt-1 text-xs text-amber-600">
+                        Quellenverwaltet
+                      </div>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">
                     {formatPrice(product.price_eur)}
@@ -1150,11 +1222,13 @@ export default function AdminProductsPage() {
                         onClick={() => handleEdit(product)}
                         className="rounded-md px-2.5 py-1 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
                       >
-                        Bearbeiten
+                        {isShampooCategory(product.category) ? "Ansehen" : "Bearbeiten"}
                       </button>
                       <button
                         onClick={() => handleDelete(product.id)}
-                        className="rounded-md px-2.5 py-1 text-xs font-medium text-red-400 hover:bg-red-900/20 transition-colors"
+                        disabled={isShampooCategory(product.category)}
+                        title={isShampooCategory(product.category) ? SHAMPOO_SOURCE_MANAGED_MESSAGE : undefined}
+                        className="rounded-md px-2.5 py-1 text-xs font-medium text-red-400 hover:bg-red-900/20 transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
                       >
                         Löschen
                       </button>

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from "next/server"
 import { isConditionerCategory } from "@/lib/conditioner/constants"
 import { isLeaveInCategory } from "@/lib/leave-in/constants"
 import { isMaskCategory } from "@/lib/mask/constants"
+import { SHAMPOO_SOURCE_MANAGED_MESSAGE, isShampooCategory } from "@/lib/shampoo/constants"
 
 export async function PUT(
   request: Request,
@@ -46,14 +47,27 @@ export async function PUT(
     )
   }
 
-  const { conditioner_specs, leave_in_specs, mask_specs, ...productPayload } = parsed.data
-
-  // Fetch existing product to check if embedding-relevant fields changed
-  const { data: existing } = await supabase
+  const { data: existing, error: existingError } = await supabase
     .from("products")
     .select("name, brand, description, tags, category")
     .eq("id", id)
     .single()
+
+  if (existingError || !existing) {
+    return NextResponse.json(
+      { error: fehler("Laden", "des Produkts") },
+      { status: 404 }
+    )
+  }
+
+  if (isShampooCategory(existing.category) || isShampooCategory(parsed.data.category)) {
+    return NextResponse.json(
+      { error: SHAMPOO_SOURCE_MANAGED_MESSAGE },
+      { status: 409 }
+    )
+  }
+
+  const { conditioner_specs, leave_in_specs, mask_specs, ...productPayload } = parsed.data
 
   const { data: product, error } = await supabase
     .from("products")
@@ -258,6 +272,26 @@ export async function DELETE(
     return NextResponse.json(
       { error: ERR_FORBIDDEN },
       { status: 403 }
+    )
+  }
+
+  const { data: existing, error: existingError } = await supabase
+    .from("products")
+    .select("category")
+    .eq("id", id)
+    .single()
+
+  if (existingError || !existing) {
+    return NextResponse.json(
+      { error: fehler("Laden", "des Produkts") },
+      { status: 404 }
+    )
+  }
+
+  if (isShampooCategory(existing.category)) {
+    return NextResponse.json(
+      { error: SHAMPOO_SOURCE_MANAGED_MESSAGE },
+      { status: 409 }
     )
   }
 

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -7,6 +7,13 @@ import { NextResponse } from "next/server"
 import { isConditionerCategory, type ProductConditionerSpecs } from "@/lib/conditioner/constants"
 import { isLeaveInCategory, type ProductLeaveInSpecs } from "@/lib/leave-in/constants"
 import { isMaskCategory, type ProductMaskSpecs } from "@/lib/mask/constants"
+import {
+  SHAMPOO_BUCKETS,
+  SHAMPOO_SOURCE_MANAGED_MESSAGE,
+  isShampooCategory,
+  type ShampooBucketPair,
+} from "@/lib/shampoo/constants"
+import { HAIR_THICKNESSES } from "@/lib/vocabulary"
 
 export async function GET() {
   const supabase = await createClient()
@@ -44,6 +51,9 @@ export async function GET() {
   }
 
   const rows = products || []
+  const shampooIds = rows
+    .filter((product) => isShampooCategory(product.category))
+    .map((product) => product.id)
   const conditionerIds = rows
     .filter((product) => isConditionerCategory(product.category))
     .map((product) => product.id)
@@ -55,6 +65,41 @@ export async function GET() {
     .map((product) => product.id)
 
   let conditionerSpecsByProductId = new Map<string, ProductConditionerSpecs>()
+  let shampooPairsByProductId = new Map<string, ShampooBucketPair[]>()
+  if (shampooIds.length > 0) {
+    const adminClient = createAdminClient()
+    const { data: shampooPairs, error: shampooPairsError } = await adminClient
+      .from("product_shampoo_specs")
+      .select("product_id, thickness, shampoo_bucket")
+      .in("product_id", shampooIds)
+
+    if (shampooPairsError) {
+      return NextResponse.json(
+        { error: fehler("Laden", "der Shampoo-Eligibility") },
+        { status: 500 }
+      )
+    }
+
+    shampooPairsByProductId = (shampooPairs || []).reduce((map, row) => {
+      const currentPairs = map.get(row.product_id) ?? []
+      currentPairs.push({
+        thickness: row.thickness as ShampooBucketPair["thickness"],
+        shampoo_bucket: row.shampoo_bucket as ShampooBucketPair["shampoo_bucket"],
+      })
+      currentPairs.sort((left, right) => {
+        const thicknessDiff =
+          HAIR_THICKNESSES.indexOf(left.thickness) - HAIR_THICKNESSES.indexOf(right.thickness)
+        if (thicknessDiff !== 0) return thicknessDiff
+
+        return (
+          SHAMPOO_BUCKETS.indexOf(left.shampoo_bucket) - SHAMPOO_BUCKETS.indexOf(right.shampoo_bucket)
+        )
+      })
+      map.set(row.product_id, currentPairs)
+      return map
+    }, new Map<string, ShampooBucketPair[]>())
+  }
+
   if (conditionerIds.length > 0) {
     const { data: specs } = await supabase
       .from("product_conditioner_rerank_specs")
@@ -92,6 +137,7 @@ export async function GET() {
 
   const hydrated = rows.map((product) => ({
     ...product,
+    shampoo_bucket_pairs: shampooPairsByProductId.get(product.id) ?? null,
     conditioner_specs: conditionerSpecsByProductId.get(product.id) ?? null,
     leave_in_specs: specsByProductId.get(product.id) ?? null,
     mask_specs: maskSpecsByProductId.get(product.id) ?? null,
@@ -130,6 +176,13 @@ export async function POST(request: Request) {
     return NextResponse.json(
       { error: ERR_INVALID_DATA, details: parsed.error.flatten() },
       { status: 400 }
+    )
+  }
+
+  if (isShampooCategory(parsed.data.category)) {
+    return NextResponse.json(
+      { error: SHAMPOO_SOURCE_MANAGED_MESSAGE },
+      { status: 409 }
     )
   }
 

--- a/src/lib/rag/product-list-chunks.ts
+++ b/src/lib/rag/product-list-chunks.ts
@@ -1,3 +1,10 @@
+import {
+  mapShampooPairsToMetadata,
+  normalizeShampooBucketPairs,
+  type ShampooBucketPairInput,
+} from "@/lib/shampoo/eligibility"
+import { isShampooCategory } from "@/lib/shampoo/constants"
+
 const CONCERN_LABELS: Record<string, string> = {
   schuppen: "Schuppen",
   irritationen: "Kopfhautirritationen",
@@ -24,7 +31,9 @@ export interface ProductListChunkProduct {
   brand?: string
   category?: string
   suitable_thicknesses?: string[]
+  suitable_hair_textures?: string[]
   suitable_concerns?: string[]
+  shampoo_bucket_pairs?: ShampooBucketPairInput[]
   tags?: string[]
 }
 
@@ -51,6 +60,18 @@ export function buildProductListChunks(
 
   for (const product of allProducts) {
     const category = product.category || "Sonstiges"
+    if (isShampooCategory(category)) {
+      const normalizedPairs = mapShampooPairsToMetadata(normalizeShampooBucketPairs(product))
+      for (const pair of normalizedPairs) {
+        const key = `${category}|${pair.thickness}|${pair.concern}`
+        if (!groups.has(key)) {
+          groups.set(key, [])
+        }
+        groups.get(key)!.push(product)
+      }
+      continue
+    }
+
     const thicknesses = uniqueValues(product.suitable_thicknesses, "alle")
     const concerns = uniqueValues(product.suitable_concerns, "allgemein")
 

--- a/src/lib/shampoo/constants.ts
+++ b/src/lib/shampoo/constants.ts
@@ -1,0 +1,59 @@
+import type { ScalpCondition, ScalpType } from "@/lib/vocabulary"
+import type { HairThickness } from "@/lib/vocabulary"
+
+export const SHAMPOO_DB_CATEGORIES = ["Shampoo", "Shampoo Profi"] as const
+export const SHAMPOO_SOURCE_MANAGED_MESSAGE =
+  "Shampoo-Produkte werden aktuell nur ueber Quelldaten und Ingest gepflegt."
+
+export const SHAMPOO_BUCKETS = [
+  "schuppen",
+  "irritationen",
+  "normal",
+  "dehydriert-fettig",
+  "trocken",
+] as const
+
+export type ShampooBucket = (typeof SHAMPOO_BUCKETS)[number]
+export interface ShampooBucketPair {
+  thickness: HairThickness
+  shampoo_bucket: ShampooBucket
+}
+
+export const SHAMPOO_BUCKET_LABELS: Record<ShampooBucket, string> = {
+  schuppen: "Schuppen",
+  irritationen: "Irritationen",
+  normal: "Normal",
+  "dehydriert-fettig": "Dehydriert / Fettig",
+  trocken: "Trocken",
+}
+
+export function isShampooCategory(category?: string | null): boolean {
+  return SHAMPOO_DB_CATEGORIES.includes((category ?? "").trim() as (typeof SHAMPOO_DB_CATEGORIES)[number])
+}
+
+export function deriveShampooBucket(
+  scalpType?: ScalpType | null,
+  scalpCondition?: ScalpCondition | null
+): ShampooBucket | null {
+  if (scalpCondition && scalpCondition !== "none") {
+    if (scalpCondition === "dandruff") return "schuppen"
+    if (scalpCondition === "irritated") return "irritationen"
+    if (scalpCondition === "dry_flakes") return "trocken"
+  }
+
+  if (scalpType === "balanced") return "normal"
+  if (scalpType === "oily") return "dehydriert-fettig"
+  if (scalpType === "dry") return "trocken"
+
+  return null
+}
+
+/** Derives a scalp-type-based bucket (ignoring scalp condition) for rotation pairing. */
+export function deriveScalpTypeBucket(
+  scalpType?: ScalpType | null,
+): ShampooBucket | null {
+  if (scalpType === "balanced") return "normal"
+  if (scalpType === "oily") return "dehydriert-fettig"
+  if (scalpType === "dry") return "trocken"
+  return "normal" // safe default for dandruff rotation
+}

--- a/src/lib/shampoo/eligibility.ts
+++ b/src/lib/shampoo/eligibility.ts
@@ -1,0 +1,121 @@
+import { HAIR_THICKNESSES, type HairThickness } from "@/lib/vocabulary"
+import {
+  SHAMPOO_BUCKETS,
+  type ShampooBucket,
+  type ShampooBucketPair,
+  isShampooCategory,
+} from "@/lib/shampoo/constants"
+
+export interface ShampooBucketPairInput {
+  thickness: string
+  shampoo_bucket?: string
+  concern?: string
+}
+
+export interface ShampooEligibilitySource {
+  name?: string
+  category?: string | null
+  suitable_thicknesses?: string[]
+  suitable_hair_textures?: string[]
+  suitable_concerns?: string[]
+  shampoo_bucket_pairs?: ShampooBucketPairInput[]
+}
+
+function sortShampooPairs(pairs: ShampooBucketPair[]): ShampooBucketPair[] {
+  return [...pairs].sort((a, b) => {
+    const thicknessDiff = HAIR_THICKNESSES.indexOf(a.thickness) - HAIR_THICKNESSES.indexOf(b.thickness)
+    if (thicknessDiff !== 0) return thicknessDiff
+
+    return SHAMPOO_BUCKETS.indexOf(a.shampoo_bucket) - SHAMPOO_BUCKETS.indexOf(b.shampoo_bucket)
+  })
+}
+
+function dedupeShampooPairs(pairs: ShampooBucketPair[]): ShampooBucketPair[] {
+  const uniquePairs = new Map<string, ShampooBucketPair>()
+
+  for (const pair of pairs) {
+    uniquePairs.set(`${pair.thickness}|${pair.shampoo_bucket}`, pair)
+  }
+
+  return sortShampooPairs([...uniquePairs.values()])
+}
+
+function getProductLabel(product: ShampooEligibilitySource): string {
+  return product.name ? `Shampoo "${product.name}"` : "Shampoo"
+}
+
+function normalizeThickness(value: string, product: ShampooEligibilitySource, sourceLabel: string): HairThickness {
+  const normalizedValue = value.trim()
+  if (HAIR_THICKNESSES.includes(normalizedValue as HairThickness)) {
+    return normalizedValue as HairThickness
+  }
+
+  throw new Error(
+    `${getProductLabel(product)} hat eine ungueltige Haardicke in ${sourceLabel}: "${value}".`
+  )
+}
+
+function normalizeBucket(value: string, product: ShampooEligibilitySource, sourceLabel: string): ShampooBucket {
+  const normalizedValue = value.trim()
+  if (SHAMPOO_BUCKETS.includes(normalizedValue as ShampooBucket)) {
+    return normalizedValue as ShampooBucket
+  }
+
+  throw new Error(
+    `${getProductLabel(product)} hat einen ungueltigen Shampoo-Bucket in ${sourceLabel}: "${value}".`
+  )
+}
+
+export function normalizeShampooBucketPairs(product: ShampooEligibilitySource): ShampooBucketPair[] {
+  if (!isShampooCategory(product.category)) return []
+
+  const explicitPairs = product.shampoo_bucket_pairs ?? []
+  if (explicitPairs.length > 0) {
+    const normalizedPairs = explicitPairs.map((pair, index) => {
+      const rawBucket = pair.shampoo_bucket ?? pair.concern
+      if (!rawBucket?.trim()) {
+        throw new Error(
+          `${getProductLabel(product)} hat ein unvollstaendiges Exact-Pair in shampoo_bucket_pairs[${index}].`
+        )
+      }
+
+      return {
+        thickness: normalizeThickness(pair.thickness, product, `shampoo_bucket_pairs[${index}].thickness`),
+        shampoo_bucket: normalizeBucket(rawBucket, product, `shampoo_bucket_pairs[${index}]`),
+      }
+    })
+
+    return dedupeShampooPairs(normalizedPairs)
+  }
+
+  const thicknesses = (product.suitable_thicknesses?.length
+    ? product.suitable_thicknesses
+    : product.suitable_hair_textures ?? [])
+    .map((value) => normalizeThickness(value, product, "suitable_thicknesses"))
+  const buckets = (product.suitable_concerns ?? [])
+    .map((value) => normalizeBucket(value, product, "suitable_concerns"))
+
+  if (thicknesses.length === 0 || buckets.length === 0) {
+    throw new Error(
+      `${getProductLabel(product)} braucht entweder shampoo_bucket_pairs oder gueltige suitable_thicknesses + suitable_concerns.`
+    )
+  }
+
+  return dedupeShampooPairs(
+    thicknesses.flatMap((thickness) =>
+      buckets.map((shampoo_bucket) => ({
+        thickness,
+        shampoo_bucket,
+      }))
+    )
+  )
+}
+
+export function mapShampooPairsToMetadata(
+  pairs: ShampooBucketPair[]
+): Array<{ thickness: string; concern: string }> {
+  return pairs.map((pair) => ({
+    thickness: pair.thickness,
+    concern: pair.shampoo_bucket,
+  }))
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,6 +32,7 @@ import type {
   ConditionerWeight,
   ConditionerRepairLevel,
 } from "@/lib/conditioner/constants"
+import type { ShampooBucket, ShampooBucketPair } from "@/lib/shampoo/constants"
 
 export type {
   HairTexture,
@@ -51,6 +52,8 @@ export type {
   PostWashAction,
   RoutinePreference,
   RoutineProduct,
+  ShampooBucket,
+  ShampooBucketPair,
 }
 
 export {
@@ -135,6 +138,7 @@ export interface Product {
   tags: string[]
   suitable_thicknesses: string[]
   suitable_concerns: string[]
+  shampoo_bucket_pairs?: ShampooBucketPair[] | null
   is_active: boolean
   sort_order: number
   conditioner_specs?: ProductConditionerSpecs | null
@@ -164,6 +168,7 @@ export type ShampooProfileField = "thickness" | "scalp_type" | "scalp_condition"
 export interface ShampooRecommendationMetadata extends BaseRecommendationMetadata {
   category: "shampoo"
   matched_profile: ShampooMatchedProfile
+  matched_bucket: ShampooBucket | null
   matched_concern_code: string | null
 }
 
@@ -231,6 +236,9 @@ export interface ShampooDecision {
   eligible: boolean
   missing_profile_fields: ShampooProfileField[]
   matched_profile: ShampooMatchedProfile
+  matched_bucket: ShampooBucket | null
+  /** Secondary bucket for dandruff rotation (scalp-type-based gentle shampoo) */
+  secondary_bucket: ShampooBucket | null
   matched_concern_code: string | null
   retrieval_filter: {
     thickness: HairThickness | null
@@ -274,6 +282,7 @@ export interface MaskDecision {
   need_strength: 0 | MaskNeedStrength
   mask_type: MaskType | null
   active_signals: MaskSignal[]
+  signal_weights?: Record<MaskSignal, number>
 }
 
 export interface MessageRagContext {

--- a/supabase/migrations/20260321113000_make_product_shampoo_specs_canonical.sql
+++ b/supabase/migrations/20260321113000_make_product_shampoo_specs_canonical.sql
@@ -1,0 +1,10 @@
+-- Make product_shampoo_specs the canonical shampoo eligibility source.
+-- Shampoo rows are now managed via source data ingest instead of product-row triggers.
+
+DROP TRIGGER IF EXISTS trg_sync_product_shampoo_specs ON public.products;
+
+DROP FUNCTION IF EXISTS public.sync_product_shampoo_specs_from_products();
+DROP FUNCTION IF EXISTS public.expand_shampoo_eligibility(text[], text[]);
+
+COMMENT ON TABLE public.product_shampoo_specs IS
+  'Canonical shampoo eligibility pairs managed via source data ingest.';

--- a/tests/shampoo-flow.spec.ts
+++ b/tests/shampoo-flow.spec.ts
@@ -7,10 +7,12 @@ import {
   buildShampooDecision,
   buildShampooRetrievalFilter,
 } from "../src/lib/rag/shampoo-decision"
+import { deriveMaskDecision } from "../src/lib/rag/mask-reranker"
 import { computeChunkBoostedScore, type RetrievedChunk } from "../src/lib/rag/retriever"
 import { buildProductListChunks } from "../src/lib/rag/product-list-chunks"
 import { buildAssistantRagContext, buildDoneEventData } from "../src/lib/rag/chat-response"
 import { evaluateRoute } from "../src/lib/rag/router"
+import { normalizeShampooBucketPairs } from "../src/lib/shampoo/eligibility"
 
 function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
   return {
@@ -109,6 +111,7 @@ test.describe("Shampoo Flow alignment", () => {
       scalp_type: "oily",
       scalp_condition: "dandruff",
     })
+    expect(decision.matched_bucket).toBe("schuppen")
     expect(decision.matched_concern_code).toBe("schuppen")
     expect(decision.retrieval_filter).toEqual({
       thickness: "fine",
@@ -147,8 +150,75 @@ test.describe("Shampoo Flow alignment", () => {
     )
 
     expect(decision.eligible).toBe(true)
+    expect(decision.matched_bucket).toBe("trocken")
     expect(decision.matched_concern_code).toBe("trocken")
     expect(decision.no_catalog_match).toBe(true)
+  })
+
+  test("active scalp conditions keep scalp type optional for the primary shampoo match", () => {
+    const decision = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: null,
+        scalp_condition: "dandruff",
+      }),
+      2
+    )
+
+    expect(decision.eligible).toBe(true)
+    expect(decision.missing_profile_fields).toEqual([])
+    expect(decision.matched_bucket).toBe("schuppen")
+    expect(decision.matched_concern_code).toBe("schuppen")
+    expect(decision.candidate_count).toBe(2)
+    expect(decision.no_catalog_match).toBe(false)
+  })
+
+  test("active scalp conditions override scalp type when deriving the shampoo bucket", () => {
+    const oilyDandruff = buildShampooDecision(
+      createProfile({
+        thickness: "normal",
+        scalp_type: "oily",
+        scalp_condition: "dandruff",
+      })
+    )
+    const dryDandruff = buildShampooDecision(
+      createProfile({
+        thickness: "normal",
+        scalp_type: "dry",
+        scalp_condition: "dandruff",
+      })
+    )
+    const balancedIrritated = buildShampooDecision(
+      createProfile({
+        thickness: "normal",
+        scalp_type: "balanced",
+        scalp_condition: "irritated",
+      })
+    )
+
+    expect(oilyDandruff.matched_bucket).toBe("schuppen")
+    expect(dryDandruff.matched_bucket).toBe("schuppen")
+    expect(balancedIrritated.matched_bucket).toBe("irritationen")
+  })
+
+  test("clearing the scalp condition reroutes shampoo matching back to the baseline scalp type", () => {
+    const activeIssue = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: "oily",
+        scalp_condition: "dandruff",
+      })
+    )
+    const recovered = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: "oily",
+        scalp_condition: "none",
+      })
+    )
+
+    expect(activeIssue.matched_bucket).toBe("schuppen")
+    expect(recovered.matched_bucket).toBe("dehydriert-fettig")
   })
 
   test("clarification questions only ask for missing shampoo profile fields", () => {
@@ -163,6 +233,19 @@ test.describe("Shampoo Flow alignment", () => {
       "Ist dein Haar eher fein, mittel oder dick?",
       "Hast du aktuell Kopfhautbeschwerden - keine, Schuppen, trockene Schuppen oder gereizte Kopfhaut?",
     ])
+  })
+
+  test("clarification skips scalp type once an active scalp condition already sets the bucket", () => {
+    const decision = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: null,
+        scalp_condition: "irritated",
+      })
+    )
+
+    expect(decision.eligible).toBe(true)
+    expect(buildShampooClarificationQuestions(decision)).toEqual([])
   })
 
   test("shampoo retrieval filter applies for advice and recommendation intents, but not outside shampoo product flows", () => {
@@ -221,6 +304,37 @@ test.describe("Shampoo Flow alignment", () => {
     expect(routerDecision.policy_overrides).not.toContain("missing_slots")
   })
 
+  test("router allows shampoo recommendations when an active scalp condition already determines the bucket", () => {
+    const routerDecision = evaluateRoute(
+      {
+        intent: "product_recommendation",
+        product_category: "shampoo",
+        complexity: "simple",
+        needs_clarification: false,
+        retrieval_mode: "hybrid",
+        normalized_filters: {
+          problem: null,
+          duration: null,
+          products_tried: null,
+          routine: null,
+          special_circumstances: null,
+        },
+        router_confidence: 0.92,
+      },
+      [],
+      createProfile({
+        thickness: "fine",
+        scalp_type: null,
+        scalp_condition: "dandruff",
+      })
+    )
+
+    expect(routerDecision.needs_clarification).toBe(false)
+    expect(routerDecision.slot_completeness).toBe(1)
+    expect(routerDecision.policy_overrides).toContain("category_product_mode")
+    expect(routerDecision.policy_overrides).not.toContain("missing_shampoo_profile")
+  })
+
   test("router still clarifies when the shampoo triple is incomplete", () => {
     const routerDecision = evaluateRoute(
       {
@@ -277,6 +391,13 @@ test.describe("Shampoo Flow alignment", () => {
     const [noisyProduct] = annotateShampooRecommendations([createCandidate("a")], noisyDecision)
 
     expect(product.recommendation_meta?.category).toBe("shampoo")
+    expect(product.recommendation_meta?.category).toBe(noisyProduct.recommendation_meta?.category)
+
+    if (!product.recommendation_meta || product.recommendation_meta.category !== "shampoo") {
+      throw new Error("Expected shampoo recommendation metadata")
+    }
+
+    expect(product.recommendation_meta.matched_bucket).toBe("irritationen")
     expect(product.recommendation_meta?.top_reasons).toEqual(noisyProduct.recommendation_meta?.top_reasons)
     expect(product.recommendation_meta?.top_reasons.join(" ")).not.toMatch(/coily|growth|taeglich|bleached|frizz|breakage/i)
   })
@@ -318,6 +439,73 @@ test.describe("Shampoo Flow alignment", () => {
     )
   })
 
+  test("exact shampoo pairs are normalized deterministically without product-name hacks", () => {
+    const pairs = normalizeShampooBucketPairs({
+      name: "Custom Exact Pair Shampoo",
+      category: "Shampoo",
+      suitable_thicknesses: ["fine", "normal"],
+      suitable_concerns: ["trocken", "normal"],
+      shampoo_bucket_pairs: [
+        { thickness: "normal", shampoo_bucket: "normal" },
+        { thickness: "fine", shampoo_bucket: "trocken" },
+        { thickness: "fine", shampoo_bucket: "trocken" },
+      ],
+    })
+
+    expect(pairs).toEqual([
+      { thickness: "fine", shampoo_bucket: "trocken" },
+      { thickness: "normal", shampoo_bucket: "normal" },
+    ])
+  })
+
+  test("standard shampoos still expand to the full cartesian pair set", () => {
+    const pairs = normalizeShampooBucketPairs({
+      name: "Classic Matrix Shampoo",
+      category: "Shampoo",
+      suitable_thicknesses: ["fine", "coarse"],
+      suitable_concerns: ["dehydriert-fettig", "schuppen"],
+    })
+
+    expect(pairs).toEqual([
+      { thickness: "fine", shampoo_bucket: "schuppen" },
+      { thickness: "fine", shampoo_bucket: "dehydriert-fettig" },
+      { thickness: "coarse", shampoo_bucket: "schuppen" },
+      { thickness: "coarse", shampoo_bucket: "dehydriert-fettig" },
+    ])
+  })
+
+  test("invalid exact shampoo pairs fail fast during normalization", () => {
+    expect(() =>
+      normalizeShampooBucketPairs({
+        name: "Broken Exact Pair Shampoo",
+        category: "Shampoo",
+        shampoo_bucket_pairs: [{ thickness: "fine", shampoo_bucket: "nicht-echt" }],
+      })
+    ).toThrow(/ungueltigen Shampoo-Bucket/i)
+  })
+
+  test("product-list chunk generation honors explicit shampoo bucket pairs for renamed products too", () => {
+    const chunks = buildProductListChunks([
+      {
+        name: "Custom Exact Pair Shampoo",
+        brand: "Test",
+        category: "Shampoo",
+        suitable_thicknesses: ["fine", "normal"],
+        suitable_concerns: ["trocken", "normal"],
+        shampoo_bucket_pairs: [
+          { thickness: "fine", shampoo_bucket: "trocken" },
+          { thickness: "normal", shampoo_bucket: "normal" },
+        ],
+      },
+    ])
+
+    expect(chunks).toHaveLength(2)
+    expect(chunks.map((chunk) => chunk.metadata)).toEqual([
+      expect.objectContaining({ thickness: "fine", concern: "trocken" }),
+      expect.objectContaining({ thickness: "normal", concern: "normal" }),
+    ])
+  })
+
   test("chat payload helpers persist and expose shampoo decisions even without sources", () => {
     const categoryDecision = buildShampooDecision(
       createProfile({
@@ -352,5 +540,124 @@ test.describe("Shampoo Flow alignment", () => {
         category_decision: categoryDecision,
       })
     )
+  })
+
+  test("dandruff user gets secondary_bucket derived from scalp type for rotation", () => {
+    const balanced = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: "balanced",
+        scalp_condition: "dandruff",
+      })
+    )
+    expect(balanced.matched_bucket).toBe("schuppen")
+    expect(balanced.secondary_bucket).toBe("normal")
+
+    const oily = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: "oily",
+        scalp_condition: "dandruff",
+      })
+    )
+    expect(oily.matched_bucket).toBe("schuppen")
+    expect(oily.secondary_bucket).toBe("dehydriert-fettig")
+  })
+
+  test("non-dandruff users have no secondary_bucket", () => {
+    const none = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: "oily",
+        scalp_condition: "none",
+      })
+    )
+    expect(none.secondary_bucket).toBeNull()
+
+    const irritated = buildShampooDecision(
+      createProfile({
+        thickness: "fine",
+        scalp_type: "balanced",
+        scalp_condition: "irritated",
+      })
+    )
+    expect(irritated.secondary_bucket).toBeNull()
+  })
+})
+
+test.describe("Mask weighted signal scoring", () => {
+  test("bleached + heat_styling user gets need_strength 2 (weight 3+1=4)", () => {
+    const decision = deriveMaskDecision(
+      createProfile({
+        chemical_treatment: ["bleached"],
+        heat_styling: "daily",
+        protein_moisture_balance: "stretches_bounces",
+      })
+    )
+
+    expect(decision.needs_mask).toBe(true)
+    expect(decision.need_strength).toBe(2)
+    expect(decision.active_signals).toContain("chemical_treatment")
+    expect(decision.active_signals).toContain("heat_styling")
+    expect(decision.signal_weights?.chemical_treatment).toBe(3)
+    expect(decision.signal_weights?.heat_styling).toBe(1)
+  })
+
+  test("bleached + deficit balance = need_strength 3 (weight 3+2=5)", () => {
+    const decision = deriveMaskDecision(
+      createProfile({
+        chemical_treatment: ["bleached"],
+        heat_styling: "never",
+        protein_moisture_balance: "snaps",
+      })
+    )
+
+    expect(decision.needs_mask).toBe(true)
+    expect(decision.need_strength).toBe(3)
+    expect(decision.signal_weights?.chemical_treatment).toBe(3)
+    expect(decision.signal_weights?.protein_moisture_balance).toBe(2)
+  })
+
+  test("heat-only user gets need_strength 1 (weight 1)", () => {
+    const decision = deriveMaskDecision(
+      createProfile({
+        chemical_treatment: ["natural"],
+        heat_styling: "daily",
+        protein_moisture_balance: "stretches_bounces",
+      })
+    )
+
+    expect(decision.needs_mask).toBe(true)
+    expect(decision.need_strength).toBe(1)
+    expect(decision.active_signals).toEqual(["heat_styling"])
+    expect(decision.signal_weights?.heat_styling).toBe(1)
+  })
+
+  test("colored (not bleached) gets weight 2 for chemical_treatment", () => {
+    const decision = deriveMaskDecision(
+      createProfile({
+        chemical_treatment: ["colored"],
+        heat_styling: "never",
+        protein_moisture_balance: "stretches_bounces",
+      })
+    )
+
+    expect(decision.needs_mask).toBe(true)
+    expect(decision.need_strength).toBe(1)
+    expect(decision.signal_weights?.chemical_treatment).toBe(2)
+  })
+
+  test("no active signals yields need_strength 0 and no signal_weights", () => {
+    const decision = deriveMaskDecision(
+      createProfile({
+        chemical_treatment: ["natural"],
+        heat_styling: "never",
+        protein_moisture_balance: "stretches_bounces",
+      })
+    )
+
+    expect(decision.needs_mask).toBe(false)
+    expect(decision.need_strength).toBe(0)
+    expect(decision.signal_weights).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- make product_shampoo_specs the canonical shampoo eligibility source
- normalize exact shampoo bucket pairs across ingest and chunk generation
- make shampoo source-managed and read-only in admin

## Verification
- npx playwright test tests/shampoo-flow.spec.ts --reporter=line
- npx tsc --noEmit
- npm run build