### PR TITLE
fix: milestone polish for Tom Review 1

### DIFF
--- a/src/app/datenschutz/page.tsx
+++ b/src/app/datenschutz/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Datenschutz",
+}
+
+export default function DatenschutzPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          Datenschutz
+        </h1>
+        <p className="text-muted-foreground">
+          Diese Seite wird in Kürze aktualisiert.
+        </p>
+        <Link
+          href="/"
+          className="inline-block text-sm text-muted-foreground hover:underline"
+        >
+          Zurück zur Startseite
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -15,10 +15,71 @@ export default function GlobalError({
   }, [error])
 
   return (
-    <html>
-      <body>
-        <h2>Etwas ist schiefgelaufen</h2>
-        <button onClick={() => reset()}>Erneut versuchen</button>
+    <html lang="de">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#111",
+          color: "#e5e5e5",
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+        }}
+      >
+        <div style={{ textAlign: "center", padding: "2rem" }}>
+          <div
+            style={{
+              fontSize: "3rem",
+              marginBottom: "1rem",
+              lineHeight: 1,
+            }}
+          >
+            ⚠
+          </div>
+          <h2
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 600,
+              margin: "0 0 0.5rem",
+            }}
+          >
+            Etwas ist schiefgelaufen
+          </h2>
+          <p
+            style={{
+              fontSize: "0.95rem",
+              color: "#999",
+              margin: "0 0 2rem",
+            }}
+          >
+            Ein unerwarteter Fehler ist aufgetreten.
+          </p>
+          <button
+            onClick={() => reset()}
+            style={{
+              padding: "0.75rem 2rem",
+              fontSize: "0.95rem",
+              fontWeight: 500,
+              color: "#111",
+              backgroundColor: "#e5e5e5",
+              border: "none",
+              borderRadius: "0.5rem",
+              cursor: "pointer",
+              transition: "background-color 0.15s ease",
+            }}
+            onMouseOver={(e) =>
+              ((e.target as HTMLButtonElement).style.backgroundColor = "#fff")
+            }
+            onMouseOut={(e) =>
+              ((e.target as HTMLButtonElement).style.backgroundColor = "#e5e5e5")
+            }
+          >
+            Erneut versuchen
+          </button>
+        </div>
       </body>
     </html>
   )

--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Impressum",
+}
+
+export default function ImpressumPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md space-y-6">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          Impressum
+        </h1>
+
+        <div className="space-y-4 text-sm text-muted-foreground">
+          <div>
+            <p className="font-medium text-foreground">Angaben gemäß § 5 TMG</p>
+            <p>Haarmony, LLC</p>
+            <p>1111B S Governors Ave Ste 84075</p>
+            <p>Dover, Delaware 19904</p>
+            <p>USA</p>
+          </div>
+
+          <div>
+            <p className="font-medium text-foreground">Kontakt</p>
+            <p>E-Mail: info@haarmony.com</p>
+          </div>
+        </div>
+
+        <Link
+          href="/"
+          className="inline-block text-sm text-muted-foreground hover:underline"
+        >
+          ← Zurück zur Startseite
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/app/result/[leadId]/page.tsx
+++ b/src/app/result/[leadId]/page.tsx
@@ -39,7 +39,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const name = lead.name as string
   const quote = (lead.share_quote as string) || "Finde heraus, was deine Haare wirklich brauchen."
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
 
   return {
     title: `${name}s Haar-Diagnose — TomBot`,

--- a/src/components/quiz/quiz-consent-sheet.tsx
+++ b/src/components/quiz/quiz-consent-sheet.tsx
@@ -31,7 +31,9 @@ export function QuizConsentSheet({ open, saving, onConsent }: QuizConsentSheetPr
           Experten-Tipps, Produkt-News und exklusive Angebote.
         </p>
         <p className="text-center text-xs text-white/38 mb-6 leading-relaxed">
-          Du kannst dich jederzeit abmelden ueber den Link in unseren E-Mails. Unsere Datenschutzerklaerung findest du hier.
+          Du kannst dich jederzeit abmelden über den Link in unseren E-Mails. Unsere{" "}
+          <a href="/datenschutz" target="_blank" className="underline hover:text-white/60">Datenschutzerklärung</a>{" "}
+          findest du hier.
         </p>
 
         <Button


### PR DESCRIPTION
## Summary
- Style `global-error.tsx` with centered dark layout (was bare unstyled HTML)
- Add `VERCEL_URL` fallback for OG image URLs so share cards work on all deployments
- Add `/impressum` page with Haarmony LLC info
- Add `/datenschutz` placeholder page (content coming later)
- Wire Datenschutz link in quiz consent sheet (was unlinked text)

## Test plan
- [ ] Visit `/impressum` — should show Haarmony LLC details
- [ ] Visit `/datenschutz` — should show placeholder text
- [ ] Auth page footer links to both pages (no more 404s)
- [ ] Quiz consent sheet Datenschutz link opens `/datenschutz` in new tab
- [ ] `npm run ci:verify` passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)