### PR TITLE
docs: add architecture overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ When entering plan mode for any task:
 
 For trivial tasks (single file, <20 lines changed), skip the options table and plan directly.
 
+## Branch Gate
+
+Before invoking `executing-plans` or `subagent-driven-development`, always invoke the `branch-gate` skill first. This is mandatory — no exceptions.
+
 ## Project Conventions
 
 - All UI text is in German

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,308 @@
+# Hair Concierge (TomBot) — Architecture Overview
+
+## What It Is
+
+A personalized AI hair care recommendation platform built around **Tom Hannemann** (German hair care expert, 1.5M DACH followers). Users take a diagnostic quiz, complete a post-auth onboarding to build a detailed hair profile, then receive expert product recommendations and hair care advice via a conversational AI chat — all in Tom's voice and methodology.
+
+**Target:** German-speaking hair care enthusiasts. All UI text is in German.
+
+---
+
+## Tech Stack
+
+| Layer | Tech |
+|-------|------|
+| Framework | Next.js 16 (React 19, TypeScript 5, App Router) |
+| Database | Supabase PostgreSQL + pgvector |
+| Auth | Supabase Auth (OAuth + email) |
+| AI/LLM | OpenAI GPT-4 (chat), GPT-4 Vision (photo analysis), text-embedding-3-large (1536-dim embeddings) |
+| Styling | Tailwind CSS 4 + shadcn/ui |
+| State | Zustand |
+| Analytics | PostHog |
+| E2E Tests | Playwright |
+| Deployment | Vercel |
+
+---
+
+## System Architecture
+
+```mermaid
+graph TB
+    subgraph Client["Client · React 19 + Tailwind v4"]
+        direction TB
+        Quiz["Quiz Flow<br/>(11 steps, pre-auth)"]
+        Auth["Auth Page<br/>(OAuth + Email)"]
+        Onboarding["Onboarding<br/>(3 steps, post-auth)"]
+        Chat["Chat Interface<br/>(SSE streaming)"]
+        Profile["User Profile"]
+        Admin["Admin Dashboard"]
+
+        subgraph State["State Management"]
+            ZustandStore["Zustand<br/>(quiz store)"]
+            AuthProvider["AuthProvider<br/>(user + profile)"]
+            UseChatHook["useChat hook<br/>(SSE + messages)"]
+        end
+    end
+
+    subgraph Server["Next.js API Routes"]
+        direction TB
+        QuizAPI["POST /api/quiz/lead<br/>POST /api/quiz/analyze"]
+        AuthAPI["POST /api/auth/callback"]
+        ChatAPI["POST /api/chat<br/>(SSE streaming)"]
+        ProductsAPI["GET /api/products"]
+        ProfileAPI["POST /api/profile"]
+        AdminAPI["/api/admin/*<br/>(CRUD endpoints)"]
+        Middleware["Middleware<br/>(session refresh,<br/>route protection)"]
+    end
+
+    subgraph RAG["RAG Pipeline · src/lib/rag/"]
+        direction TB
+        Router["Intent Router<br/>(classify user intent)"]
+        Retriever["Hybrid Retriever<br/>(dense + lexical + RRF)"]
+        ProductMatcher["Product Matcher<br/>(category-specific)"]
+        Synthesizer["Synthesizer<br/>(Tom's voice + citations)"]
+
+        Router --> Retriever
+        Retriever --> ProductMatcher
+        ProductMatcher --> Synthesizer
+    end
+
+    subgraph CategoryLogic["Category Engines"]
+        Shampoo["Shampoo<br/>(6 buckets)"]
+        Conditioner["Conditioner<br/>(weight/repair)"]
+        LeaveIn["Leave-In<br/>(need/styling)"]
+        Oil["Oil<br/>(subtype/mode)"]
+        Mask["Mask<br/>(concentration)"]
+    end
+
+    subgraph Supabase["Supabase · Postgres + pgvector"]
+        direction TB
+        AuthDB["Auth (users, sessions)"]
+        ProfilesDB["profiles<br/>hair_profiles"]
+        ProductsDB["products +<br/>category spec tables<br/>(shampoo, conditioner,<br/>leave-in, oil, mask)"]
+        ContentDB["content_chunks<br/>(book, courses, QA)<br/>+ 1536-dim embeddings"]
+        ChatDB["conversations<br/>messages"]
+        LeadsDB["leads<br/>(pre-auth quiz data)"]
+        RPCFunctions["RPC Functions<br/>(match_content_chunks,<br/>match_*_products,<br/>lexical search)"]
+    end
+
+    subgraph External["External Services"]
+        OpenAI["OpenAI API<br/>(GPT-4 chat,<br/>GPT-4 Vision,<br/>text-embedding-3-large)"]
+        PostHog["PostHog<br/>(analytics)"]
+        Vercel["Vercel<br/>(hosting)"]
+    end
+
+    Quiz --> QuizAPI
+    Auth --> AuthAPI
+    Chat --> ChatAPI
+    Profile --> ProfileAPI
+    Admin --> AdminAPI
+
+    ChatAPI --> Router
+
+    ProductMatcher --> Shampoo
+    ProductMatcher --> Conditioner
+    ProductMatcher --> LeaveIn
+    ProductMatcher --> Oil
+    ProductMatcher --> Mask
+
+    QuizAPI --> LeadsDB
+    AuthAPI --> AuthDB
+    Retriever --> RPCFunctions
+    RPCFunctions --> ContentDB
+    RPCFunctions --> ProductsDB
+    CategoryLogic --> RPCFunctions
+    ChatAPI --> ChatDB
+    ProfileAPI --> ProfilesDB
+    Middleware --> AuthDB
+
+    Router --> OpenAI
+    Synthesizer --> OpenAI
+    Retriever --> OpenAI
+    Client --> PostHog
+```
+
+---
+
+## User Journey
+
+```mermaid
+flowchart LR
+    A["Landing"] --> B["Quiz<br/>(7 hair questions)"]
+    B --> C["Results Card<br/>(shareable)"]
+    C --> D["Auth<br/>(signup/login)"]
+    D --> E["Onboarding<br/>(goals, profile, routine)"]
+    E --> F["Chat<br/>(AI consultation)"]
+    F --> G["Product Recs<br/>(with citations)"]
+```
+
+### Flow Details
+
+1. **Quiz** (pre-auth) — 7-question hair diagnostic covering texture, thickness, cuticle condition, protein-moisture balance, scalp type, chemical treatments, and goals
+2. **Lead capture** — name + email stored in `leads` table
+3. **Auth** — Supabase OAuth (Google, etc.) + email signup; lead data linked to new user
+4. **Onboarding** (post-auth) — additional profile fields: wash frequency, goals, density, mechanical stress
+5. **Chat** — streaming SSE responses, RAG-powered, Tom's personality and methodology
+
+---
+
+## RAG Pipeline
+
+The core intelligence of the app. Each user message flows through this pipeline:
+
+```mermaid
+flowchart TD
+    Msg["User sends message"] --> Vision{"Has image?"}
+    Vision -->|Yes| Analyze["GPT-4 Vision<br/>analyze hair photo"]
+    Vision -->|No| Intent
+    Analyze --> Intent["Intent Router<br/>(classify intent)"]
+
+    Intent --> Load["Load in parallel:<br/>hair_profile + last 10 messages"]
+    Load --> Route["Policy Engine<br/>(select content sources)"]
+
+    Route --> Dense["pgvector<br/>semantic search"]
+    Route --> Lexical["BM25<br/>full-text search"]
+    Dense --> RRF["RRF Fusion<br/>(k=60)"]
+    Lexical --> RRF
+    RRF --> Rerank["Cross-encoder<br/>reranking"]
+
+    Rerank --> Match["Category-Specific<br/>Product Matching"]
+    Match --> Eligibility["Check eligibility<br/>(per category rules)"]
+    Eligibility --> Score["Score & rank<br/>(profile-aware)"]
+
+    Score --> Synth["Synthesize Response<br/>(Tom's voice + citations)"]
+    Synth --> Stream["Stream via SSE<br/>to client"]
+    Stream --> Save["Save to DB"]
+```
+
+### Recommendation Engine (Per Category)
+
+Each of the 5 product categories follows a 3-stage pipeline:
+
+1. **Decision Builder** — checks eligibility, infers derived fields from profile (e.g., `scalp_type` → `shampoo_bucket`)
+2. **Product Matcher** — hybrid retrieval: pgvector semantic search + trigram lexical search + metadata filtering via Supabase RPC functions
+3. **Reranker** — category-specific scoring rules, returns top results with reasons and usage hints
+
+**Categories:** Shampoo (6 buckets), Conditioner (weight/repair levels), Leave-in (need bucket/styling context), Oil (subtype/use mode), Mask (concentration/dosing)
+
+---
+
+## Data Model
+
+```mermaid
+erDiagram
+    users ||--o| profiles : has
+    users ||--o| hair_profiles : has
+    users ||--o{ conversations : owns
+    conversations ||--o{ messages : contains
+    leads ||--o| users : converts_to
+
+    products ||--o| shampoo_specs : has
+    products ||--o| conditioner_specs : has
+    products ||--o| leave_in_specs : has
+    products ||--o| oil_specs : has
+    products ||--o| mask_specs : has
+
+    content_chunks }|--|| knowledge_base : "book, courses, QA"
+
+    hair_profiles {
+        uuid user_id
+        enum hair_texture
+        enum thickness
+        enum density
+        enum scalp_type
+        jsonb concerns
+        jsonb goals
+    }
+
+    products {
+        uuid id
+        text name
+        text category
+        vector embedding_1536
+        boolean active
+    }
+
+    content_chunks {
+        uuid id
+        text content
+        text source_type
+        vector embedding_1536
+    }
+
+    messages {
+        uuid id
+        text role
+        text content
+        jsonb recommendations
+    }
+```
+
+---
+
+## Key Directories
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── api/chat/           # Chat SSE streaming endpoint
+│   ├── api/quiz/           # Quiz analysis + lead capture
+│   ├── api/admin/          # Admin CRUD endpoints
+│   ├── quiz/               # Quiz UI
+│   ├── auth/               # Login/signup
+│   ├── onboarding/         # Post-auth profile collection
+│   ├── chat/               # Chat interface
+│   ├── profile/            # User settings
+│   ├── admin/              # Admin dashboard
+│   └── result/[leadId]/    # Public shareable result card
+│
+├── components/
+│   ├── ui/                 # shadcn/ui primitives (25+ components)
+│   ├── quiz/               # Quiz-specific components (13 files)
+│   ├── chat/               # Chat components (9 files)
+│   ├── onboarding/         # Onboarding steps (4 files)
+│   └── admin/              # Admin panel components
+│
+├── lib/
+│   ├── rag/                # RAG pipeline (21 files) — the brain of the app
+│   ├── quiz/               # Quiz state, questions, normalization
+│   ├── supabase/           # DB clients (browser, server, admin)
+│   ├── openai/             # LLM wrappers (chat, embeddings, vision)
+│   ├── vocabulary/         # Centralized German labels (single source of truth)
+│   ├── validators/         # Zod schemas
+│   └── {shampoo,conditioner,leave-in,oil,mask}/  # Category constants
+│
+├── hooks/                  # useChat, useHairProfile
+├── providers/              # AuthProvider, PostHog, Toast
+└── middleware.ts           # Route protection + session refresh
+
+supabase/
+└── migrations/             # 35+ SQL migrations (schema, RPC functions, RLS)
+
+data/
+└── markdown-cleaned/       # RAG knowledge base (book, courses, products, QA)
+```
+
+---
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Deterministic product matching** (not pure LLM) | Category-specific rules ensure consistent, explainable recommendations |
+| **Hybrid retrieval** (vector + lexical + RRF) | Catches both semantic and keyword matches for better recall |
+| **Category-specific spec tables** (not generic JSON) | Type-safe, queryable product attributes per category |
+| **Pre-auth quiz → post-auth onboarding** | Low-friction entry; captures lead before requiring signup |
+| **SSE streaming** (not WebSockets) | Simpler, works with Vercel edge, progressive response display |
+| **German-only UI with centralized vocabulary** | Single source of truth in `src/lib/vocabulary/` |
+| **Zustand** (not Redux/Context) | Lightweight, minimal boilerplate for quiz + chat state |
+
+---
+
+## Current Status (March 2026)
+
+**Done:** Quiz, auth, chat with streaming + RAG, product recommendations (5 categories), intent router, admin panel, image analysis, mechanical stress onboarding
+
+**In progress:** Onboarding finalization, shareable diagnosis card (Instagram Story format), routine recommendation design spec
+
+**Planned:** Cross-category routine engine, paywall enforcement, Stripe integration, barcode scanner, seasonal refresh notifications

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -15,7 +15,7 @@ A personalized AI hair care recommendation platform built around **Tom Hannemann
 | Framework | Next.js 16 (React 19, TypeScript 5, App Router) |
 | Database | Supabase PostgreSQL + pgvector |
 | Auth | Supabase Auth (OAuth + email) |
-| AI/LLM | OpenAI GPT-4 (chat), GPT-4 Vision (photo analysis), text-embedding-3-large (1536-dim embeddings) |
+| AI/LLM | OpenAI GPT-4o (chat/classification), text-embedding-3-large embeddings |
 | Styling | Tailwind CSS 4 + shadcn/ui |
 | State | Zustand |
 | Analytics | PostHog |
@@ -87,7 +87,7 @@ graph TB
     end
 
     subgraph External["External Services"]
-        OpenAI["OpenAI API<br/>(GPT-4 chat,<br/>GPT-4 Vision,<br/>text-embedding-3-large)"]
+        OpenAI["OpenAI API<br/>(GPT-4o chat/classification,<br/>text-embedding-3-large)"]
         PostHog["PostHog<br/>(analytics)"]
         Vercel["Vercel<br/>(hosting)"]
     end
@@ -152,10 +152,7 @@ The core intelligence of the app. Each user message flows through this pipeline:
 
 ```mermaid
 flowchart TD
