### PR TITLE
feat: add brush/tools guidance to routine planner

### DIFF
--- a/docs/brush-tools-guidance.md
+++ b/docs/brush-tools-guidance.md
@@ -1,0 +1,25 @@
+# Buersten & Tools
+
+## Kernlogik
+
+- Zum Entwirren im nassen oder feuchten Zustand lieber mit Slip arbeiten. Conditioner oder ein leichtes Leave-in helfen beim Gleiten.
+- Beim Entwirren immer in den Spitzen anfangen und von unten nach oben arbeiten. Bei dichterem, welligem, lockigem oder stark verknotetem Haar lieber in Sektionen.
+- Eine weiche Detangling-Buerste oder ein grobzinkiger Kamm ist die sicherste Basis fuer schonendes Entwirren.
+- Paddle- und Rundbuersten eher fuer trockenes Styling, Foehnen und Formen nutzen - nicht als Standard fuer nasses Entwirren.
+- Fuer Kopfhaut-Oel oder -Seren scheitelweise mit Applikatorflasche oder Kamm-Applikator arbeiten und sparsam dosieren.
+- Scalp-Brushes nur sanft einsetzen. Die Kopfhaut locker bewegen statt mit Druck ueber die Haut zu schrubben.
+- Fuer Wellen oder Locken zwischen den Waeschen reicht oft Wasser aus einer Spruehflasche zum Reaktivieren, bevor weiteres Produkt dazukommt.
+- Ein Stielkamm ist vor allem zum Abteilen, Scheitel ziehen und Hochstecken sinnvoll - nicht zum groben Entwirren.
+
+## Sicherheitsgrenzen
+
+- Bei gereizter, schuppiger oder empfindlicher Kopfhaut auf harte Scalp-Brushes, viel Druck und Reibung verzichten.
+- Bei Haarausfall oder Ausduennung besonders sanft arbeiten und keine aggressive Kopfhautmassage empfehlen.
+- Beim Foehnen mit Buerste lieber mit Hitzeschutz und moderater Temperatur arbeiten.
+- Tools regelmaessig reinigen und nicht teilen.
+
+## Nicht als harte Regel behandeln
+
+- Eine bestimmte Detangler-Buerste ist nicht fuer jede Person Pflicht.
+- Paddle-Brushes sind nicht pauschal verboten, aber fuer nasses Entwirren meist nicht die beste Default-Wahl.
+- Marken- oder Modellvergleiche bleiben Einzelfallberatung und sind keine deterministische Routine-Logik.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "ci:verify": "npm run typecheck && npm run lint && npm run build",
     "test:extract": "tsx scripts/extract-qa-fixtures.ts",
     "test:qa": "playwright test qa-validation",
+    "test:chat": "tsx scripts/eval-chat/run.ts --skip-judge",
+    "test:chat:judge": "tsx scripts/eval-chat/run.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -881,7 +881,8 @@ Wenn ein Routine-Plan vorhanden ist:
 10. Bei Kopfhautthemen bleibe konservativ und nicht-medizinisch.
 11. Wenn Bond Builder relevant ist: Olaplex No. 0+3, K18 Molecular Repair Leave-in und Epres gehoeren zu den wenigen Produkten mit nachgewiesener Bond-Technologie. Viele Produkte mit "Bond" im Namen pflegen nur die Oberflaeche, reparieren aber nicht die innere Haarstruktur. Das sind Technologie-Beispiele, keine Produktempfehlungen.
 12. Nenne bei Bond Builder den Unterschied zwischen Laengs- und Querverbindungen nur, wenn der Routine-Plan das vorgibt. Erfinde keine eigene K18-vs-Olaplex-Logik.
