### PR TITLE
feat: add user memory controls

### DIFF
--- a/src/app/api/chat/[id]/route.ts
+++ b/src/app/api/chat/[id]/route.ts
@@ -1,4 +1,6 @@
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { deleteConversationSourcedMemories } from "@/lib/rag/user-memory"
 import { ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
 
@@ -53,6 +55,9 @@ export async function DELETE(
   if (!user) {
     return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
   }
+
+  const admin = createAdminClient()
+  await deleteConversationSourcedMemories(user.id, id, admin)
 
   const { error } = await supabase
     .from("conversations")

--- a/src/app/api/memory/[id]/route.ts
+++ b/src/app/api/memory/[id]/route.ts
@@ -25,7 +25,13 @@ export async function PATCH(
     return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
   }
 
-  const body = await request.json()
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: ERR_INVALID_DATA }, { status: 400 })
+  }
+
   const parsed = memoryUpdateSchema.safeParse(body)
 
   if (!parsed.success) {

--- a/src/app/api/memory/[id]/route.ts
+++ b/src/app/api/memory/[id]/route.ts
@@ -1,0 +1,66 @@
+import { z } from "zod"
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import {
+  deleteUserMemoryEntry,
+  updateUserMemoryEntry,
+} from "@/lib/rag/user-memory"
+import { ERR_UNAUTHORIZED, ERR_INVALID_DATA } from "@/lib/vocabulary"
+
+const memoryUpdateSchema = z.object({
+  content: z.string().trim().min(1).max(500),
+})
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const parsed = memoryUpdateSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: ERR_INVALID_DATA, details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const memory = await updateUserMemoryEntry(user.id, id, parsed.data.content)
+  if (!memory) {
+    return NextResponse.json({ error: "Erinnerung nicht gefunden" }, { status: 404 })
+  }
+
+  return NextResponse.json({ memory })
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const deleted = await deleteUserMemoryEntry(user.id, id)
+  if (!deleted) {
+    return NextResponse.json({ error: "Erinnerung nicht gefunden" }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -44,7 +44,13 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
   }
 
-  const body = await request.json()
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: ERR_INVALID_DATA }, { status: 400 })
+  }
+
   const parsed = memorySettingsSchema.safeParse(body)
 
   if (!parsed.success) {

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,0 +1,75 @@
+import { z } from "zod"
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import {
+  backfillLegacyConversationMemory,
+  ensureUserMemorySettings,
+  listUserMemoryEntries,
+} from "@/lib/rag/user-memory"
+import { ERR_UNAUTHORIZED, ERR_INVALID_DATA, fehler } from "@/lib/vocabulary"
+
+const memorySettingsSchema = z.object({
+  memory_enabled: z.boolean(),
+})
+
+export async function GET() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const admin = createAdminClient()
+  const memoryEnabled = await ensureUserMemorySettings(user.id, admin)
+  await backfillLegacyConversationMemory(user.id, admin)
+  const entries = await listUserMemoryEntries(user.id, admin)
+
+  return NextResponse.json({
+    settings: { memory_enabled: memoryEnabled },
+    entries,
+  })
+}
+
+export async function PATCH(request: Request) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const body = await request.json()
+  const parsed = memorySettingsSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: ERR_INVALID_DATA, details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from("user_memory_settings")
+    .upsert(
+      {
+        user_id: user.id,
+        memory_enabled: parsed.data.memory_enabled,
+      },
+      { onConflict: "user_id" }
+    )
+    .select("memory_enabled")
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: fehler("Speichern") }, { status: 500 })
+  }
+
+  return NextResponse.json({ settings: data })
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -27,10 +27,12 @@ import {
   ROUTINE_PREFERENCE_OPTIONS,
   ROUTINE_PRODUCT_OPTIONS,
 } from "@/lib/types"