-    Msg["User sends message"] --> Vision{"Has image?"}
-    Vision -->|Yes| Analyze["GPT-4 Vision<br/>analyze hair photo"]
-    Vision -->|No| Intent
-    Analyze --> Intent["Intent Router<br/>(classify intent)"]
+    Msg["User sends message"] --> Intent["Intent Router<br/>(classify intent)"]
 
     Intent --> Load["Load in parallel:<br/>hair_profile + last 10 messages"]
     Load --> Route["Policy Engine<br/>(select content sources)"]
@@ -267,7 +264,7 @@ src/
 │   ├── rag/                # RAG pipeline (21 files) — the brain of the app
 │   ├── quiz/               # Quiz state, questions, normalization
 │   ├── supabase/           # DB clients (browser, server, admin)
-│   ├── openai/             # LLM wrappers (chat, embeddings, vision)
+│   ├── openai/             # LLM wrappers (chat, embeddings)
 │   ├── vocabulary/         # Centralized German labels (single source of truth)
 │   ├── validators/         # Zod schemas
 │   └── {shampoo,conditioner,leave-in,oil,mask}/  # Category constants
@@ -299,10 +296,10 @@ data/
 
 ---
 
-## Current Status (March 2026)
+## Current Status (April 2026)
 
-**Done:** Quiz, auth, chat with streaming + RAG, product recommendations (5 categories), intent router, admin panel, image analysis, mechanical stress onboarding
+**Done:** Quiz, auth, chat with streaming + RAG, product recommendations (5 categories), intent router, admin panel, mechanical stress onboarding
 