-13. Wenn der Routine-Plan Vergleichsmodus fuer CWC/OWC signalisiert, erklaere erst kurz den Unterschied beider Methoden, waehle dann die passendere Option fuer dieses Profil und fuehre nur mit dieser Variante weiter.`,
+13. Wenn der Routine-Plan Vergleichsmodus fuer CWC/OWC signalisiert, erklaere erst kurz den Unterschied beider Methoden, waehle dann die passendere Option fuer dieses Profil und fuehre nur mit dieser Variante weiter.
+14. Wenn Buersten & Tools relevant sind, bleibe bei Funktionslogik und Sicherheitsregeln: Slip beim Entwirren, von unten nach oben arbeiten, sanfter Druck auf der Kopfhaut und keine improvisierten Marken- oder Tool-Empfehlungen.`,
   mask: `
 
 ## Masken-Empfehlungen:

--- a/src/lib/routines/brush-tools.ts
+++ b/src/lib/routines/brush-tools.ts
@@ -4,8 +4,7 @@ import type {
   RoutineSlotAction,
   RoutineSlotAdvice,
 } from "@/lib/types"
-
-const CURLY_TEXTURES = new Set(["wavy", "curly", "coily"])
+import { CURLY_TEXTURES } from "@/lib/routines/constants"
 
 const BRUSH_TOOLS_TERMS = [
   "buerste",
@@ -56,14 +55,16 @@ const DRY_STYLING_BRUSH_TERMS = [
 const SCALP_TOOL_TERMS = [
   "kopfhaut",
   "scalp",
-  "serum",
-  "oel",
-  "oil",
+  "kopfhautserum",
+  "scalp serum",
+  "haaroel",
+  "kopfhautoel",
+  "hair oil",
   "applikator",
   "applikatorflasche",
   "kamm applikator",
   "scalp brush",
-  "massage",
+  "kopfhautmassage",
   "einmassieren",
 ]
 
@@ -97,21 +98,22 @@ function includesAny(text: string, terms: string[]): boolean {
   return terms.some((term) => text.includes(normalizeText(term)))
 }
 
-export function hasExplicitBrushToolsRequest(message: string): boolean {
-  return includesAny(normalizeText(message), BRUSH_TOOLS_TERMS)
+/** Accepts an already-normalized message string (via normalizeText). */
+export function hasExplicitBrushToolsRequest(normalizedMessage: string): boolean {
+  return includesAny(normalizedMessage, BRUSH_TOOLS_TERMS)
 }
 
+/** Accepts an already-normalized message string (via normalizeText). */
 export function hasBrushToolsNeed(
   profile: HairProfile | null,
-  message: string,
+  normalizedMessage: string,
   context: RoutineContext,
 ): boolean {
-  const normalizedMessage = normalizeText(message)
-
   return (
     context.mechanical_stress_factors.includes("rough_brushing") ||
     profile?.brush_type === "paddle" ||
     profile?.brush_type === "round" ||
+    profile?.brush_type === "boar_bristle" ||
     includesAny(normalizedMessage, DETANGLING_TERMS)
   )
 }
@@ -119,10 +121,9 @@ export function hasBrushToolsNeed(
 export function buildBrushToolsSlot(
   profile: HairProfile | null,
   context: RoutineContext,
-  message: string,
+  normalizedMessage: string,
 ): RoutineSlotAdvice {
-  const normalizedMessage = normalizeText(message)
-  const explicitBrushRequest = hasExplicitBrushToolsRequest(message)
+  const explicitBrushRequest = hasExplicitBrushToolsRequest(normalizedMessage)
   const wetDetanglingRelevant =
     context.mechanical_stress_factors.includes("rough_brushing") ||
     includesAny(normalizedMessage, DETANGLING_TERMS) ||
@@ -138,8 +139,7 @@ export function buildBrushToolsSlot(
       CURLY_TEXTURES.has(context.hair_texture)
     )
   const sectioningRelevant =
-    includesAny(normalizedMessage, SECTIONING_TERMS) ||
-    scalpToolRelevant
+    includesAny(normalizedMessage, SECTIONING_TERMS)
   const dryStylingBrushRelevant =
     profile?.brush_type === "paddle" ||
     profile?.brush_type === "round" ||
@@ -228,10 +228,12 @@ export function buildBrushToolsSlot(
     )
   }
 
-  const action: RoutineSlotAction =
-    profile?.brush_type || context.mechanical_stress_factors.length > 0
-      ? "adjust"
-      : "add"
+  const needsAdjustment =
+    profile?.brush_type === "paddle" ||
+    profile?.brush_type === "round" ||
+    profile?.brush_type === "boar_bristle" ||
+    context.mechanical_stress_factors.length > 0
+  const action: RoutineSlotAction = needsAdjustment ? "adjust" : "add"
 
   return {
     id: "maintenance-brush-tools",

--- a/src/lib/routines/brush-tools.ts
+++ b/src/lib/routines/brush-tools.ts
@@ -1,0 +1,253 @@
+import type {
+  HairProfile,
+  RoutineContext,
+  RoutineSlotAction,
+  RoutineSlotAdvice,
+} from "@/lib/types"
+
+const CURLY_TEXTURES = new Set(["wavy", "curly", "coily"])
+
+const BRUSH_TOOLS_TERMS = [
+  "buerste",
+  "burste",
+  "brush",
+  "detangler",
+  "detangling",
+  "kamm",
+  "comb",
+  "paddle",
+  "rundburste",
+  "round brush",
+  "fingerbrush",
+  "denman",
+  "scalp brush",
+  "kopfhautbuerste",
+  "applikator",
+  "spruhflasche",
+  "spruehflasche",
+  "spruh bottle",
+  "spray bottle",
+  "stielkamm",
+]
+
+const DETANGLING_TERMS = [
+  "entwirren",
+  "detangle",
+  "verhakt",
+  "verknotet",
+  "knoten",
+  "kaemmbar",
+  "kammen",
+  "kaemmen",
+  "nasses haar",
+  "nasses entwirren",
+  "wet detangling",
+]
+
+const DRY_STYLING_BRUSH_TERMS = [
+  "paddle",
+  "rundburste",
+  "round brush",
+  "foehnburste",
+  "fohnburste",
+  "blow dry brush",
+]
+
+const SCALP_TOOL_TERMS = [
+  "kopfhaut",
+  "scalp",
+  "serum",
+  "oel",
+  "oil",
+  "applikator",
+  "applikatorflasche",
+  "kamm applikator",
+  "scalp brush",
+  "massage",
+  "einmassieren",
+]
+
+const REFRESH_TOOL_TERMS = [
+  "spruhflasche",
+  "spruehflasche",
+  "spray bottle",
+  "sprayer",
+  "refresh",
+  "lockenrefresh",
+  "auffrischen",
+]
+
+const SECTIONING_TERMS = [
+  "stielkamm",
+  "abteilen",
+  "scheitel",
+  "sektion",
+  "zopf",
+  "hochstecken",
+]
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+}
+
+function includesAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(normalizeText(term)))
+}
+
+export function hasExplicitBrushToolsRequest(message: string): boolean {
+  return includesAny(normalizeText(message), BRUSH_TOOLS_TERMS)
+}
+
+export function hasBrushToolsNeed(
+  profile: HairProfile | null,
+  message: string,
+  context: RoutineContext,
+): boolean {
+  const normalizedMessage = normalizeText(message)
+
+  return (
+    context.mechanical_stress_factors.includes("rough_brushing") ||
+    profile?.brush_type === "paddle" ||
+    profile?.brush_type === "round" ||
+    includesAny(normalizedMessage, DETANGLING_TERMS)
+  )
+}
+
+export function buildBrushToolsSlot(
+  profile: HairProfile | null,
+  context: RoutineContext,
+  message: string,
+): RoutineSlotAdvice {
+  const normalizedMessage = normalizeText(message)
+  const explicitBrushRequest = hasExplicitBrushToolsRequest(message)
+  const wetDetanglingRelevant =
+    context.mechanical_stress_factors.includes("rough_brushing") ||
+    includesAny(normalizedMessage, DETANGLING_TERMS) ||
+    explicitBrushRequest
+  const scalpToolRelevant =
+    includesAny(normalizedMessage, SCALP_TOOL_TERMS) ||
+    context.explicit_topic_ids.includes("hair_oiling")
+  const refreshToolRelevant =
+    includesAny(normalizedMessage, REFRESH_TOOL_TERMS) ||
+    (
+      context.has_between_wash_days &&
+      context.hair_texture !== null &&
+      CURLY_TEXTURES.has(context.hair_texture)
+    )
+  const sectioningRelevant =
+    includesAny(normalizedMessage, SECTIONING_TERMS) ||
+    scalpToolRelevant
+  const dryStylingBrushRelevant =
+    profile?.brush_type === "paddle" ||
+    profile?.brush_type === "round" ||
+    includesAny(normalizedMessage, DRY_STYLING_BRUSH_TERMS)
+
+  const rationale: string[] = []
+
+  if (wetDetanglingRelevant) {
+    rationale.push(
+      "Zum Entwirren im nassen oder feuchten Zustand lieber mit Slip arbeiten - Conditioner oder ein leichtes Leave-in helfen beim Gleiten."
+    )
+    rationale.push(
+      "Beim Entwirren immer in den Spitzen anfangen und von unten nach oben arbeiten; bei dichterem oder stark verknotetem Haar lieber in Sektionen."
+    )
+    rationale.push(
+      "Eine weiche Detangling-Buerste oder ein grobzinkiger Kamm ist hier meist die sicherere Basis als eine straffere Stylingbuerste."
+    )
+  }
+
+  if (dryStylingBrushRelevant) {
+    rationale.push(
+      "Paddle- und Rundbuersten eher fuer trockenes Styling, Foehnen und Formen nutzen - nicht als Standard fuer nasses Entwirren."
+    )
+  }
+
+  if (scalpToolRelevant) {
+    rationale.push(
+      "Fuer Kopfhaut-Oel oder -Seren lieber scheitelweise mit Applikatorflasche oder Kamm-Applikator arbeiten und sparsam dosieren."
+    )
+    rationale.push(
+      "Eine Scalp-Brush bleibt optional: eher locker fuehren und die Kopfhaut sanft bewegen statt mit Druck ueber die Haut zu schrubben."
+    )
+  }
+
+  if (refreshToolRelevant) {
+    rationale.push(
+      "Fuer Wellen oder Locken zwischen den Waeschen reicht oft Wasser aus einer Spruehflasche zum Reaktivieren, bevor weiteres Produkt dazukommt."
+    )
+  }
+
+  if (sectioningRelevant) {
+    rationale.push(
+      "Ein Stielkamm ist vor allem zum Abteilen, Scheitel ziehen und Hochstecken sinnvoll - nicht zum groben Entwirren."
+    )
+  }
+
+  if (rationale.length === 0) {
+    rationale.push(
+      "Buersten und Tools sollten immer nach Funktion gewaehlt werden: schonendes Entwirren, sauberes Abteilen oder gezieltes Styling."
+    )
+    rationale.push(
+      "Je mehr Reibung und Zug entstehen, desto wichtiger werden weiche Tools, Slip und ein ruhiges Arbeiten in kleinen Abschnitten."
+    )
+  }
+
+  const caveats: string[] = [
+    "Tools regelmaessig reinigen und nicht teilen, damit Rueckstaende und Kopfhautthemen nicht mitgeschleppt werden."
+  ]
+
+  if (
+    context.scalp_condition === "irritated" ||
+    context.scalp_condition === "dry_flakes" ||
+    context.scalp_condition === "dandruff"
+  ) {
+    caveats.push(
+      "Bei gereizter oder schuppiger Kopfhaut auf harte Scalp-Brushes, viel Druck und Reibung verzichten."
+    )
+  }
+
+  if (
+    context.concerns.includes("hair_loss") ||
+    context.concerns.includes("thinning")
+  ) {
+    caveats.push(
+      "Bei Haarausfall oder Ausduennung lieber besonders sanft arbeiten und keine aggressive Kopfhautmassage oder ruckartiges Entwirren empfehlen."
+    )
+  }
+
+  if (
+    context.post_wash_actions.includes("heat_tool_styling") ||
+    context.post_wash_actions.includes("blow_dry_only") ||
+    (context.heat_styling !== null && context.heat_styling !== "never")
+  ) {
+    caveats.push(
+      "Beim Foehnen mit Buerste lieber mit Hitzeschutz und moderater Temperatur arbeiten, damit das Tool nicht zusaetzlich Schaden verstaerkt."
+    )
+  }
+
+  const action: RoutineSlotAction =
+    profile?.brush_type || context.mechanical_stress_factors.length > 0
+      ? "adjust"
+      : "add"
+
+  return {
+    id: "maintenance-brush-tools",
+    kind: "instruction",
+    phase: "maintenance",
+    label: "Buersten & Tools",
+    action,
+    category: null,
+    cadence: explicitBrushRequest
+      ? "je nach Bedarf beim Entwirren, Auffrischen oder scheitelweisen Auftragen"
+      : "im Alltag moeglichst reibungsarm einsetzen",
+    rationale,
+    caveats,
+    topic_ids: ["brush_tools"],
+    product_linkable: false,
+    product_query: null,
+    attachment_priority: 94,
+  }
+}

--- a/src/lib/routines/constants.ts
+++ b/src/lib/routines/constants.ts
@@ -1,0 +1,3 @@
+import type { HairTexture } from "@/lib/types"
+
+export const CURLY_TEXTURES: ReadonlySet<HairTexture> = new Set(["wavy", "curly", "coily"])

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -8,6 +8,11 @@ import {
 } from "@/lib/vocabulary"
 import { CONDITIONER_REPAIR_LEVEL_LABELS } from "@/lib/conditioner/constants"
 import { LEAVE_IN_NEED_BUCKET_LABELS, LEAVE_IN_STYLING_CONTEXT_LABELS } from "@/lib/leave-in/constants"
+import {
+  buildBrushToolsSlot,
+  hasBrushToolsNeed,
+  hasExplicitBrushToolsRequest,
+} from "@/lib/routines/brush-tools"
 import { buildConditionerDecision } from "@/lib/rag/conditioner-decision"
 import { buildLeaveInDecision } from "@/lib/rag/leave-in-decision"
 import { deriveMaskDecision } from "@/lib/rag/mask-reranker"
@@ -32,6 +37,7 @@ const ROUTINE_TOPIC_LABELS: Record<RoutineTopicId, string> = {
   tiefenreinigung: "Tiefenreinigung",
   hair_oiling: "Hair Oiling",
   bond_builder: "Bond Builder",
+  brush_tools: "Buersten & Tools",
   lockenrefresh: "Lockenrefresh",
   cwc: "CWC",
   owc: "OWC",
@@ -515,6 +521,7 @@ function getExplicitTopicIds(message: string): RoutineTopicId[] {
   if (includesAny(normalizedMessage, CLARIFY_TERMS)) topics.push("tiefenreinigung")
   if (includesAny(normalizedMessage, OILING_TERMS)) topics.push("hair_oiling")
   if (includesAny(normalizedMessage, BOND_BUILDER_TERMS)) topics.push("bond_builder")
+  if (hasExplicitBrushToolsRequest(message)) topics.push("brush_tools")
   if (includesAny(normalizedMessage, REFRESH_TERMS)) topics.push("lockenrefresh")
   if (includesAny(normalizedMessage, CWC_TERMS)) topics.push("cwc")
   if (includesAny(normalizedMessage, OWC_TERMS)) topics.push("owc")
@@ -695,6 +702,17 @@ export function activateRoutineTopics(
         true,
       )
     }
+  }
+
+  if (explicit.has("brush_tools") || hasBrushToolsNeed(profile, message, context)) {
+    push(
+      "brush_tools",
+      explicit.has("brush_tools")
+        ? "Buersten oder Tools wurden direkt angefragt."
+        : "Mechanische Belastung oder Entwirr-Signale sprechen fuer gezielte Tool- und Anwendungshinweise.",
+      55,
+      true,
+    )
   }
 
   if (
@@ -910,6 +928,7 @@ function buildOwcTechniqueSlot(
 function buildRoutineSlots(
   profile: HairProfile | null,
   context: RoutineContext,
+  message: string,
   activations: RoutineTopicActivation[],
   decisionContext: RoutineDecisionContext,
   options: { usesBondBuilder: boolean },
@@ -1143,6 +1162,10 @@ function buildRoutineSlots(
     })
   }
 
+  if (activeTopicIds.has("brush_tools")) {
+    pushSlot(sections, buildBrushToolsSlot(profile, context, message))
+  }
+
   if (maskDecision.needs_mask || maskPresent) {
     pushSlot(sections, {
       id: "occasional-mask",
@@ -1338,7 +1361,7 @@ export function buildRoutinePlan(
   const activeTopics = activateRoutineTopics(profile, message, context)
   const compareMode = isCwcOwcComparisonRequest(message)
   const decisionContext = buildRoutineDecisionContext(profile)
-  const sectionSlots = buildRoutineSlots(profile, context, activeTopics, decisionContext, {
+  const sectionSlots = buildRoutineSlots(profile, context, message, activeTopics, decisionContext, {
     usesBondBuilder: options.usesBondBuilder ?? false,
   })
 

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -13,6 +13,7 @@ import {
   hasBrushToolsNeed,
   hasExplicitBrushToolsRequest,
 } from "@/lib/routines/brush-tools"
+import { CURLY_TEXTURES } from "@/lib/routines/constants"
 import { buildConditionerDecision } from "@/lib/rag/conditioner-decision"
 import { buildLeaveInDecision } from "@/lib/rag/leave-in-decision"
 import { deriveMaskDecision } from "@/lib/rag/mask-reranker"
@@ -156,7 +157,6 @@ const WASH_LESS_TERMS = [
   "langer frisch",
 ]
 
-const CURLY_TEXTURES = new Set(["wavy", "curly", "coily"])
 const HEAVY_ROUTINE_PRODUCTS = new Set(["mask", "oil", "leave_in"])
 
 const STYLING_KIND_MAP: [RegExp, string][] = [
@@ -521,7 +521,7 @@ function getExplicitTopicIds(message: string): RoutineTopicId[] {
   if (includesAny(normalizedMessage, CLARIFY_TERMS)) topics.push("tiefenreinigung")
   if (includesAny(normalizedMessage, OILING_TERMS)) topics.push("hair_oiling")
   if (includesAny(normalizedMessage, BOND_BUILDER_TERMS)) topics.push("bond_builder")
-  if (hasExplicitBrushToolsRequest(message)) topics.push("brush_tools")
+  if (hasExplicitBrushToolsRequest(normalizedMessage)) topics.push("brush_tools")
   if (includesAny(normalizedMessage, REFRESH_TERMS)) topics.push("lockenrefresh")
   if (includesAny(normalizedMessage, CWC_TERMS)) topics.push("cwc")
   if (includesAny(normalizedMessage, OWC_TERMS)) topics.push("owc")
@@ -623,6 +623,7 @@ export function activateRoutineTopics(
   message: string,
   context: RoutineContext = deriveRoutineContext(profile, message),
 ): RoutineTopicActivation[] {
+  const normalizedMessage = normalizeText(message)
   const activations: RoutineTopicActivation[] = []
   const seen = new Set<RoutineTopicId>()
 
@@ -704,7 +705,7 @@ export function activateRoutineTopics(
     }
   }
 
-  if (explicit.has("brush_tools") || hasBrushToolsNeed(profile, message, context)) {
+  if (explicit.has("brush_tools") || hasBrushToolsNeed(profile, normalizedMessage, context)) {
     push(
       "brush_tools",
       explicit.has("brush_tools")
@@ -1163,7 +1164,7 @@ function buildRoutineSlots(
   }
 
   if (activeTopicIds.has("brush_tools")) {
-    pushSlot(sections, buildBrushToolsSlot(profile, context, message))
+    pushSlot(sections, buildBrushToolsSlot(profile, context, normalizeText(message)))
   }
 
   if (maskDecision.needs_mask || maskPresent) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -380,6 +380,7 @@ export type RoutineTopicId =
   | "tiefenreinigung"
   | "hair_oiling"
   | "bond_builder"
+  | "brush_tools"
   | "lockenrefresh"
   | "cwc"
   | "owc"

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -1128,4 +1128,70 @@ test.describe("Routine planner", () => {
       expect(bondSlot?.action).toBe("adjust")
     })
   })
+
+  test.describe("Brush tools logic", () => {
+    test("explicit brush question activates brush_tools", () => {
+      const topics = activateRoutineTopics(
+        createProfile(),
+        "Welche Buerste ist fuer nasses Entwirren am besten?"
+      )
+
+      expect(topics.map((topic) => topic.id)).toContain("brush_tools")
+    })
+
+    test("rough brushing proactively adds a brush tools slot", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          brush_type: "paddle",
+          mechanical_stress_factors: ["rough_brushing"],
+        }),
+        "Welche Routine passt zu mir?"
+      )
+
+      const topicIds = plan.active_topics.map((topic) => topic.id)
+      const brushSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "maintenance-brush-tools")
+
+      expect(topicIds).toContain("brush_tools")
+      expect(brushSlot?.action).toBe("adjust")
+      expect(brushSlot?.rationale.some((line) => line.includes("von unten nach oben"))).toBe(true)
+      expect(brushSlot?.rationale.some((line) => line.includes("Paddle- und Rundbuersten"))).toBe(true)
+    })
+
+    test("scalp-sensitive profiles get gentle scalp tool caveats", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          scalp_condition: "irritated",
+          concerns: ["hair_loss"],
+        }),
+        "Welches Tool passt fuer Kopfhautserum und Scalp Brush?"
+      )
+
+      const brushSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "maintenance-brush-tools")
+
+      expect(brushSlot?.rationale.some((line) => line.includes("Applikatorflasche"))).toBe(true)
+      expect(brushSlot?.caveats.some((line) => line.includes("gereizter oder schuppiger Kopfhaut"))).toBe(true)
+      expect(brushSlot?.caveats.some((line) => line.includes("Haarausfall oder Ausduennung"))).toBe(true)
+    })
+
+    test("curl refresh tool questions surface the spray-bottle hint", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          hair_texture: "curly",
+          wash_frequency: "every_2_3_days",
+        }),
+        "Brauche ich eine Spruehflasche fuer meinen Lockenrefresh?"
+      )
+
+      const brushSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "maintenance-brush-tools")
+
+      expect(plan.active_topics.map((topic) => topic.id)).toContain("brush_tools")
+      expect(brushSlot?.rationale.some((line) => line.includes("Spruehflasche"))).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add a new `brush_tools` routine topic for deterministic brush/tool guidance
- surface safe detangling, scalp-tool, sectioning, and curl-refresh instructions in the routine planner
- add prompt guidance, repo documentation, and planner tests for the new topic

## Testing
- npm run typecheck
- npx playwright test tests/routine-planner.spec.ts

## Notes
- includes `docs/brush-tools-guidance.md` as source documentation, but this PR does not run markdown ingestion for RAG content