### PR TITLE
feat(routine): add deterministic CWC/OWC wash protection logic

### DIFF
--- a/plans/cwc-owc-routine-logic-plan.md
+++ b/plans/cwc-owc-routine-logic-plan.md
@@ -1,0 +1,91 @@
+# Variant-Aware CWC/OWC Routine Logic
+
+## Summary
+
+- Replace the current generic `CWC/OWC` routine topic with **variant-aware logic** that chooses **CWC** or **OWC** deterministically.
+- Require a **real need signal** before surfacing either method. Hair pattern decides the default branch; damage/dryness/frequency/stress signals decide whether it appears at all.
+- Keep this as a **routine-planner + synthesis change only** for v1: no new onboarding fields, no DB/schema work.
+- Surface the chosen method inside the **wash-day/base routine**, with a **compact ordered technique outline** and clear guardrails.
+
+## Implementation Changes
+
+### Planner and Topic Selection
+
+- Replace umbrella routine topic usage with distinct planner behavior for `cwc` and `owc`.
+- Add a selector helper that:
+  - first checks for at least one **need signal**
+  - then chooses the variant by pattern + intensity + guardrails
+- Count as need signals:
+  - dryness, frizz, split ends, hair damage
+  - rough/slightly rough cuticle
+  - colored/bleached hair
+  - frequent washing (`daily`, `every_2_3_days`)
+  - mechanical stress / wash-day friction proxies already in profile
+- Variant rules:
+  - **CWC**: default for `straight` and most `wavy` hair with need signals
+  - **OWC**: allowed for `wavy`, `curly`, and `coily`, but only when the profile is clearly **dry/stressed/dyed** and oil-weight risk is acceptable
+  - `wavy` stays **CWC by default**; it upgrades to **OWC** only on the stronger textured/dry/stressed branch
+- Guardrails:
+  - do not proactively surface either method with no need signal
+  - demote/suppress proactive **OWC** for oily scalp, buildup-prone routines, or strong oil-weight risk
+  - treat color as a strengthening modifier, not a sole selector
+
+### Routine Slot Behavior
+
+- Remove the current generic occasional `CWC / OWC als Technik-Option` slot.
+- Add a variant-specific **base-wash instruction slot**:
+  - `CWC als Wash-Day-Schutz`
+  - `OWC als Wash-Day-Schutz`
+- Keep the rest of the routine modular:
+  - **CWC** reuses normal shampoo + conditioner slots
+  - **OWC** reuses shampoo + conditioner and should also reuse/inject the existing oil slot path so current oil matching can support it
+- Slot copy should include compact steps:
+  - **CWC**: conditioner on dry lengths/spitzen -> shampoo only at scalp -> foam through lengths -> final conditioner
+  - **OWC**: oil on dry lengths with praying hands/scrunch -> shampoo at scalp on dry hair -> add water and spread foam -> final conditioner
+- Add concise caveats:
+  - optional technique, not a universal default
+  - clarify/reset may matter if residue/build-up increases
+  - OWC should stay conservative for oil-sensitive profiles
+
+### Synthesis and Retrieval
+
+- Update routine synthesis so CWC/OWC is the one allowed exception to "high level only":
+  - include a **short ordered technique outline** for the selected method
+  - do not explain both methods unless the user explicitly asks for a comparison
+- Retrieval hints/subqueries should use the chosen variant label (`CWC` or `OWC`) instead of the current generic topic.
+- If the user explicitly asks about CWC/OWC but the profile is too incomplete to choose safely, ask one targeted follow-up instead of guessing.
+
+## Important Interface Changes
+
+- `RoutineTopicId` should support variant-specific handling for `cwc` and `owc` instead of relying on one generic `cwc_owc` path.
+- `RoutineContext` should expose enough derived signal state for wash-protection selection, either via new derived flags or a dedicated variant-selection helper.
+- `RoutineSlotAdvice` for this feature becomes variant-specific in `id`, `label`, `topic_ids`, cadence, rationale, and caveats.
+- No public API, onboarding schema, or Supabase table changes in this phase.
+
+## Test Plan
+
+- Activation:
+  - straight/fine/dyed + frequent washing -> `CWC`
+  - wavy + mild need -> `CWC`
+  - wavy + strong dryness/stress/dye + acceptable oil profile -> `OWC`
+  - curly/coily + dry/stressed/dyed -> `OWC`
+  - oily scalp / buildup-prone / no need signals -> neither method
+- Slot construction:
+  - chosen technique appears in `base_wash`, not `occasional`
+  - CWC slot contains the compact 4-step sequence
+  - OWC slot contains oil-first + shampoo-on-dry-scalp + final conditioner sequence
+  - OWC reuses or activates the oil product path correctly
+- Synthesis:
+  - routine prompt includes compact steps only for the active variant
+  - no generic "CWC/OWC" wording remains in the final answer path
+  - explicit comparison requests can explain both briefly without breaking the routine structure
+- Non-regression:
+  - existing shampoo, conditioner, leave-in, mask, hair-oiling, and lockenrefresh behavior stays unchanged when CWC/OWC is not selected
+
+## Assumptions
+
+- The chosen threshold is **"need signal required"**.
+- **OWC** is allowed for **broad textured hair**, including `wavy`, but only on the stronger dry/stressed/dyed branch.
+- Compact technique steps should appear directly in the routine answer when the method is active.
+- v1 should avoid new profile questions and instead use existing profile signals plus current routine heuristics.
+- Technique-specific product support should reuse existing category logic, not add a new product category.

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -554,7 +554,19 @@ function formatRoutinePlan(routinePlan?: RoutinePlan): string {
     )
   }
 