-**In progress:** Onboarding finalization, shareable diagnosis card (Instagram Story format), routine recommendation design spec
+**In progress:** Onboarding finalization, shareable diagnosis card (Instagram Story format), routine recommendation design spec, chat photo upload disabled for launch
 
 **Planned:** Cross-category routine engine, paywall enforcement, Stripe integration, barcode scanner, seasonal refresh notifications

--- a/docs/superpowers/plans/2026-03-24-ux-audit-phases-0-4.md
+++ b/docs/superpowers/plans/2026-03-24-ux-audit-phases-0-4.md
@@ -19,8 +19,8 @@
 | 0: PostHog | — | `src/app/quiz/page.tsx` |
 | 1: Copy | — | `src/lib/quiz/questions.ts`, `src/components/quiz/quiz-scalp-question.tsx`, `src/components/quiz/quiz-results.tsx` |
 | 2: Refactors | — | `src/lib/vocabulary/onboarding-goals.ts`, `src/components/onboarding/onboarding-goals.tsx`, `src/components/onboarding/onboarding-routine.tsx`, `src/app/onboarding/goals/page.tsx`, `src/app/onboarding/routine/page.tsx`, `tests/onboarding-goal-flow.test.ts` |
-| 3: None-states | `supabase/migrations/2026MMDD_add_answered_fields.sql` | `src/components/onboarding/onboarding-mechanical-stress.tsx`, `src/components/onboarding/onboarding-routine.tsx`, `src/components/onboarding/onboarding-goals.tsx` |
-| 4: Resequence | — | `src/lib/quiz/store.ts`, `src/lib/quiz/questions.ts`, `src/app/quiz/page.tsx`, `src/components/quiz/quiz-question.tsx`, `src/components/quiz/quiz-scalp-question.tsx`, `src/components/quiz/quiz-brand-panel.tsx` |
+| 3: None-states | `supabase/migrations/20260324120000_add_answered_fields.sql`, `src/lib/onboarding/answered-fields.ts` | `src/components/onboarding/onboarding-mechanical-stress.tsx`, `src/components/onboarding/onboarding-routine.tsx` |
+| 4: Resequence | — | `src/lib/quiz/store.ts`, `src/lib/quiz/questions.ts`, `src/components/quiz/quiz-scalp-question.tsx`, `src/components/quiz/quiz-brand-panel.tsx` |
 
 ---
 
@@ -82,16 +82,18 @@ instruction:
 
 - [ ] **Step 2: Shorten texture wet-strand instruction in questions.ts**
 
-Find the step 2 (texture) question. Replace the multi-line instruction with a condensed one-liner:
+Find the step 2 (texture) question. Replace the instruction with a condensed one-liner.
 
-Old:
+**IMPORTANT:** The codebase uses an en-dash (`\u2013` / `–`), not an em-dash. Match the exact character when finding the old string.
+
+Old (line 9, step 2 instruction):
 ```
-"Mach eine Straehne richtig nass – sie muss tropfnass sein. Halte sie am Ansatz fest, druecke sie oben zusammen und lass los. Schau, was passiert:"
+"Mach eine Straehne richtig nass \u2013 sie muss tropfnass sein. Halte sie am Ansatz fest, druecke sie oben zusammen und lass los. Schau, was passiert:"
 ```
 
 New:
 ```
-"Mach eine Straehne tropfnass, druecke sie oben zusammen und lass los — was passiert?"
+"Mach eine Straehne tropfnass, druecke sie oben zusammen und lass los \u2013 was passiert?"
 ```
 
 - [ ] **Step 3: Reframe surface + pull tests as Mini-Haarcheck in questions.ts**
