### PR TITLE
feat(admin): add chat observability traces

### DIFF
--- a/src/app/admin/conversations/[id]/page.tsx
+++ b/src/app/admin/conversations/[id]/page.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useParams } from "next/navigation"
 import Link from "next/link"
 import { useToast } from "@/providers/toast-provider"
+import type { ConversationTurnTrace, MessageRagContext } from "@/lib/types"
 import { fehler } from "@/lib/vocabulary"
 import { ArrowLeft } from "lucide-react"
 
@@ -12,6 +13,7 @@ interface MessageRow {
   role: "user" | "assistant" | "system"
   content: string | null
   created_at: string
+  rag_context?: MessageRagContext | null
 }
 
 interface ConversationDetail {
@@ -23,11 +25,315 @@ interface ConversationDetail {
     updated_at: string
   }
   messages: MessageRow[]
+  traces: ConversationTurnTrace[]
   user: {
     id: string
     full_name: string | null
     email: string
   } | null
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function formatTime(value: string): string {
+  return new Date(value).toLocaleTimeString("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function formatDuration(value?: number): string {
+  if (value == null || Number.isNaN(value)) return "—"
+  if (value < 1000) return `${value} ms`
+  return `${(value / 1000).toFixed(2)} s`
+}
+
+function TraceBadge({
+  label,
+  tone = "default",
+}: {
+  label: string
+  tone?: "default" | "success" | "danger"
+}) {
+  const className =
+    tone === "success"
+      ? "bg-emerald-500/10 text-emerald-700 border-emerald-500/20"
+      : tone === "danger"
+        ? "bg-rose-500/10 text-rose-700 border-rose-500/20"
+        : "bg-muted text-muted-foreground border-border"
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  )
+}
+
+function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
+  const trace = traceRecord.trace
+  const totalLatency = trace.latencies_ms.total_ms
+  const retrievalChunks = trace.retrieval.chunks ?? []
+  const matchedProducts = trace.decision_context.matched_products ?? []
+
+  return (
+    <details className="mt-3 rounded-xl border border-dashed bg-background/70 p-3">
+      <summary className="cursor-pointer list-none">
+        <div className="flex flex-wrap items-center gap-2">
+          <TraceBadge
+            label={trace.status === "completed" ? "Trace ok" : "Trace fehlgeschlagen"}
+            tone={trace.status === "completed" ? "success" : "danger"}
+          />
+          <TraceBadge label={trace.intent} />
+          <TraceBadge label={trace.router_decision.retrieval_mode} />
+          {trace.product_category ? <TraceBadge label={trace.product_category} /> : null}
+          <span className="text-xs text-muted-foreground">
+            Gesamt: {formatDuration(totalLatency)}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            Request: {trace.request_id}
+          </span>
+        </div>
+      </summary>
+
+      <div className="mt-4 space-y-4 text-sm">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div className="rounded-lg border bg-card p-3">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Routing</p>
+            <p className="mt-1 font-medium text-foreground">
+              {trace.router_decision.needs_clarification ? "Klaerungsrunde" : "Direkte Antwort"}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Confidence: {trace.router_decision.confidence.toFixed(2)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Slot-Completeness: {(trace.router_decision.slot_completeness * 100).toFixed(0)}%
+            </p>
+          </div>
+
+          <div className="rounded-lg border bg-card p-3">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Retrieval</p>
+            <p className="mt-1 font-medium text-foreground">
+              {trace.retrieval.final_context_count} finale Chunks
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Kandidaten vor Rerank: {trace.retrieval.candidate_count_before_rerank}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Rerankt: {trace.retrieval.reranked_count}
+            </p>
+          </div>
+
+          <div className="rounded-lg border bg-card p-3">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Produkte</p>
+            <p className="mt-1 font-medium text-foreground">
+              {matchedProducts.length} gematcht
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Routine-Plan: {trace.decision_context.should_plan_routine ? "ja" : "nein"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Antwortquellen: {trace.response.sources.length}
+            </p>
+          </div>
+
+          <div className="rounded-lg border bg-card p-3">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Timings</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Klassifikation: {formatDuration(trace.latencies_ms.classification_ms)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Retrieval: {formatDuration(trace.latencies_ms.retrieval_ms)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Prompt: {formatDuration(trace.latencies_ms.prompt_build_ms)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Stream: {formatDuration(trace.latencies_ms.stream_read_ms)}
+            </p>
+          </div>
+        </div>
+
+        {trace.router_decision.policy_overrides.length > 0 ? (
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Policy Overrides
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {trace.router_decision.policy_overrides.map((override) => (
+                <TraceBadge key={override} label={override} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {trace.clarification_questions.length > 0 ? (
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Klaerungsfragen
+            </p>
+            <div className="space-y-2 rounded-lg border bg-card p-3">
+              {trace.clarification_questions.map((question) => (
+                <p key={question} className="text-sm text-foreground">
+                  {question}
+                </p>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <div>
+          <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+            Retrieval-Pfad
+          </p>
+          <div className="rounded-lg border bg-card p-3">
+            <p className="text-xs text-muted-foreground">
+              Subqueries:{" "}
+              {trace.retrieval.subqueries.length > 0
+                ? trace.retrieval.subqueries.join(" | ")
+                : "—"}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Metadata-Filter:{" "}
+              {trace.retrieval.metadata_filter
+                ? JSON.stringify(trace.retrieval.metadata_filter)
+                : "—"}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Fallback: {trace.retrieval.fallback_used ? "ja" : "nein"}
+            </p>
+
+            <div className="mt-3 space-y-2">
+              {retrievalChunks.length === 0 ? (
+                <p className="text-xs text-muted-foreground">Keine Chunks gespeichert.</p>
+              ) : (
+                retrievalChunks.map((chunk) => (
+                  <div key={chunk.chunk_id} className="rounded-md border bg-background p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <TraceBadge label={chunk.source_type} />
+                      {chunk.retrieval_path ? <TraceBadge label={chunk.retrieval_path} /> : null}
+                      <span className="text-xs text-muted-foreground">
+                        Score: {chunk.weighted_similarity.toFixed(4)}
+                      </span>
+                      {chunk.source_name ? (
+                        <span className="text-xs text-muted-foreground">
+                          {chunk.source_name}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">
+                      {chunk.content_preview}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+            Gematchte Produkte
+          </p>
+          <div className="rounded-lg border bg-card p-3">
+            {matchedProducts.length === 0 ? (
+              <p className="text-xs text-muted-foreground">Keine Produktmatches fuer diesen Turn.</p>
+            ) : (
+              <div className="space-y-2">
+                {matchedProducts.map((product) => (
+                  <div key={product.id} className="rounded-md border bg-background p-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium text-foreground">
+                        {product.brand ? `${product.name} von ${product.brand}` : product.name}
+                      </span>
+                      {product.category ? <TraceBadge label={product.category} /> : null}
+                      <span className="text-xs text-muted-foreground">
+                        Score: {product.score != null ? product.score.toFixed(1) : "—"}
+                      </span>
+                    </div>
+                    {product.top_reasons.length > 0 ? (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {product.top_reasons.join(" | ")}
+                      </p>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-3 xl:grid-cols-2">
+          <div className="rounded-lg border bg-card p-3">
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Prompt Snapshot
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Modell: {trace.prompt.model} · Temperatur: {trace.prompt.temperature}
+            </p>
+            <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-background p-3 text-xs text-foreground">
+              {trace.prompt.system_prompt}
+            </pre>
+          </div>
+
+          <div className="rounded-lg border bg-card p-3">
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Modell-Input
+            </p>
+            <div className="max-h-72 space-y-2 overflow-auto">
+              {trace.prompt.messages.map((message, index) => (
+                <div key={`${message.role}-${index}`} className="rounded-md border bg-background p-3">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {message.role}
+                  </p>
+                  <pre className="mt-2 whitespace-pre-wrap text-xs text-foreground">
+                    {message.content}
+                  </pre>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-3 xl:grid-cols-2">
+          <div className="rounded-lg border bg-card p-3">
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Entscheidungskontext
+            </p>
+            <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-background p-3 text-xs text-foreground">
+              {JSON.stringify({
+                classification: trace.classification,
+                router_decision: trace.router_decision,
+                category_decision: trace.decision_context.category_decision,
+                routine_plan: trace.decision_context.routine_plan,
+              }, null, 2)}
+            </pre>
+          </div>
+
+          <div className="rounded-lg border bg-card p-3">
+            <p className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
+              Profil Snapshot
+            </p>
+            <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-background p-3 text-xs text-foreground">
+              {JSON.stringify({
+                hair_profile_snapshot: trace.hair_profile_snapshot,
+                memory_context: trace.memory_context,
+                response: trace.response,
+                error: trace.error,
+              }, null, 2)}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </details>
+  )
 }
 
 export default function AdminConversationDetailPage() {
@@ -59,6 +365,21 @@ export default function AdminConversationDetailPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id])
 
+  const traceByAssistantMessageId = useMemo(() => {
+    const map = new Map<string, ConversationTurnTrace>()
+    for (const trace of data?.traces ?? []) {
+      if (trace.assistant_message_id) {
+        map.set(trace.assistant_message_id, trace)
+      }
+    }
+    return map
+  }, [data?.traces])
+
+  const orphanTraces = useMemo(
+    () => (data?.traces ?? []).filter((trace) => !trace.assistant_message_id),
+    [data?.traces]
+  )
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -75,74 +396,103 @@ export default function AdminConversationDetailPage() {
     )
   }
 
-  const { conversation, messages, user: chatUser } = data
+  const { conversation, messages, user: chatUser, traces } = data
 
   return (
     <div>
-      {/* Header */}
       <div className="mb-6">
         <Link
           href="/admin/conversations"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+          className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" />
           Zurueck zu Chats
         </Link>
 
-        <div className="flex items-start justify-between">
+        <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <h1 className="text-2xl font-bold">
               {conversation.title || "Konversation"}
             </h1>
-            <p className="text-sm text-muted-foreground mt-1">
-              {chatUser?.full_name || "Unbekannt"} ({chatUser?.email}) &middot;{" "}
-              {messages.length} Nachrichten &middot;{" "}
-              {new Date(conversation.created_at).toLocaleDateString("de-DE")}
+            <p className="mt-1 text-sm text-muted-foreground">
+              {chatUser?.full_name || "Unbekannt"} ({chatUser?.email}) ·{" "}
+              {messages.length} Nachrichten · {formatDateTime(conversation.created_at)}
+            </p>
+          </div>
+          <div className="rounded-xl border bg-card px-4 py-3 text-sm">
+            <p className="text-muted-foreground">Observability</p>
+            <p className="mt-1 font-medium text-foreground">
+              {traces.length} gespeicherte Turn-Traces
             </p>
           </div>
         </div>
       </div>
 
-      {/* Messages */}
       <div className="space-y-4 rounded-xl border bg-card p-4">
         {messages.length === 0 ? (
-          <p className="text-center text-muted-foreground py-8">
+          <p className="py-8 text-center text-muted-foreground">
             Keine Nachrichten vorhanden.
           </p>
         ) : (
-          messages.map((msg) => (
-            <div
-              key={msg.id}
-              className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
-            >
-              <div
-                className={`max-w-[80%] rounded-xl px-4 py-3 ${
-                  msg.role === "user"
-                    ? "bg-primary text-primary-foreground"
-                    : msg.role === "assistant"
-                      ? "bg-muted"
-                      : "bg-muted/50 text-xs italic"
-                }`}
-              >
-                <div className="flex items-center gap-2 mb-1">
-                  <span className="text-xs font-medium opacity-70">
-                    {msg.role === "user" ? "Nutzer" : msg.role === "assistant" ? "TomBot" : "System"}
-                  </span>
-                  <span className="text-xs opacity-50">
-                    {new Date(msg.created_at).toLocaleTimeString("de-DE", {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </span>
+          messages.map((msg) => {
+            const trace = traceByAssistantMessageId.get(msg.id)
+
+            return (
+              <div key={msg.id}>
+                <div
+                  className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-xl px-4 py-3 ${
+                      msg.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : msg.role === "assistant"
+                          ? "bg-muted"
+                          : "bg-muted/50 text-xs italic"
+                    }`}
+                  >
+                    <div className="mb-1 flex items-center gap-2">
+                      <span className="text-xs font-medium opacity-70">
+                        {msg.role === "user"
+                          ? "Nutzer"
+                          : msg.role === "assistant"
+                            ? "TomBot"
+                            : "System"}
+                      </span>
+                      <span className="text-xs opacity-50">
+                        {formatTime(msg.created_at)}
+                      </span>
+                    </div>
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed">
+                      {msg.content || "—"}
+                    </p>
+                    {msg.rag_context?.sources?.length ? (
+                      <p className="mt-2 text-xs opacity-60">
+                        Quellen gespeichert: {msg.rag_context.sources.length}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
-                <p className="text-sm whitespace-pre-wrap leading-relaxed">
-                  {msg.content || "—"}
-                </p>
+                {trace ? <TraceCard traceRecord={trace} /> : null}
               </div>
-            </div>
-          ))
+            )
+          })
         )}
       </div>
+
+      {orphanTraces.length > 0 ? (
+        <div className="mt-6 rounded-xl border bg-card p-4">
+          <h2 className="text-lg font-semibold">Fehlgeschlagene oder verwaiste Traces</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Diese Traces konnten keiner gespeicherten Assistant-Nachricht zugeordnet werden.
+          </p>
+          <div className="mt-4 space-y-3">
+            {orphanTraces.map((trace) => (
+              <TraceCard key={trace.id} traceRecord={trace} />
+            ))}
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/app/api/admin/conversations/[id]/route.ts
+++ b/src/app/api/admin/conversations/[id]/route.ts
@@ -50,7 +50,7 @@ export async function GET(
   // Fetch messages
   const { data: messages, error: msgError } = await admin
     .from("messages")
-    .select("id, conversation_id, role, content, product_recommendations, created_at")
+    .select("id, conversation_id, role, content, product_recommendations, rag_context, created_at")
     .eq("conversation_id", id)
     .order("created_at", { ascending: true })
 
@@ -59,6 +59,19 @@ export async function GET(
       { error: fehler("Laden", "der Nachrichten") },
       { status: 500 }
     )
+  }
+
+  let traces: unknown[] = []
+  const { data: traceRows, error: traceError } = await admin
+    .from("conversation_turn_traces")
+    .select("id, conversation_id, user_id, user_message_id, assistant_message_id, status, trace, created_at, updated_at")
+    .eq("conversation_id", id)
+    .order("created_at", { ascending: true })
+
+  if (traceError) {
+    console.error("Error fetching conversation turn traces:", traceError)
+  } else {
+    traces = traceRows ?? []
   }
 
   // Fetch user profile + hair profile
@@ -71,6 +84,7 @@ export async function GET(
   return NextResponse.json({
     conversation,
     messages: messages || [],
+    traces,
     user: userProfile,
   })
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -3,6 +3,10 @@ import { createAdminClient } from "@/lib/supabase/admin"
 import { runPipeline } from "@/lib/rag/pipeline"
 import { buildAssistantRagContext, buildDoneEventData } from "@/lib/rag/chat-response"
 import { extractConversationMemory } from "@/lib/rag/memory-extractor"
+import {
+  buildRetrievalDebugEventData,
+  finalizeChatTurnTrace,
+} from "@/lib/rag/debug-trace"
 import { chatMessageSchema } from "@/lib/validators"
 import { ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
@@ -27,6 +31,25 @@ function checkRateLimit(userId: string): boolean {
 
   entry.count++
   return true
+}
+
+async function persistConversationTurnTrace(params: {
+  conversation_id: string | null
+  user_id: string
+  user_message_id: string | null
+  assistant_message_id: string | null
+  status: "completed" | "failed"
+  trace: unknown
+}) {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin.from("conversation_turn_traces").insert(params)
+    if (error) {
+      console.error("Failed to persist conversation turn trace:", error)
+    }
+  } catch (error) {
+    console.error("Failed to persist conversation turn trace:", error)
+  }
 }
 
 export async function POST(request: Request) {
@@ -57,6 +80,8 @@ export async function POST(request: Request) {
   }
 
   const { message, conversation_id } = parsed.data
+  const requestId = crypto.randomUUID()
+  const requestStart = performance.now()
 
   try {
     const {
@@ -68,19 +93,29 @@ export async function POST(request: Request) {
       retrievalSummary,
       routerDecision,
       categoryDecision,
+      debugTrace,
     } = await runPipeline({
       message,
       conversationId: conversation_id,
       userId: user.id,
+      requestId,
     })
 
     // Save user message
     const admin = createAdminClient()
-    await admin.from("messages").insert({
-      conversation_id: conversationId,
-      role: "user",
-      content: message,
-    })
+    const { data: userMessageRow, error: userMessageError } = await admin
+      .from("messages")
+      .insert({
+        conversation_id: conversationId,
+        role: "user",
+        content: message,
+      })
+      .select("id")
+      .single()
+
+    if (userMessageError) {
+      console.error("Failed to save user message:", userMessageError)
+    }
 
     // Create SSE response
     const encoder = new TextEncoder()
@@ -106,8 +141,18 @@ export async function POST(request: Request) {
           )
         )
 
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "retrieval_debug",
+              data: buildRetrievalDebugEventData(debugTrace),
+            })}\n\n`
+          )
+        )
+
         const reader = stream.getReader()
         let fullContent = ""
+        const streamReadStart = performance.now()
 
         try {
           while (true) {
@@ -147,13 +192,21 @@ export async function POST(request: Request) {
 
           // Save assistant message (with products for persistence)
           const admin = createAdminClient()
-          await admin.from("messages").insert({
-            conversation_id: conversationId,
-            role: "assistant",
-            content: fullContent,
-            rag_context: buildAssistantRagContext(sources, categoryDecision),
-            product_recommendations: productsToSend.length > 0 ? productsToSend : null,
-          })
+          const { data: assistantMessageRow, error: assistantMessageError } = await admin
+            .from("messages")
+            .insert({
+              conversation_id: conversationId,
+              role: "assistant",
+              content: fullContent,
+              rag_context: buildAssistantRagContext(sources, categoryDecision),
+              product_recommendations: productsToSend.length > 0 ? productsToSend : null,
+            })
+            .select("id")
+            .single()
+
+          if (assistantMessageError) {
+            console.error("Failed to save assistant message:", assistantMessageError)
+          }
 
           // Update conversation updated_at
           await admin
@@ -180,6 +233,24 @@ export async function POST(request: Request) {
             })
             .eq("id", user.id)
 
+          const completedTrace = finalizeChatTurnTrace(debugTrace, {
+            assistant_content: fullContent,
+            sources,
+            product_count: productsToSend.length,
+            status: "completed",
+            stream_read_ms: Math.round(performance.now() - streamReadStart),
+            total_ms: Math.round(performance.now() - requestStart),
+          })
+
+          await persistConversationTurnTrace({
+            conversation_id: conversationId,
+            user_id: user.id,
+            user_message_id: userMessageRow?.id ?? null,
+            assistant_message_id: assistantMessageRow?.id ?? null,
+            status: "completed",
+            trace: completedTrace,
+          })
+
           controller.enqueue(
             encoder.encode(
               `data: ${JSON.stringify({
@@ -193,12 +264,33 @@ export async function POST(request: Request) {
               })}\n\n`
             )
           )
-        } catch {
+        } catch (error) {
           controller.enqueue(
             encoder.encode(
               `data: ${JSON.stringify({ type: "error", data: { message: "Stream-Fehler aufgetreten" } })}\n\n`
             )
           )
+
+          const errorMessage =
+            error instanceof Error ? error.message : "Unbekannter Stream-Fehler"
+          const failedTrace = finalizeChatTurnTrace(debugTrace, {
+            assistant_content: fullContent,
+            sources,
+            product_count: 0,
+            status: "failed",
+            error: errorMessage,
+            stream_read_ms: Math.round(performance.now() - streamReadStart),
+            total_ms: Math.round(performance.now() - requestStart),
+          })
+
+          await persistConversationTurnTrace({
+            conversation_id: conversationId,
+            user_id: user.id,
+            user_message_id: userMessageRow?.id ?? null,
+            assistant_message_id: null,
+            status: "failed",
+            trace: failedTrace,
+          })
         }
 
         controller.close()

--- a/src/lib/openai/chat.ts
+++ b/src/lib/openai/chat.ts
@@ -1,6 +1,9 @@
 import { getOpenAI } from "@/lib/openai/client"
 import type OpenAI from "openai"
 
+export const DEFAULT_CHAT_COMPLETION_MODEL = "gpt-4o"
+export const DEFAULT_CHAT_COMPLETION_TEMPERATURE = 0.7
+
 export interface StreamChatCompletionParams {
   messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]
   model?: string
@@ -15,8 +18,8 @@ export interface StreamChatCompletionParams {
  */
 export async function streamChatCompletion({
   messages,
-  model = "gpt-4o",
-  temperature = 0.7,
+  model = DEFAULT_CHAT_COMPLETION_MODEL,
+  temperature = DEFAULT_CHAT_COMPLETION_TEMPERATURE,
 }: StreamChatCompletionParams): Promise<ReadableStream<Uint8Array>> {
   const response = await getOpenAI().chat.completions.create({
     model,

--- a/src/lib/rag/debug-trace.ts
+++ b/src/lib/rag/debug-trace.ts
@@ -1,0 +1,231 @@
+import type { RetrieveContextDebug, RetrievedChunk } from "@/lib/rag/retriever"
+import type {
+  CategoryDecision,
+  ChatMatchedProductTrace,
+  ChatPromptSnapshot,
+  ChatRetrievedChunkTrace,
+  ChatTraceLatencyBreakdown,
+  ChatTurnTrace,
+  CitationSource,
+  ClassificationResult,
+  HairProfile,
+  Product,
+  ProductCategory,
+  RoutinePlan,
+  RouterDecision,
+} from "@/lib/types"
+
+const CHAT_TURN_TRACE_VERSION = 1
+const CONTENT_PREVIEW_LIMIT = 240
+
+export interface PipelineTraceDraft {
+  request_id: string
+  started_at: string
+  user_message: string
+  conversation_id: string | null
+  intent: ChatTurnTrace["intent"]
+  product_category: ProductCategory
+  conversation_history_count: number
+  classification: ClassificationResult
+  router_decision: RouterDecision
+  clarification_questions: string[]
+  hair_profile_snapshot: HairProfile | null
+  memory_context: string | null
+  retrieval: ChatTurnTrace["retrieval"]
+  decision_context: {
+    should_plan_routine: boolean
+    routine_plan: RoutinePlan | null
+    category_decision: CategoryDecision | null
+    matched_products: ChatMatchedProductTrace[]
+  }
+  prompt: ChatPromptSnapshot
+  latencies_ms: ChatTraceLatencyBreakdown
+}
+
+function toContentPreview(content: string): string {
+  return content.length > CONTENT_PREVIEW_LIMIT
+    ? `${content.slice(0, CONTENT_PREVIEW_LIMIT)}...`
+    : content
+}
+
+export function buildRetrievedChunkTrace(
+  chunks: RetrievedChunk[],
+): ChatRetrievedChunkTrace[] {
+  return chunks.map((chunk) => ({
+    chunk_id: chunk.id,
+    source_type: chunk.source_type,
+    source_name: chunk.source_name,
+    retrieval_path: chunk.retrieval_path,
+    weighted_similarity: chunk.weighted_similarity,
+    similarity: chunk.similarity,
+    dense_score: chunk.dense_score,
+    lexical_score: chunk.lexical_score,
+    fused_score: chunk.fused_score,
+    content_preview: toContentPreview(chunk.content),
+  }))
+}
+
+export function buildMatchedProductTrace(
+  products: Product[],
+): ChatMatchedProductTrace[] {
+  return products.map((product) => ({
+    id: product.id,
+    name: product.name,
+    brand: product.brand,
+    category: product.category,
+    score: product.recommendation_meta?.score ?? null,
+    top_reasons: product.recommendation_meta?.top_reasons ?? [],
+  }))
+}
+
+export function buildPipelineTraceDraft(params: {
+  request_id: string
+  started_at: string
+  user_message: string
+  conversation_id: string | null
+  intent: ChatTurnTrace["intent"]
+  product_category: ProductCategory
+  conversation_history_count: number
+  classification: ClassificationResult
+  router_decision: RouterDecision
+  clarification_questions?: string[]
+  hair_profile_snapshot: HairProfile | null
+  memory_context: string | null
+  retrieval_debug: RetrieveContextDebug
+  retrieval_count: number
+  retrieved_chunks: RetrievedChunk[]
+  should_plan_routine: boolean
+  routine_plan?: RoutinePlan
+  category_decision?: CategoryDecision
+  matched_products?: Product[]
+  prompt: ChatPromptSnapshot
+  latencies_ms: ChatTraceLatencyBreakdown
+}): PipelineTraceDraft {
+  const {
+    request_id,
+    started_at,
+    user_message,
+    conversation_id,
+    intent,
+    product_category,
+    conversation_history_count,
+    classification,
+    router_decision,
+    clarification_questions,
+    hair_profile_snapshot,
+    memory_context,
+    retrieval_debug,
+    retrieval_count,
+    retrieved_chunks,
+    should_plan_routine,
+    routine_plan,
+    category_decision,
+    matched_products,
+    prompt,
+    latencies_ms,
+  } = params
+
+  return {
+    request_id,
+    started_at,
+    user_message,
+    conversation_id,
+    intent,
+    product_category,
+    conversation_history_count,
+    classification,
+    router_decision,
+    clarification_questions: clarification_questions ?? [],
+    hair_profile_snapshot,
+    memory_context,
+    retrieval: {
+      requested_count: retrieval_count,
+      source_types: retrieval_debug.source_types,
+      metadata_filter: retrieval_debug.metadata_filter,
+      subqueries: retrieval_debug.subqueries,
+      candidate_count_before_rerank: retrieval_debug.candidate_count_before_rerank,
+      reranked_count: retrieval_debug.reranked_count,
+      fallback_used: retrieval_debug.fallback_used,
+      final_context_count: retrieved_chunks.length,
+      chunks: buildRetrievedChunkTrace(retrieved_chunks),
+    },
+    decision_context: {
+      should_plan_routine,
+      routine_plan: routine_plan ?? null,
+      category_decision: category_decision ?? null,
+      matched_products: buildMatchedProductTrace(matched_products ?? []),
+    },
+    prompt,
+    latencies_ms,
+  }
+}
+
+export function finalizeChatTurnTrace(
+  draft: PipelineTraceDraft,
+  params: {
+    assistant_content: string
+    sources: CitationSource[]
+    product_count: number
+    status: ChatTurnTrace["status"]
+    error?: string | null
+    completed_at?: string
+    stream_read_ms?: number
+    total_ms?: number
+  },
+): ChatTurnTrace {
+  const { assistant_content, sources, product_count, status, error, completed_at, stream_read_ms, total_ms } = params
+
+  return {
+    trace_version: CHAT_TURN_TRACE_VERSION,
+    request_id: draft.request_id,
+    started_at: draft.started_at,
+    completed_at: completed_at ?? new Date().toISOString(),
+    status,
+    user_message: draft.user_message,
+    conversation_id: draft.conversation_id,
+    intent: draft.intent,
+    product_category: draft.product_category,
+    conversation_history_count: draft.conversation_history_count,
+    classification: draft.classification,
+    router_decision: draft.router_decision,
+    clarification_questions: draft.clarification_questions,
+    hair_profile_snapshot: draft.hair_profile_snapshot,
+    memory_context: draft.memory_context,
+    retrieval: draft.retrieval,
+    decision_context: draft.decision_context,
+    prompt: draft.prompt,
+    response: {
+      assistant_content,
+      sources,
+      product_count,
+    },
+    latencies_ms: {
+      ...draft.latencies_ms,
+      ...(stream_read_ms !== undefined ? { stream_read_ms } : {}),
+      ...(total_ms !== undefined ? { total_ms } : {}),
+    },
+    error: error ?? null,
+  }
+}
+
+export function buildRetrievalDebugEventData(
+  draft: PipelineTraceDraft,
+): Record<string, unknown> {
+  return {
+    request_id: draft.request_id,
+    intent: draft.intent,
+    product_category: draft.product_category,
+    retrieval_mode: draft.router_decision.retrieval_mode,
+    needs_clarification: draft.router_decision.needs_clarification,
+    clarification_questions: draft.clarification_questions,
+    policy_overrides: draft.router_decision.policy_overrides,
+    subqueries: draft.retrieval.subqueries,
+    metadata_filter: draft.retrieval.metadata_filter,
+    final_context_count: draft.retrieval.final_context_count,
+    matched_products: draft.decision_context.matched_products.map((product) => ({
+      id: product.id,
+      name: product.name,
+      score: product.score,
+    })),
+  }
+}

--- a/src/lib/rag/pipeline.ts
+++ b/src/lib/rag/pipeline.ts
@@ -40,6 +40,10 @@ import { formatSourceName } from "@/lib/rag/source-names"
 import { generateConversationTitle } from "@/lib/rag/title-generator"
 import { emitRouterEvent } from "@/lib/rag/retrieval-telemetry"
 import {
+  buildPipelineTraceDraft,
+  type PipelineTraceDraft,
+} from "@/lib/rag/debug-trace"
+import {
   buildRoutineClarificationQuestions,
   buildRoutinePlan,
   buildRoutineRetrievalSubqueries,
@@ -69,6 +73,7 @@ export interface PipelineParams {
   message: string
   conversationId?: string
   userId: string
+  requestId: string
 }
 
 export interface PipelineResult {
@@ -82,6 +87,18 @@ export interface PipelineResult {
   /** Retrieval summary for the done event */
   retrievalSummary: {
     final_context_count: number
+  }
+  debugTrace: PipelineTraceDraft
+}
+
+async function measureAsync<T>(
+  work: () => Promise<T>,
+): Promise<{ result: T; durationMs: number }> {
+  const start = performance.now()
+  const result = await work()
+  return {
+    result,
+    durationMs: Math.round(performance.now() - start),
   }
 }
 
@@ -100,46 +117,62 @@ export interface PipelineResult {
 export async function runPipeline(
   params: PipelineParams
 ): Promise<PipelineResult> {
-  const { message, userId } = params
+  const { message, userId, requestId } = params
   let { conversationId } = params
+  const startedAt = new Date().toISOString()
 
   const supabase = createAdminClient()
 
-  // ── Step 1: Load conversation history + hair profile + memory (parallel) ─
-  const [conversationData, hairProfileResult, memoryContext] = await Promise.all([
-    conversationId
-      ? supabase
-          .from("messages")
-          .select("*")
-          .eq("conversation_id", conversationId)
-          .order("created_at", { ascending: true })
-          .limit(10)
-          .then(({ data }) => data)
-      : Promise.resolve(null),
-    supabase
-      .from("hair_profiles")
-      .select("*")
-      .eq("user_id", userId)
-      .single(),
-    loadUserMemoryContext(userId, supabase),
+  // ── Step 1: Load conversation history + hair profile + memory ─────
+  const [
+    { result: conversationData, durationMs: historyLoadMs },
+    { result: hairProfileResult, durationMs: hairProfileLoadMs },
+    { result: memoryContext, durationMs: memoryLoadMs },
+  ] = await Promise.all([
+    measureAsync(async () =>
+      conversationId
+        ? await supabase
+            .from("messages")
+            .select("*")
+            .eq("conversation_id", conversationId)
+            .order("created_at", { ascending: true })
+            .limit(10)
+            .then(({ data }) => data)
+        : null
+    ),
+    measureAsync(async () =>
+      await supabase
+        .from("hair_profiles")
+        .select("*")
+        .eq("user_id", userId)
+        .single()
+    ),
+    measureAsync(() => loadUserMemoryContext(userId, supabase)),
   ])
   const conversationHistory: Message[] = (conversationData as Message[]) ?? []
   const hairProfile: HairProfile | null = hairProfileResult.data ?? null
 
   // ── Step 1b: Classify intent (with conversation context) ───────────
-  const classification = await classifyIntent(message, conversationHistory)
+  const { result: classification, durationMs: classificationMs } = await measureAsync(() =>
+    classifyIntent(message, conversationHistory)
+  )
   const { intent, product_category } = classification
   const shouldPlanRoutine = intent === "routine_help" || product_category === "routine"
   let routinePlan: RoutinePlan | undefined
+  let routinePlanningMs = 0
   if (shouldPlanRoutine) {
-    const bondBuilderUsage = await supabase
-      .from("user_product_usage")
-      .select("id")
-      .eq("user_id", userId)
-      .eq("category", "bondbuilder")
-      .limit(1)
-    const usesBondBuilder = (bondBuilderUsage.data?.length ?? 0) > 0
-    routinePlan = buildRoutinePlan(hairProfile, message, { usesBondBuilder })
+    const routinePlanning = await measureAsync(async () => {
+      const bondBuilderUsage = await supabase
+        .from("user_product_usage")
+        .select("id")
+        .eq("user_id", userId)
+        .eq("category", "bondbuilder")
+        .limit(1)
+      const usesBondBuilder = (bondBuilderUsage.data?.length ?? 0) > 0
+      return buildRoutinePlan(hairProfile, message, { usesBondBuilder })
+    })
+    routinePlan = routinePlanning.result
+    routinePlanningMs = routinePlanning.durationMs
   }
   let shampooDecision = product_category === "shampoo"
     ? buildShampooDecision(hairProfile)
@@ -160,8 +193,9 @@ export async function runPipeline(
     : null
 
   // ── Step 2: Evaluate routing decision ───────────────────────────────
-  const routerStart = Date.now()
+  const routerStart = performance.now()
   const routerDecision = evaluateRoute(classification, conversationHistory, hairProfile, message)
+  const routerMs = Math.round(performance.now() - routerStart)
 
   emitRouterEvent({
     event: "router_classified",
@@ -172,7 +206,7 @@ export async function runPipeline(
     needs_clarification: routerDecision.needs_clarification,
     slot_completeness: routerDecision.slot_completeness,
     policy_overrides: routerDecision.policy_overrides,
-    stage_latency_ms: Date.now() - routerStart,
+    stage_latency_ms: routerMs,
   })
 
   // Emit override events if policy diverged from LLM suggestion
@@ -203,16 +237,21 @@ export async function runPipeline(
   }
 
   // ── Create conversation if it doesn't exist yet ─────────────────────
+  let conversationCreateMs = 0
   if (!conversationId) {
-    const { data: newConversation, error: convError } = await supabase
-      .from("conversations")
-      .insert({
-        user_id: userId,
-        title: null, // Title will be generated asynchronously
-        is_active: true,
-      })
-      .select("id")
-      .single()
+    const conversationCreate = await measureAsync(async () =>
+      supabase
+        .from("conversations")
+        .insert({
+          user_id: userId,
+          title: null, // Title will be generated asynchronously
+          is_active: true,
+        })
+        .select("id")
+        .single()
+    )
+    const { data: newConversation, error: convError } = conversationCreate.result
+    conversationCreateMs = conversationCreate.durationMs
 
     if (convError || !newConversation) {
       throw new Error(`Failed to create conversation: ${convError?.message}`)
@@ -242,14 +281,17 @@ export async function runPipeline(
           )
 
     // Minimal retrieval for context (but no product matching)
-    const ragChunks = await retrieveContext(message, {
+    const clarificationRetrievalCount = 3
+    const retrievalStart = performance.now()
+    const { chunks: ragChunks, debug: retrievalDebug } = await retrieveContext(message, {
       intent,
       hairProfile,
       shampooConcern: shampooDecision?.matched_concern_code ?? null,
-      count: 3,
+      count: clarificationRetrievalCount,
       subqueries: routinePlan ? buildRoutineRetrievalSubqueries(message, routinePlan) : undefined,
       userId,
     })
+    const retrievalMs = Math.round(performance.now() - retrievalStart)
 
     const sources: EnrichedCitationSource[] = ragChunks.map((chunk, i) => ({
       index: i + 1,
@@ -261,7 +303,7 @@ export async function runPipeline(
       retrieval_path: chunk.retrieval_path,
     }))
 
-    const stream = await synthesizeResponse({
+    const synthesisResult = await synthesizeResponse({
       userMessage: message,
       conversationHistory,
       hairProfile,
@@ -275,18 +317,56 @@ export async function runPipeline(
       memoryContext: memoryContext.promptContext,
       clarificationQuestions,
     })
+    const categoryDecision =
+      shampooDecision ?? conditionerDecision ?? leaveInDecision ?? oilDecision
+    const debugTrace = buildPipelineTraceDraft({
+      request_id: requestId,
+      started_at: startedAt,
+      user_message: message,
+      conversation_id: conversationId ?? null,
+      intent,
+      product_category,
+      conversation_history_count: conversationHistory.length,
+      classification,
+      router_decision: routerDecision,
+      clarification_questions: clarificationQuestions,
+      hair_profile_snapshot: hairProfile,
+      memory_context: memoryContext.promptContext,
+      retrieval_debug: retrievalDebug,
+      retrieval_count: clarificationRetrievalCount,
+      retrieved_chunks: ragChunks,
+      should_plan_routine: shouldPlanRoutine,
+      routine_plan: routinePlan,
+      category_decision: categoryDecision,
+      matched_products: [],
+      prompt: synthesisResult.debug.prompt,
+      latencies_ms: {
+        classification_ms: classificationMs,
+        hair_profile_load_ms: hairProfileLoadMs,
+        memory_load_ms: memoryLoadMs,
+        routine_planning_ms: routinePlanningMs,
+        history_load_ms: historyLoadMs,
+        router_ms: routerMs,
+        conversation_create_ms: conversationCreateMs,
+        retrieval_ms: retrievalMs,
+        product_matching_ms: 0,
+        prompt_build_ms: synthesisResult.debug.prompt_build_ms,
+        stream_setup_ms: synthesisResult.debug.stream_setup_ms,
+      },
+    })
 
     return {
-      stream,
+      stream: synthesisResult.stream,
       conversationId: conversationId!,
       intent,
       matchedProducts: [],
       sources,
       routerDecision,
-      categoryDecision: shampooDecision ?? conditionerDecision ?? leaveInDecision ?? oilDecision,
+      categoryDecision,
       retrievalSummary: {
         final_context_count: ragChunks.length,
       },
+      debugTrace,
     }
   }
 
@@ -312,7 +392,8 @@ export async function runPipeline(
   // FAQ mode: smaller retrieval, skip reranker
   const retrievalCount = routerDecision.retrieval_mode === "faq" ? 3 : 5
 
-  const ragChunks = await retrieveContext(message, {
+  const retrievalStart = performance.now()
+  const { chunks: ragChunks, debug: retrievalDebug } = await retrieveContext(message, {
     intent,
     hairProfile,
     metadataFilter,
@@ -321,6 +402,7 @@ export async function runPipeline(
     subqueries: routinePlan ? buildRoutineRetrievalSubqueries(message, routinePlan) : undefined,
     userId,
   })
+  const retrievalMs = Math.round(performance.now() - retrievalStart)
 
   // ── Build enriched citation sources from retrieved chunks ─────────
   const sources: EnrichedCitationSource[] = ragChunks.map((chunk, i) => ({
@@ -336,6 +418,7 @@ export async function runPipeline(
   // ── Step 4: Match products (if intent requires it) ──────────────────
   let matchedProducts: Product[] | undefined = undefined
   let maskDecision: MaskDecision | undefined
+  const productMatchingStart = performance.now()
   if (shouldPlanRoutine && routinePlan) {
     const routineResult = await attachProductsToRoutinePlan({
       plan: routinePlan,
@@ -537,13 +620,14 @@ export async function runPipeline(
       })
     }
   }
+  const productMatchingMs = Math.round(performance.now() - productMatchingStart)
 
   if (matchedProducts && !shouldPlanRoutine) {
     matchedProducts = applyProductMemoryConstraints(matchedProducts, memoryContext)
   }
 
   // ── Step 5: Synthesize streaming response ───────────────────────────
-  const stream = await synthesizeResponse({
+  const synthesisResult = await synthesizeResponse({
     userMessage: message,
     conversationHistory,
     hairProfile,
@@ -559,17 +643,54 @@ export async function runPipeline(
     routinePlan,
     memoryContext: memoryContext.promptContext,
   })
+  const categoryDecision =
+    shampooDecision ?? conditionerDecision ?? leaveInDecision ?? oilDecision
+  const debugTrace = buildPipelineTraceDraft({
+    request_id: requestId,
+    started_at: startedAt,
+    user_message: message,
+    conversation_id: conversationId ?? null,
+    intent,
+    product_category,
+    conversation_history_count: conversationHistory.length,
+    classification,
+    router_decision: routerDecision,
+    hair_profile_snapshot: hairProfile,
+    memory_context: memoryContext.promptContext,
+    retrieval_debug: retrievalDebug,
+    retrieval_count: retrievalCount,
+    retrieved_chunks: ragChunks,
+    should_plan_routine: shouldPlanRoutine,
+    routine_plan: routinePlan,
+    category_decision: categoryDecision,
+    matched_products: matchedProducts ?? [],
+    prompt: synthesisResult.debug.prompt,
+    latencies_ms: {
+      classification_ms: classificationMs,
+      hair_profile_load_ms: hairProfileLoadMs,
+      memory_load_ms: memoryLoadMs,
+      routine_planning_ms: routinePlanningMs,
+      history_load_ms: historyLoadMs,
+      router_ms: routerMs,
+      conversation_create_ms: conversationCreateMs,
+      retrieval_ms: retrievalMs,
+      product_matching_ms: productMatchingMs,
+      prompt_build_ms: synthesisResult.debug.prompt_build_ms,
+      stream_setup_ms: synthesisResult.debug.stream_setup_ms,
+    },
+  })
 
   return {
-    stream,
+    stream: synthesisResult.stream,
     conversationId: conversationId!,
     intent,
     matchedProducts: matchedProducts ?? [],
     sources,
     routerDecision,
-    categoryDecision: shampooDecision ?? conditionerDecision ?? leaveInDecision ?? oilDecision,
+    categoryDecision,
     retrievalSummary: {
       final_context_count: ragChunks.length,
     },
+    debugTrace,
   }
 }

--- a/src/lib/rag/retriever.ts
+++ b/src/lib/rag/retriever.ts
@@ -58,6 +58,20 @@ export interface RetrieveOptions {
   userId?: string
 }
 
+export interface RetrieveContextDebug {
+  subqueries: string[]
+  source_types: string[] | null
+  metadata_filter: Record<string, string> | null
+  candidate_count_before_rerank: number
+  reranked_count: number
+  fallback_used: boolean
+}
+
+export interface RetrieveContextResult {
+  chunks: RetrievedChunk[]
+  debug: RetrieveContextDebug
+}
+
 // ── Internal types for RRF fusion ─────────────────────────────────────────────
 
 interface DenseRow {
@@ -366,7 +380,7 @@ function applyProfileBoostAndDedup(
 export async function retrieveContext(
   query: string,
   options: RetrieveOptions = {},
-): Promise<RetrievedChunk[]> {
+): Promise<RetrieveContextResult> {
   const {
     intent,
     hairProfile,
@@ -386,6 +400,7 @@ export async function retrieveContext(
     const subqueries = providedSubqueries ?? await decomposeQuery(query)
 
     let candidates: RetrievedChunk[]
+    const fallbackUsed = false
 
     if (includeKeyword) {
       // Hybrid path: dense + lexical + RRF
@@ -429,7 +444,17 @@ export async function retrieveContext(
       top_source_types: topSourceTypes(reranked.slice(0, count)),
     })
 
-    return applyProfileBoostAndDedup(reranked, hairProfile, shampooConcern, count)
+    return {
+      chunks: applyProfileBoostAndDedup(reranked, hairProfile, shampooConcern, count),
+      debug: {
+        subqueries,
+        source_types: sourceTypes,
+        metadata_filter: metadataFilter ?? null,
+        candidate_count_before_rerank: candidates.length,
+        reranked_count: reranked.length,
+        fallback_used: fallbackUsed,
+      },
+    }
   } catch (error) {
     // FR-11: Fail safe to dense-only retrieval
     console.error("Hybrid retrieval failed, falling back to dense-only:", error)
@@ -441,10 +466,30 @@ export async function retrieveContext(
     })
     try {
       const candidates = await retrieveDenseOnly(query, sourceTypes, metadataFilter)
-      return applyProfileBoostAndDedup(candidates, hairProfile, shampooConcern, count)
+      return {
+        chunks: applyProfileBoostAndDedup(candidates, hairProfile, shampooConcern, count),
+        debug: {
+          subqueries: providedSubqueries ?? [query],
+          source_types: sourceTypes,
+          metadata_filter: metadataFilter ?? null,
+          candidate_count_before_rerank: candidates.length,
+          reranked_count: candidates.length,
+          fallback_used: true,
+        },
+      }
     } catch (fallbackError) {
       console.error("Dense-only fallback also failed:", fallbackError)
-      return []
+      return {
+        chunks: [],
+        debug: {
+          subqueries: providedSubqueries ?? [query],
+          source_types: sourceTypes,
+          metadata_filter: metadataFilter ?? null,
+          candidate_count_before_rerank: 0,
+          reranked_count: 0,
+          fallback_used: true,
+        },
+      }
     }
   }
 }

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -1,4 +1,8 @@
-import { streamChatCompletion } from "@/lib/openai/chat"
+import {
+  DEFAULT_CHAT_COMPLETION_MODEL,
+  DEFAULT_CHAT_COMPLETION_TEMPERATURE,
+  streamChatCompletion,
+} from "@/lib/openai/chat"
 import { SYSTEM_PROMPT } from "@/lib/rag/prompts"
 import {
   CONDITIONER_REPAIR_LEVEL_LABELS,
@@ -52,6 +56,8 @@ import type {
   LeaveInDecision,
   OilDecision,
   RoutinePlan,
+  ChatPromptMessageSnapshot,
+  ChatPromptSnapshot,
 } from "@/lib/types"
 import type OpenAI from "openai"
 
@@ -72,6 +78,15 @@ export interface SynthesizeParams {
   memoryContext?: string | null
   /** Slot-aware clarification questions from the router (replaces consultationMode) */
   clarificationQuestions?: string[]
+}
+
+export interface SynthesisResult {
+  stream: ReadableStream<Uint8Array>
+  debug: {
+    prompt: ChatPromptSnapshot
+    prompt_build_ms: number
+    stream_setup_ms: number
+  }
 }
 
 function appendMemoryContext(profileText: string, memoryContext?: string | null): string {
@@ -957,7 +972,7 @@ export function buildSystemPrompt(
  */
 export async function synthesizeResponse(
   params: SynthesizeParams
-): Promise<ReadableStream<Uint8Array>> {
+): Promise<SynthesisResult> {
   const {
     userMessage,
     conversationHistory,
@@ -975,6 +990,7 @@ export async function synthesizeResponse(
     clarificationQuestions,
   } = params
 
+  const promptBuildStart = performance.now()
   const systemPrompt = buildSystemPrompt(
     hairProfile,
     ragChunks,
@@ -1009,5 +1025,42 @@ export async function synthesizeResponse(
   // Add the current user message
   messages.push({ role: "user", content: userMessage })
 
-  return streamChatCompletion({ messages })
+  const promptMessages: ChatPromptMessageSnapshot[] = messages
+    .filter(
+      (
+        msg,
+      ): msg is OpenAI.Chat.Completions.ChatCompletionMessageParam & {
+        role: "system" | "user" | "assistant"
+        content: string
+      } =>
+        (msg.role === "system" || msg.role === "user" || msg.role === "assistant") &&
+        typeof msg.content === "string",
+    )
+    .map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }))
+
+  const promptBuildMs = Math.round(performance.now() - promptBuildStart)
+  const streamSetupStart = performance.now()
+  const stream = await streamChatCompletion({
+    messages,
+    model: DEFAULT_CHAT_COMPLETION_MODEL,
+    temperature: DEFAULT_CHAT_COMPLETION_TEMPERATURE,
+  })
+  const streamSetupMs = Math.round(performance.now() - streamSetupStart)
+
+  return {
+    stream,
+    debug: {
+      prompt: {
+        model: DEFAULT_CHAT_COMPLETION_MODEL,
+        temperature: DEFAULT_CHAT_COMPLETION_TEMPERATURE,
+        system_prompt: systemPrompt,
+        messages: promptMessages,
+      },
+      prompt_build_ms: promptBuildMs,
+      stream_setup_ms: streamSetupMs,
+    },
+  }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -481,6 +481,111 @@ export interface MessageRagContext {
   category_decision?: CategoryDecision | null
 }
 
+export interface ChatPromptMessageSnapshot {
+  role: "system" | "user" | "assistant"
+  content: string
+}
+
+export interface ChatPromptSnapshot {
+  model: string
+  temperature: number
+  system_prompt: string
+  messages: ChatPromptMessageSnapshot[]
+}
+
+export interface ChatRetrievedChunkTrace {
+  chunk_id: string
+  source_type: string
+  source_name: string | null
+  retrieval_path?: "dense" | "lexical" | "hybrid"
+  weighted_similarity: number
+  similarity: number
+  dense_score?: number
+  lexical_score?: number
+  fused_score?: number
+  content_preview: string
+}
+
+export interface ChatMatchedProductTrace {
+  id: string
+  name: string
+  brand: string | null
+  category: string | null
+  score: number | null
+  top_reasons: string[]
+}
+
+export interface ChatTraceLatencyBreakdown {
+  classification_ms: number
+  hair_profile_load_ms: number
+  memory_load_ms: number
+  routine_planning_ms: number
+  history_load_ms: number
+  router_ms: number
+  conversation_create_ms: number
+  retrieval_ms: number
+  product_matching_ms: number
+  prompt_build_ms: number
+  stream_setup_ms: number
+  stream_read_ms?: number
+  total_ms?: number
+}
+
+export interface ChatTurnTrace {
+  trace_version: number
+  request_id: string
+  started_at: string
+  completed_at: string
+  status: "completed" | "failed"
+  user_message: string
+  conversation_id: string | null
+  intent: IntentType
+  product_category: ProductCategory
+  conversation_history_count: number
+  classification: ClassificationResult
+  router_decision: RouterDecision
+  clarification_questions: string[]
+  hair_profile_snapshot: HairProfile | null
+  memory_context: string | null
+  retrieval: {
+    requested_count: number
+    source_types: string[] | null
+    metadata_filter: Record<string, string> | null
+    subqueries: string[]
+    candidate_count_before_rerank: number
+    reranked_count: number
+    fallback_used: boolean
+    final_context_count: number
+    chunks: ChatRetrievedChunkTrace[]
+  }
+  decision_context: {
+    should_plan_routine: boolean
+    routine_plan: RoutinePlan | null
+    category_decision: CategoryDecision | null
+    matched_products: ChatMatchedProductTrace[]
+  }
+  prompt: ChatPromptSnapshot
+  response: {
+    assistant_content: string
+    sources: CitationSource[]
+    product_count: number
+  }
+  latencies_ms: ChatTraceLatencyBreakdown
+  error: string | null
+}
+
+export interface ConversationTurnTrace {
+  id: string
+  conversation_id: string | null
+  user_id: string
+  user_message_id: string | null
+  assistant_message_id: string | null
+  status: "completed" | "failed"
+  trace: ChatTurnTrace
+  created_at: string
+  updated_at: string
+}
+
 export interface Conversation {
   id: string
   user_id: string

--- a/supabase/migrations/20260410113000_add_conversation_turn_traces.sql
+++ b/supabase/migrations/20260410113000_add_conversation_turn_traces.sql
@@ -1,0 +1,27 @@
+create table conversation_turn_traces (
+    id                 uuid primary key default uuid_generate_v4(),
+    conversation_id    uuid references conversations (id) on delete set null,
+    user_id            uuid not null references profiles (id) on delete cascade,
+    user_message_id    uuid references messages (id) on delete set null,
+    assistant_message_id uuid references messages (id) on delete set null,
+    status             text not null check (status in ('completed', 'failed')),
+    trace              jsonb not null,
+    created_at         timestamptz default now(),
+    updated_at         timestamptz default now()
+);
+
+create index idx_conversation_turn_traces_conversation_id
+    on conversation_turn_traces (conversation_id, created_at desc);
+
+create index idx_conversation_turn_traces_user_id
+    on conversation_turn_traces (user_id, created_at desc);
+
+create index idx_conversation_turn_traces_assistant_message_id
+    on conversation_turn_traces (assistant_message_id);
+
+alter table conversation_turn_traces enable row level security;
+
+create trigger set_updated_at_conversation_turn_traces
+    before update on conversation_turn_traces
+    for each row
+    execute function public.update_updated_at_column();

--- a/tests/chat-debug-trace.spec.ts
+++ b/tests/chat-debug-trace.spec.ts
@@ -1,0 +1,373 @@
+import { expect, test } from "@playwright/test"
+import {
+  buildPipelineTraceDraft,
+  buildRetrievalDebugEventData,
+  finalizeChatTurnTrace,
+} from "../src/lib/rag/debug-trace"
+import type { RetrievedChunk } from "../src/lib/rag/retriever"
+import type {
+  ChatPromptSnapshot,
+  ClassificationResult,
+  HairProfile,
+  Product,
+  RouterDecision,
+  RoutinePlan,
+} from "../src/lib/types"
+
+function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
+  return {
+    id: "profile-1",
+    user_id: "user-1",
+    hair_texture: "wavy",
+    thickness: "fine",
+    density: "medium",
+    concerns: ["frizz"],
+    products_used: null,
+    wash_frequency: "every_2_3_days",
+    heat_styling: "never",
+    styling_tools: [],
+    goals: ["less_frizz"],
+    cuticle_condition: "rough",
+    protein_moisture_balance: "stretches_bounces",
+    scalp_type: "balanced",
+    scalp_condition: "none",
+    chemical_treatment: ["colored"],
+    desired_volume: "balanced",
+    post_wash_actions: ["air_dry"],
+    routine_preference: "balanced",
+    current_routine_products: ["shampoo", "conditioner"],
+    mechanical_stress_factors: [],
+    towel_material: null,
+    towel_technique: null,
+    drying_method: [],
+    brush_type: null,
+    night_protection: [],
+    uses_heat_protection: false,
+    additional_notes: null,
+    conversation_memory: null,
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function createClassification(
+  overrides: Partial<ClassificationResult> = {},
+): ClassificationResult {
+  return {
+    intent: "routine_help",
+    product_category: "routine",
+    complexity: "multi_constraint",
+    needs_clarification: false,
+    retrieval_mode: "hybrid",
+    normalized_filters: {
+      problem: "Frizz in den Laengen",
+      duration: null,
+      products_tried: null,
+      routine: "2-3x pro Woche waschen",
+      special_circumstances: "coloriert",
+    },
+    router_confidence: 0.91,
+    ...overrides,
+  }
+}
+
+function createRouterDecision(
+  overrides: Partial<RouterDecision> = {},
+): RouterDecision {
+  return {
+    retrieval_mode: "hybrid",
+    needs_clarification: false,
+    clarification_reason: undefined,
+    slot_completeness: 0.8,
+    confidence: 0.91,
+    policy_overrides: ["faq_shortcut"],
+    ...overrides,
+  }
+}
+
+function createRetrievedChunk(
+  overrides: Partial<RetrievedChunk> = {},
+): RetrievedChunk {
+  return {
+    id: "chunk-1",
+    source_type: "book",
+    source_name: "Routine Kapitel",
+    chunk_index: 0,
+    content: "OWC ist eine Wash-Day-Technik zum Schutz der Laengen vor der Waesche.",
+    metadata: { topic: "owc" },
+    token_count: 20,
+    created_at: "2026-04-10T00:00:00.000Z",
+    similarity: 0.81,
+    weighted_similarity: 0.88,
+    retrieval_path: "hybrid",
+    dense_score: 0.79,
+    lexical_score: 12,
+    fused_score: 0.45,
+    ...overrides,
+  }
+}
+
+function createProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "product-1",
+    name: "Repair Conditioner",
+    brand: "HC",
+    description: null,
+    short_description: "Leichter Conditioner",
+    tom_take: null,
+    category: "conditioner",
+    affiliate_link: null,
+    image_url: null,
+    price_eur: 19.9,
+    currency: "EUR",
+    tags: [],
+    suitable_thicknesses: ["fine"],
+    suitable_concerns: ["frizz"],
+    shampoo_bucket_pairs: null,
+    is_active: true,
+    sort_order: 0,
+    conditioner_specs: null,
+    leave_in_specs: null,
+    mask_specs: null,
+    recommendation_meta: {
+      category: "conditioner",
+      score: 8.7,
+      top_reasons: ["leicht genug fuer feines Haar", "passt zum Feuchtigkeitsfokus"],
+      tradeoffs: [],
+      usage_hint: "Nur in Laengen und Spitzen.",
+      matched_profile: {
+        thickness: "fine",
+        density: "medium",
+        protein_moisture_balance: "stretches_bounces",
+        cuticle_condition: "rough",
+        chemical_treatment: ["colored"],
+      },
+      matched_weight: "light",
+      matched_repair_level: "medium",
+      matched_balance_need: "moisture",
+    },
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function createRoutinePlan(): RoutinePlan {
+  return {
+    base_topic_id: "owc",
+    primary_focuses: [{ kind: "topic", code: "owc", label: "Wash Protection" }],
+    active_topics: [
+      {
+        id: "owc",
+        label: "OWC",
+        reason: "Mehrere Schadenssignale vorhanden.",
+        priority: 10,
+        instruction_only: false,
+      },
+    ],
+    compare_cwc_owc: false,
+    sections: [],
+    decision_context: {
+      shampoo: {
+        category: "shampoo",
+        eligible: true,
+        missing_profile_fields: [],
+        matched_profile: {
+          thickness: "fine",
+          scalp_type: "balanced",
+          scalp_condition: "none",
+        },
+        matched_bucket: "normal",
+        secondary_bucket: null,
+        matched_concern_code: null,
+        retrieval_filter: {
+          thickness: "fine",
+          concern: null,
+        },
+        candidate_count: 0,
+        no_catalog_match: false,
+      },
+      conditioner: {
+        category: "conditioner",
+        eligible: true,
+        missing_profile_fields: [],
+        matched_profile: {
+          thickness: "fine",
+          density: "medium",
+          protein_moisture_balance: "stretches_bounces",
+          cuticle_condition: "rough",
+          chemical_treatment: ["colored"],
+        },
+        matched_concern_code: null,
+        matched_balance_need: "moisture",
+        matched_weight: "light",
+        matched_repair_level: "medium",
+        candidate_count: 0,
+        no_catalog_match: false,
+        used_density: true,
+      },
+      leave_in: {
+        category: "leave_in",
+        eligible: true,
+        missing_profile_fields: [],
+        matched_profile: {
+          hair_texture: "wavy",
+          thickness: "fine",
+          density: "medium",
+          cuticle_condition: "rough",
+          chemical_treatment: ["colored"],
+        },
+        need_bucket: "curl_definition",
+        styling_context: "air_dry",
+        conditioner_relationship: "booster_only",
+        matched_weight: "light",
+        candidate_count: 0,
+        no_catalog_match: false,
+      },
+      mask: {
+        needs_mask: false,
+        mask_type: null,
+        need_strength: 0,
+        active_signals: [],
+      },
+    },
+  }
+}
+
+function createPromptSnapshot(): ChatPromptSnapshot {
+  return {
+    model: "gpt-4o",
+    temperature: 0.7,
+    system_prompt: "System prompt snapshot",
+    messages: [
+      { role: "system", content: "System prompt snapshot" },
+      { role: "user", content: "Soll ich OWC testen?" },
+    ],
+  }
+}
+
+test.describe("Chat debug trace", () => {
+  test("builds a draft with retrieval and matching details", () => {
+    const draft = buildPipelineTraceDraft({
+      request_id: "req-1",
+      started_at: "2026-04-10T10:00:00.000Z",
+      user_message: "Soll ich OWC testen?",
+      conversation_id: "conv-1",
+      intent: "routine_help",
+      product_category: "routine",
+      conversation_history_count: 2,
+      classification: createClassification(),
+      router_decision: createRouterDecision(),
+      clarification_questions: [],
+      hair_profile_snapshot: createProfile(),
+      memory_context: "Nutzer mochte leichte Produkte.",
+      retrieval_debug: {
+        subqueries: ["OWC", "Frizz in Wellen"],
+        source_types: ["book", "community_qa"],
+        metadata_filter: { thickness: "fine" },
+        candidate_count_before_rerank: 8,
+        reranked_count: 5,
+        fallback_used: false,
+      },
+      retrieval_count: 5,
+      retrieved_chunks: [createRetrievedChunk()],
+      should_plan_routine: true,
+      routine_plan: createRoutinePlan(),
+      matched_products: [createProduct()],
+      prompt: createPromptSnapshot(),
+      latencies_ms: {
+        classification_ms: 20,
+        hair_profile_load_ms: 5,
+        memory_load_ms: 4,
+        routine_planning_ms: 8,
+        history_load_ms: 3,
+        router_ms: 1,
+        conversation_create_ms: 7,
+        retrieval_ms: 42,
+        product_matching_ms: 18,
+        prompt_build_ms: 10,
+        stream_setup_ms: 55,
+      },
+    })
+
+    expect(draft.retrieval.subqueries).toEqual(["OWC", "Frizz in Wellen"])
+    expect(draft.retrieval.chunks[0].content_preview).toContain("Wash-Day-Technik")
+    expect(draft.decision_context.matched_products[0].top_reasons).toContain(
+      "leicht genug fuer feines Haar"
+    )
+  })
+
+  test("finalizes the trace and exposes a compact retrieval debug payload", () => {
+    const draft = buildPipelineTraceDraft({
+      request_id: "req-2",
+      started_at: "2026-04-10T10:00:00.000Z",
+      user_message: "Was ist besser, CWC oder OWC?",
+      conversation_id: "conv-2",
+      intent: "routine_help",
+      product_category: "routine",
+      conversation_history_count: 0,
+      classification: createClassification(),
+      router_decision: createRouterDecision({ policy_overrides: ["missing_routine_frame"] }),
+      clarification_questions: ["Wie oft waeschst du aktuell?"],
+      hair_profile_snapshot: createProfile(),
+      memory_context: null,
+      retrieval_debug: {
+        subqueries: ["CWC", "OWC"],
+        source_types: ["book"],
+        metadata_filter: null,
+        candidate_count_before_rerank: 4,
+        reranked_count: 4,
+        fallback_used: false,
+      },
+      retrieval_count: 3,
+      retrieved_chunks: [createRetrievedChunk()],
+      should_plan_routine: true,
+      routine_plan: createRoutinePlan(),
+      matched_products: [],
+      prompt: createPromptSnapshot(),
+      latencies_ms: {
+        classification_ms: 12,
+        hair_profile_load_ms: 4,
+        memory_load_ms: 3,
+        routine_planning_ms: 7,
+        history_load_ms: 2,
+        router_ms: 1,
+        conversation_create_ms: 0,
+        retrieval_ms: 31,
+        product_matching_ms: 0,
+        prompt_build_ms: 9,
+        stream_setup_ms: 44,
+      },
+    })
+
+    const trace = finalizeChatTurnTrace(draft, {
+      assistant_content: "OWC passt hier eher als gezielter Wash-Day-Schutz.",
+      sources: [
+        {
+          index: 1,
+          source_type: "book",
+          label: "Fachbuch",
+          source_name: "Routine Kapitel",
+          snippet: "OWC ist eine Wash-Day-Technik...",
+        },
+      ],
+      product_count: 0,
+      status: "completed",
+      stream_read_ms: 120,
+      total_ms: 240,
+    })
+
+    const debugEvent = buildRetrievalDebugEventData(draft)
+
+    expect(trace.status).toBe("completed")
+    expect(trace.latencies_ms.total_ms).toBe(240)
+    expect(trace.response.sources).toHaveLength(1)
+    expect(debugEvent).toMatchObject({
+      request_id: "req-2",
+      retrieval_mode: "hybrid",
+      clarification_questions: ["Wie oft waeschst du aktuell?"],
+      final_context_count: 1,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add persisted per-turn chat observability traces across routing, retrieval, prompt building, and response generation
- expose trace inspection in the admin conversation detail page
- add the Supabase migration for conversation turn trace storage and a focused contract test

## Verification
- npm run typecheck
- npx playwright test tests/chat-debug-trace.spec.ts
- npx eslint --no-warn-ignored 'src/app/admin/conversations/[id]/page.tsx' 'src/app/api/admin/conversations/[id]/route.ts' src/app/api/chat/route.ts src/lib/openai/chat.ts src/lib/rag/pipeline.ts src/lib/rag/retriever.ts src/lib/rag/synthesizer.ts src/lib/rag/debug-trace.ts src/lib/types.ts\n\n## Notes\n- local next build still requires a valid OPENAI_API_KEY during page-data collection for /api/quiz/analyze