### PR TITLE
feat(routine): bond builder severity tiers and activation refinement

### DIFF
--- a/src/lib/rag/pipeline.ts
+++ b/src/lib/rag/pipeline.ts
@@ -62,6 +62,7 @@ import type {
   RouterDecision,
   MaskDecision,
   CategoryDecision,
+  RoutinePlan,
 } from "@/lib/types"
 
 export interface PipelineParams {
@@ -105,7 +106,7 @@ export async function runPipeline(
   const supabase = createAdminClient()
 
   // ── Step 1: Classify intent + load hair profile (parallel) ─────────
-  const [classification, hairProfileResult, memoryContext, bondBuilderUsage] = await Promise.all([
+  const [classification, hairProfileResult, memoryContext] = await Promise.all([
     classifyIntent(message),
     supabase
       .from("hair_profiles")
@@ -113,20 +114,21 @@ export async function runPipeline(
       .eq("user_id", userId)
       .single(),
     loadUserMemoryContext(userId, supabase),
-    supabase
+  ])
+  const { intent, product_category } = classification
+  const hairProfile: HairProfile | null = hairProfileResult.data ?? null
+  const shouldPlanRoutine = intent === "routine_help" || product_category === "routine"
+  let routinePlan: RoutinePlan | undefined
+  if (shouldPlanRoutine) {
+    const bondBuilderUsage = await supabase
       .from("user_product_usage")
       .select("id")
       .eq("user_id", userId)
       .eq("category", "bondbuilder")
-      .limit(1),
-  ])
-  const { intent, product_category } = classification
-  const hairProfile: HairProfile | null = hairProfileResult.data ?? null
-  const usesBondBuilder = (bondBuilderUsage.data?.length ?? 0) > 0
-  const shouldPlanRoutine = intent === "routine_help" || product_category === "routine"
-  let routinePlan = shouldPlanRoutine
-    ? buildRoutinePlan(hairProfile, message, { usesBondBuilder })
-    : undefined
+      .limit(1)
+    const usesBondBuilder = (bondBuilderUsage.data?.length ?? 0) > 0
+    routinePlan = buildRoutinePlan(hairProfile, message, { usesBondBuilder })
+  }
   let shampooDecision = product_category === "shampoo"
     ? buildShampooDecision(hairProfile)
     : undefined

--- a/src/lib/rag/pipeline.ts
+++ b/src/lib/rag/pipeline.ts
@@ -105,7 +105,7 @@ export async function runPipeline(
   const supabase = createAdminClient()
 
   // ── Step 1: Classify intent + load hair profile (parallel) ─────────
-  const [classification, hairProfileResult, memoryContext] = await Promise.all([
+  const [classification, hairProfileResult, memoryContext, bondBuilderUsage] = await Promise.all([
     classifyIntent(message),
     supabase
       .from("hair_profiles")
@@ -113,12 +113,19 @@ export async function runPipeline(
       .eq("user_id", userId)
       .single(),
     loadUserMemoryContext(userId, supabase),
+    supabase
+      .from("user_product_usage")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("category", "bondbuilder")
+      .limit(1),
   ])
   const { intent, product_category } = classification
   const hairProfile: HairProfile | null = hairProfileResult.data ?? null
+  const usesBondBuilder = (bondBuilderUsage.data?.length ?? 0) > 0
   const shouldPlanRoutine = intent === "routine_help" || product_category === "routine"
   let routinePlan = shouldPlanRoutine
-    ? buildRoutinePlan(hairProfile, message)
+    ? buildRoutinePlan(hairProfile, message, { usesBondBuilder })
     : undefined
   let shampooDecision = product_category === "shampoo"
     ? buildShampooDecision(hairProfile)

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -866,7 +866,9 @@ Wenn ein Routine-Plan vorhanden ist:
 7. Wenn keine Produkte angehaengt sind, bleibe bei Kategorien und Routine-Logik statt konkrete Produkte zu improvisieren.
 8. Erfinde keine zusaetzlichen Kategorien, Schritte oder Produkttypen ausserhalb des Routine-Plans.
 9. Detaillierte Anwendungstechniken gehoeren NICHT in diese Antwort.
-10. Bei Kopfhautthemen bleibe konservativ und nicht-medizinisch.`,
+10. Bei Kopfhautthemen bleibe konservativ und nicht-medizinisch.
+11. Wenn Bond Builder relevant ist: Olaplex No. 0+3, K18 Molecular Repair Leave-in und Epres gehoeren zu den wenigen Produkten mit nachgewiesener Bond-Technologie. Viele Produkte mit "Bond" im Namen pflegen nur die Oberflaeche, reparieren aber nicht die innere Haarstruktur. Das sind Technologie-Beispiele, keine Produktempfehlungen.
+12. Nenne bei Bond Builder den Unterschied zwischen Laengs- und Querverbindungen nur, wenn der Routine-Plan das vorgibt. Erfinde keine eigene K18-vs-Olaplex-Logik.`,
   mask: `
 
 ## Masken-Empfehlungen:

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -137,6 +137,34 @@ const WASH_LESS_TERMS = [
 const CURLY_TEXTURES = new Set(["wavy", "curly", "coily"])
 const HEAVY_ROUTINE_PRODUCTS = new Set(["mask", "oil", "leave_in"])
 
+const STYLING_KIND_MAP: [RegExp, string][] = [
+  [/lockencreme|curl\s*cream/i, "Lockencreme"],
+  [/mousse|schaum/i, "Mousse"],
+  [/gel\b/i, "Gel"],
+  [/creme|cream/i, "Stylingcreme"],
+]
+
+function detectStylingProductKind(productsUsed: string | null): string | null {
+  if (!productsUsed) return null
+  const text = normalizeText(productsUsed)
+  for (const [pattern, label] of STYLING_KIND_MAP) {
+    if (pattern.test(text)) return label
+  }
+  return null
+}
+
+function hasRefreshDrynessNeed(profile: HairProfile | null): boolean {
+  const concerns = profile?.concerns ?? []
+  const goals = profile?.goals ?? []
+  return (
+    concerns.includes("dryness") ||
+    concerns.includes("hair_damage") ||
+    goals.includes("healthier_hair") ||
+    profile?.cuticle_condition === "rough" ||
+    (profile?.chemical_treatment ?? []).some((t) => t !== "natural")
+  )
+}
+
 function normalizeText(value: string): string {
   return value
     .toLowerCase()
@@ -208,6 +236,13 @@ function hasDrynessDamageSignals(profile: HairProfile | null): boolean {
   )
 }
 
+function hasFrequentUnprotectedHeat(profile: HairProfile | null): boolean {
+  return (
+    (profile?.heat_styling === "daily" || profile?.heat_styling === "several_weekly") &&
+    !(profile?.uses_heat_protection ?? false)
+  )
+}
+
 function hasDamageSignals(profile: HairProfile | null): boolean {
   const concerns = new Set(profile?.concerns ?? [])
   const treatments = new Set(profile?.chemical_treatment ?? [])
@@ -217,8 +252,50 @@ function hasDamageSignals(profile: HairProfile | null): boolean {
     concerns.has("split_ends") ||
     profile?.cuticle_condition === "rough" ||
     treatments.has("colored") ||
-    treatments.has("bleached")
+    treatments.has("bleached") ||
+    hasFrequentUnprotectedHeat(profile)
   )
+}
+
+function hasBondBuilderSignals(profile: HairProfile | null): boolean {
+  if (!hasDamageSignals(profile)) return false
+
+  const concerns = new Set(profile?.concerns ?? [])
+  const treatments = new Set(profile?.chemical_treatment ?? [])
+  const hasColoredOnly =
+    treatments.has("colored") &&
+    !treatments.has("bleached") &&
+    !concerns.has("hair_damage") &&
+    !concerns.has("split_ends") &&
+    profile?.cuticle_condition !== "rough" &&
+    !hasFrequentUnprotectedHeat(profile)
+
+  return !hasColoredOnly
+}
+
+function countDamageSignals(profile: HairProfile | null): number {
+  const concerns = new Set(profile?.concerns ?? [])
+  const treatments = new Set(profile?.chemical_treatment ?? [])
+  let count = 0
+
+  if (treatments.has("bleached")) count++
+  if (treatments.has("colored")) count++
+  if (profile?.cuticle_condition === "rough") count++
+  if (concerns.has("hair_damage")) count++
+  if (concerns.has("split_ends")) count++
+  if (hasFrequentUnprotectedHeat(profile)) count++
+
+  return count
+}
+
+function deriveBondBuilderSeverity(profile: HairProfile | null): "moderate" | "severe" {
+  const treatments = new Set(profile?.chemical_treatment ?? [])
+
+  if (profile?.protein_moisture_balance === "snaps") return "severe"
+  if (treatments.has("bleached") && countDamageSignals(profile) >= 2) return "severe"
+  if (countDamageSignals(profile) >= 3) return "severe"
+
+  return "moderate"
 }
 
 function hasOilWeightRisk(profile: HairProfile | null): boolean {
@@ -365,8 +442,10 @@ export function deriveRoutineContext(
     has_buildup_signals: hasBuildupSignals(profile, normalizedMessage),
     has_dryness_damage_signals: hasDrynessDamageSignals(profile),
     has_damage_signals: hasDamageSignals(profile),
+    has_bond_builder_signals: hasBondBuilderSignals(profile),
     has_oil_weight_risk: hasOilWeightRisk(profile),
     has_strong_technique_fit: hasStrongTechniqueFit(profile),
+    uses_heat_protection: profile?.uses_heat_protection ?? false,
   }
 }
 
@@ -469,7 +548,7 @@ export function activateRoutineTopics(
     )
   }
 
-  if (explicit.has("bond_builder") || context.has_damage_signals) {
+  if (explicit.has("bond_builder") || context.has_bond_builder_signals) {
     push(
       "bond_builder",
       explicit.has("bond_builder")
@@ -478,6 +557,15 @@ export function activateRoutineTopics(
       45,
       true,
     )
+
+    if (!seen.has("tiefenreinigung")) {
+      push(
+        "tiefenreinigung",
+        "Bond Builder brauchen Zugang zur inneren Haarstruktur — Rueckstaende von Silikonen oder Stylingprodukten koennen die Aufnahme blockieren.",
+        30,
+        true,
+      )
+    }
   }
 
   if (
@@ -585,6 +673,7 @@ function buildRoutineSlots(
   context: RoutineContext,
   activations: RoutineTopicActivation[],
   decisionContext: RoutineDecisionContext,
+  options: { usesBondBuilder: boolean },
 ): Map<RoutinePlanSection["phase"], RoutineSlotAdvice[]> {
   const sections = new Map<RoutinePlanSection["phase"], RoutineSlotAdvice[]>()
   const activeTopicIds = new Set(activations.map((entry) => entry.id))
@@ -714,6 +803,26 @@ function buildRoutineSlots(
   }
 
   if (activeTopicIds.has("lockenrefresh")) {
+    const stylingKind = detectStylingProductKind(profile?.products_used ?? null)
+    const productEcho = stylingKind
+      ? `Verwende dein ${stylingKind} vom letzten Waschtag — nicht mit neuen Produkten experimentieren.`
+      : "Verwende dasselbe Styling-Produkt vom letzten Waschtag — nicht mit neuen Produkten experimentieren."
+
+    const refreshRationale = [
+      "Lockenrefresh ist eine abgekuerzte Version des letzten Steps der Locken-Routine — nur leicht anfeuchten, Produkt auffrischen, trocknen lassen.",
+      productEcho,
+      "Regelmaessiges Auffrischen trainiert langfristig die Lockenstruktur.",
+    ]
+
+    const refreshCaveats: string[] = []
+
+    if (hasRefreshDrynessNeed(profile)) {
+      refreshRationale.splice(2, 0, "Bei Bedarf vorher etwas Leave-In in trockene Laengen einarbeiten (siehe Leave-In-Slot).")
+      if (profile?.thickness === "fine") {
+        refreshCaveats.push("Bei feinem Haar reicht oft schon ein minimaler Tropfen Leave-In, damit die Locken nicht beschwert werden.")
+      }
+    }
+
     pushSlot(sections, {
       id: "maintenance-refresh",
       kind: "instruction",
@@ -721,12 +830,9 @@ function buildRoutineSlots(
       label: "Lockenrefresh",
       action: leaveInPresent ? "adjust" : "add",
       category: null,
-      cadence: "an Tagen zwischen den Waeschen",
-      rationale: [
-        "Wellen und Locken profitieren oft von einem leichten Refresh statt einer kompletten Neuwaesche.",
-        "Der Punkt bleibt bewusst auf Routine-Ebene und geht noch nicht in Anwendungstechnik.",
-      ],
-      caveats: [],
+      cadence: "an Tagen zwischen den Waeschen, ca. 10 Min.",
+      rationale: refreshRationale,
+      caveats: refreshCaveats,
       topic_ids: ["lockenrefresh"],
       product_linkable: false,
       product_query: null,
@@ -768,6 +874,7 @@ function buildRoutineSlots(
   }
 
   if (activeTopicIds.has("tiefenreinigung")) {
+    const bondBuilderDriven = activeTopicIds.has("bond_builder")
     pushSlot(sections, {
       id: "occasional-clarify",
       kind: "instruction",
@@ -776,10 +883,15 @@ function buildRoutineSlots(
       action: shampooPresent ? "adjust" : "add",
       category: null,
       cadence: context.scalp_type === "oily" ? "alle 1-2 Wochen nach Bedarf" : "alle 2-3 Wochen oder bei Build-up",
-      rationale: [
-        "Tiefenreinigung ist ein gezielter Reset und kein Pflichtschritt fuer jede Waesche.",
-        "Sie wird vor allem dann relevant, wenn Kopfhaut, Build-up oder Produktueberlagerung die Routine schwerer machen.",
-      ],
+      rationale: bondBuilderDriven
+        ? [
+          "Bond Builder brauchen saubere Haarstruktur — Rueckstaende blockieren die Aufnahme.",
+          "Tiefenreinigung vor dem Bond Builder sorgt fuer maximale Wirkung.",
+        ]
+        : [
+          "Tiefenreinigung ist ein gezielter Reset und kein Pflichtschritt fuer jede Waesche.",
+          "Sie wird vor allem dann relevant, wenn Kopfhaut, Build-up oder Produktueberlagerung die Routine schwerer machen.",
+        ],
       caveats: (
         context.scalp_condition === "irritated" ||
         context.scalp_condition === "dry_flakes"
@@ -839,19 +951,52 @@ function buildRoutineSlots(
   }
 
   if (activeTopicIds.has("bond_builder")) {
+    const severity = deriveBondBuilderSeverity(profile)
+    const treatments = new Set(profile?.chemical_treatment ?? [])
+    const hasChemical = treatments.has("bleached") || treatments.has("colored")
+    const explicitWithoutSignals =
+      context.explicit_topic_ids.includes("bond_builder") && !context.has_bond_builder_signals
+
+    const bondRationale: string[] = severity === "severe"
+      ? [
+        "Die Kombination aus K18 und Olaplex kann die Reparatur deutlich verstaerken — K18 fuer Laengsverbindungen, Olaplex fuer Querverbindungen.",
+      ]
+      : hasChemical
+        ? [
+          "Bond Builder kann hier gezielt unterstuetzen.",
+          "Bei chemischer Belastung kann Olaplex (Querverbindungen) besonders sinnvoll sein.",
+        ]
+        : [
+          "Bond Builder kann hier gezielt unterstuetzen.",
+          "Bei allgemeiner Schaedigung ohne Chemie ist K18 (Laengsverbindungen) oft der bessere Einstieg.",
+        ]
+
+    const bondCaveats: string[] = [
+      "Zu haeufige Anwendung kann das Haar steif und sproede machen — Pausen einhalten.",
+    ]
+
+    if (profile?.protein_moisture_balance === "snaps") {
+      bondCaveats.push("Die Haare reissen aktuell leicht — ein professionelles Beratungsgespraech kann hier zusaetzlich helfen.")
+    } else if (profile?.protein_moisture_balance === "stretches_stays") {
+      bondCaveats.push("Bond Builder und Protein koennen parallel laufen, solange die Haare noch ueberdehnt sind.")
+    } else if (profile?.protein_moisture_balance === "stretches_bounces") {
+      bondCaveats.push("Die Haare sind aktuell stabil — Protein-Behandlungen dazu sind nicht mehr noetig, Feuchtigkeit reicht.")
+    }
+
+    if (explicitWithoutSignals) {
+      bondCaveats.push("Dein Profil zeigt aktuell keine starken Schadenssignale — Bond Builder ist hier eher optional, aber wir erklaeren gerne wie es funktioniert.")
+    }
+
     pushSlot(sections, {
       id: "occasional-bond-builder",
       kind: "instruction",
       phase: "occasional",
       label: "Bond Builder / Repair-Support",
-      action: maskPresent ? "adjust" : "add",
+      action: options.usesBondBuilder ? "adjust" : "add",
       category: null,
-      cadence: "kurweise oder in stressigeren Phasen",
-      rationale: [
-        "Bond Builder wird nur dann relevant, wenn echte Schadens- oder Chemie-Signale mitlaufen.",
-        "Der Punkt bleibt in v1 bewusst instruktional und nicht produktzentriert.",
-      ],
-      caveats: [],
+      cadence: "4 Anwendungen am Stueck, dann 4 Waeschen Pause, danach nach Bedarf",
+      rationale: bondRationale,
+      caveats: bondCaveats,
       topic_ids: ["bond_builder"],
       product_linkable: false,
       product_query: null,
@@ -886,11 +1031,14 @@ function buildRoutineSlots(
 export function buildRoutinePlan(
   profile: HairProfile | null,
   message: string,
+  options: { usesBondBuilder?: boolean } = {},
 ): RoutinePlan {
   const context = deriveRoutineContext(profile, message)
   const activeTopics = activateRoutineTopics(profile, message, context)
   const decisionContext = buildRoutineDecisionContext(profile)
-  const sectionSlots = buildRoutineSlots(profile, context, activeTopics, decisionContext)
+  const sectionSlots = buildRoutineSlots(profile, context, activeTopics, decisionContext, {
+    usesBondBuilder: options.usesBondBuilder ?? false,
+  })
 
   const phases: RoutinePlanSection["phase"][] = ["base_wash", "maintenance", "occasional"]
   const sections: RoutinePlanSection[] = phases
@@ -941,7 +1089,7 @@ export function buildRoutineRetrievalSubqueries(
     }
   }
 
-  return [...queries].slice(0, 6)
+  return [...queries].slice(0, 7)
 }
 
 export function getRoutineAutofillSlots(plan: RoutinePlan): RoutineSlotAdvice[] {
@@ -954,4 +1102,4 @@ export function getRoutineAutofillSlots(plan: RoutinePlan): RoutineSlotAdvice[] 
     .sort((a, b) => a.attachment_priority - b.attachment_priority)
 }
 
-export { ROUTINE_TOPIC_LABELS }
+export { detectStylingProductKind, ROUTINE_TOPIC_LABELS }

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -248,6 +248,7 @@ function hasDamageSignals(profile: HairProfile | null): boolean {
   const treatments = new Set(profile?.chemical_treatment ?? [])
 
   return (
+    profile?.protein_moisture_balance === "snaps" ||
     concerns.has("hair_damage") ||
     concerns.has("split_ends") ||
     profile?.cuticle_condition === "rough" ||
@@ -278,6 +279,7 @@ function countDamageSignals(profile: HairProfile | null): number {
   const treatments = new Set(profile?.chemical_treatment ?? [])
   let count = 0
 
+  if (profile?.protein_moisture_balance === "snaps") count++
   if (treatments.has("bleached")) count++
   if (treatments.has("colored")) count++
   if (profile?.cuticle_condition === "rough") count++
@@ -549,6 +551,8 @@ export function activateRoutineTopics(
   }
 
   if (explicit.has("bond_builder") || context.has_bond_builder_signals) {
+    const explicitOnly = explicit.has("bond_builder") && !context.has_bond_builder_signals
+
     push(
       "bond_builder",
       explicit.has("bond_builder")
@@ -558,7 +562,7 @@ export function activateRoutineTopics(
       true,
     )
 
-    if (!seen.has("tiefenreinigung")) {
+    if (!explicitOnly && !seen.has("tiefenreinigung")) {
       push(
         "tiefenreinigung",
         "Bond Builder brauchen Zugang zur inneren Haarstruktur — Rueckstaende von Silikonen oder Stylingprodukten koennen die Aufnahme blockieren.",
@@ -951,57 +955,76 @@ function buildRoutineSlots(
   }
 
   if (activeTopicIds.has("bond_builder")) {
-    const severity = deriveBondBuilderSeverity(profile)
-    const treatments = new Set(profile?.chemical_treatment ?? [])
-    const hasChemical = treatments.has("bleached") || treatments.has("colored")
     const explicitWithoutSignals =
       context.explicit_topic_ids.includes("bond_builder") && !context.has_bond_builder_signals
 
-    const bondRationale: string[] = severity === "severe"
-      ? [
-        "Die Kombination aus K18 und Olaplex kann die Reparatur deutlich verstaerken — K18 fuer Laengsverbindungen, Olaplex fuer Querverbindungen.",
-      ]
-      : hasChemical
-        ? [
-          "Bond Builder kann hier gezielt unterstuetzen.",
-          "Bei chemischer Belastung kann Olaplex (Querverbindungen) besonders sinnvoll sein.",
-        ]
-        : [
-          "Bond Builder kann hier gezielt unterstuetzen.",
-          "Bei allgemeiner Schaedigung ohne Chemie ist K18 (Laengsverbindungen) oft der bessere Einstieg.",
-        ]
-
-    const bondCaveats: string[] = [
-      "Zu haeufige Anwendung kann das Haar steif und sproede machen — Pausen einhalten.",
-    ]
-
-    if (profile?.protein_moisture_balance === "snaps") {
-      bondCaveats.push("Die Haare reissen aktuell leicht — ein professionelles Beratungsgespraech kann hier zusaetzlich helfen.")
-    } else if (profile?.protein_moisture_balance === "stretches_stays") {
-      bondCaveats.push("Bond Builder und Protein koennen parallel laufen, solange die Haare noch ueberdehnt sind.")
-    } else if (profile?.protein_moisture_balance === "stretches_bounces") {
-      bondCaveats.push("Die Haare sind aktuell stabil — Protein-Behandlungen dazu sind nicht mehr noetig, Feuchtigkeit reicht.")
-    }
-
     if (explicitWithoutSignals) {
-      bondCaveats.push("Dein Profil zeigt aktuell keine starken Schadenssignale — Bond Builder ist hier eher optional, aber wir erklaeren gerne wie es funktioniert.")
-    }
+      pushSlot(sections, {
+        id: "occasional-bond-builder",
+        kind: "instruction",
+        phase: "occasional",
+        label: "Bond Builder / Repair-Support",
+        action: options.usesBondBuilder ? "adjust" : "add",
+        category: null,
+        cadence: null,
+        rationale: [
+          "Bond Builder ist ein optionaler Baustein fuer gezielte Reparatur auf molekularer Ebene.",
+        ],
+        caveats: [
+          "Dein Profil zeigt aktuell keine starken Schadenssignale — Bond Builder ist hier eher optional, aber wir erklaeren gerne wie es funktioniert.",
+        ],
+        topic_ids: ["bond_builder"],
+        product_linkable: false,
+        product_query: null,
+        attachment_priority: 96,
+      })
+    } else {
+      const severity = deriveBondBuilderSeverity(profile)
+      const treatments = new Set(profile?.chemical_treatment ?? [])
+      const hasChemical = treatments.has("bleached") || treatments.has("colored")
 
-    pushSlot(sections, {
-      id: "occasional-bond-builder",
-      kind: "instruction",
-      phase: "occasional",
-      label: "Bond Builder / Repair-Support",
-      action: options.usesBondBuilder ? "adjust" : "add",
-      category: null,
-      cadence: "4 Anwendungen am Stueck, dann 4 Waeschen Pause, danach nach Bedarf",
-      rationale: bondRationale,
-      caveats: bondCaveats,
-      topic_ids: ["bond_builder"],
-      product_linkable: false,
-      product_query: null,
-      attachment_priority: 96,
-    })
+      const bondRationale: string[] = severity === "severe"
+        ? [
+          "Die Kombination aus K18 und Olaplex kann die Reparatur deutlich verstaerken — K18 fuer Laengsverbindungen, Olaplex fuer Querverbindungen.",
+        ]
+        : hasChemical
+          ? [
+            "Bond Builder kann hier gezielt unterstuetzen.",
+            "Bei chemischer Belastung kann Olaplex (Querverbindungen) besonders sinnvoll sein.",
+          ]
+          : [
+            "Bond Builder kann hier gezielt unterstuetzen.",
+            "Bei allgemeiner Schaedigung ohne Chemie ist K18 (Laengsverbindungen) oft der bessere Einstieg.",
+          ]
+
+      const bondCaveats: string[] = [
+        "Zu haeufige Anwendung kann das Haar steif und sproede machen — Pausen einhalten.",
+      ]
+
+      if (profile?.protein_moisture_balance === "snaps") {
+        bondCaveats.push("Die Haare reissen aktuell leicht — ein professionelles Beratungsgespraech kann hier zusaetzlich helfen.")
+      } else if (profile?.protein_moisture_balance === "stretches_stays") {
+        bondCaveats.push("Bond Builder und Protein koennen parallel laufen, solange die Haare noch ueberdehnt sind.")
+      } else if (profile?.protein_moisture_balance === "stretches_bounces") {
+        bondCaveats.push("Die Haare sind aktuell stabil — Protein-Behandlungen dazu sind nicht mehr noetig, Feuchtigkeit reicht.")
+      }
+
+      pushSlot(sections, {
+        id: "occasional-bond-builder",
+        kind: "instruction",
+        phase: "occasional",
+        label: "Bond Builder / Repair-Support",
+        action: options.usesBondBuilder ? "adjust" : "add",
+        category: null,
+        cadence: "4 Anwendungen am Stueck, dann 4 Waeschen Pause, danach nach Bedarf",
+        rationale: bondRationale,
+        caveats: bondCaveats,
+        topic_ids: ["bond_builder"],
+        product_linkable: false,
+        product_query: null,
+        attachment_priority: 96,
+      })
+    }
   }
 
   if (activeTopicIds.has("cwc_owc")) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -421,8 +421,10 @@ export interface RoutineContext {
   has_buildup_signals: boolean
   has_dryness_damage_signals: boolean
   has_damage_signals: boolean
+  has_bond_builder_signals: boolean
   has_oil_weight_risk: boolean
   has_strong_technique_fit: boolean
+  uses_heat_protection: boolean
 }
 
 export interface RoutineTopicActivation {

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -4,6 +4,7 @@ import {
   buildRoutinePlan,
   buildRoutineRetrievalSubqueries,
   deriveRoutineContext,
+  detectStylingProductKind,
   getRoutineAutofillSlots,
 } from "../src/lib/routines/planner"
 import { evaluateRoute } from "../src/lib/rag/router"
@@ -427,6 +428,177 @@ test.describe("Routine planner", () => {
     expect(context.primary_focuses.map((focus) => focus.label)).not.toContain("minimal")
   })
 
+  test.describe("detectStylingProductKind", () => {
+    test("detects Gel from free text", () => {
+      expect(detectStylingProductKind("Balea Styling Gel")).toBe("Gel")
+    })
+
+    test("detects Mousse/Schaum", () => {
+      expect(detectStylingProductKind("Ich nutze einen Locken-Schaum von Schwarzkopf")).toBe("Mousse")
+      expect(detectStylingProductKind("Mousse von Cantu")).toBe("Mousse")
+    })
+
+    test("detects Lockencreme before generic Creme", () => {
+      expect(detectStylingProductKind("Lockencreme von Cantu und Gel")).toBe("Lockencreme")
+      expect(detectStylingProductKind("Curl Cream plus Gel")).toBe("Lockencreme")
+    })
+
+    test("detects generic Stylingcreme", () => {
+      expect(detectStylingProductKind("eine Creme fuer die Haare")).toBe("Stylingcreme")
+    })
+
+    test("returns null for empty or no-match input", () => {
+      expect(detectStylingProductKind(null)).toBeNull()
+      expect(detectStylingProductKind("")).toBeNull()
+      expect(detectStylingProductKind("ich benutze nichts besonderes")).toBeNull()
+    })
+
+    test("handles mixed casing and diacritics", () => {
+      expect(detectStylingProductKind("STYLING GEL von Wella")).toBe("Gel")
+      expect(detectStylingProductKind("Schäum-Mousse")).toBe("Mousse")
+    })
+
+    test("matches German compound words", () => {
+      expect(detectStylingProductKind("Stylinggel von dm")).toBe("Gel")
+      expect(detectStylingProductKind("Lockenschaum")).toBe("Mousse")
+    })
+
+    test("does not match gel inside gelb", () => {
+      expect(detectStylingProductKind("gelbliches Serum")).toBeNull()
+    })
+  })
+
+  test("refresh slot echoes product kind from products_used", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        products_used: "Balea Styling Gel",
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot).toBeDefined()
+    expect(refreshSlot?.rationale.some((line) => line.includes("dein Gel vom letzten Waschtag"))).toBe(true)
+  })
+
+  test("refresh slot uses generic product echo when products_used has no styling match", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        products_used: null,
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot?.rationale.some((line) => line.includes("dasselbe Styling-Produkt vom letzten Waschtag"))).toBe(true)
+  })
+
+  test("refresh slot adds leave-in cross-reference for dry/damaged hair", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        concerns: ["dryness"],
+        cuticle_condition: "rough",
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot?.rationale.some((line) => line.includes("Leave-In"))).toBe(true)
+    expect(refreshSlot?.rationale.some((line) => line.includes("trainiert langfristig"))).toBe(true)
+  })
+
+  test("refresh slot adds fine-hair caveat when thickness is fine and dryness signals present", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        thickness: "fine",
+        concerns: ["dryness"],
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot?.caveats.some((line) => line.includes("feinem Haar"))).toBe(true)
+  })
+
+  test("refresh slot has no leave-in cross-reference when no dryness signals", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        concerns: [],
+        goals: [],
+        cuticle_condition: "smooth",
+        chemical_treatment: ["natural"],
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot?.rationale.every((line) => !line.includes("Leave-In"))).toBe(true)
+    expect(refreshSlot?.caveats).toHaveLength(0)
+  })
+
+  test("refresh slot includes duration in cadence", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot?.cadence).toContain("ca. 10 Min.")
+  })
+
+  test("chemical treatment alone triggers leave-in cross-reference on refresh", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        thickness: "normal",
+        chemical_treatment: ["colored"],
+        cuticle_condition: "smooth",
+        concerns: [],
+        goals: [],
+        current_routine_products: ["shampoo", "conditioner", "leave_in"],
+      }),
+      "Welche Routine passt zu mir?"
+    )
+
+    const refreshSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-refresh")
+
+    expect(refreshSlot?.rationale.some((line) => line.includes("Leave-In"))).toBe(true)
+    expect(refreshSlot?.caveats).toHaveLength(0)
+  })
+
   test("routine system prompt includes the plan, softer avoid wording, and reasoning-first product instructions", () => {
     const profile = createProfile({
       current_routine_products: ["shampoo", "conditioner", "mask"],
@@ -454,5 +626,215 @@ test.describe("Routine planner", () => {
     expect(prompt).toContain("Begruende pro relevantem Slot erst kurz den Fit zum Profil")
     expect(prompt).toContain("ordne sie direkt dem gerade erklaerten Slot")
     expect(prompt).not.toContain("Routine-Detailgrad")
+  })
+
+  test.describe("Bond builder logic", () => {
+    test("colored alone does NOT activate bond builder", () => {
+      const topics = activateRoutineTopics(
+        createProfile({
+          chemical_treatment: ["colored"],
+          cuticle_condition: "smooth",
+          concerns: [],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      expect(topics.map((topic) => topic.id)).not.toContain("bond_builder")
+    })
+
+    test("colored + rough cuticle activates bond builder", () => {
+      const topics = activateRoutineTopics(
+        createProfile({
+          chemical_treatment: ["colored"],
+          cuticle_condition: "rough",
+          concerns: [],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      expect(topics.map((topic) => topic.id)).toContain("bond_builder")
+    })
+
+    test("heat damage without protection activates bond builder", () => {
+      const topics = activateRoutineTopics(
+        createProfile({
+          heat_styling: "daily",
+          uses_heat_protection: false,
+          cuticle_condition: "smooth",
+          concerns: [],
+          chemical_treatment: ["natural"],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      expect(topics.map((topic) => topic.id)).toContain("bond_builder")
+    })
+
+    test("explicit request without damage signals adds optional caveat", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          cuticle_condition: "smooth",
+          chemical_treatment: ["natural"],
+          concerns: [],
+          heat_styling: "never",
+        }),
+        "Was ist ein Bond Builder?"
+      )
+
+      const bondSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(bondSlot).toBeDefined()
+      expect(bondSlot?.caveats.some((line) => line.includes("eher optional"))).toBe(true)
+    })
+
+    test("snaps = severe tier with pro note", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          protein_moisture_balance: "snaps",
+          chemical_treatment: ["bleached"],
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const bondSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(bondSlot?.rationale.some((line) => line.includes("Kombination aus K18 und Olaplex"))).toBe(true)
+      expect(bondSlot?.caveats.some((line) => line.includes("professionelles Beratungsgespraech"))).toBe(true)
+    })
+
+    test("moderate + chemical treatment leans Olaplex", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          chemical_treatment: ["colored"],
+          cuticle_condition: "rough",
+          concerns: [],
+          protein_moisture_balance: "stretches_bounces",
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const bondSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(bondSlot?.rationale.some((line) => line.includes("Olaplex (Querverbindungen)"))).toBe(true)
+    })
+
+    test("moderate + no chemical treatment leans K18", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          chemical_treatment: ["natural"],
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+          protein_moisture_balance: "stretches_bounces",
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const bondSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(bondSlot?.rationale.some((line) => line.includes("K18 (Laengsverbindungen)"))).toBe(true)
+    })
+
+    test("bond builder co-activates tiefenreinigung", () => {
+      const topics = activateRoutineTopics(
+        createProfile({
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+          chemical_treatment: ["bleached"],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const topicIds = topics.map((topic) => topic.id)
+      expect(topicIds).toContain("bond_builder")
+      expect(topicIds).toContain("tiefenreinigung")
+
+      const tiefenreinigung = topics.find((topic) => topic.id === "tiefenreinigung")
+      expect(tiefenreinigung?.reason).toContain("Rueckstaende")
+    })
+
+    test("repair fatigue caveat is always present on bond builder slot", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const bondSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(bondSlot?.caveats.some((line) => line.includes("steif und sproede"))).toBe(true)
+    })
+
+    test("protein interaction caveat varies by balance", () => {
+      const stretchesPlan = buildRoutinePlan(
+        createProfile({
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+          protein_moisture_balance: "stretches_stays",
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const stretchesSlot = stretchesPlan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(stretchesSlot?.caveats.some((line) => line.includes("parallel laufen"))).toBe(true)
+
+      const balancedPlan = buildRoutinePlan(
+        createProfile({
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+          protein_moisture_balance: "stretches_bounces",
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const balancedSlot = balancedPlan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(balancedSlot?.caveats.some((line) => line.includes("Feuchtigkeit reicht"))).toBe(true)
+    })
+
+    test("system prompt includes bond builder synth rules when bond_builder is active", () => {
+      const profile = createProfile({
+        cuticle_condition: "rough",
+        concerns: ["hair_damage"],
+        chemical_treatment: ["bleached"],
+      })
+      const routinePlan = buildRoutinePlan(profile, "Welche Routine passt zu mir?")
+
+      const prompt = buildSystemPrompt(
+        profile,
+        [createChunk()],
+        [],
+        "routine",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        routinePlan,
+        null,
+        undefined,
+      )
+
+      expect(prompt).toContain("nachgewiesener Bond-Technologie")
+      expect(prompt).toContain("Laengs- und Querverbindungen")
+    })
   })
 })

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -670,7 +670,7 @@ test.describe("Routine planner", () => {
       expect(topics.map((topic) => topic.id)).toContain("bond_builder")
     })
 
-    test("explicit request without damage signals adds optional caveat", () => {
+    test("explicit request without damage signals uses educational mode", () => {
       const plan = buildRoutinePlan(
         createProfile({
           cuticle_condition: "smooth",
@@ -684,9 +684,14 @@ test.describe("Routine planner", () => {
       const bondSlot = plan.sections
         .flatMap((section) => section.slots)
         .find((slot) => slot.id === "occasional-bond-builder")
+      const topicIds = plan.active_topics.map((topic) => topic.id)
 
       expect(bondSlot).toBeDefined()
       expect(bondSlot?.caveats.some((line) => line.includes("eher optional"))).toBe(true)
+      expect(bondSlot?.cadence).toBeNull()
+      expect(bondSlot?.rationale.some((line) => line.includes("optionaler Baustein"))).toBe(true)
+      expect(topicIds).toContain("bond_builder")
+      expect(topicIds).not.toContain("tiefenreinigung")
     })
 
     test("snaps = severe tier with pro note", () => {
@@ -835,6 +840,38 @@ test.describe("Routine planner", () => {
 
       expect(prompt).toContain("nachgewiesener Bond-Technologie")
       expect(prompt).toContain("Laengs- und Querverbindungen")
+    })
+
+    test("snaps alone activates bond builder via damage signals", () => {
+      const topics = activateRoutineTopics(
+        createProfile({
+          protein_moisture_balance: "snaps",
+          cuticle_condition: "smooth",
+          chemical_treatment: ["natural"],
+          concerns: [],
+          heat_styling: "never",
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      expect(topics.map((topic) => topic.id)).toContain("bond_builder")
+    })
+
+    test("usesBondBuilder flag sets slot action to adjust", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          cuticle_condition: "rough",
+          concerns: ["hair_damage"],
+        }),
+        "Welche Routine passt zu mir?",
+        { usesBondBuilder: true },
+      )
+
+      const bondSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-bond-builder")
+
+      expect(bondSlot?.action).toBe("adjust")
     })
   })
 })


### PR DESCRIPTION
## Summary
- **Activation refinement**: colored-only hair now needs +1 damage signal; frequent unprotected heat added as a standalone trigger
- **Severity tiers**: moderate (K18 or Olaplex lean based on chemical vs general damage) vs severe (combined K18+Olaplex for snaps, bleached+1, or 3+ signals)
- **Module dependencies**: bond builder auto-co-activates tiefenreinigung with bond-builder-specific rationale
- **Caveats**: repair fatigue warning, protein interaction (varies by stretch test), professional consult for snaps, educational note for explicit requests without damage
- **Synthesis guidance**: rules 11-12 for bond builder product naming (Olaplex, K18, Epres as technology examples) and K18/Olaplex logic guard
- **Pipeline**: loads bond builder usage from `user_product_usage` to determine adjust vs add action
- **Query cap**: bumped from 6 to 7 to absorb co-activated tiefenreinigung

## Test plan
- [x] 11 new bond builder tests (activation, severity, co-activation, caveats, synthesis)
- [x] All 47 routine planner tests pass
- [x] Type check clean
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)