@@ -202,7 +204,7 @@ After removal, straight has: `healthy_scalp`, `less_frizz`, `shine`, `less_split
 
 - [ ] **Step 2: Update goal-flow test**
 
-In `tests/onboarding-goal-flow.test.ts`, update the straight goals expectation to match the new data (volume removed, less_split_ends still present):
+In `tests/onboarding-goal-flow.test.ts`, the existing test 3 is currently **failing** — it was written as a TDD target that expects `["healthy_scalp", "less_frizz", "shine"]` but `getOnboardingGoalCards("straight")` currently returns all 5 goals. After removing volume, straight will have 4 goals. Update the test to match the new data:
 
 ```typescript
 test("straight onboarding cards are unique and no longer use the old volume chip", () => {
@@ -215,10 +217,12 @@ test("straight onboarding cards are unique and no longer use the old volume chip
 })
 ```
 
+Note: `less_split_ends` remains — further goal curation (removing goals from the chip list) is Phase 7 scope.
+
 - [ ] **Step 3: Run tests**
 
-Run: `node --test tests/onboarding-goal-flow.test.ts`
-Expected: All 3 tests pass.
+Run: `npx tsx --test tests/onboarding-goal-flow.test.ts`
+Expected: All 3 tests pass (test 3 was previously failing, now passes).
 
 - [ ] **Step 4: Fetch routine_preference in goals server component**
 
@@ -259,22 +263,25 @@ const [routinePreference, setRoutinePreference] = useState(
 )
 ```
 
-4. Add import at top:
+4. Extend the existing `@/lib/types` import (line 10 already imports `DESIRED_VOLUME_LABELS`):
 ```typescript
-import { ROUTINE_PREFERENCE_OPTIONS } from "@/lib/types"
+import { DESIRED_VOLUME_LABELS, ROUTINE_PREFERENCE_OPTIONS } from "@/lib/types"
 ```
 
-5. Add routine_preference to the `handleSave` Supabase update:
+5. Add `routine_preference` to the existing `handleSave` Supabase update. **CRITICAL: preserve the existing `onboarding_completed` write to the `profiles` table AND the `router.push("/chat")` redirect that follow.** Only add `routine_preference` to the `hair_profiles` update object:
 ```typescript
+// Add routine_preference to the EXISTING hair_profiles update (do NOT replace handleSave):
 const { error: hairProfileError } = await supabase
   .from("hair_profiles")
   .update({
     goals: derivedGoals,
     desired_volume: desiredVolume,
-    routine_preference: routinePreference || null,
+    routine_preference: routinePreference || null, // ← add this line
     updated_at: new Date().toISOString(),
   })
   .eq("user_id", userId)
+
+// The existing onboarding_completed write + router.push("/chat") MUST remain after this
 ```
 
 6. Add the routine_preference section in the JSX, AFTER the goals section and BEFORE the save button:
@@ -360,9 +367,9 @@ git commit -m "feat(onboarding): remove volume dedup from straight goals, move r
 
 **Files:**
 - Create: `supabase/migrations/20260324120000_add_answered_fields.sql`
+- Create: `src/lib/onboarding/answered-fields.ts` (shared helper)
 - Modify: `src/components/onboarding/onboarding-mechanical-stress.tsx`
 - Modify: `src/components/onboarding/onboarding-routine.tsx`
-- Modify: `src/components/onboarding/onboarding-goals.tsx` (save `answered_fields` for goals-owned fields)
 
 - [ ] **Step 1: Create Supabase migration**
 
@@ -455,13 +462,15 @@ const { error } = await supabase
 
 4. Update `handleSave` to also mark the field as answered (same merge pattern as above).
 
-**Refactoring note:** The `answered_fields` merge pattern repeats. Extract a helper:
+**Before continuing:** Extract the `answered_fields` merge pattern into a shared helper. Create `src/lib/onboarding/answered-fields.ts`:
 
 ```typescript
-async function mergeAnsweredFields(
+import { createClient } from "@/lib/supabase/client"
+
+export async function mergeAnsweredFields(
   supabase: ReturnType<typeof createClient>,
   userId: string,
-  fieldName: string
+  fieldNames: string[]
 ): Promise<string[]> {
   const { data } = await supabase
     .from("hair_profiles")
@@ -469,11 +478,32 @@ async function mergeAnsweredFields(
     .eq("user_id", userId)
     .single()
   const current = (data?.answered_fields as string[]) ?? []
-  return [...new Set([...current, fieldName])]
+  return [...new Set([...current, ...fieldNames])]
 }
 ```
 
-Place this in a shared location like `src/lib/onboarding/answered-fields.ts` and import where needed.
+Import this helper in both `onboarding-mechanical-stress.tsx` and `onboarding-routine.tsx`. Use it in all save/nichts-davon handlers instead of duplicating the merge logic inline.
+
+Refactor the "Nichts davon" button in Step 3 above to use this helper:
+```tsx
+onClick={async () => {
+  setSaving(true)
+  const supabase = createClient()
+  const updatedAnswered = await mergeAnsweredFields(supabase, userId, ["mechanical_stress_factors"])
+
+  const { error } = await supabase
+    .from("hair_profiles")
+    .update({
+      mechanical_stress_factors: [],
+      answered_fields: updatedAnswered,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("user_id", userId)
+  // ... error handling + router.push
+}}
+```
+
+Similarly, refactor `handleSave` to use the helper instead of inline merge.
 
 - [ ] **Step 4: Add "Nichts davon" to routine component (post_wash_actions + current_routine_products)**
 
@@ -546,7 +576,7 @@ const { error } = await supabase
   .eq("user_id", userId)
 ```
 
-Adjust the `mergeAnsweredFields` helper to accept an array of field names.
+The `mergeAnsweredFields` helper already accepts `string[]` — pass the array directly.
 
 - [ ] **Step 5: Build and verify**
 
@@ -568,12 +598,16 @@ git commit -m "feat(onboarding): add answered_fields metadata column and Nichts-
 
 **Key insight:** Step NUMBERS (2, 3, 4, 5, 6, 7) stay the same — they identify which component renders. Only the ORDER changes, plus the displayed question numbers.
 
+**No changes needed (confirmed):**
+- `src/lib/quiz/types.ts` — `QuizStep` is a union of literals, does not encode order
+- `src/components/quiz/quiz-question.tsx` `ANSWER_KEY_MAP` — maps step numbers to answer keys; step numbers are unchanged, only order changes
+- Scalp navigation logic (`goNext`/`goBack` in `quiz-scalp-question.tsx`) — already uses store's `goNext()` which follows `STEP_ORDER`, so resequencing is automatic
+
 **Files:**
 - Modify: `src/lib/quiz/store.ts:25` (STEP_ORDER)
 - Modify: `src/lib/quiz/questions.ts` (questionNumber + motivation for each question)
 - Modify: `src/components/quiz/quiz-scalp-question.tsx:168-170` (progress bar + counter)
 - Modify: `src/components/quiz/quiz-brand-panel.tsx:9` (question number derivation)
-- Modify: `src/app/quiz/page.tsx:15-27` (STEP_NAMES order comment, no functional change)
 
 - [ ] **Step 1: Update STEP_ORDER in store.ts**
 

--- a/docs/superpowers/plans/2026-03-24-ux-audit-phases-0-4.md
+++ b/docs/superpowers/plans/2026-03-24-ux-audit-phases-0-4.md
@@ -1,0 +1,706 @@
+# UX Audit Phases 0–4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the first five phases of the UX audit — PostHog instrumentation, copy quick-wins, small refactors, none-states metadata, and quiz resequencing.
+
+**Architecture:** Each phase is a self-contained task that ships independently. Phases 0, 1, 4 are fully independent. Phase 3 modifies `onboarding-routine.tsx` (adding "Nichts davon" buttons) so it should merge after Phase 2 (which removes `routine_preference` from the same file). All changes are frontend + one DB migration.
+
+**Tech Stack:** Next.js 15 (App Router), React, Zustand, Supabase (Postgres), PostHog, TypeScript
+
+**Spec:** `docs/quiz-onboarding-ux-audit-review.md`
+
+---
+
+## File Map
+
+| Task | Creates | Modifies |
+|------|---------|----------|
+| 0: PostHog | — | `src/app/quiz/page.tsx` |
+| 1: Copy | — | `src/lib/quiz/questions.ts`, `src/components/quiz/quiz-scalp-question.tsx`, `src/components/quiz/quiz-results.tsx` |
+| 2: Refactors | — | `src/lib/vocabulary/onboarding-goals.ts`, `src/components/onboarding/onboarding-goals.tsx`, `src/components/onboarding/onboarding-routine.tsx`, `src/app/onboarding/goals/page.tsx`, `src/app/onboarding/routine/page.tsx`, `tests/onboarding-goal-flow.test.ts` |
+| 3: None-states | `supabase/migrations/2026MMDD_add_answered_fields.sql` | `src/components/onboarding/onboarding-mechanical-stress.tsx`, `src/components/onboarding/onboarding-routine.tsx`, `src/components/onboarding/onboarding-goals.tsx` |
+| 4: Resequence | — | `src/lib/quiz/store.ts`, `src/lib/quiz/questions.ts`, `src/app/quiz/page.tsx`, `src/components/quiz/quiz-question.tsx`, `src/components/quiz/quiz-scalp-question.tsx`, `src/components/quiz/quiz-brand-panel.tsx` |
+
+---
+
+### Task 0: PostHog Instrumentation Prep
+
+**Context:** PostHog currently sends both `step_number` and `step_name` in `quiz_step_viewed`. After Phase 4 resequences steps, `step_number` meanings change. We need `step_name` as the canonical identifier so dashboards don't break.
+
+**Files:**
+- Modify: `src/app/quiz/page.tsx:15-36`
+
+- [ ] **Step 1: Update PostHog event to lead with step_name**
+
+In `src/app/quiz/page.tsx`, reorder the event properties so `step_name` is primary and add a deprecation note on `step_number`:
+
+```typescript
+useEffect(() => {
+  posthog.capture("quiz_step_viewed", {
+    step_name: STEP_NAMES[step] || `step_${step}`,
+    step_number: step, // deprecated: use step_name after Phase 4 resequencing
+  })
+}, [step])
+```
+
+- [ ] **Step 2: Verify no other quiz events use step_number without step_name**
+
+Check these files send named identifiers (not just numeric):
+- `src/components/quiz/quiz-lead-capture.tsx` — `quiz_lead_captured` (no step ref, OK)
+- `src/components/quiz/quiz-results.tsx` — `quiz_completed` (no step ref, OK)
+
+No changes needed — only `quiz_step_viewed` uses step identifiers.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/quiz/page.tsx
+git commit -m "chore(posthog): make step_name primary identifier in quiz events"
+```
+
+---
+
+### Task 1: Copy-Only Quick Wins
+
+**Context:** String changes across quiz components. No logic changes. The spec notes exact German strings are product decisions — this task uses the strings specified in the audit document.
+
+**Files:**
+- Modify: `src/lib/quiz/questions.ts` (question titles, descriptions, option labels)
+- Modify: `src/components/quiz/quiz-scalp-question.tsx` (scalp title, follow-up wording)
+- Modify: `src/components/quiz/quiz-results.tsx` (results continuation copy)
+
+- [ ] **Step 1: Add thickness clarifier in questions.ts**
+
+In `src/lib/quiz/questions.ts`, find the step 3 (thickness) question. Add the clarifier line after the existing instruction:
+
+```typescript
+// step 3 question object
+instruction:
+  "Nimm ein einzelnes Haar und halte es zwischen Daumen und Zeigefinger. Vergleiche es mit einem Naehfaden – das ist der beste Referenzpunkt.\n\nGemeint ist ein einzelnes Haar, nicht wie viele Haare du insgesamt hast.",
+```
+
+- [ ] **Step 2: Shorten texture wet-strand instruction in questions.ts**
+
+Find the step 2 (texture) question. Replace the multi-line instruction with a condensed one-liner:
+
+Old:
+```
+"Mach eine Straehne richtig nass – sie muss tropfnass sein. Halte sie am Ansatz fest, druecke sie oben zusammen und lass los. Schau, was passiert:"
+```
+
+New:
+```
+"Mach eine Straehne tropfnass, druecke sie oben zusammen und lass los — was passiert?"
+```
+
+- [ ] **Step 3: Reframe surface + pull tests as Mini-Haarcheck in questions.ts**
+
+Find step 4 (surface) question title. Change:
+```
+"DER OBERFLAECHENTEST" → "MINI-HAARCHECK 1 VON 2: OBERFLAECHE"
+```
+
+Find step 5 (pull) question title. Change:
+```
+"DER ZUGTEST" → "MINI-HAARCHECK 2 VON 2: ZUGTEST"
+```
+
+- [ ] **Step 4: Add pull test helper line in questions.ts**
+
+Find step 5 (pull) question. Append helper to the instruction:
+
+```typescript
+instruction:
+  "Nimm dasselbe Haar. Klemm es zwischen Ringfinger und Zeigefinger auf der einen Seite und zwischen Ringfinger und Mittelfinger auf der anderen. Zieh jetzt vorsichtig – wirklich mit Gefuehl, nicht reissen. Beobachte genau, was passiert:\n\nZiehe nur leicht. Uns geht es um die Tendenz, nicht um Perfektion.",
+```
+
+- [ ] **Step 5: Reword scalp question title + follow-up in quiz-scalp-question.tsx**
+
+In `src/components/quiz/quiz-scalp-question.tsx`:
+
+Change scalp type title:
+```
+"WIE IST DEIN KOPFHAUTTYP?" → "WIE SCHNELL FETTEN DEINE ANSAETZE NACH?"
+```
+
+Change scalp type instruction:
+```
+"Sei ehrlich: Wie oft musst du wirklich waschen? Deine Gesichtshaut gibt dir einen guten Hinweis — oelige T-Zone deutet auf fettige Kopfhaut hin."
+→
+"Deine Gesichtshaut gibt dir einen guten Hinweis — oelige T-Zone deutet auf fettige Kopfhaut hin."
+```
+
+Change gate question:
+```
+"HAST DU KOPFHAUTBESCHWERDEN?" → "HAST DU ZUSAETZLICH BESCHWERDEN WIE SCHUPPEN, JUCKREIZ ODER ROETUNGEN?"
+```
+
+Change gate instruction:
+```
+"Schuppen, Jucken oder Roetungen — oder ist alles im gruenen Bereich?"
+→
+(remove — the gate question itself now contains this context)
+```
+
+Change condition title:
+```
+"WELCHE BESCHWERDEN HAST DU?" → "WAS IST AKTUELL DEIN HAUPTPROBLEM?"
+```
+
+- [ ] **Step 6: Update results copy in quiz-results.tsx**
+
+In `src/components/quiz/quiz-results.tsx`, find the subtitle line:
+
+```
+"Deine Diagnose steht. Im naechsten Schritt legst du Ziele und Routinepraeferenzen fest."
+→
+"Dein Profil ist fast fertig — im naechsten Schritt geht es weiter mit deinen Zielen und deiner Routine."
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `npx next build`
+Expected: Build succeeds (these are string-only changes, no type errors)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/quiz/questions.ts src/components/quiz/quiz-scalp-question.tsx src/components/quiz/quiz-results.tsx
+git commit -m "feat(quiz): update copy — thickness clarifier, mini-haarcheck framing, scalp reword, results continuation"
+```
+
+---
+
+### Task 2: Small Refactors — Volume Dedup + Routine Preference Move
+
+**Context:** Two changes: (1) Remove `Mehr Volumen` from `ONBOARDING_GOALS.straight` since `desired_volume` already captures this. (2) Move `routine_preference` from the routine page to the goals page so it groups with goal-setting.
+
+**Files:**
+- Modify: `src/lib/vocabulary/onboarding-goals.ts:37-42` (remove volume entry)
+- Modify: `src/components/onboarding/onboarding-goals.tsx` (add routine_preference section + save it)
+- Modify: `src/components/onboarding/onboarding-routine.tsx` (remove routine_preference section + state)
+- Modify: `src/app/onboarding/goals/page.tsx` (fetch + pass routine_preference)
+- Modify: `src/app/onboarding/routine/page.tsx` (stop fetching routine_preference)
+- Modify: `tests/onboarding-goal-flow.test.ts` (update test expectations)
+
+- [ ] **Step 1: Remove volume goal from straight in onboarding-goals.ts**
+
+In `src/lib/vocabulary/onboarding-goals.ts`, delete the volume entry from the `straight` array (lines 37-42):
+
+```typescript
+// DELETE this entire object from the straight array:
+{
+  key: "volume",
+  label: "Mehr Volumen",
+  description: "Mehr Fuelle und Bewegung im Haar",
+  emoji: "💨",
+},
+```
+
+After removal, straight has: `healthy_scalp`, `less_frizz`, `shine`, `less_split_ends`.
+
+- [ ] **Step 2: Update goal-flow test**
+
+In `tests/onboarding-goal-flow.test.ts`, update the straight goals expectation to match the new data (volume removed, less_split_ends still present):
+
+```typescript
+test("straight onboarding cards are unique and no longer use the old volume chip", () => {
+  const straightGoals = getOnboardingGoalCards("straight")
+  const keys = straightGoals.map((goal) => goal.key)
+
+  assert.deepEqual(keys, ["healthy_scalp", "less_frizz", "shine", "less_split_ends"])
+  assert.equal(new Set(keys).size, keys.length)
+  assert.ok(!keys.includes("volume"))
+})
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `node --test tests/onboarding-goal-flow.test.ts`
+Expected: All 3 tests pass.
+
+- [ ] **Step 4: Fetch routine_preference in goals server component**
+
+In `src/app/onboarding/goals/page.tsx`, add `routine_preference` to the select query and pass it as a prop:
+
+```typescript
+// Change the select query from:
+.select("hair_texture, goals, desired_volume")
+// to:
+.select("hair_texture, goals, desired_volume, routine_preference")
+
+// Add prop to OnboardingGoals:
+<OnboardingGoals
+  hairTexture={(profile?.hair_texture as HairTexture) ?? null}
+  existingGoals={(profile?.goals as string[]) ?? []}
+  existingDesiredVolume={(profile?.desired_volume as "less" | "balanced" | "more" | null) ?? null}
+  existingRoutinePreference={(profile?.routine_preference as string) ?? null}
+  userId={user.id}
+  hasProfile={!!profile}
+/>
+```
+
+- [ ] **Step 5: Add routine_preference UI to onboarding-goals.tsx**
+
+In `src/components/onboarding/onboarding-goals.tsx`:
+
+1. Add to `OnboardingGoalsProps` interface:
+```typescript
+existingRoutinePreference: string | null
+```
+
+2. Pass it through to `GoalSelector` and add to the GoalSelector props destructuring.
+
+3. Add state in `GoalSelector`:
+```typescript
+const [routinePreference, setRoutinePreference] = useState(
+  existingRoutinePreference ?? ""
+)
+```
+
+4. Add import at top:
+```typescript
+import { ROUTINE_PREFERENCE_OPTIONS } from "@/lib/types"
+```
+
+5. Add routine_preference to the `handleSave` Supabase update:
+```typescript
+const { error: hairProfileError } = await supabase
+  .from("hair_profiles")
+  .update({
+    goals: derivedGoals,
+    desired_volume: desiredVolume,
+    routine_preference: routinePreference || null,
+    updated_at: new Date().toISOString(),
+  })
+  .eq("user_id", userId)
+```
+
+6. Add the routine_preference section in the JSX, AFTER the goals section and BEFORE the save button:
+
+```tsx
+{/* Routine preference */}
+<div className="mb-8 animate-fade-in-up" style={{ animationDelay: "620ms" }}>
+  <h2 className="font-header text-2xl leading-tight text-white mb-2">
+    Wie detailliert soll deine Routine sein?
+  </h2>
+  <div className="flex flex-wrap gap-2">
+    {ROUTINE_PREFERENCE_OPTIONS.map((option) => (
+      <button
+        key={option.value}
+        type="button"
+        onClick={() => setRoutinePreference(option.value)}
+        className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+          routinePreference === option.value
+            ? "border-[#F5C518] bg-[#F5C518] text-[#1A1618]"
+            : "border-white/20 text-white/70 hover:border-white/35 hover:text-white"
+        }`}
+      >
+        {option.label}
+      </button>
+    ))}
+  </div>
+</div>
+```
+
+- [ ] **Step 6: Remove routine_preference from onboarding-routine.tsx**
+
+In `src/components/onboarding/onboarding-routine.tsx`:
+
+1. Remove from `OnboardingRoutineProps` interface: `existingRoutinePreference: string | null`
+2. Remove from component destructuring: `existingRoutinePreference`
+3. Remove state: `const [routinePreference, setRoutinePreference] = useState(...)`
+4. Remove from `handleSave` update object: `routine_preference: routinePreference || null,`
+5. Remove the entire Section 5 (`"Wie detailliert soll deine Routine sein?"` block, ~animationDelay: "380ms")
+6. Remove unused import: `ROUTINE_PREFERENCE_OPTIONS` from `@/lib/types`
+
+- [ ] **Step 7: Remove routine_preference from routine server component**
+
+In `src/app/onboarding/routine/page.tsx`:
+
+1. Remove `routine_preference` from the select query:
+```typescript
+// From:
+.select("wash_frequency, heat_styling, post_wash_actions, routine_preference, current_routine_products")
+// To:
+.select("wash_frequency, heat_styling, post_wash_actions, current_routine_products")
+```
+
+2. Remove the `existingRoutinePreference` prop:
+```typescript
+// Delete this line from OnboardingRoutine props:
+existingRoutinePreference={(profile.routine_preference as string) ?? null}
+```
+
+- [ ] **Step 8: Build and verify**
+
+Run: `npx next build`
+Expected: Build succeeds with no type errors.
+
+- [ ] **Step 9: Run tests**
+
+Run: `node --test tests/onboarding-goal-flow.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/lib/vocabulary/onboarding-goals.ts src/components/onboarding/onboarding-goals.tsx src/components/onboarding/onboarding-routine.tsx src/app/onboarding/goals/page.tsx src/app/onboarding/routine/page.tsx tests/onboarding-goal-flow.test.ts
+git commit -m "feat(onboarding): remove volume dedup from straight goals, move routine_preference to goals page"
+```
+
+---
+
+### Task 3: None-States via answered_fields Metadata
+
+**Context:** Currently there's no way to distinguish "user skipped a field" from "user explicitly chose nothing." The solution is an `answered_fields` metadata column on `hair_profiles`. When a user explicitly clicks "Nichts davon," the field value stays `[]` AND the field name is added to `answered_fields`. Pipeline code: zero changes — `[]` continues to mean "no items."
+
+**Dependencies:** Merge after Task 2 (both modify `onboarding-routine.tsx`).
+
+**Files:**
+- Create: `supabase/migrations/20260324120000_add_answered_fields.sql`
+- Modify: `src/components/onboarding/onboarding-mechanical-stress.tsx`
+- Modify: `src/components/onboarding/onboarding-routine.tsx`
+- Modify: `src/components/onboarding/onboarding-goals.tsx` (save `answered_fields` for goals-owned fields)
+
+- [ ] **Step 1: Create Supabase migration**
+
+Create `supabase/migrations/20260324120000_add_answered_fields.sql`:
+
+```sql
+ALTER TABLE hair_profiles
+ADD COLUMN IF NOT EXISTS answered_fields text[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN hair_profiles.answered_fields IS
+  'Tracks which fields the user explicitly answered. A field in answered_fields with value [] means "user said none." A field NOT in answered_fields means "user never saw/answered it."';
+```
+
+- [ ] **Step 2: Apply migration**
+
+Run: `npx supabase db push` or apply via Supabase dashboard.
+Expected: Migration succeeds, column added.
+
+- [ ] **Step 3: Add "Nichts davon" to mechanical stress component**
+
+In `src/components/onboarding/onboarding-mechanical-stress.tsx`:
+
+1. Add `answeredFields` state tracking:
+```typescript
+const [answeredFields, setAnsweredFields] = useState<string[]>([])
+```
+
+2. In `handleSave`, include `answered_fields` in the update. We merge with existing answered_fields:
+```typescript
+const supabase = createClient()
+const { data: existing } = await supabase
+  .from("hair_profiles")
+  .select("answered_fields")
+  .eq("user_id", userId)
+  .single()
+
+const currentAnswered = (existing?.answered_fields as string[]) ?? []
+const updatedAnswered = [...new Set([...currentAnswered, "mechanical_stress_factors"])]
+
+const { error } = await supabase
+  .from("hair_profiles")
+  .update({
+    mechanical_stress_factors: [...selected],
+    answered_fields: updatedAnswered,
+    updated_at: new Date().toISOString(),
+  })
+  .eq("user_id", userId)
+```
+
+3. Add a "Nichts davon regelmaessig" button after the factor options, before the save/skip buttons:
+
+```tsx
+<button
+  type="button"
+  onClick={async () => {
+    setSaving(true)
+    const supabase = createClient()
+    const { data: existing } = await supabase
+      .from("hair_profiles")
+      .select("answered_fields")
+      .eq("user_id", userId)
+      .single()
+
+    const currentAnswered = (existing?.answered_fields as string[]) ?? []
+    const updatedAnswered = [...new Set([...currentAnswered, "mechanical_stress_factors"])]
+
+    const { error } = await supabase
+      .from("hair_profiles")
+      .update({
+        mechanical_stress_factors: [],
+        answered_fields: updatedAnswered,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId)
+
+    if (error) {
+      toast({ title: "Fehler beim Speichern. Bitte versuche es erneut.", variant: "destructive" })
+      setSaving(false)
+      return
+    }
+    router.push("/onboarding/routine")
+  }}
+  disabled={saving}
+  className="animate-fade-in-up mt-4 w-full rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-center text-sm text-white/60 transition-all hover:border-white/25 hover:text-white/80"
+  style={{ animationDelay: "360ms" }}
+>
+  Nichts davon regelmaessig
+</button>
+```
+
+4. Update `handleSave` to also mark the field as answered (same merge pattern as above).
+
+**Refactoring note:** The `answered_fields` merge pattern repeats. Extract a helper:
+
+```typescript
+async function mergeAnsweredFields(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+  fieldName: string
+): Promise<string[]> {
+  const { data } = await supabase
+    .from("hair_profiles")
+    .select("answered_fields")
+    .eq("user_id", userId)
+    .single()
+  const current = (data?.answered_fields as string[]) ?? []
+  return [...new Set([...current, fieldName])]
+}
+```
+
+Place this in a shared location like `src/lib/onboarding/answered-fields.ts` and import where needed.
+
+- [ ] **Step 4: Add "Nichts davon" to routine component (post_wash_actions + current_routine_products)**
+
+In `src/components/onboarding/onboarding-routine.tsx`, after the multi-select buttons for each of these sections, add a "Nichts davon regelmaessig" toggle button that:
+- Clears the selection set for that field
+- Tracks the field as answered via local state
+
+Add local state:
+```typescript
+const [answeredPostWash, setAnsweredPostWash] = useState(false)
+const [answeredProducts, setAnsweredProducts] = useState(false)
+```
+
+For each multi-select section (post_wash_actions at ~delay 320ms, current_routine_products at ~delay 200ms), add after the chip buttons:
+
+```tsx
+<button
+  type="button"
+  onClick={() => {
+    setSelectedPostWashActions(new Set())  // or setSelectedRoutineProducts
+    setAnsweredPostWash(true)  // or setAnsweredProducts
+  }}
+  className={`mt-2 rounded-full border px-3 py-1.5 text-sm transition-colors ${
+    answeredPostWash && selectedPostWashActions.size === 0
+      ? "border-[#F5C518] bg-[#F5C518] text-[#1A1618]"
+      : "border-white/20 text-white/70 hover:border-white/35 hover:text-white"
+  }`}
+>
+  Nichts davon regelmaessig
+</button>
+```
+
+When the user selects an actual option, clear the "none" flag:
+```typescript
+function toggleSetValue(
+  setState: (updater: (prev: Set<string>) => Set<string>) => void,
+  key: string,
+  clearNoneFlag?: () => void
+) {
+  setState((prev) => {
+    const next = new Set(prev)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
+  clearNoneFlag?.()
+}
+```
+
+In `handleSave`, build the answered_fields list and include it in the update:
+
+```typescript
+const fieldsAnswered: string[] = []
+if (answeredPostWash || selectedPostWashActions.size > 0) fieldsAnswered.push("post_wash_actions")
+if (answeredProducts || selectedRoutineProducts.size > 0) fieldsAnswered.push("current_routine_products")
+
+// Merge with existing answered_fields
+const merged = await mergeAnsweredFields(supabase, userId, fieldsAnswered)
+
+const { error } = await supabase
+  .from("hair_profiles")
+  .update({
+    wash_frequency: washFrequency,
+    heat_styling: heatStyling || null,
+    post_wash_actions: [...selectedPostWashActions],
+    current_routine_products: [...selectedRoutineProducts],
+    answered_fields: merged,
+    updated_at: new Date().toISOString(),
+  })
+  .eq("user_id", userId)
+```
+
+Adjust the `mergeAnsweredFields` helper to accept an array of field names.
+
+- [ ] **Step 5: Build and verify**
+
+Run: `npx next build`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260324120000_add_answered_fields.sql src/lib/onboarding/answered-fields.ts src/components/onboarding/onboarding-mechanical-stress.tsx src/components/onboarding/onboarding-routine.tsx
+git commit -m "feat(onboarding): add answered_fields metadata column and Nichts-davon buttons"
+```
+
+---
+
+### Task 4: Quiz Resequencing
+
+**Context:** Reorder quiz questions from texture-first to chemical-first. New order: chemical → scalp → texture → thickness → surface → pull. This means changing `STEP_ORDER`, question numbers, progress bars, motivation texts, and the brand panel number derivation.
+
+**Key insight:** Step NUMBERS (2, 3, 4, 5, 6, 7) stay the same — they identify which component renders. Only the ORDER changes, plus the displayed question numbers.
+
+**Files:**
+- Modify: `src/lib/quiz/store.ts:25` (STEP_ORDER)
+- Modify: `src/lib/quiz/questions.ts` (questionNumber + motivation for each question)
+- Modify: `src/components/quiz/quiz-scalp-question.tsx:168-170` (progress bar + counter)
+- Modify: `src/components/quiz/quiz-brand-panel.tsx:9` (question number derivation)
+- Modify: `src/app/quiz/page.tsx:15-27` (STEP_NAMES order comment, no functional change)
+
+- [ ] **Step 1: Update STEP_ORDER in store.ts**
+
+In `src/lib/quiz/store.ts`, change:
+
+```typescript
+// Old:
+const STEP_ORDER: QuizStep[] = [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 14]
+
+// New (chemical first, then scalp, then texture/thickness/surface/pull):
+const STEP_ORDER: QuizStep[] = [1, 7, 6, 2, 3, 4, 5, 9, 10, 11, 14]
+```
+
+- [ ] **Step 2: Update questionNumber in questions.ts**
+
+In `src/lib/quiz/questions.ts`, update the `questionNumber` field for each question to reflect the new order:
+
+| Step | Question | Old questionNumber | New questionNumber |
+|------|----------|-------------------|-------------------|
+| 7 | chemical_treatment | 6 | 1 |
+| 2 | hair_texture | 1 | 3 |
+| 3 | hair_thickness | 2 | 4 |
+| 4 | surface_test | 3 | 5 |
+| 5 | pull_test | 4 | 6 |
+
+(Step 6 / scalp is handled separately in quiz-scalp-question.tsx → becomes Q2)
+
+Also update motivation texts to match new position in flow:
+
+| Step | New Q# | New motivation |
+|------|--------|----------------|
+| 7 | Q1 | `"Super, du bist gerade erst gestartet. Noch 5 kurze Fragen."` |
+| 2 | Q3 | `"Klasse – du hilfst TomBot, deine Haare richtig einzuschaetzen."` |
+| 3 | Q4 | `"Top, schon ein gutes Stueck geschafft."` |
+| 4 | Q5 | `"Fast geschafft – noch ein letzter Test."` |
+| 5 | Q6 | `"Letzte Frage – gleich siehst du dein Profil."` |
+
+- [ ] **Step 3: Update scalp question progress in quiz-scalp-question.tsx**
+
+In `src/components/quiz/quiz-scalp-question.tsx`, find the hardcoded progress values (around line 168):
+
+```tsx
+// Old:
+<QuizProgressBar current={5} total={6} />
+// ...
+<span className="text-sm text-white/38 tabular-nums">5/6</span>
+
+// New (scalp is now Q2):
+<QuizProgressBar current={2} total={6} />
+// ...
+<span className="text-sm text-white/38 tabular-nums">2/6</span>
+```
+
+Also update the scalp motivation text:
+```
+// Old:
+"Nur noch 1 Frage — du machst das super."
+// New:
+"Top, die Kopfhaut-Frage ist geschafft."
+```
+
+- [ ] **Step 4: Update brand panel question number derivation**
+
+In `src/components/quiz/quiz-brand-panel.tsx`, the current formula is:
+```typescript
+const questionNumber = step >= 2 && step <= 7 ? step - 1 : null
+```
+
+This breaks with the new order. Replace with an explicit map:
+
+```typescript
+const QUESTION_NUMBER_MAP: Record<number, number> = {
+  7: 1,  // chemical
+  6: 2,  // scalp
+  2: 3,  // texture
+  3: 4,  // thickness
+  4: 5,  // surface
+  5: 6,  // pull
+}
+const questionNumber = QUESTION_NUMBER_MAP[step] ?? null
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `npx next build`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Manual smoke test**
+
+Open the quiz in browser. Verify:
+1. Landing → Chemical treatment (Q1) → Scalp type (Q2) → [if yes: scalp condition] → Texture (Q3) → Thickness (Q4) → Surface (Q5) → Pull (Q6) → Lead capture → Analysis → Results → Welcome
+2. Brand panel shows correct "FRAGE N VON 6" for each step
+3. Progress bars advance correctly
+4. Back button navigates to the correct previous step
+5. Scalp "Nein" skips to texture (step 2), "Ja" shows condition then texture
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/quiz/store.ts src/lib/quiz/questions.ts src/components/quiz/quiz-scalp-question.tsx src/components/quiz/quiz-brand-panel.tsx
+git commit -m "feat(quiz): resequence to chemical-first order for higher confidence opening"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 0 (PostHog)  ──┐
+Task 1 (Copy)     ──┤── all independent, can run in parallel
+Task 4 (Resequence)──┘
+Task 2 (Refactors) ─── then ─── Task 3 (None-states)
+```
+
+Tasks 0, 1, 2, and 4 can all start simultaneously. Task 3 starts after Task 2 merges (shared file: `onboarding-routine.tsx`).
+
+## Verification Checklist (after all tasks merged)
+
+- [ ] `npx next build` succeeds
+- [ ] `node --test tests/onboarding-goal-flow.test.ts` passes
+- [ ] Quiz flow: chemical → scalp → texture → thickness → surface → pull (correct order)
+- [ ] Brand panel: FRAGE 1–6 VON 6 labels match step
+- [ ] Progress bars: correct on all quiz steps including scalp
+- [ ] Goals page: shows routine_preference section, saves correctly
+- [ ] Routine page: no routine_preference section
+- [ ] Mechanical stress: "Nichts davon regelmaessig" saves `[]` + marks `answered_fields`
+- [ ] Routine page: "Nichts davon" buttons for post_wash_actions and current_routine_products work
+- [ ] PostHog: `quiz_step_viewed` events include `step_name`
+- [ ] Thickness question shows clarifier text
+- [ ] Surface/pull tests labeled as "Mini-Haarcheck 1/2 von 2"

--- a/docs/superpowers/specs/2026-03-22-branch-gate-design.md
+++ b/docs/superpowers/specs/2026-03-22-branch-gate-design.md
@@ -1,0 +1,71 @@
+# Branch Gate Skill — Design Spec
+
+**Date:** 2026-03-22
+**Status:** Approved
+
+## Purpose
+
+Automatically assess a plan before execution and recommend whether to build on a feature branch or directly on main. Invoked automatically via CLAUDE.md rule — the user never needs to call it manually.
+
+## Trigger
+
+Always called before `executing-plans` or `subagent-driven-development`. Enforced by a mandatory rule in the project's CLAUDE.md.
+
+## Process
+
+1. Read the plan file from the current conversation context
+2. Extract signals: task count, file count, new files, migrations, uncertainty keywords
+3. Score against heuristics
+4. Present recommendation with one-line reasoning
+5. On approval: create branch and proceed to execution skill
+6. On rejection: proceed on main (or accept user's alternative)
+
+## Heuristics
+
+| Signal | Weight | Rationale |
+|--------|--------|-----------|
+| 3+ tasks in plan | +1 | Multi-step work is harder to revert |
+| 5+ files touched | +1 | Wide blast radius |
+| Creates new files | +1 | New files = new feature, not a tweak |
+| Includes DB migrations | +2 | Migrations are hard to undo — auto-triggers branch |
+| Uncertainty keywords (explore, prototype, try, experiment) | +1 | Experimental work may be discarded |
+| Single task | -1 | Likely small and safe |
+| 3 or fewer files | -1 | Narrow scope |
+| Bug fix or config change | -1 | Low risk, targeted |
+
+**Decision rule:** Score >= 2 recommends a branch. Any migration present always recommends a branch regardless of score.
+
+## Branch Naming
+
+Auto-generated from plan title:
+- Features: `feat/<slugified-plan-title>` (e.g., `feat/oil-recommendation-flow`)
+- Bug fixes: `fix/<slug>` (e.g., `fix/og-share-image`)
+- Refactors: `refactor/<slug>`
+
+## Output Format
+
+```
+Branch assessment: This plan has [N] tasks touching [M] files [with K migration(s)]
+— score [X]. Recommending branch `feat/example-name`.
+
+Create branch and proceed? (y/n)
+```
+
+If main is recommended:
+```
+Branch assessment: Single task, 2 files, bug fix — score -1.
+Proceeding on main. (Say "branch" if you'd prefer a branch anyway.)
+```
+
+## Files
+
+- **Create:** `~/.claude/skills/branch-gate/SKILL.md`
+- **Modify:** `CLAUDE.md` — add mandatory invocation rule
+
+## Integration
+
+```
+writing-plans → branch-gate → executing-plans / subagent-driven-development
+```
+
+The branch-gate skill does NOT replace `using-git-worktrees`. If the execution skill needs a worktree (parallel work), that's a separate concern. Branch-gate only handles the branch/main decision.


### PR DESCRIPTION
## Summary
- adds a high-level architecture overview with Mermaid diagrams
- documents the quiz, onboarding, chat/RAG, recommendation, and Supabase architecture
- updates the overview to match the launch scope: no chat photo upload or Vision analysis

## Merge order
Merge after #3. Prefer merging after #4 so the documented launch chat scope matches the code state.

## Validation
- git diff --check
- rg check for stale Vision/photo-analysis mentions in OVERVIEW.md