-import type { Goal, HairProfile } from "@/lib/types"
+import type { Goal, HairProfile, UserMemoryEntry } from "@/lib/types"
 import { createClient } from "@/lib/supabase/client"
 import { useEffect, useMemo, useState } from "react"
 import { SegmentedControl } from "@/components/ui/segmented-control"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
 import {
   Accordion,
   AccordionItem,
@@ -176,6 +178,11 @@ const FIELD_TO_SECTION: Record<string, string> = {
   products_used: "routine",
 }
 
+type MemoryApiResponse = {
+  settings: { memory_enabled: boolean }
+  entries: UserMemoryEntry[]
+}
+
 export default function ProfilePage() {
   const { user, profile, loading: authLoading, signOut } = useAuth()
   const { toast } = useToast()
@@ -185,6 +192,12 @@ export default function ProfilePage() {
   const [editSection, setEditSection] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [memoryEntries, setMemoryEntries] = useState<UserMemoryEntry[]>([])
+  const [memoryEnabled, setMemoryEnabled] = useState(true)
+  const [memoryLoading, setMemoryLoading] = useState(true)
+  const [memorySaving, setMemorySaving] = useState(false)
+  const [editingMemoryId, setEditingMemoryId] = useState<string | null>(null)
+  const [memoryDraft, setMemoryDraft] = useState("")
 
   // Edit form state
   const [formData, setFormData] = useState({
@@ -246,6 +259,30 @@ export default function ProfilePage() {
     loadProfile()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id])
+
+  useEffect(() => {
+    async function loadMemory() {
+      if (!user) {
+        setMemoryLoading(false)
+        return
+      }
+
+      setMemoryLoading(true)
+      try {
+        const res = await fetch("/api/memory")
+        if (!res.ok) throw new Error("Memory konnte nicht geladen werden")
+        const data = (await res.json()) as MemoryApiResponse
+        setMemoryEnabled(data.settings.memory_enabled)
+        setMemoryEntries(data.entries ?? [])
+      } catch (err) {
+        console.error("Error loading memory:", err)
+      } finally {
+        setMemoryLoading(false)
+      }
+    }
+
+    loadMemory()
+  }, [user])
 
   // Pre-compute field values for read-mode display
   const fieldValues = useMemo(
@@ -325,6 +362,80 @@ export default function ProfilePage() {
     return arr.includes(item)
       ? arr.filter((i) => i !== item)
       : [...arr, item]
+  }
+
+  async function handleMemoryToggle(checked: boolean) {
+    setMemoryEnabled(checked)
+    setMemorySaving(true)
+
+    try {
+      const res = await fetch("/api/memory", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memory_enabled: checked }),
+      })
+
+      if (!res.ok) throw new Error("Memory setting failed")
+      toast({ title: checked ? "Erinnerungen aktiviert" : "Erinnerungen pausiert" })
+    } catch (err) {
+      console.error("Error saving memory setting:", err)
+      setMemoryEnabled(!checked)
+      toast({ title: fehler("Speichern"), variant: "destructive" })
+    } finally {
+      setMemorySaving(false)
+    }
+  }
+
+  function startEditingMemory(entry: UserMemoryEntry) {
+    setEditingMemoryId(entry.id)
+    setMemoryDraft(entry.content)
+  }
+
+  async function handleSaveMemory(memoryId: string) {
+    const content = memoryDraft.trim()
+    if (!content) return
+
+    setMemorySaving(true)
+    try {
+      const res = await fetch(`/api/memory/${memoryId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+      })
+
+      if (!res.ok) throw new Error("Memory update failed")
+      const data = (await res.json()) as { memory: UserMemoryEntry }
+      setMemoryEntries((entries) =>
+        entries.map((entry) => entry.id === memoryId ? data.memory : entry)
+      )
+      setEditingMemoryId(null)
+      setMemoryDraft("")
+      toast({ title: "Erinnerung gespeichert" })
+    } catch (err) {
+      console.error("Error saving memory:", err)
+      toast({ title: fehler("Speichern"), variant: "destructive" })
+    } finally {
+      setMemorySaving(false)
+    }
+  }
+
+  async function handleDeleteMemory(memoryId: string) {
+    setMemorySaving(true)
+    try {
+      const res = await fetch(`/api/memory/${memoryId}`, { method: "DELETE" })
+      if (!res.ok) throw new Error("Memory delete failed")
+      setMemoryEntries((entries) => entries.filter((entry) => entry.id !== memoryId))
+      if (editingMemoryId === memoryId) {
+        setEditingMemoryId(null)
+        setMemoryDraft("")
+      }
+      toast({ title: "Erinnerung gelöscht" })
+    } catch (err) {
+      console.error("Error deleting memory:", err)
+      toast({ title: fehler("Löschen"), variant: "destructive" })
+    } finally {
+      setMemorySaving(false)
+    }
   }
 
   if (authLoading || loading) {
@@ -811,6 +922,96 @@ export default function ProfilePage() {
                   </div>
                 </div>
               )}
+            </div>
+          )}
+        </section>
+
+        <section className="mt-6 rounded-xl border bg-card p-6">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold">Was TomBot sich merkt</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Diese Haarpflege-Erinnerungen helfen bei Antworten und Produktempfehlungen.
+              </p>
+            </div>
+            <Switch
+              checked={memoryEnabled}
+              disabled={memoryLoading || memorySaving}
+              onCheckedChange={handleMemoryToggle}
+              aria-label="Erinnerungen aktivieren"
+            />
+          </div>
+
+          {memoryLoading ? (
+            <p className="text-sm text-muted-foreground">Erinnerungen werden geladen...</p>
+          ) : memoryEntries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Noch keine gespeicherten Erinnerungen. Wenn du TomBot im Chat konkrete
+              Haarpflege-Infos gibst, kann er sie hier ablegen.
+            </p>
+          ) : (
+            <div className="divide-y">
+              {memoryEntries.map((entry) => (
+                <div key={entry.id} className="py-4 first:pt-0 last:pb-0">
+                  {editingMemoryId === entry.id ? (
+                    <div className="space-y-3">
+                      <Textarea
+                        value={memoryDraft}
+                        onChange={(event) => setMemoryDraft(event.target.value)}
+                        rows={3}
+                        maxLength={500}
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleSaveMemory(entry.id)}
+                          disabled={memorySaving || !memoryDraft.trim()}
+                          className="rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+                        >
+                          Speichern
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditingMemoryId(null)
+                            setMemoryDraft("")
+                          }}
+                          className="rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:bg-accent"
+                        >
+                          Abbrechen
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <p className="text-sm">{entry.content}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Aktualisiert am{" "}
+                          {new Date(entry.updated_at).toLocaleDateString("de-DE")}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 gap-2">
+                        <button
+                          type="button"
+                          onClick={() => startEditingMemory(entry)}
+                          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                          Bearbeiten
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteMemory(entry.id)}
+                          disabled={memorySaving}
+                          className="text-xs font-medium text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
+                        >
+                          Löschen
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
             </div>
           )}
         </section>

--- a/src/lib/rag/memory-extractor.ts
+++ b/src/lib/rag/memory-extractor.ts
@@ -1,13 +1,89 @@
+import { z } from "zod"
 import { getOpenAI } from "@/lib/openai/client"
 import { createAdminClient } from "@/lib/supabase/admin"
-import { MEMORY_EXTRACTION_PROMPT } from "@/lib/rag/prompts"
+import {
+  buildMemoryPromptContext,
+  getUserMemoryEnabled,
+  insertExtractedMemories,
+  listUserMemoryEntries,
+  type ExtractedMemoryCandidate,
+} from "@/lib/rag/user-memory"
+import type { UserMemoryKind } from "@/lib/types"
 
-const MEMORY_HARD_CAP = 2000
 const MIN_USER_MESSAGES = 3
 
+const extractedMemorySchema = z.object({
+  kind: z.enum([
+    "preference",
+    "routine",
+    "product_experience",
+    "hair_history",
+    "progress",
+    "sensitivity",
+    "medical_context",
+    "legacy_summary",
+    "other",
+  ]),
+  memory_key: z.string().nullable().optional(),
+  content: z.string(),
+  evidence: z.string().nullable().optional(),
+  confidence: z.number().min(0).max(1).nullable().optional(),
+  product_names: z.array(z.string()).nullable().optional(),
+  sentiment: z.enum(["positive", "negative", "neutral"]).nullable().optional(),
+})
+
+const extractionResponseSchema = z.object({
+  memories: z.array(extractedMemorySchema).default([]),
+})
+
+export const MEMORY_EXTRACTION_JSON_PROMPT = `Du bist ein Analyse-Assistent fuer TomBot. Extrahiere dauerhafte, haarspezifische Erinnerungen aus einem Gespraech.
+
+Antworte NUR als JSON:
+{"memories":[{"kind":"preference|routine|product_experience|hair_history|progress|sensitivity|medical_context|other","memory_key":"stabiler_key","content":"deutscher Satz","evidence":"kurzes Nutzerzitat","confidence":0.0,"product_names":["..."],"sentiment":"positive|negative|neutral"}]}
+
+Regeln:
+- Speichere nur Fakten, die der NUTZER explizit sagt oder bestaetigt.
+- Speichere keine Empfehlungen, Erklaerungen oder Annahmen von Tom.
+- Speichere nur hair-care-relevante Fakten: Vorlieben, Routine, Produkterfahrungen, Haarhistorie, Fortschritt, Reaktionen, Sensitivitaeten.
+- Medizinisch angrenzende Fakten wie Haarausfall, Kopfhautbeschwerden, Schwangerschaft, Medikamente oder Allergien nur speichern, wenn der Nutzer sie explizit als relevant nennt.
+- Keine Smalltalk-Fakten, keine allgemeinen Lebensdetails ohne Haarpflegebezug.
+- Bei Produkterfahrungen setze product_names und sentiment. Negative sentiment bedeutet: Produkt nicht wieder priorisieren.
+- memory_key muss stabil sein, z.B. "product:olaplex_no_3", "preference:duft", "routine:wash_frequency". Bei neuem Widerspruch denselben memory_key verwenden, damit die neueste Aussage gewinnt.
+- Wenn nichts Neues speicherwuerdig ist: {"memories":[]}.`
+
+export function parseMemoryExtractionResult(content: string): ExtractedMemoryCandidate[] {
+  try {
+    const parsed = extractionResponseSchema.safeParse(JSON.parse(content))
+    if (!parsed.success) return []
+
+    return parsed.data.memories.map((memory) => ({
+      kind: memory.kind as UserMemoryKind,
+      memory_key: memory.memory_key,
+      content: memory.content,
+      evidence: memory.evidence,
+      confidence: memory.confidence,
+      product_names: memory.product_names,
+      sentiment: memory.sentiment,
+    }))
+  } catch {
+    return []
+  }
+}
+
+async function markConversationExtracted(
+  conversationId: string,
+  messageCount: number,
+  supabase: ReturnType<typeof createAdminClient>
+) {
+  await supabase
+    .from("conversations")
+    .update({ memory_extracted_at_count: messageCount })
+    .eq("id", conversationId)
+}
+
 /**
- * Extracts durable facts from a conversation and merges them into the
- * user's hair profile memory. Fire-and-forget — never throws.
+ * Extracts durable user-controlled memory from a conversation.
+ * Fire-and-forget: logs errors but never throws into the chat response path.
  */
 export async function extractConversationMemory(
   conversationId: string,
@@ -16,7 +92,6 @@ export async function extractConversationMemory(
   try {
     const supabase = createAdminClient()
 
-    // Load all messages for this conversation
     const { data: messages } = await supabase
       .from("messages")
       .select("role, content")
@@ -25,11 +100,9 @@ export async function extractConversationMemory(
 
     if (!messages) return
 
-    // Count user messages — skip extraction for short conversations
-    const userMessageCount = messages.filter((m) => m.role === "user").length
+    const userMessageCount = messages.filter((message) => message.role === "user").length
     if (userMessageCount < MIN_USER_MESSAGES) return
 
-    // Check if already extracted at this message count
     const { data: conversation } = await supabase
       .from("conversations")
       .select("memory_extracted_at_count")
@@ -37,71 +110,44 @@ export async function extractConversationMemory(
       .single()
 
     if (!conversation) return
-    if (conversation.memory_extracted_at_count >= messages.length) return
+    if ((conversation.memory_extracted_at_count ?? 0) >= messages.length) return
 
-    // Load current memory from hair profile
-    const { data: profile } = await supabase
-      .from("hair_profiles")
-      .select("conversation_memory")
-      .eq("user_id", userId)
-      .single()
+    const memoryEnabled = await getUserMemoryEnabled(userId, supabase)
+    if (!memoryEnabled) {
+      await markConversationExtracted(conversationId, messages.length, supabase)
+      return
+    }
 
-    if (!profile) return
+    const existingMemory = buildMemoryPromptContext(
+      await listUserMemoryEntries(userId, supabase)
+    )
 
-    const existingMemory = profile.conversation_memory || ""
-
-    // Build conversation transcript for the LLM
     const transcript = messages
-      .map((m) => `${m.role === "user" ? "Nutzer" : "Tom"}: ${m.content ?? ""}`)
+      .map((message) => `${message.role === "user" ? "Nutzer" : "Tom"}: ${message.content ?? ""}`)
       .join("\n")
 
-    const prompt = existingMemory
-      ? `${MEMORY_EXTRACTION_PROMPT}\n\nBestehendes Gedaechtnis:\n${existingMemory}\n\nGespraech:\n${transcript}`
-      : `${MEMORY_EXTRACTION_PROMPT}\n\nGespraech:\n${transcript}`
+    const prompt = [
+      MEMORY_EXTRACTION_JSON_PROMPT,
+      existingMemory ? `\nBestehende aktive Erinnerungen:\n${existingMemory}` : "",
+      `\nGespraech:\n${transcript}`,
+    ].join("\n")
 
     const completion = await getOpenAI().chat.completions.create({
       model: "gpt-4o-mini",
       messages: [{ role: "user", content: prompt }],
       max_tokens: 800,
-      temperature: 0.3,
+      temperature: 0.1,
+      response_format: { type: "json_object" },
     })
 
-    const result = completion.choices[0]?.message?.content?.trim()
-    if (!result || result === "KEINE_NEUEN_FAKTEN") {
-      // Still update the extraction count to avoid re-processing
-      await supabase
-        .from("conversations")
-        .update({ memory_extracted_at_count: messages.length })
-        .eq("id", conversationId)
-      return
+    const content = completion.choices[0]?.message?.content
+    const memories = content ? parseMemoryExtractionResult(content) : []
+
+    if (memories.length > 0) {
+      await insertExtractedMemories(userId, conversationId, memories, supabase)
     }
 
-    // Merge: if there's existing memory, combine; otherwise use new result
-    let updatedMemory = existingMemory
-      ? `${existingMemory}\n${result}`
-      : result
-
-    // Hard cap at 2000 chars
-    if (updatedMemory.length > MEMORY_HARD_CAP) {
-      updatedMemory = updatedMemory.slice(0, MEMORY_HARD_CAP)
-      // Trim to last complete bullet point
-      const lastNewline = updatedMemory.lastIndexOf("\n")
-      if (lastNewline > 0) {
-        updatedMemory = updatedMemory.slice(0, lastNewline)
-      }
-    }
-
-    // Write updated memory to hair profile
-    await supabase
-      .from("hair_profiles")
-      .update({ conversation_memory: updatedMemory })
-      .eq("user_id", userId)
-
-    // Mark extraction count
-    await supabase
-      .from("conversations")
-      .update({ memory_extracted_at_count: messages.length })
-      .eq("id", conversationId)
+    await markConversationExtracted(conversationId, messages.length, supabase)
   } catch (error) {
     console.error("Memory extraction failed:", error)
   }

--- a/src/lib/rag/pipeline.ts
+++ b/src/lib/rag/pipeline.ts
@@ -39,6 +39,10 @@ import { SOURCE_TYPE_LABELS } from "@/lib/vocabulary"
 import { formatSourceName } from "@/lib/rag/source-names"
 import { generateConversationTitle } from "@/lib/rag/title-generator"
 import { emitRouterEvent } from "@/lib/rag/retrieval-telemetry"
+import {
+  applyProductMemoryConstraints,
+  loadUserMemoryContext,
+} from "@/lib/rag/user-memory"
 import type { ProductLeaveInSpecs } from "@/lib/leave-in/constants"
 import type { ProductMaskSpecs } from "@/lib/mask/constants"
 import type { ProductConditionerSpecs } from "@/lib/conditioner/constants"
@@ -95,13 +99,14 @@ export async function runPipeline(
   const supabase = createAdminClient()
 
   // ── Step 1: Classify intent + load hair profile (parallel) ─────────
-  const [classification, hairProfileResult] = await Promise.all([
+  const [classification, hairProfileResult, memoryContext] = await Promise.all([
     classifyIntent(message),
     supabase
       .from("hair_profiles")
       .select("*")
       .eq("user_id", userId)
       .single(),
+    loadUserMemoryContext(userId, supabase),
   ])
   const { intent, product_category } = classification
   const hairProfile: HairProfile | null = hairProfileResult.data ?? null
@@ -245,6 +250,7 @@ export async function runPipeline(
       conditionerDecision,
       leaveInDecision,
       oilDecision,
+      memoryContext: memoryContext.promptContext,
       clarificationQuestions,
     })
 
@@ -305,7 +311,7 @@ export async function runPipeline(
   }))
 
   // ── Step 4: Match products (if intent requires it) ──────────────────
-  let matchedProducts = undefined
+  let matchedProducts: Product[] | undefined = undefined
   let maskDecision: MaskDecision | undefined
   if (PRODUCT_INTENTS.includes(intent)) {
     if (product_category === "shampoo") {
@@ -368,10 +374,13 @@ export async function runPipeline(
             console.error("Failed to load conditioner specs for reranking:", conditionerSpecsError)
           }
 
-          matchedProducts = rerankConditionerProducts(
-            conditionerCandidates,
-            (conditionerSpecs ?? []) as ProductConditionerSpecs[],
-            conditionerDecision
+          matchedProducts = applyProductMemoryConstraints(
+            rerankConditionerProducts(
+              conditionerCandidates,
+              (conditionerSpecs ?? []) as ProductConditionerSpecs[],
+              conditionerDecision
+            ),
+            memoryContext
           ).slice(0, 3)
         }
       }
@@ -406,10 +415,13 @@ export async function runPipeline(
             leaveInDecision = buildLeaveInDecision(hairProfile, 0)
             matchedProducts = []
           } else {
-            const rerankedLeaveIns = rerankLeaveInProducts(
-              leaveInCandidates,
-              (leaveInSpecs ?? []) as ProductLeaveInSpecs[],
-              leaveInDecision
+            const rerankedLeaveIns = applyProductMemoryConstraints(
+              rerankLeaveInProducts(
+                leaveInCandidates,
+                (leaveInSpecs ?? []) as ProductLeaveInSpecs[],
+                leaveInDecision
+              ),
+              memoryContext
             )
 
             leaveInDecision = buildLeaveInDecision(hairProfile, rerankedLeaveIns.length)
@@ -434,7 +446,10 @@ export async function runPipeline(
         })
 
         oilDecision = buildOilDecision(hairProfile, message, oilCandidates.length)
-        matchedProducts = annotateOilRecommendations(oilCandidates.slice(0, 3), oilDecision)
+        matchedProducts = annotateOilRecommendations(
+          applyProductMemoryConstraints(oilCandidates, memoryContext).slice(0, 3),
+          oilDecision
+        )
       }
     } else if (product_category === "mask") {
       maskDecision = deriveMaskDecision(hairProfile)
@@ -497,6 +512,10 @@ export async function runPipeline(
     }
   }
 
+  if (matchedProducts) {
+    matchedProducts = applyProductMemoryConstraints(matchedProducts, memoryContext)
+  }
+
   // ── Step 5: Synthesize streaming response ───────────────────────────
   const stream = await synthesizeResponse({
     userMessage: message,
@@ -511,6 +530,7 @@ export async function runPipeline(
     conditionerDecision,
     leaveInDecision,
     oilDecision,
+    memoryContext: memoryContext.promptContext,
   })
 
   return {

--- a/src/lib/rag/pipeline.ts
+++ b/src/lib/rag/pipeline.ts
@@ -374,13 +374,10 @@ export async function runPipeline(
             console.error("Failed to load conditioner specs for reranking:", conditionerSpecsError)
           }
 
-          matchedProducts = applyProductMemoryConstraints(
-            rerankConditionerProducts(
-              conditionerCandidates,
-              (conditionerSpecs ?? []) as ProductConditionerSpecs[],
-              conditionerDecision
-            ),
-            memoryContext
+          matchedProducts = rerankConditionerProducts(
+            conditionerCandidates,
+            (conditionerSpecs ?? []) as ProductConditionerSpecs[],
+            conditionerDecision
           ).slice(0, 3)
         }
       }
@@ -415,13 +412,10 @@ export async function runPipeline(
             leaveInDecision = buildLeaveInDecision(hairProfile, 0)
             matchedProducts = []
           } else {
-            const rerankedLeaveIns = applyProductMemoryConstraints(
-              rerankLeaveInProducts(
-                leaveInCandidates,
-                (leaveInSpecs ?? []) as ProductLeaveInSpecs[],
-                leaveInDecision
-              ),
-              memoryContext
+            const rerankedLeaveIns = rerankLeaveInProducts(
+              leaveInCandidates,
+              (leaveInSpecs ?? []) as ProductLeaveInSpecs[],
+              leaveInDecision
             )
 
             leaveInDecision = buildLeaveInDecision(hairProfile, rerankedLeaveIns.length)
@@ -447,7 +441,7 @@ export async function runPipeline(
 
         oilDecision = buildOilDecision(hairProfile, message, oilCandidates.length)
         matchedProducts = annotateOilRecommendations(
-          applyProductMemoryConstraints(oilCandidates, memoryContext).slice(0, 3),
+          oilCandidates.slice(0, 3),
           oilDecision
         )
       }

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -62,8 +62,14 @@ export interface SynthesizeParams {
   conditionerDecision?: ConditionerDecision
   leaveInDecision?: LeaveInDecision
   oilDecision?: OilDecision
+  memoryContext?: string | null
   /** Slot-aware clarification questions from the router (replaces consultationMode) */
   clarificationQuestions?: string[]
+}
+
+function appendMemoryContext(profileText: string, memoryContext?: string | null): string {
+  if (!memoryContext) return profileText
+  return `${profileText}\n\nErinnerungen aus frueheren Gespraechen:\n${memoryContext}`
 }
 
 /**
@@ -73,9 +79,13 @@ export interface SynthesizeParams {
 function formatUserProfile(
   profile: HairProfile | null,
   clarificationQuestions?: string[],
+  memoryContext?: string | null,
 ): string {
   if (!profile) {
-    return "Kein Haarprofil vorhanden. Frage den Nutzer nach seinen Haardetails, wenn relevant."
+    return appendMemoryContext(
+      "Kein Haarprofil vorhanden. Frage den Nutzer nach seinen Haardetails, wenn relevant.",
+      memoryContext
+    )
   }
 
   const parts: string[] = []
@@ -145,8 +155,10 @@ function formatUserProfile(
     ? parts.join("\n")
     : "Haarprofil angelegt, aber noch keine Details eingetragen."
 
-  if (profile.conversation_memory) {
-    result += `\n\nErinnerungen aus frueheren Gespraechen:\n${profile.conversation_memory}`
+  const effectiveMemory =
+    memoryContext === undefined ? profile.conversation_memory : memoryContext
+  if (effectiveMemory) {
+    result = appendMemoryContext(result, effectiveMemory)
   }
 
   if (clarificationQuestions && clarificationQuestions.length > 0) {
@@ -164,9 +176,13 @@ function formatUserProfile(
 function formatShampooProfile(
   profile: HairProfile | null,
   clarificationQuestions?: string[],
+  memoryContext?: string | null,
 ): string {
   if (!profile) {
-    return "Kein Shampoo-Profil vorhanden. Frage nur nach Haardicke, Kopfhaut-Typ und Kopfhaut-Beschwerden."
+    return appendMemoryContext(
+      "Kein Shampoo-Profil vorhanden. Frage nur nach Haardicke, Kopfhaut-Typ und Kopfhaut-Beschwerden.",
+      memoryContext
+    )
   }
 
   const parts: string[] = []
@@ -188,6 +204,12 @@ function formatShampooProfile(
   let result = parts.length > 0
     ? parts.join("\n")
     : "Shampoo-Profil angelegt, aber die drei Pflichtfelder fehlen noch."
+
+  const effectiveMemory =
+    memoryContext === undefined ? profile.conversation_memory : memoryContext
+  if (effectiveMemory) {
+    result = appendMemoryContext(result, effectiveMemory)
+  }
 
   if (clarificationQuestions && clarificationQuestions.length > 0) {
     result += "\n\n(HINWEIS: Shampoo-Klaerungsrunde. Stelle AUSSCHLIESSLICH Rueckfragen zu den fehlenden Shampoo-Feldern."
@@ -765,6 +787,7 @@ function buildSystemPrompt(
   conditionerDecision?: ConditionerDecision,
   leaveInDecision?: LeaveInDecision,
   oilDecision?: OilDecision,
+  memoryContext?: string | null,
   clarificationQuestions?: string[],
 ): string {
   let prompt = SYSTEM_PROMPT
@@ -775,8 +798,8 @@ function buildSystemPrompt(
   }
 
   const userProfileContext = productCategory === "shampoo"
-    ? formatShampooProfile(hairProfile, clarificationQuestions)
-    : formatUserProfile(hairProfile, clarificationQuestions)
+    ? formatShampooProfile(hairProfile, clarificationQuestions, memoryContext)
+    : formatUserProfile(hairProfile, clarificationQuestions, memoryContext)
 
   prompt = prompt.replace("{{USER_PROFILE}}", userProfileContext)
 
@@ -820,6 +843,7 @@ export async function synthesizeResponse(
     conditionerDecision,
     leaveInDecision,
     oilDecision,
+    memoryContext,
     clarificationQuestions,
   } = params
 
@@ -833,6 +857,7 @@ export async function synthesizeResponse(
     conditionerDecision,
     leaveInDecision,
     oilDecision,
+    memoryContext,
     clarificationQuestions,
   )
 

--- a/src/lib/rag/user-memory.ts
+++ b/src/lib/rag/user-memory.ts
@@ -446,6 +446,19 @@ export async function updateUserMemoryEntry(
     content: nextContent,
   })
 
+  const { data: collision } = await supabase
+    .from("user_memory_entries")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("normalized_key", normalizedKey)
+    .eq("status", "active")
+    .neq("id", memoryId)
+    .maybeSingle()
+
+  if (collision) {
+    return null
+  }
+
   const { data, error } = await supabase
     .from("user_memory_entries")
     .update({

--- a/src/lib/rag/user-memory.ts
+++ b/src/lib/rag/user-memory.ts
@@ -1,0 +1,514 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import type { Product, UserMemoryEntry, UserMemoryKind } from "@/lib/types"
+
+const MEMORY_HARD_CAP = 2000
+
+export const USER_MEMORY_KINDS: UserMemoryKind[] = [
+  "preference",
+  "routine",
+  "product_experience",
+  "hair_history",
+  "progress",
+  "sensitivity",
+  "medical_context",
+  "legacy_summary",
+  "other",
+]
+
+export interface UserMemoryContext {
+  enabled: boolean
+  entries: UserMemoryEntry[]
+  promptContext: string | null
+  dislikedProductNames: string[]
+}
+
+export interface ExtractedMemoryCandidate {
+  kind: UserMemoryKind
+  memory_key?: string | null
+  content: string
+  evidence?: string | null
+  confidence?: number | null
+  product_names?: string[] | null
+  sentiment?: "positive" | "negative" | "neutral" | null
+}
+
+type SupabaseAdmin = ReturnType<typeof createAdminClient>
+
+function hasMissingMemoryTable(error: { code?: string; message?: string } | null): boolean {
+  return Boolean(
+    error &&
+      (error.code === "42P01" ||
+        error.code === "42703" ||
+        error.message?.includes("user_memory_") ||
+        error.message?.includes("conversation_memory") ||
+        error.message?.includes("memory_extracted_at_count"))
+  )
+}
+
+export function normalizeMemoryToken(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " und ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+}
+
+export function normalizeProductName(value: string): string {
+  return normalizeMemoryToken(value).replace(/_/g, "")
+}
+
+export function normalizeMemoryKey(memory: Pick<ExtractedMemoryCandidate, "kind" | "content" | "memory_key" | "product_names">): string {
+  const productName = memory.product_names?.find((name) => name.trim().length > 0)
+  const keySource = memory.memory_key?.trim() || productName || memory.content
+  return `${memory.kind}:${normalizeMemoryToken(keySource).slice(0, 120)}`
+}
+
+export function isValidMemoryKind(kind: string): kind is UserMemoryKind {
+  return USER_MEMORY_KINDS.includes(kind as UserMemoryKind)
+}
+
+export function sanitizeMemoryCandidate(candidate: ExtractedMemoryCandidate): ExtractedMemoryCandidate | null {
+  const content = candidate.content.trim().replace(/\s+/g, " ")
+  const confidence = candidate.confidence ?? null
+
+  if (!isValidMemoryKind(candidate.kind)) return null
+  if (content.length < 8 || content.length > 500) return null
+  if (confidence != null && (confidence < 0 || confidence > 1)) return null
+  if (confidence != null && confidence < 0.72) return null
+
+  return {
+    ...candidate,
+    content,
+    evidence: candidate.evidence?.trim() || null,
+    confidence,
+    product_names: (candidate.product_names ?? [])
+      .map((name) => name.trim())
+      .filter(Boolean)
+      .slice(0, 5),
+    sentiment: candidate.sentiment ?? null,
+  }
+}
+
+export function buildMemoryPromptContext(entries: UserMemoryEntry[]): string | null {
+  const activeEntries = entries.filter((entry) => entry.status === "active" && entry.content.trim())
+  if (activeEntries.length === 0) return null
+
+  return activeEntries
+    .map((entry) => `- ${entry.content.trim()}`)
+    .join("\n")
+    .slice(0, MEMORY_HARD_CAP)
+}
+
+export function extractDislikedProductNames(entries: UserMemoryEntry[]): string[] {
+  const names = new Set<string>()
+
+  for (const entry of entries) {
+    if (entry.status !== "active" || entry.kind !== "product_experience") continue
+    if (entry.metadata?.sentiment !== "negative") continue
+
+    const productNames = Array.isArray(entry.metadata.product_names)
+      ? entry.metadata.product_names
+      : []
+
+    for (const productName of productNames) {
+      if (typeof productName === "string" && productName.trim()) {
+        names.add(productName.trim())
+      }
+    }
+  }
+
+  return [...names]
+}
+
+function productMatchesMemoryName(product: Product, dislikedProductName: string): boolean {
+  const productName = normalizeProductName(product.name)
+  const memoryName = normalizeProductName(dislikedProductName)
+
+  if (!productName || !memoryName) return false
+  return productName === memoryName
+}
+
+export function applyProductMemoryConstraints<T extends Product>(
+  products: T[],
+  memoryContext: Pick<UserMemoryContext, "enabled" | "dislikedProductNames">
+): T[] {
+  if (!memoryContext.enabled || memoryContext.dislikedProductNames.length === 0) {
+    return products
+  }
+
+  const disliked = memoryContext.dislikedProductNames
+  const neutralProducts: T[] = []
+  const dislikedProducts: T[] = []
+
+  for (const product of products) {
+    if (disliked.some((name) => productMatchesMemoryName(product, name))) {
+      dislikedProducts.push(product)
+    } else {
+      neutralProducts.push(product)
+    }
+  }
+
+  return [...neutralProducts, ...dislikedProducts]
+}
+
+export async function ensureUserMemorySettings(
+  userId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<boolean> {
+  const { data: existing, error: loadError } = await supabase
+    .from("user_memory_settings")
+    .select("memory_enabled")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (loadError) {
+    if (!hasMissingMemoryTable(loadError)) {
+      console.error("Failed to load user memory settings:", loadError)
+    }
+    return true
+  }
+
+  if (existing) return existing.memory_enabled ?? true
+
+  const { data, error } = await supabase
+    .from("user_memory_settings")
+    .insert({ user_id: userId, memory_enabled: true })
+    .select("memory_enabled")
+    .single()
+
+  if (error) {
+    if (!hasMissingMemoryTable(error)) {
+      console.error("Failed to ensure user memory settings:", error)
+    }
+    return true
+  }
+
+  return data?.memory_enabled ?? true
+}
+
+export async function getUserMemoryEnabled(
+  userId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("user_memory_settings")
+    .select("memory_enabled")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (error) {
+    if (!hasMissingMemoryTable(error)) {
+      console.error("Failed to load memory settings:", error)
+    }
+    return true
+  }
+
+  return data?.memory_enabled ?? true
+}
+
+export async function listUserMemoryEntries(
+  userId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<UserMemoryEntry[]> {
+  const { data, error } = await supabase
+    .from("user_memory_entries")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .order("updated_at", { ascending: false })
+
+  if (error) {
+    if (!hasMissingMemoryTable(error)) {
+      console.error("Failed to load memory entries:", error)
+    }
+    return []
+  }
+
+  return (data ?? []) as UserMemoryEntry[]
+}
+
+export async function loadUserMemoryContext(
+  userId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<UserMemoryContext> {
+  const enabled = await getUserMemoryEnabled(userId, supabase)
+  if (!enabled) {
+    return {
+      enabled: false,
+      entries: [],
+      promptContext: null,
+      dislikedProductNames: [],
+    }
+  }
+
+  const entries = await listUserMemoryEntries(userId, supabase)
+
+  return {
+    enabled,
+    entries,
+    promptContext: buildMemoryPromptContext(entries),
+    dislikedProductNames: extractDislikedProductNames(entries),
+  }
+}
+
+export async function backfillLegacyConversationMemory(
+  userId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<void> {
+  const { data: existingEntries, error: entryError } = await supabase
+    .from("user_memory_entries")
+    .select("id")
+    .eq("user_id", userId)
+    .limit(1)
+
+  if (entryError) {
+    if (!hasMissingMemoryTable(entryError)) {
+      console.error("Failed to check legacy memory backfill:", entryError)
+    }
+    return
+  }
+
+  if ((existingEntries ?? []).length > 0) return
+
+  const { data: profile, error: profileError } = await supabase
+    .from("hair_profiles")
+    .select("conversation_memory")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (profileError) {
+    if (!hasMissingMemoryTable(profileError)) {
+      console.error("Failed to load legacy memory:", profileError)
+    }
+    return
+  }
+
+  const legacyMemory = profile?.conversation_memory?.trim()
+  if (!legacyMemory) return
+
+  await supabase.from("user_memory_entries").insert({
+    user_id: userId,
+    kind: "legacy_summary",
+    content: legacyMemory.slice(0, 500),
+    normalized_key: "legacy_summary:conversation_memory",
+    source: "legacy",
+    confidence: null,
+    metadata: {},
+  })
+}
+
+export async function rebuildConversationMemoryCache(
+  userId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<void> {
+  const entries = await listUserMemoryEntries(userId, supabase)
+  const cache = buildMemoryPromptContext(entries)
+
+  const { error } = await supabase
+    .from("hair_profiles")
+    .update({ conversation_memory: cache })
+    .eq("user_id", userId)
+
+  if (error && !hasMissingMemoryTable(error)) {
+    console.error("Failed to rebuild conversation memory cache:", error)
+  }
+}
+
+export async function insertExtractedMemories(
+  userId: string,
+  conversationId: string,
+  candidates: ExtractedMemoryCandidate[],
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<void> {
+  for (const rawCandidate of candidates) {
+    const candidate = sanitizeMemoryCandidate(rawCandidate)
+    if (!candidate) continue
+
+    const normalizedKey = normalizeMemoryKey(candidate)
+
+    const { data: existing, error: existingError } = await supabase
+      .from("user_memory_entries")
+      .select("id, content")
+      .eq("user_id", userId)
+      .eq("normalized_key", normalizedKey)
+      .eq("status", "active")
+      .maybeSingle()
+
+    if (existingError) {
+      if (!hasMissingMemoryTable(existingError)) {
+        console.error("Failed to load matching memory:", existingError)
+      }
+      continue
+    }
+
+    if (existing?.content?.trim() === candidate.content) {
+      continue
+    }
+
+    if (existing?.id) {
+      const { error: archiveBeforeInsertError } = await supabase
+        .from("user_memory_entries")
+        .update({
+          status: "archived",
+          archived_at: new Date().toISOString(),
+        })
+        .eq("id", existing.id)
+        .eq("user_id", userId)
+
+      if (archiveBeforeInsertError) {
+        if (!hasMissingMemoryTable(archiveBeforeInsertError)) {
+          console.error("Failed to archive previous memory:", archiveBeforeInsertError)
+        }
+        continue
+      }
+    }
+
+    const metadata = {
+      product_names: candidate.product_names ?? [],
+      sentiment: candidate.sentiment ?? null,
+    }
+
+    const { data: inserted, error: insertError } = await supabase
+      .from("user_memory_entries")
+      .insert({
+        user_id: userId,
+        kind: candidate.kind,
+        content: candidate.content,
+        normalized_key: normalizedKey,
+        source: "chat",
+        source_conversation_id: conversationId,
+        evidence: candidate.evidence,
+        confidence: candidate.confidence,
+        metadata,
+      })
+      .select("id")
+      .single()
+
+    if (insertError) {
+      if (!hasMissingMemoryTable(insertError)) {
+        console.error("Failed to insert memory:", insertError)
+      }
+      if (existing?.id) {
+        await supabase
+          .from("user_memory_entries")
+          .update({ status: "active", archived_at: null })
+          .eq("id", existing.id)
+          .eq("user_id", userId)
+      }
+      continue
+    }
+
+    if (existing?.id && inserted?.id) {
+      const { error: archiveError } = await supabase
+        .from("user_memory_entries")
+        .update({
+          superseded_by: inserted.id,
+        })
+        .eq("id", existing.id)
+        .eq("user_id", userId)
+
+      if (archiveError && !hasMissingMemoryTable(archiveError)) {
+        console.error("Failed to archive superseded memory:", archiveError)
+      }
+    }
+  }
+
+  await rebuildConversationMemoryCache(userId, supabase)
+}
+
+export async function updateUserMemoryEntry(
+  userId: string,
+  memoryId: string,
+  content: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<UserMemoryEntry | null> {
+  const nextContent = content.trim().replace(/\s+/g, " ")
+  if (!nextContent) return null
+
+  const { data: current, error: currentError } = await supabase
+    .from("user_memory_entries")
+    .select("kind")
+    .eq("id", memoryId)
+    .eq("user_id", userId)
+    .single()
+
+  if (currentError || !current) {
+    if (currentError && !hasMissingMemoryTable(currentError)) {
+      console.error("Failed to load memory before update:", currentError)
+    }
+    return null
+  }
+
+  const normalizedKey = normalizeMemoryKey({
+    kind: current.kind as UserMemoryKind,
+    content: nextContent,
+  })
+
+  const { data, error } = await supabase
+    .from("user_memory_entries")
+    .update({
+      content: nextContent,
+      normalized_key: normalizedKey,
+      source: "manual",
+      source_conversation_id: null,
+      evidence: null,
+      metadata: {},
+    })
+    .eq("id", memoryId)
+    .eq("user_id", userId)
+    .select("*")
+    .single()
+
+  if (error) {
+    if (!hasMissingMemoryTable(error)) {
+      console.error("Failed to update memory:", error)
+    }
+    return null
+  }
+
+  await rebuildConversationMemoryCache(userId, supabase)
+  return data as UserMemoryEntry
+}
+
+export async function deleteUserMemoryEntry(
+  userId: string,
+  memoryId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<boolean> {
+  const { error } = await supabase
+    .from("user_memory_entries")
+    .delete()
+    .eq("id", memoryId)
+    .eq("user_id", userId)
+
+  if (error) {
+    if (!hasMissingMemoryTable(error)) {
+      console.error("Failed to delete memory:", error)
+    }
+    return false
+  }
+
+  await rebuildConversationMemoryCache(userId, supabase)
+  return true
+}
+
+export async function deleteConversationSourcedMemories(
+  userId: string,
+  conversationId: string,
+  supabase: SupabaseAdmin = createAdminClient()
+): Promise<void> {
+  const { error } = await supabase
+    .from("user_memory_entries")
+    .delete()
+    .eq("user_id", userId)
+    .eq("source", "chat")
+    .eq("source_conversation_id", conversationId)
+
+  if (error && !hasMissingMemoryTable(error)) {
+    console.error("Failed to delete conversation-sourced memories:", error)
+  }
+
+  await rebuildConversationMemoryCache(userId, supabase)
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -130,6 +130,45 @@ export interface HairProfile {
   updated_at: string
 }
 
+export type UserMemoryKind =
+  | "preference"
+  | "routine"
+  | "product_experience"
+  | "hair_history"
+  | "progress"
+  | "sensitivity"
+  | "medical_context"
+  | "legacy_summary"
+  | "other"
+
+export type UserMemorySource = "chat" | "manual" | "legacy"
+export type UserMemoryStatus = "active" | "archived"
+
+export interface UserMemorySettings {
+  user_id: string
+  memory_enabled: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface UserMemoryEntry {
+  id: string
+  user_id: string
+  kind: UserMemoryKind
+  content: string
+  normalized_key: string
+  source: UserMemorySource
+  source_conversation_id: string | null
+  evidence: string | null
+  confidence: number | null
+  metadata: Record<string, unknown>
+  status: UserMemoryStatus
+  superseded_by: string | null
+  archived_at: string | null
+  created_at: string
+  updated_at: string
+}
+
 export interface Product {
   id: string
   name: string

--- a/supabase/migrations/20260408130000_add_user_memory.sql
+++ b/supabase/migrations/20260408130000_add_user_memory.sql
@@ -1,0 +1,164 @@
+-- User-controlled memory layer.
+-- V1 stores curated hair-care memories separately from structured hair_profiles.
+
+ALTER TABLE public.hair_profiles
+  ADD COLUMN IF NOT EXISTS conversation_memory text;
+
+ALTER TABLE public.conversations
+  ADD COLUMN IF NOT EXISTS memory_extracted_at_count integer DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS public.user_memory_settings (
+  user_id uuid PRIMARY KEY REFERENCES public.profiles (id) ON DELETE CASCADE,
+  memory_enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_memory_entries (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id uuid NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  kind text NOT NULL CHECK (
+    kind IN (
+      'preference',
+      'routine',
+      'product_experience',
+      'hair_history',
+      'progress',
+      'sensitivity',
+      'medical_context',
+      'legacy_summary',
+      'other'
+    )
+  ),
+  content text NOT NULL CHECK (char_length(trim(content)) > 0),
+  normalized_key text NOT NULL,
+  source text NOT NULL DEFAULT 'chat' CHECK (source IN ('chat', 'manual', 'legacy')),
+  source_conversation_id uuid REFERENCES public.conversations (id) ON DELETE CASCADE,
+  evidence text,
+  confidence numeric CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  metadata jsonb NOT NULL DEFAULT '{}',
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  superseded_by uuid REFERENCES public.user_memory_entries (id) ON DELETE SET NULL,
+  archived_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_memory_entries_user_status
+  ON public.user_memory_entries (user_id, status, updated_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_memory_entries_user_key_active
+  ON public.user_memory_entries (user_id, normalized_key)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_user_memory_entries_source_conversation
+  ON public.user_memory_entries (source_conversation_id)
+  WHERE source_conversation_id IS NOT NULL;
+
+ALTER TABLE public.user_memory_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_memory_entries ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'set_updated_at_user_memory_settings'
+  ) THEN
+    CREATE TRIGGER set_updated_at_user_memory_settings
+      BEFORE UPDATE ON public.user_memory_settings
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'set_updated_at_user_memory_entries'
+  ) THEN
+    CREATE TRIGGER set_updated_at_user_memory_entries
+      BEFORE UPDATE ON public.user_memory_entries
+      FOR EACH ROW
+      EXECUTE FUNCTION public.update_updated_at_column();
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_settings'
+      AND policyname = 'user_memory_settings_select_own'
+  ) THEN
+    CREATE POLICY "user_memory_settings_select_own"
+      ON public.user_memory_settings FOR SELECT
+      USING (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_settings'
+      AND policyname = 'user_memory_settings_insert_own'
+  ) THEN
+    CREATE POLICY "user_memory_settings_insert_own"
+      ON public.user_memory_settings FOR INSERT
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_settings'
+      AND policyname = 'user_memory_settings_update_own'
+  ) THEN
+    CREATE POLICY "user_memory_settings_update_own"
+      ON public.user_memory_settings FOR UPDATE
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_entries'
+      AND policyname = 'user_memory_entries_select_own'
+  ) THEN
+    CREATE POLICY "user_memory_entries_select_own"
+      ON public.user_memory_entries FOR SELECT
+      USING (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_entries'
+      AND policyname = 'user_memory_entries_insert_own'
+  ) THEN
+    CREATE POLICY "user_memory_entries_insert_own"
+      ON public.user_memory_entries FOR INSERT
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_entries'
+      AND policyname = 'user_memory_entries_update_own'
+  ) THEN
+    CREATE POLICY "user_memory_entries_update_own"
+      ON public.user_memory_entries FOR UPDATE
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'user_memory_entries'
+      AND policyname = 'user_memory_entries_delete_own'
+  ) THEN
+    CREATE POLICY "user_memory_entries_delete_own"
+      ON public.user_memory_entries FOR DELETE
+      USING (user_id = auth.uid());
+  END IF;
+END $$;

--- a/tests/user-memory.spec.ts
+++ b/tests/user-memory.spec.ts
@@ -449,6 +449,73 @@ test.describe("User memory persistence with fake Supabase", () => {
     )
   })
 
+  test("manual edit returns null when normalized_key collides with another active memory", async () => {
+    const fake = new FakeSupabase({
+      user_memory_entries: [
+        createMemoryEntry({
+          id: "memory-1",
+          kind: "preference",
+          content: "Der Nutzer mag leichte Texturen.",
+          normalized_key: "preference:der_nutzer_mag_leichte_texturen",
+        }),
+        createMemoryEntry({
+          id: "memory-2",
+          kind: "preference",
+          content: "Der Nutzer bevorzugt duftfreie Produkte.",
+          normalized_key: "preference:der_nutzer_bevorzugt_duftfreie_produkte",
+        }),
+      ],
+      hair_profiles: [{ user_id: "user-1", conversation_memory: null }],
+    })
+
+    // Editing memory-1 to content that normalizes to the same key as memory-2
+    const result = await updateUserMemoryEntry(
+      "user-1",
+      "memory-1",
+      "Der Nutzer bevorzugt duftfreie Produkte.",
+      asSupabase(fake)
+    )
+
+    expect(result).toBeNull()
+    // Original memory should be unchanged
+    expect(fake.tables.user_memory_entries?.[0]).toEqual(
+      expect.objectContaining({
+        id: "memory-1",
+        content: "Der Nutzer mag leichte Texturen.",
+      })
+    )
+  })
+
+  test("manual edit succeeds when normalized_key changes but no collision exists", async () => {
+    const fake = new FakeSupabase({
+      user_memory_entries: [
+        createMemoryEntry({
+          id: "memory-1",
+          kind: "preference",
+          content: "Der Nutzer mag leichte Texturen.",
+          normalized_key: "preference:der_nutzer_mag_leichte_texturen",
+        }),
+      ],
+      hair_profiles: [{ user_id: "user-1", conversation_memory: null }],
+    })
+
+    const result = await updateUserMemoryEntry(
+      "user-1",
+      "memory-1",
+      "Der Nutzer bevorzugt schwere Oele.",
+      asSupabase(fake)
+    )
+
+    expect(result).not.toBeNull()
+    expect(fake.tables.user_memory_entries?.[0]).toEqual(
+      expect.objectContaining({
+        id: "memory-1",
+        content: "Der Nutzer bevorzugt schwere Oele.",
+        source: "manual",
+      })
+    )
+  })
+
   test("deletes single memories and conversation-sourced memories without touching manual rows", async () => {
     const fake = new FakeSupabase({
       user_memory_entries: [

--- a/tests/user-memory.spec.ts
+++ b/tests/user-memory.spec.ts
@@ -1,0 +1,484 @@
+import { expect, test } from "@playwright/test"
+import {
+  applyProductMemoryConstraints,
+  buildMemoryPromptContext,
+  deleteConversationSourcedMemories,
+  deleteUserMemoryEntry,
+  ensureUserMemorySettings,
+  extractDislikedProductNames,
+  insertExtractedMemories,
+  loadUserMemoryContext,
+  normalizeMemoryKey,
+  normalizeMemoryToken,
+  sanitizeMemoryCandidate,
+  updateUserMemoryEntry,
+} from "../src/lib/rag/user-memory"
+import {
+  MEMORY_EXTRACTION_JSON_PROMPT,
+  parseMemoryExtractionResult,
+} from "../src/lib/rag/memory-extractor"
+import type { Product, UserMemoryEntry } from "../src/lib/types"
+
+type TableRow = Record<string, unknown> & {
+  id?: unknown
+  user_id?: unknown
+}
+type Tables = Record<string, TableRow[]>
+type QueryResult = { data: unknown; error: null | { code?: string; message?: string } }
+
+const NOW = "2026-04-08T00:00:00.000Z"
+
+function createMemoryEntry(
+  overrides: Partial<UserMemoryEntry> = {}
+): UserMemoryEntry & Record<string, unknown> {
+  return {
+    id: "memory-1",
+    user_id: "user-1",
+    kind: "preference",
+    content: "Der Nutzer mag leichte Texturen.",
+    normalized_key: "preference:textur",
+    source: "chat",
+    source_conversation_id: "conversation-1",
+    evidence: "Ich mag leichte Texturen.",
+    confidence: 0.9,
+    metadata: {},
+    status: "active",
+    superseded_by: null,
+    archived_at: null,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  } as UserMemoryEntry & Record<string, unknown>
+}
+
+function createProduct(id: string, name: string): Product {
+  return {
+    id,
+    name,
+    brand: "Test",
+    description: null,
+    short_description: null,
+    tom_take: null,
+    category: "Oel",
+    affiliate_link: null,
+    image_url: null,
+    price_eur: null,
+    currency: "EUR",
+    tags: [],
+    suitable_thicknesses: [],
+    suitable_concerns: [],
+    is_active: true,
+    sort_order: 1,
+    created_at: NOW,
+    updated_at: NOW,
+  }
+}
+
+class FakeSupabaseQuery {
+  private filters: Array<{ column: string; value: unknown }> = []
+  private operation: "select" | "insert" | "update" | "delete" = "select"
+  private payload: Record<string, unknown> | Record<string, unknown>[] | null = null
+  private maxRows: number | null = null
+  private orderColumn: string | null = null
+
+  constructor(
+    private tables: Tables,
+    private tableName: string
+  ) {}
+
+  select(columns?: string) {
+    void columns
+    return this
+  }
+
+  eq(column: string, value: unknown) {
+    this.filters.push({ column, value })
+    return this
+  }
+
+  order(column: string, options?: { ascending?: boolean }) {
+    void options
+    this.orderColumn = column
+    return this
+  }
+
+  limit(count: number) {
+    this.maxRows = count
+    return this
+  }
+
+  insert(payload: Record<string, unknown> | Record<string, unknown>[]) {
+    this.operation = "insert"
+    this.payload = payload
+    return this
+  }
+
+  update(payload: Record<string, unknown>) {
+    this.operation = "update"
+    this.payload = payload
+    return this
+  }
+
+  delete() {
+    this.operation = "delete"
+    return this
+  }
+
+  async maybeSingle(): Promise<QueryResult> {
+    const { data, error } = await this.execute()
+    return {
+      data: Array.isArray(data) ? data[0] ?? null : data,
+      error,
+    }
+  }
+
+  async single(): Promise<QueryResult> {
+    const { data, error } = await this.execute()
+    return {
+      data: Array.isArray(data) ? data[0] ?? null : data,
+      error,
+    }
+  }
+
+  then<TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?: ((value: QueryResult) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private async execute(): Promise<QueryResult> {
+    const rows = this.tables[this.tableName] ?? []
+
+    if (this.operation === "insert") {
+      const payloads = Array.isArray(this.payload) ? this.payload : [this.payload ?? {}]
+      const inserted = payloads.map((payload, index) => ({
+        id: typeof payload.id === "string"
+          ? payload.id
+          : `inserted-${rows.length + index + 1}`,
+        ...(this.tableName === "user_memory_entries"
+          ? { status: payload.status ?? "active" }
+          : {}),
+        created_at: typeof payload.created_at === "string" ? payload.created_at : NOW,
+        updated_at: typeof payload.updated_at === "string" ? payload.updated_at : NOW,
+        ...payload,
+      }))
+
+      this.tables[this.tableName] = [...rows, ...inserted]
+      return { data: inserted, error: null }
+    }
+
+    const matchedRows = this.filterRows(rows)
+
+    if (this.operation === "update") {
+      const payload = this.payload && !Array.isArray(this.payload) ? this.payload : {}
+      for (const row of matchedRows) {
+        Object.assign(row, payload, { updated_at: NOW })
+      }
+      return { data: matchedRows, error: null }
+    }
+
+    if (this.operation === "delete") {
+      this.tables[this.tableName] = rows.filter((row) => !matchedRows.includes(row))
+      return { data: matchedRows, error: null }
+    }
+
+    return { data: matchedRows, error: null }
+  }
+
+  private filterRows(rows: TableRow[]): TableRow[] {
+    let result = rows.filter((row) =>
+      this.filters.every(({ column, value }) => row[column] === value)
+    )
+
+    if (this.orderColumn) {
+      result = [...result].sort((a, b) =>
+        String(b[this.orderColumn!] ?? "").localeCompare(String(a[this.orderColumn!] ?? ""))
+      )
+    }
+
+    if (this.maxRows != null) {
+      result = result.slice(0, this.maxRows)
+    }
+
+    return result
+  }
+}
+
+class FakeSupabase {
+  constructor(public tables: Tables) {}
+
+  from(tableName: string) {
+    if (!this.tables[tableName]) {
+      this.tables[tableName] = []
+    }
+    return new FakeSupabaseQuery(this.tables, tableName)
+  }
+}
+
+function asSupabase(fake: FakeSupabase): Parameters<typeof insertExtractedMemories>[3] {
+  return fake as unknown as Parameters<typeof insertExtractedMemories>[3]
+}
+
+test.describe("User memory extraction contracts", () => {
+  test("documents the explicit hair-care-only extraction boundary", () => {
+    expect(MEMORY_EXTRACTION_JSON_PROMPT).toContain("NUTZER explizit")
+    expect(MEMORY_EXTRACTION_JSON_PROMPT).toContain("haarspezifische Erinnerungen")
+    expect(MEMORY_EXTRACTION_JSON_PROMPT).toContain("Medizinisch angrenzende Fakten")
+    expect(MEMORY_EXTRACTION_JSON_PROMPT).toContain("Negative sentiment")
+  })
+
+  test("parses valid structured JSON and rejects malformed or unsupported output", () => {
+    const parsed = parseMemoryExtractionResult(JSON.stringify({
+      memories: [
+        {
+          kind: "product_experience",
+          memory_key: "product:heavy_oil",
+          content: "Der Nutzer hat Heavy Oil nicht gut vertragen.",
+          evidence: "Heavy Oil hat bei mir Juckreiz gemacht.",
+          confidence: 0.91,
+          product_names: ["Heavy Oil"],
+          sentiment: "negative",
+        },
+      ],
+    }))
+
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0]?.kind).toBe("product_experience")
+    expect(normalizeMemoryKey(parsed[0]!)).toBe("product_experience:product_heavy_oil")
+
+    expect(parseMemoryExtractionResult("{not json")).toEqual([])
+    expect(parseMemoryExtractionResult(JSON.stringify({
+      memories: [{ kind: "unsupported", content: "Nope" }],
+    }))).toEqual([])
+  })
+})
+
+test.describe("User memory pure rules", () => {
+  test("normalizes stable keys and sanitizes candidate payloads", () => {
+    expect(normalizeMemoryToken("Öl & Duft / Heavy!")).toBe("ol_und_duft_heavy")
+
+    expect(
+      sanitizeMemoryCandidate({
+        kind: "preference",
+        content: "  Der Nutzer mag leichte Texturen.  ",
+        evidence: "  mag leichte Texturen  ",
+        confidence: 0.8,
+        product_names: ["  Produkt A  ", ""],
+      })
+    ).toEqual({
+      kind: "preference",
+      content: "Der Nutzer mag leichte Texturen.",
+      evidence: "mag leichte Texturen",
+      confidence: 0.8,
+      product_names: ["Produkt A"],
+      sentiment: null,
+    })
+
+    expect(
+      sanitizeMemoryCandidate({
+        kind: "preference",
+        content: "Der Nutzer mag Duft.",
+        confidence: 0.4,
+      })
+    ).toBeNull()
+  })
+
+  test("builds compact prompt context from active memories only", () => {
+    const prompt = buildMemoryPromptContext([
+      createMemoryEntry({ content: "Der Nutzer mag leichte Leave-ins." }),
+      createMemoryEntry({
+        id: "memory-2",
+        content: "Archiviert",
+        status: "archived",
+      }),
+    ])
+
+    expect(prompt).toContain("Der Nutzer mag leichte Leave-ins.")
+    expect(prompt).not.toContain("Archiviert")
+  })
+
+  test("downranks exact disliked products only when memory is enabled", () => {
+    const memories = [
+      createMemoryEntry({
+        kind: "product_experience",
+        content: "Der Nutzer mochte Heavy Oil nicht.",
+        metadata: {
+          sentiment: "negative",
+          product_names: ["Heavy Oil"],
+        },
+      }),
+    ]
+
+    const products = [
+      createProduct("heavy", "Heavy Oil"),
+      createProduct("heavy-plus", "Heavy Oil Plus"),
+      createProduct("light", "Light Leave-in"),
+    ]
+
+    expect(extractDislikedProductNames(memories)).toEqual(["Heavy Oil"])
+    expect(
+      applyProductMemoryConstraints(products, {
+        enabled: true,
+        dislikedProductNames: ["Heavy Oil"],
+      }).map((product) => product.id)
+    ).toEqual(["heavy-plus", "light", "heavy"])
+
+    expect(
+      applyProductMemoryConstraints(products, {
+        enabled: false,
+        dislikedProductNames: ["Heavy Oil"],
+      }).map((product) => product.id)
+    ).toEqual(["heavy", "heavy-plus", "light"])
+  })
+})
+
+test.describe("User memory persistence with fake Supabase", () => {
+  test("ensures default settings and respects disabled memory context", async () => {
+    const fake = new FakeSupabase({
+      user_memory_settings: [],
+      user_memory_entries: [
+        createMemoryEntry({
+          kind: "product_experience",
+          metadata: { sentiment: "negative", product_names: ["Heavy Oil"] },
+        }),
+      ],
+    })
+
+    await expect(ensureUserMemorySettings("user-1", asSupabase(fake))).resolves.toBe(true)
+    expect(fake.tables.user_memory_settings).toEqual([
+      expect.objectContaining({ user_id: "user-1", memory_enabled: true }),
+    ])
+
+    fake.tables.user_memory_settings = [{ user_id: "user-1", memory_enabled: false }]
+    await expect(loadUserMemoryContext("user-1", asSupabase(fake))).resolves.toEqual({
+      enabled: false,
+      entries: [],
+      promptContext: null,
+      dislikedProductNames: [],
+    })
+  })
+
+  test("latest-wins insert archives the old memory and rebuilds the prompt cache", async () => {
+    const fake = new FakeSupabase({
+      user_memory_entries: [
+        createMemoryEntry({
+          id: "old-memory",
+          kind: "preference",
+          content: "Der Nutzer mag Duftstoffe.",
+          normalized_key: "preference:preference_duft",
+        }),
+      ],
+      hair_profiles: [{ user_id: "user-1", conversation_memory: null }],
+    })
+
+    await insertExtractedMemories(
+      "user-1",
+      "conversation-2",
+      [
+        {
+          kind: "preference",
+          memory_key: "preference:duft",
+          content: "Der Nutzer bevorzugt duftfreie Produkte.",
+          evidence: "Ich will lieber ohne Duft.",
+          confidence: 0.93,
+        },
+      ],
+      asSupabase(fake)
+    )
+
+    expect(fake.tables.user_memory_entries).toEqual([
+      expect.objectContaining({
+        id: "old-memory",
+        status: "archived",
+        superseded_by: "inserted-2",
+      }),
+      expect.objectContaining({
+        id: "inserted-2",
+        status: "active",
+        content: "Der Nutzer bevorzugt duftfreie Produkte.",
+        source_conversation_id: "conversation-2",
+      }),
+    ])
+    expect(fake.tables.hair_profiles?.[0]).toEqual(
+      expect.objectContaining({
+        conversation_memory: "- Der Nutzer bevorzugt duftfreie Produkte.",
+      })
+    )
+  })
+
+  test("manual edits clear hidden product metadata and rebuild cache", async () => {
+    const fake = new FakeSupabase({
+      user_memory_entries: [
+        createMemoryEntry({
+          id: "memory-1",
+          kind: "product_experience",
+          metadata: { sentiment: "negative", product_names: ["Heavy Oil"] },
+        }),
+      ],
+      hair_profiles: [{ user_id: "user-1", conversation_memory: null }],
+    })
+
+    await updateUserMemoryEntry(
+      "user-1",
+      "memory-1",
+      "Der Nutzer mag inzwischen leichte Oele.",
+      asSupabase(fake)
+    )
+
+    expect(fake.tables.user_memory_entries?.[0]).toEqual(
+      expect.objectContaining({
+        content: "Der Nutzer mag inzwischen leichte Oele.",
+        source: "manual",
+        source_conversation_id: null,
+        evidence: null,
+        metadata: {},
+      })
+    )
+    expect(fake.tables.hair_profiles?.[0]).toEqual(
+      expect.objectContaining({
+        conversation_memory: "- Der Nutzer mag inzwischen leichte Oele.",
+      })
+    )
+  })
+
+  test("deletes single memories and conversation-sourced memories without touching manual rows", async () => {
+    const fake = new FakeSupabase({
+      user_memory_entries: [
+        createMemoryEntry({
+          id: "delete-me",
+          source: "chat",
+          source_conversation_id: "conversation-1",
+        }),
+        createMemoryEntry({
+          id: "manual-keep",
+          content: "Manuell gepflegte Erinnerung.",
+          source: "manual",
+          source_conversation_id: null,
+        }),
+        createMemoryEntry({
+          id: "other-conversation",
+          source: "chat",
+          source_conversation_id: "conversation-2",
+        }),
+      ],
+      hair_profiles: [{ user_id: "user-1", conversation_memory: null }],
+    })
+
+    await expect(deleteUserMemoryEntry("user-1", "delete-me", asSupabase(fake))).resolves.toBe(true)
+    expect(fake.tables.user_memory_entries?.map((entry) => entry.id)).toEqual([
+      "manual-keep",
+      "other-conversation",
+    ])
+
+    await deleteConversationSourcedMemories("user-1", "conversation-2", asSupabase(fake))
+    expect(fake.tables.user_memory_entries?.map((entry) => entry.id)).toEqual([
+      "manual-keep",
+    ])
+    expect(fake.tables.hair_profiles?.[0]).toEqual(
+      expect.objectContaining({
+        conversation_memory: "- Manuell gepflegte Erinnerung.",
+      })
+    )
+  })
+})

--- a/tests/user-memory.spec.ts
+++ b/tests/user-memory.spec.ts
@@ -75,7 +75,7 @@ function createProduct(id: string, name: string): Product {
 }
 
 class FakeSupabaseQuery {
-  private filters: Array<{ column: string; value: unknown }> = []
+  private filters: Array<{ column: string; value: unknown; op: "eq" | "neq" }> = []
   private operation: "select" | "insert" | "update" | "delete" = "select"
   private payload: Record<string, unknown> | Record<string, unknown>[] | null = null
   private maxRows: number | null = null
@@ -92,7 +92,12 @@ class FakeSupabaseQuery {
   }
 
   eq(column: string, value: unknown) {
-    this.filters.push({ column, value })
+    this.filters.push({ column, value, op: "eq" })
+    return this
+  }
+
+  neq(column: string, value: unknown) {
+    this.filters.push({ column, value, op: "neq" })
     return this
   }
 
@@ -188,7 +193,9 @@ class FakeSupabaseQuery {
 
   private filterRows(rows: TableRow[]): TableRow[] {
     let result = rows.filter((row) =>
-      this.filters.every(({ column, value }) => row[column] === value)
+      this.filters.every(({ column, value, op }) =>
+        op === "neq" ? row[column] !== value : row[column] === value
+      )
     )
 
     if (this.orderColumn) {


### PR DESCRIPTION
## Summary
- Adds user-controlled memory system: structured memory extraction from chat conversations, CRUD API routes, profile page UI, and product de-prioritization for disliked products
- New `user_memory_settings` and `user_memory_entries` tables with RLS policies
- Legacy `conversation_memory` backfill migration for existing users
- Memory context injected into chat synthesis and product ranking pipeline
- Review fixes: removed redundant product constraint calls, added key collision guard, hardened JSON parsing in API routes

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx playwright test tests/user-memory.spec.ts` — 9/9 pass
- [ ] Walk profile page: toggle memory on/off, edit/delete memory entries
- [ ] Verify chat extraction: send 3+ messages, check memories appear on profile
- [ ] Verify disliked product de-prioritization in recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)