-  parts.push("- Niveau: Hohe Ebene, keine Detail-Anwendungsschritte.")
+  if (routinePlan.compare_cwc_owc) {
+    parts.push("- Vergleichsmodus: Erklaere CWC und OWC erst kurz gegeneinander und entscheide dich dann fuer die passendere Variante fuer dieses Profil.")
+  }
+
+  const hasWashProtectionTechnique = routinePlan.sections
+    .flatMap((section) => section.slots)
+    .some((slot) => slot.topic_ids.includes("cwc") || slot.topic_ids.includes("owc"))
+
+  parts.push(
+    hasWashProtectionTechnique
+      ? "- Niveau: Hohe Ebene fuer alle Slots; nur bei CWC/OWC sind kompakte nummerierte Wash-Day-Schritte erlaubt."
+      : "- Niveau: Hohe Ebene, keine Detail-Anwendungsschritte."
+  )
 
   for (const section of routinePlan.sections) {
     parts.push(`\n${section.title}: ${section.summary}`)
@@ -853,22 +865,23 @@ Wenn du Oel-Empfehlungen gibst:
 6. Begruende den Fit danach nur ueber Oel-Typ, Haardicke und die Anwendungslogik aus den Metadaten.
 7. Wenn Kopfhautthemen mitlaufen, ordne natuerliche Oele nur als unterstuetzende Zusatzpflege ein. Stelle sie NICHT als primaeren Behandlungsweg fuer Schuppen, gereizte Kopfhaut oder Haarwachstum dar.
 8. Wenn der Nutzer gezielt ein Therapie-Oel oder eine spezifische Oelmischung sucht und diese nicht im Katalog ist, sage das ehrlich statt einen Ersatz zu erfinden.`,
-  routine: `
+ routine: `
 
 ## Routine-Antworten:
 Wenn ein Routine-Plan vorhanden ist:
 1. Nutze den Routine-Plan als primaeren Rahmen der Antwort.
-2. Bleibe bewusst auf hoher Ebene: Kombinationen, Frequenz, Rollen der Schritte und das Warum dahinter.
+2. Bleibe bewusst auf hoher Ebene: Kombinationen, Frequenz, Rollen der Schritte und das Warum dahinter. Ausnahme: Bei aktiven CWC/OWC-Slots darfst du die kompakten nummerierten Wash-Day-Schritte aus dem Routine-Plan uebernehmen.
 3. Erklaere die Slots gemaess ihrer Aktion: keep = bestaetigen, adjust = Frequenz/Fokus anpassen, add = neu einfuehren, upgrade = gleicher Slot aber gezielterer Fokus, avoid = fuer jetzt eher nicht priorisieren.
 4. Starte mit den Bausteinen, die schon gut sitzen oder nur leicht angepasst werden sollten. Erklaere danach, was fehlt oder gezielter werden darf.
 5. Begruende pro relevantem Slot erst kurz den Fit zum Profil, also ueber Haarmuster, Ziele, Probleme oder Routinekontext, bevor du ein Produkt nennst.
 6. Wenn Produkte angehaengt sind, nenne nur diese Produkte und ordne sie direkt dem gerade erklaerten Slot im selben Absatz oder Bullet zu.
 7. Wenn keine Produkte angehaengt sind, bleibe bei Kategorien und Routine-Logik statt konkrete Produkte zu improvisieren.
 8. Erfinde keine zusaetzlichen Kategorien, Schritte oder Produkttypen ausserhalb des Routine-Plans.
-9. Detaillierte Anwendungstechniken gehoeren NICHT in diese Antwort.
+9. Detaillierte Anwendungstechniken gehoeren NICHT in diese Antwort, ausser die kompakten nummerierten CWC/OWC-Schritte stehen bereits im Routine-Plan.
 10. Bei Kopfhautthemen bleibe konservativ und nicht-medizinisch.
 11. Wenn Bond Builder relevant ist: Olaplex No. 0+3, K18 Molecular Repair Leave-in und Epres gehoeren zu den wenigen Produkten mit nachgewiesener Bond-Technologie. Viele Produkte mit "Bond" im Namen pflegen nur die Oberflaeche, reparieren aber nicht die innere Haarstruktur. Das sind Technologie-Beispiele, keine Produktempfehlungen.
-12. Nenne bei Bond Builder den Unterschied zwischen Laengs- und Querverbindungen nur, wenn der Routine-Plan das vorgibt. Erfinde keine eigene K18-vs-Olaplex-Logik.`,
+12. Nenne bei Bond Builder den Unterschied zwischen Laengs- und Querverbindungen nur, wenn der Routine-Plan das vorgibt. Erfinde keine eigene K18-vs-Olaplex-Logik.
+13. Wenn der Routine-Plan Vergleichsmodus fuer CWC/OWC signalisiert, erklaere erst kurz den Unterschied beider Methoden, waehle dann die passendere Option fuer dieses Profil und fuehre nur mit dieser Variante weiter.`,
   mask: `
 
 ## Masken-Empfehlungen:

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -343,8 +343,7 @@ function hasStrongDrynessDamageCluster(profile: HairProfile | null): boolean {
   return (
     concerns.has("dryness") ||
     concerns.has("hair_damage") ||
-    concerns.has("split_ends") ||
-    (concerns.has("dryness") && concerns.has("frizz"))
+    concerns.has("split_ends")
   )
 }
 
@@ -402,19 +401,6 @@ function isCwcOwcComparisonRequest(message: string): boolean {
   )
 }
 
-function getWashProtectionFallbackTopic(profile: HairProfile | null): "cwc" | "owc" | null {
-  switch (profile?.hair_texture) {
-    case "straight":
-    case "wavy":
-      return "cwc"
-    case "curly":
-    case "coily":
-      return "owc"
-    default:
-      return null
-  }
-}
-
 function selectWashProtectionTopic(
   profile: HairProfile | null,
   context: RoutineContext,
@@ -425,15 +411,13 @@ function selectWashProtectionTopic(
   const explicitOwc = context.explicit_topic_ids.includes("owc")
 
   if (compareMode) {
-    return {
-      topicId:
-        (hasOwcFit(profile, context)
-          ? "owc"
-          : context.has_wash_protection_need
-            ? "cwc"
-            : getWashProtectionFallbackTopic(profile)),
-      compareMode,
-    }
+    const topicId = hasOwcFit(profile, context)
+      ? "owc"
+      : context.has_wash_protection_need
+        ? "cwc"
+        : null
+
+    return { topicId, compareMode }
   }
 
   if (explicitOwc) {
@@ -737,18 +721,18 @@ export function activateRoutineTopics(
       (topicId === "cwc" && explicit.has("cwc")) ||
       (topicId === "owc" && explicit.has("owc"))
 
-    push(
-      topicId,
-      washProtectionSelection.compareMode
-        ? `CWC und OWC wurden direkt verglichen; ${ROUTINE_TOPIC_LABELS[topicId]} passt hier voraussichtlich besser.`
-        : explicitRequest
-          ? `${ROUTINE_TOPIC_LABELS[topicId]} wurde direkt angefragt.`
-          : topicId === "cwc"
-            ? "Das Profil spricht eher fuer eine schonende Conditioner-Schutzwaesche."
-            : "Das Profil spricht eher fuer eine Oel-Vorwaesche mit anschliessender Schutzpflege.",
-      60,
-      true,
-    )
+    let reason: string
+    if (washProtectionSelection.compareMode) {
+      reason = `CWC und OWC wurden direkt verglichen; ${ROUTINE_TOPIC_LABELS[topicId]} passt hier voraussichtlich besser.`
+    } else if (explicitRequest) {
+      reason = `${ROUTINE_TOPIC_LABELS[topicId]} wurde direkt angefragt.`
+    } else if (topicId === "cwc") {
+      reason = "Das Profil spricht eher fuer eine schonende Conditioner-Schutzwaesche."
+    } else {
+      reason = "Das Profil spricht eher fuer eine Oel-Vorwaesche mit anschliessender Schutzpflege."
+    }
+
+    push(topicId, reason, 60, true)
   }
 
   return activations.sort((a, b) => a.priority - b.priority)
@@ -849,7 +833,6 @@ function buildCwcTechniqueSlot(): RoutineSlotAdvice {
 }
 
 function buildOwcOilSlot(
-  profile: HairProfile | null,
   context: RoutineContext,
   explicitOwcRequest: boolean,
   oilPresent: boolean,
@@ -1014,13 +997,62 @@ function buildRoutineSlots(
     attachment_priority: 20,
   })
 
+  const explicitWashProtectionWithoutNeed =
+    activeWashProtectionTopic !== null &&
+    (context.explicit_topic_ids.includes("cwc") || context.explicit_topic_ids.includes("owc")) &&
+    !context.has_wash_protection_need
+
   if (activeWashProtectionTopic === "cwc") {
-    pushSlot(sections, buildCwcTechniqueSlot())
+    if (explicitWashProtectionWithoutNeed) {
+      pushSlot(sections, {
+        id: "base-cwc-technique",
+        kind: "instruction",
+        phase: "base_wash",
+        label: "CWC als Wash-Day-Schutz",
+        action: "add",
+        category: null,
+        cadence: null,
+        rationale: [
+          "CWC ist ein optionaler Wash-Day-Baustein fuer gezielte Pflege und kein Pflichtschritt.",
+        ],
+        caveats: [
+          "Dein Profil zeigt aktuell keine starken Trockenheits- oder Schadenssignale — CWC ist hier eher optional, aber wir erklaeren gerne wie es funktioniert.",
+        ],
+        topic_ids: ["cwc"],
+        product_linkable: false,
+        product_query: null,
+        attachment_priority: 92,
+      })
+    } else {
+      pushSlot(sections, buildCwcTechniqueSlot())
+    }
   }
 
   if (activeWashProtectionTopic === "owc") {
-    pushSlot(sections, buildOwcOilSlot(profile, context, explicitOwcRequest, oilPresent))
-    pushSlot(sections, buildOwcTechniqueSlot(profile, context))
+    if (explicitWashProtectionWithoutNeed) {
+      pushSlot(sections, {
+        id: "base-owc-technique",
+        kind: "instruction",
+        phase: "base_wash",
+        label: "OWC als Wash-Day-Schutz",
+        action: "add",
+        category: null,
+        cadence: null,
+        rationale: [
+          "OWC ist ein optionaler Wash-Day-Baustein fuer gezielte Pflege und kein Pflichtschritt.",
+        ],
+        caveats: [
+          "Dein Profil zeigt aktuell keine starken Trockenheits- oder Schadenssignale — OWC ist hier eher optional, aber wir erklaeren gerne wie es funktioniert.",
+        ],
+        topic_ids: ["owc"],
+        product_linkable: false,
+        product_query: null,
+        attachment_priority: 92,
+      })
+    } else {
+      pushSlot(sections, buildOwcOilSlot(context, explicitOwcRequest, oilPresent))
+      pushSlot(sections, buildOwcTechniqueSlot(profile, context))
+    }
   }
 
   const shouldUseLeaveIn =
@@ -1176,7 +1208,7 @@ function buildRoutineSlots(
     })
   }
 
-  if (activeTopicIds.has("hair_oiling") || oilPresent) {
+  if ((activeTopicIds.has("hair_oiling") || oilPresent) && activeWashProtectionTopic !== "owc") {
     const oilAction: RoutineSlotAction = !activeTopicIds.has("hair_oiling")
       ? "avoid"
       : oilPresent
@@ -1304,7 +1336,7 @@ export function buildRoutinePlan(
 ): RoutinePlan {
   const context = deriveRoutineContext(profile, message)
   const activeTopics = activateRoutineTopics(profile, message, context)
-  const { compareMode } = selectWashProtectionTopic(profile, context, message)
+  const compareMode = isCwcOwcComparisonRequest(message)
   const decisionContext = buildRoutineDecisionContext(profile)
   const sectionSlots = buildRoutineSlots(profile, context, activeTopics, decisionContext, {
     usesBondBuilder: options.usesBondBuilder ?? false,

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -33,7 +33,8 @@ const ROUTINE_TOPIC_LABELS: Record<RoutineTopicId, string> = {
   hair_oiling: "Hair Oiling",
   bond_builder: "Bond Builder",
   lockenrefresh: "Lockenrefresh",
-  cwc_owc: "CWC/OWC",
+  cwc: "CWC",
+  owc: "OWC",
 }
 
 const MASK_TYPE_LABELS = {
@@ -87,13 +88,28 @@ const REFRESH_TERMS = [
   "naechster tag",
 ]
 
-const CWC_OWC_TERMS = [
+const CWC_TERMS = [
   "cwc",
-  "owc",
-  "owc methode",
   "cwc methode",
   "conditioner wash conditioner",
+]
+
+const OWC_TERMS = [
+  "owc",
+  "owc methode",
   "oel waschen conditioner",
+  "oil wash conditioner",
+]
+
+const CWC_OWC_COMPARISON_TERMS = [
+  "cwc oder owc",
+  "owc oder cwc",
+  "cwc vs owc",
+  "owc vs cwc",
+  "cwc und owc",
+  "owc und cwc",
+  "unterschied cwc owc",
+  "unterschied zwischen cwc und owc",
 ]
 
 const HEAVY_STYLING_TERMS = [
@@ -306,20 +322,143 @@ function hasOilWeightRisk(profile: HairProfile | null): boolean {
   )
 }
 
-function hasStrongTechniqueFit(profile: HairProfile | null): boolean {
-  const treatments = new Set(profile?.chemical_treatment ?? [])
+function hasFrequentWashNeed(washFrequency: HairProfile["wash_frequency"]): boolean {
+  return washFrequency === "daily" || washFrequency === "every_2_3_days"
+}
+
+function hasMechanicalStressNeed(profile: HairProfile | null): boolean {
+  return (profile?.mechanical_stress_factors?.length ?? 0) > 0
+}
+
+function hasWashProtectionNeed(profile: HairProfile | null): boolean {
+  return (
+    hasDrynessDamageSignals(profile) ||
+    hasMechanicalStressNeed(profile)
+  )
+}
+
+function hasStrongDrynessDamageCluster(profile: HairProfile | null): boolean {
+  const concerns = new Set(profile?.concerns ?? [])
 
   return (
-    hasDrynessDamageSignals(profile) &&
-    (
-      profile?.cuticle_condition === "rough" ||
-      profile?.cuticle_condition === "slightly_rough" ||
-      treatments.has("colored") ||
-      treatments.has("bleached") ||
-      profile?.thickness === "normal" ||
-      profile?.thickness === "coarse"
-    )
+    concerns.has("dryness") ||
+    concerns.has("hair_damage") ||
+    concerns.has("split_ends") ||
+    (concerns.has("dryness") && concerns.has("frizz"))
   )
+}
+
+function countOwcSupportSignals(
+  profile: HairProfile | null,
+  context: RoutineContext,
+): number {
+  const treatments = new Set(profile?.chemical_treatment ?? [])
+  let count = 0
+
+  if (treatments.has("colored") || treatments.has("bleached")) count++
+  if (
+    profile?.cuticle_condition === "rough" ||
+    profile?.cuticle_condition === "slightly_rough"
+  ) {
+    count++
+  }
+  if (hasStrongDrynessDamageCluster(profile)) count++
+  if (hasFrequentWashNeed(context.wash_frequency)) count++
+  if (context.mechanical_stress_factors.length > 0) count++
+
+  return count
+}
+
+function hasOwcProactiveBlock(context: RoutineContext): boolean {
+  return (
+    context.has_oil_weight_risk ||
+    context.scalp_type === "oily" ||
+    context.has_buildup_signals
+  )
+}
+
+function hasOwcFit(
+  profile: HairProfile | null,
+  context: RoutineContext,
+): boolean {
+  if (!context.has_wash_protection_need) return false
+
+  switch (profile?.hair_texture) {
+    case "wavy":
+      return countOwcSupportSignals(profile, context) >= 2 && !hasOwcProactiveBlock(context)
+    case "curly":
+    case "coily":
+      return !hasOwcProactiveBlock(context)
+    default:
+      return false
+  }
+}
+
+function isCwcOwcComparisonRequest(message: string): boolean {
+  const normalizedMessage = normalizeText(message)
+  return (
+    (includesAny(normalizedMessage, CWC_TERMS) && includesAny(normalizedMessage, OWC_TERMS)) ||
+    includesAny(normalizedMessage, CWC_OWC_COMPARISON_TERMS)
+  )
+}
+
+function getWashProtectionFallbackTopic(profile: HairProfile | null): "cwc" | "owc" | null {
+  switch (profile?.hair_texture) {
+    case "straight":
+    case "wavy":
+      return "cwc"
+    case "curly":
+    case "coily":
+      return "owc"
+    default:
+      return null
+  }
+}
+
+function selectWashProtectionTopic(
+  profile: HairProfile | null,
+  context: RoutineContext,
+  message: string,
+): { topicId: "cwc" | "owc" | null; compareMode: boolean } {
+  const compareMode = isCwcOwcComparisonRequest(message)
+  const explicitCwc = context.explicit_topic_ids.includes("cwc")
+  const explicitOwc = context.explicit_topic_ids.includes("owc")
+
+  if (compareMode) {
+    return {
+      topicId:
+        (hasOwcFit(profile, context)
+          ? "owc"
+          : context.has_wash_protection_need
+            ? "cwc"
+            : getWashProtectionFallbackTopic(profile)),
+      compareMode,
+    }
+  }
+
+  if (explicitOwc) {
+    return { topicId: "owc", compareMode }
+  }
+
+  if (explicitCwc) {
+    return { topicId: "cwc", compareMode }
+  }
+
+  if (!context.has_wash_protection_need) {
+    return { topicId: null, compareMode }
+  }
+
+  switch (profile?.hair_texture) {
+    case "straight":
+      return { topicId: "cwc", compareMode }
+    case "wavy":
+      return { topicId: hasOwcFit(profile, context) ? "owc" : "cwc", compareMode }
+    case "curly":
+    case "coily":
+      return { topicId: hasOwcFit(profile, context) ? "owc" : null, compareMode }
+    default:
+      return { topicId: null, compareMode }
+  }
 }
 
 function buildPrimaryFocuses(
@@ -393,7 +532,8 @@ function getExplicitTopicIds(message: string): RoutineTopicId[] {
   if (includesAny(normalizedMessage, OILING_TERMS)) topics.push("hair_oiling")
   if (includesAny(normalizedMessage, BOND_BUILDER_TERMS)) topics.push("bond_builder")
   if (includesAny(normalizedMessage, REFRESH_TERMS)) topics.push("lockenrefresh")
-  if (includesAny(normalizedMessage, CWC_OWC_TERMS)) topics.push("cwc_owc")
+  if (includesAny(normalizedMessage, CWC_TERMS)) topics.push("cwc")
+  if (includesAny(normalizedMessage, OWC_TERMS)) topics.push("owc")
 
   return topics
 }
@@ -446,7 +586,7 @@ export function deriveRoutineContext(
     has_damage_signals: hasDamageSignals(profile),
     has_bond_builder_signals: hasBondBuilderSignals(profile),
     has_oil_weight_risk: hasOilWeightRisk(profile),
-    has_strong_technique_fit: hasStrongTechniqueFit(profile),
+    has_wash_protection_need: hasWashProtectionNeed(profile),
     uses_heat_protection: profile?.uses_heat_protection ?? false,
   }
 }
@@ -517,6 +657,7 @@ export function activateRoutineTopics(
   }
 
   const explicit = new Set(context.explicit_topic_ids)
+  const washProtectionSelection = selectWashProtectionTopic(profile, context, message)
 
   if (
     explicit.has("tiefenreinigung") ||
@@ -590,12 +731,21 @@ export function activateRoutineTopics(
     )
   }
 
-  if (explicit.has("cwc_owc") || context.has_strong_technique_fit) {
+  if (washProtectionSelection.topicId) {
+    const topicId = washProtectionSelection.topicId
+    const explicitRequest =
+      (topicId === "cwc" && explicit.has("cwc")) ||
+      (topicId === "owc" && explicit.has("owc"))
+
     push(
-      "cwc_owc",
-      explicit.has("cwc_owc")
-        ? "CWC/OWC wurde direkt angefragt."
-        : "Trockenheits- und Schadenssignale sprechen fuer eine optionale Technik-Variante.",
+      topicId,
+      washProtectionSelection.compareMode
+        ? `CWC und OWC wurden direkt verglichen; ${ROUTINE_TOPIC_LABELS[topicId]} passt hier voraussichtlich besser.`
+        : explicitRequest
+          ? `${ROUTINE_TOPIC_LABELS[topicId]} wurde direkt angefragt.`
+          : topicId === "cwc"
+            ? "Das Profil spricht eher fuer eine schonende Conditioner-Schutzwaesche."
+            : "Das Profil spricht eher fuer eine Oel-Vorwaesche mit anschliessender Schutzpflege.",
       60,
       true,
     )
@@ -672,6 +822,108 @@ function buildRoutineDecisionContext(profile: HairProfile | null): RoutineDecisi
   }
 }
 
+function buildCwcTechniqueSlot(): RoutineSlotAdvice {
+  return {
+    id: "base-cwc-technique",
+    kind: "instruction",
+    phase: "base_wash",
+    label: "CWC als Wash-Day-Schutz",
+    action: "add",
+    category: null,
+    cadence: "als Wash-Day-Variante bei Bedarf",
+    rationale: [
+      "CWC ist hier eine Wash-Day-Variante, kein Pflichtschritt fuer jede Waesche.",
+      "1. Conditioner auf trockene Laengen und Spitzen geben.",
+      "2. Shampoo nur an der Kopfhaut verwenden.",
+      "3. Den entstehenden Schaum sanft durch die Laengen gleiten lassen.",
+      "4. Zum Schluss erneut Conditioner auftragen und ausspuelen.",
+    ],
+    caveats: [
+      "Wenn die Haare schnell belegt wirken, nicht als Standard fuer jede Waesche etablieren.",
+    ],
+    topic_ids: ["cwc"],
+    product_linkable: false,
+    product_query: null,
+    attachment_priority: 92,
+  }
+}
+
+function buildOwcOilSlot(
+  profile: HairProfile | null,
+  context: RoutineContext,
+  explicitOwcRequest: boolean,
+  oilPresent: boolean,
+): RoutineSlotAdvice {
+  const oilAction: RoutineSlotAction = oilPresent ? "adjust" : "add"
+  const cautiousDueToWeight = context.has_oil_weight_risk
+
+  return {
+    id: "base-owc-oil",
+    kind: "product_slot",
+    phase: "base_wash",
+    label: "OWC Oel-Schutz",
+    action: oilAction,
+    category: "oil",
+    cadence: "als Wash-Day-Variante bei Bedarf",
+    rationale: [
+      "Fuer OWC braucht es ein sparsam dosiertes Oel nur fuer Laengen und Spitzen vor dem Waschen.",
+      oilPresent
+        ? "Wenn schon ein Oel in der Routine ist, hier eher Dosierung und Einsatz pruefen als direkt mehr Produkt zu stapeln."
+        : "Wenn noch kein Oel da ist, reicht fuer OWC ein leichtes Pre-Wash-Oel statt eines schweren Finish-Oels.",
+    ],
+    caveats: [
+      "Bei schnell fettender Kopfhaut oder Build-up nicht als Standard etablieren.",
+      "Bei feinem, dichtem Haar nur sehr sparsam dosieren.",
+      "Wenn die Haare schnell belegt wirken, eher bei CWC bleiben oder OWC nur punktuell testen.",
+    ],
+    topic_ids: ["owc"],
+    product_linkable: oilAction === "add" && !(explicitOwcRequest && cautiousDueToWeight),
+    product_query: "Ich suche ein natuerliches Oel fuer OWC vor dem Waschen.",
+    attachment_priority: 15,
+  }
+}
+
+function buildOwcTechniqueSlot(
+  profile: HairProfile | null,
+  context: RoutineContext,
+): RoutineSlotAdvice {
+  const caveats = [
+    "Bei schnell fettender Kopfhaut oder Build-up nicht als Standard etablieren.",
+    "Bei feinem, dichtem Haar nur sehr sparsam dosieren.",
+    "Wenn die Haare schnell belegt wirken, eher bei CWC bleiben oder OWC nur punktuell testen.",
+  ]
+
+  if (profile?.hair_texture === "straight") {
+    caveats.unshift("OWC ist bei glattem Haar meist nicht die erste Wahl und eher ein gezielter Test als ein Default.")
+  }
+
+  if (context.has_oil_weight_risk) {
+    caveats.push("Das Profil hat ein hoeheres Beschwerungsrisiko — lieber mit minimaler Menge starten.")
+  }
+
+  return {
+    id: "base-owc-technique",
+    kind: "instruction",
+    phase: "base_wash",
+    label: "OWC als Wash-Day-Schutz",
+    action: "add",
+    category: null,
+    cadence: "als Wash-Day-Variante bei Bedarf",
+    rationale: [
+      "OWC ist hier eine Wash-Day-Variante fuer mehr Schutz, nicht automatisch die Basis jeder Waesche.",
+      "1. Oel mit Praying Hands oder Scrunching sparsam in trockene Laengen und Spitzen geben.",
+      "2. Shampoo zuerst direkt am trockenen Ansatz verteilen.",
+      "3. Dann Wasser dazugeben und den Schaum sanft durch die Laengen ziehen.",
+      "4. Zum Schluss Conditioner auftragen und ausspuelen.",
+    ],
+    caveats,
+    topic_ids: ["owc"],
+    product_linkable: false,
+    product_query: null,
+    attachment_priority: 91,
+  }
+}
+
 function buildRoutineSlots(
   profile: HairProfile | null,
   context: RoutineContext,
@@ -681,6 +933,12 @@ function buildRoutineSlots(
 ): Map<RoutinePlanSection["phase"], RoutineSlotAdvice[]> {
   const sections = new Map<RoutinePlanSection["phase"], RoutineSlotAdvice[]>()
   const activeTopicIds = new Set(activations.map((entry) => entry.id))
+  const activeWashProtectionTopic = activeTopicIds.has("owc")
+    ? "owc"
+    : activeTopicIds.has("cwc")
+      ? "cwc"
+      : null
+  const explicitOwcRequest = context.explicit_topic_ids.includes("owc")
   const shampooPresent = hasCurrentProduct(profile, "shampoo")
   const conditionerPresent = hasCurrentProduct(profile, "conditioner")
   const leaveInPresent = hasCurrentProduct(profile, "leave_in")
@@ -755,6 +1013,15 @@ function buildRoutineSlots(
     product_query: "Ich suche einen Conditioner fuer meine Basisroutine.",
     attachment_priority: 20,
   })
+
+  if (activeWashProtectionTopic === "cwc") {
+    pushSlot(sections, buildCwcTechniqueSlot())
+  }
+
+  if (activeWashProtectionTopic === "owc") {
+    pushSlot(sections, buildOwcOilSlot(profile, context, explicitOwcRequest, oilPresent))
+    pushSlot(sections, buildOwcTechniqueSlot(profile, context))
+  }
 
   const shouldUseLeaveIn =
     Boolean(leaveInDecision.need_bucket) ||
@@ -1027,27 +1294,6 @@ function buildRoutineSlots(
     }
   }
 
-  if (activeTopicIds.has("cwc_owc")) {
-    pushSlot(sections, {
-      id: "occasional-cwc-owc",
-      kind: "instruction",
-      phase: "occasional",
-      label: "CWC / OWC als Technik-Option",
-      action: "add",
-      category: null,
-      cadence: "als Option statt dauerhaftem Pflichtschritt",
-      rationale: [
-        "CWC/OWC bleibt eine Technik-Variante fuer bestimmte Trockenheits- oder Schadenslagen.",
-        "Die Routine soll dadurch flexibler werden, nicht komplizierter.",
-      ],
-      caveats: [],
-      topic_ids: ["cwc_owc"],
-      product_linkable: false,
-      product_query: null,
-      attachment_priority: 97,
-    })
-  }
-
   return sections
 }
 
@@ -1058,6 +1304,7 @@ export function buildRoutinePlan(
 ): RoutinePlan {
   const context = deriveRoutineContext(profile, message)
   const activeTopics = activateRoutineTopics(profile, message, context)
+  const { compareMode } = selectWashProtectionTopic(profile, context, message)
   const decisionContext = buildRoutineDecisionContext(profile)
   const sectionSlots = buildRoutineSlots(profile, context, activeTopics, decisionContext, {
     usesBondBuilder: options.usesBondBuilder ?? false,
@@ -1082,6 +1329,7 @@ export function buildRoutinePlan(
     base_topic_id: getBaseRoutineTopicId(profile),
     primary_focuses: context.primary_focuses,
     active_topics: activeTopics,
+    compare_cwc_owc: compareMode,
     sections,
     decision_context: decisionContext,
   }
@@ -1092,11 +1340,17 @@ export function buildRoutineRetrievalSubqueries(
   plan: RoutinePlan,
 ): string[] {
   const focusSummary = plan.primary_focuses
+    .filter((focus) => !(focus.kind === "topic" && (focus.code === "cwc" || focus.code === "owc")))
     .slice(0, 2)
     .map((focus) => focus.label)
     .join(" ")
 
   const queries = new Set<string>([message])
+
+  if (plan.compare_cwc_owc) {
+    queries.add("CWC")
+    queries.add("OWC")
+  }
 
   for (const topic of plan.active_topics) {
     const query = focusSummary

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -381,7 +381,8 @@ export type RoutineTopicId =
   | "hair_oiling"
   | "bond_builder"
   | "lockenrefresh"
-  | "cwc_owc"
+  | "cwc"
+  | "owc"
 
 export type RoutineFocusKind = "goal" | "concern" | "topic" | "pattern" | "scalp"
 export type RoutineSlotAction = "keep" | "adjust" | "add" | "upgrade" | "avoid"
@@ -423,7 +424,7 @@ export interface RoutineContext {
   has_damage_signals: boolean
   has_bond_builder_signals: boolean
   has_oil_weight_risk: boolean
-  has_strong_technique_fit: boolean
+  has_wash_protection_need: boolean
   uses_heat_protection: boolean
 }
 
@@ -470,6 +471,7 @@ export interface RoutinePlan {
   base_topic_id: RoutineTopicId | null
   primary_focuses: RoutineFocus[]
   active_topics: RoutineTopicActivation[]
+  compare_cwc_owc: boolean
   sections: RoutinePlanSection[]
   decision_context: RoutineDecisionContext
 }

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -324,6 +324,174 @@ test.describe("Routine planner", () => {
     expect(plan.active_topics.map((topic) => topic.id)).not.toContain("hair_oiling")
   })
 
+  test("straight dry profile activates CWC as optional wash-day variant", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        concerns: ["dryness"],
+        chemical_treatment: ["colored"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine hilft gegen trockene Laengen?"
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("owc")
+
+    const cwcSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-cwc-technique")
+
+    expect(cwcSlot?.phase).toBe("base_wash")
+    expect(cwcSlot?.cadence).toBe("als Wash-Day-Variante bei Bedarf")
+    expect(cwcSlot?.rationale[0]).toContain("kein Pflichtschritt")
+    expect(cwcSlot?.rationale.some((line) => line.startsWith("1. Conditioner"))).toBe(true)
+  })
+
+  test("wavy mild need stays on CWC", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "wavy",
+        concerns: ["frizz"],
+        cuticle_condition: "smooth",
+        chemical_treatment: ["natural"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Meine welligen Haare haben Frizz."
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("owc")
+  })
+
+  test("wavy profile upgrades to OWC only with multiple stronger support signals", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "wavy",
+        concerns: ["dryness"],
+        cuticle_condition: "slightly_rough",
+        chemical_treatment: ["colored"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Meine welligen Haare sind trocken und strapaziert."
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("cwc")
+  })
+
+  test("curly dry profile gets OWC and a dedicated base-wash oil slot", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        thickness: "normal",
+        density: "medium",
+        concerns: [],
+        cuticle_condition: "smooth",
+        mechanical_stress_factors: ["rough_brushing"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu meinen Locken, wenn sie sich an Waschtagen schnell verhaken?"
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("hair_oiling")
+
+    const owcOilSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-owc-oil")
+    const occasionalOilSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-oil")
+
+    expect(owcOilSlot?.phase).toBe("base_wash")
+    expect(owcOilSlot?.category).toBe("oil")
+    expect(owcOilSlot?.action).toBe("add")
+    expect(owcOilSlot?.product_linkable).toBe(true)
+    expect(occasionalOilSlot).toBeUndefined()
+  })
+
+  test("OWC is not proactively activated when oil-weight risk is present", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        thickness: "fine",
+        density: "high",
+        concerns: ["dryness"],
+        cuticle_condition: "rough",
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu meinen Locken?"
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("owc")
+    expect(plan.sections.flatMap((section) => section.slots).find((slot) => slot.id === "base-owc-oil")).toBeUndefined()
+  })
+
+  test("explicit OWC ask with oil-weight risk keeps the slot but disables oil product matching", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        thickness: "fine",
+        density: "high",
+        concerns: ["dryness"],
+        cuticle_condition: "rough",
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Soll ich OWC testen?"
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
+
+    const owcOilSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-owc-oil")
+
+    expect(owcOilSlot?.action).toBe("add")
+    expect(owcOilSlot?.product_linkable).toBe(false)
+    expect(owcOilSlot?.caveats.some((line) => line.includes("feinem, dichtem Haar"))).toBe(true)
+  })
+
+  test("comparison requests set compare mode and still personalize to one variant", () => {
+    const profile = createProfile({
+      hair_texture: "curly",
+      concerns: ["dryness"],
+      cuticle_condition: "rough",
+      current_routine_products: ["shampoo", "conditioner"],
+    })
+
+    const plan = buildRoutinePlan(
+      profile,
+      "Was ist der Unterschied zwischen CWC und OWC?"
+    )
+    const prompt = buildSystemPrompt(
+      profile,
+      [createChunk()],
+      [],
+      "routine",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      plan,
+      null,
+      undefined,
+    )
+    const subqueries = buildRoutineRetrievalSubqueries(
+      "Was ist der Unterschied zwischen CWC und OWC?",
+      plan
+    )
+
+    expect(plan.compare_cwc_owc).toBe(true)
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("cwc")
+    expect(subqueries).toContain("CWC")
+    expect(subqueries).toContain("OWC")
+    expect(prompt).toContain("Vergleichsmodus")
+    expect(prompt).toContain("kompakten nummerierten Wash-Day-Schritte")
+  })
+
   test("unnecessary mask steps can still be deprioritized", () => {
     const maskPlan = buildRoutinePlan(
       createProfile({

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -246,6 +246,7 @@ test.describe("Routine planner", () => {
   test("active oiling slot includes wash-out rationale and essential oil caveat", () => {
     const plan = buildRoutinePlan(
       createProfile({
+        hair_texture: "straight",
         thickness: "normal",
         density: "low",
         concerns: ["dryness"],
@@ -284,6 +285,7 @@ test.describe("Routine planner", () => {
   test("irritated scalp gets both irritation caveat and essential oil caveat on active oiling", () => {
     const plan = buildRoutinePlan(
       createProfile({
+        hair_texture: "straight",
         thickness: "normal",
         density: "low",
         scalp_type: "dry",
@@ -490,6 +492,90 @@ test.describe("Routine planner", () => {
     expect(subqueries).toContain("OWC")
     expect(prompt).toContain("Vergleichsmodus")
     expect(prompt).toContain("kompakten nummerierten Wash-Day-Schritte")
+  })
+
+  test("explicit CWC on healthy profile uses educational mode", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        concerns: [],
+        goals: [],
+        cuticle_condition: "smooth",
+        chemical_treatment: ["natural"],
+        mechanical_stress_factors: [],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Was ist die CWC Methode?"
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
+
+    const cwcSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-cwc-technique")
+
+    expect(cwcSlot?.cadence).toBeNull()
+    expect(cwcSlot?.caveats.some((line) => line.includes("eher optional"))).toBe(true)
+    expect(cwcSlot?.product_linkable).toBe(false)
+    expect(cwcSlot?.rationale.some((line) => line.startsWith("1."))).toBe(false)
+  })
+
+  test("comparison on healthy profile does not activate any wash protection topic", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        concerns: [],
+        goals: [],
+        cuticle_condition: "smooth",
+        chemical_treatment: ["natural"],
+        mechanical_stress_factors: [],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Was ist der Unterschied zwischen CWC und OWC?"
+    )
+
+    expect(plan.compare_cwc_owc).toBe(true)
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("cwc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("owc")
+
+    const cwcSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-cwc-technique")
+    const owcSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-owc-technique")
+
+    expect(cwcSlot).toBeUndefined()
+    expect(owcSlot).toBeUndefined()
+  })
+
+  test("OWC suppresses duplicate occasional-oil slot when hair_oiling also activates", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "curly",
+        thickness: "normal",
+        density: "medium",
+        concerns: ["dryness"],
+        cuticle_condition: "rough",
+        scalp_condition: "dry_flakes",
+        mechanical_stress_factors: ["rough_brushing"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu meinen Locken?"
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
+
+    const owcOilSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-owc-oil")
+    const occasionalOilSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-oil")
+
+    expect(owcOilSlot).toBeDefined()
+    expect(owcOilSlot?.phase).toBe("base_wash")
+    expect(occasionalOilSlot).toBeUndefined()
   })
 
   test("unnecessary mask steps can still be deprioritized", () => {


### PR DESCRIPTION
## Summary
- replace the generic `cwc_owc` planner path with deterministic `cwc` vs `owc` selection
- keep CWC/OWC as optional wash-day variants and add a dedicated OWC base-wash oil slot
- add comparison-mode prompt behavior plus targeted routine planner coverage

## Testing
- `npm run typecheck`
- `npx playwright test tests/routine-planner.spec.ts`
