### PR TITLE
feat: chat design polish — animations, product cards, atmosphere, a11y

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,19 +228,8 @@
 }
 
 /* Chat message entrance — snappier variant for conversational context */
-@keyframes fadeInUpFast {
-  from {
-    opacity: 0;
-    transform: translateY(14px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 .animate-fade-in-up-fast {
-  animation: fadeInUpFast 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: fadeInUp 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 /* Scale-in animation for popups */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,6 +227,22 @@
   animation: fadeInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+/* Chat message entrance — snappier variant for conversational context */
+@keyframes fadeInUpFast {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up-fast {
+  animation: fadeInUpFast 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 /* Scale-in animation for popups */
 @keyframes scaleIn {
   from {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -305,3 +305,25 @@
   --tw-prose-pre-code: var(--text-body);
   --tw-prose-pre-bg: var(--brand-plum-ice);
 }
+
+/* Brand selection + scrollbar */
+::selection {
+  background: rgba(var(--brand-plum-rgb), 0.2);
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(var(--brand-plum-rgb), 0.2);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(var(--brand-plum-rgb), 0.35);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -280,6 +280,25 @@
   to { opacity: 0; }
 }
 
+/* Sidebar slide animations */
+@keyframes slideInLeft {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes slideOutLeft {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+
+.animate-slide-in-left {
+  animation: slideInLeft 0.3s cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+
+.animate-slide-out-left {
+  animation: slideOutLeft 0.25s cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+
 /* Comb sway animation for loading indicator */
 @keyframes combSway {
   0%, 100% { transform: rotate(-15deg); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -346,3 +346,14 @@
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(var(--brand-plum-rgb), 0.35);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up,
+  .animate-fade-in-up-fast,
+  .animate-scale-in,
+  .animate-comb-sway,
+  .animate-slide-in-left,
+  .animate-slide-out-left {
+    animation: none !important;
+  }
+}

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -10,7 +10,9 @@ import { ChatLoadingIndicator } from "./chat-loading-indicator"
 import { ProductDetailDrawer } from "./product-detail-drawer"
 import { ConversationSidebar } from "./conversation-sidebar"
 import { useEffect, useMemo, useRef, useState, useCallback } from "react"
-import { Menu, Sparkles } from "lucide-react"
+import { Menu } from "lucide-react"
+import { CombIcon } from "@/components/ui/comb-icon"
+import { Icon } from "@/components/ui/icon"
 import type { Product } from "@/lib/types"
 
 export function ChatContainer() {
@@ -139,21 +141,30 @@ export function ChatContainer() {
         <div className="flex-1 overflow-y-auto">
           {isEmpty ? (
             <div className="flex h-full flex-col items-center justify-center px-4">
-              <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary">
-                <Sparkles className="h-8 w-8 text-primary-foreground" />
+              <div className="animate-scale-in mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary">
+                <CombIcon className="h-8 w-8 text-primary-foreground" />
               </div>
-              <h2 className="mb-2 text-2xl font-bold">{greeting}</h2>
-              <p className="mb-8 max-w-md text-center text-sm text-muted-foreground">
+              <h2 className="animate-fade-in-up mb-2 type-h2" style={{ animationDelay: "150ms" }}>
+                {greeting}
+              </h2>
+              <p
+                className="animate-fade-in-up mb-8 max-w-md text-center text-sm text-muted-foreground"
+                style={{ animationDelay: "250ms" }}
+              >
                 Frag mich alles rund ums Thema Haare — von Pflege-Tipps bis Produktempfehlungen!
               </p>
               <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
-                {suggestedPrompts.map((prompt) => (
+                {suggestedPrompts.map((prompt, index) => (
                   <button
-                    key={prompt}
-                    onClick={() => sendMessage(prompt)}
-                    className="rounded-xl border px-4 py-3 text-left text-sm transition-colors hover:bg-accent"
+                    key={prompt.text}
+                    onClick={() => sendMessage(prompt.text)}
+                    className="animate-fade-in-up flex items-start gap-2.5 rounded-xl border px-4 py-3 text-left text-sm transition-all duration-200 hover:border-primary/40 hover:bg-accent hover:shadow-sm hover:-translate-y-0.5"
+                    style={{ animationDelay: `${350 + index * 80}ms` }}
                   >
-                    {prompt}
+                    {prompt.icon && (
+                      <Icon name={prompt.icon} size={18} className="shrink-0 text-primary" />
+                    )}
+                    {prompt.text}
                   </button>
                 ))}
               </div>

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -156,7 +156,9 @@ export function ChatContainer() {
 
   const firstName = profile?.full_name?.split(" ")[0] || null
   const hour = new Date().getHours()
-  const timeGreeting = hour < 12 ? "Guten Morgen" : hour < 18 ? "Guten Tag" : "Guten Abend"
+  let timeGreeting = "Guten Abend"
+  if (hour < 12) timeGreeting = "Guten Morgen"
+  else if (hour < 18) timeGreeting = "Guten Tag"
   const greeting = firstName ? `${timeGreeting}, ${firstName}` : timeGreeting
 
   const isEmpty = messages.length === 0
@@ -292,11 +294,9 @@ export function ChatContainer() {
                   const dateChanged =
                     !prevDate || msgDate.toDateString() !== prevDate.toDateString()
                   if (dateChanged) {
-                    const label = isToday(msgDate)
-                      ? "Heute"
-                      : isYesterday(msgDate)
-                        ? "Gestern"
-                        : format(msgDate, "dd. MMM", { locale: de })
+                    let label = format(msgDate, "dd. MMM", { locale: de })
+                    if (isToday(msgDate)) label = "Heute"
+                    else if (isYesterday(msgDate)) label = "Gestern"
                     dateSeparator = (
                       <div className="flex items-center gap-3 py-2">
                         <div className="h-px flex-1 bg-border" />

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -28,23 +28,54 @@ export function ChatContainer() {
   } = useChat()
 
   const { hairProfile } = useHairProfile()
-  const suggestedPrompts = useMemo(
-    () => generateSuggestedPrompts(hairProfile),
-    [hairProfile]
-  )
+  const suggestedPrompts = useMemo(() => generateSuggestedPrompts(hairProfile), [hairProfile])
 
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [drawerProduct, setDrawerProduct] = useState<Product | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
+  // Track IDs of messages appended during this session (not from history loads).
+  // Uses the "update state during render" pattern recommended by React for
+  // derived state that depends on previous values.
+  const [newMessageIds, setNewMessageIds] = useState<Set<string>>(() => new Set())
+  const [prevMessageCount, setPrevMessageCount] = useState(0)
+  const [prevConversationId, setPrevConversationId] = useState(currentConversationId)
+
+  // Reset when conversation changes (update-during-render pattern)
+  if (prevConversationId !== currentConversationId) {
+    setNewMessageIds(new Set())
+    setPrevMessageCount(0)
+    setPrevConversationId(currentConversationId)
+  }
+
+  // Detect newly appended messages (update-during-render pattern)
+  const currentCount = messages.length
+  if (currentCount > prevMessageCount && prevMessageCount > 0) {
+    const next = new Set(newMessageIds)
+    for (let i = prevMessageCount; i < currentCount; i++) {
+      next.add(messages[i].id)
+    }
+    setNewMessageIds(next)
+    setPrevMessageCount(currentCount)
+  } else if (currentCount !== prevMessageCount) {
+    setPrevMessageCount(currentCount)
+  }
+
+  const hasNewMessages = currentCount > 0 && newMessageIds.size > 0
+
   useEffect(() => {
     loadConversations()
   }, [loadConversations])
 
+  // Scroll behavior: smooth for appended messages, instant for history loads
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  }, [messages])
+    if (hasNewMessages) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    } else if (messages.length > 0) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "instant" })
+    }
+  }, [messages, hasNewMessages])
 
   const handleProductClick = useCallback((product: Product) => {
     setDrawerProduct(product)
@@ -53,8 +84,7 @@ export function ChatContainer() {
 
   const firstName = profile?.full_name?.split(" ")[0] || null
   const hour = new Date().getHours()
-  const timeGreeting =
-    hour < 12 ? "Guten Morgen" : hour < 18 ? "Guten Tag" : "Guten Abend"
+  const timeGreeting = hour < 12 ? "Guten Morgen" : hour < 18 ? "Guten Tag" : "Guten Abend"
   const greeting = firstName ? `${timeGreeting}, ${firstName}` : timeGreeting
 
   const isEmpty = messages.length === 0
@@ -75,10 +105,7 @@ export function ChatContainer() {
       {/* Mobile Sidebar Overlay */}
       {sidebarOpen && (
         <div className="fixed inset-0 z-50 flex md:hidden">
-          <div
-            className="absolute inset-0 bg-black/50"
-            onClick={() => setSidebarOpen(false)}
-          />
+          <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)} />
           <div className="relative w-72">
             <ConversationSidebar
               conversations={conversations}
@@ -117,8 +144,7 @@ export function ChatContainer() {
               </div>
               <h2 className="mb-2 text-2xl font-bold">{greeting}</h2>
               <p className="mb-8 max-w-md text-center text-sm text-muted-foreground">
-                Frag mich alles rund ums Thema Haare — von Pflege-Tipps bis
-                Produktempfehlungen!
+                Frag mich alles rund ums Thema Haare — von Pflege-Tipps bis Produktempfehlungen!
               </p>
               <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
                 {suggestedPrompts.map((prompt) => (
@@ -144,6 +170,7 @@ export function ChatContainer() {
                     message={msg}
                     hairProfile={hairProfile}
                     onProductClick={handleProductClick}
+                    isNew={newMessageIds.has(msg.id)}
                   />
                 )
               })}
@@ -151,9 +178,7 @@ export function ChatContainer() {
               {/* Streaming indicator */}
               {isStreaming &&
                 messages[messages.length - 1]?.role === "assistant" &&
-                !messages[messages.length - 1]?.content && (
-                  <ChatLoadingIndicator />
-                )}
+                !messages[messages.length - 1]?.content && <ChatLoadingIndicator />}
 
               <div ref={messagesEndRef} />
             </div>

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -69,6 +69,16 @@ export function ChatContainer() {
 
   const hasNewMessages = currentCount > 0 && newMessageIds.size > 0
 
+  // Clear newMessageIds after animation completes so streaming deltas don't get smooth-scroll
+  useEffect(() => {
+    if (newMessageIds.size > 0) {
+      const timer = setTimeout(() => {
+        setNewMessageIds(new Set())
+      }, 400) // match fadeInUpFast duration (300ms) + buffer
+      return () => clearTimeout(timer)
+    }
+  }, [newMessageIds])
+
   useEffect(() => {
     loadConversations()
   }, [loadConversations])
@@ -82,7 +92,12 @@ export function ChatContainer() {
     }
   }, [messages, hasNewMessages])
 
-  const openSidebar = useCallback(() => setSidebarState("open"), [])
+  const triggerRef = useRef<HTMLElement | null>(null)
+
+  const openSidebar = useCallback(() => {
+    triggerRef.current = document.activeElement as HTMLElement
+    setSidebarState("open")
+  }, [])
   const closeSidebar = useCallback(() => setSidebarState("closing"), [])
 
   // Focus trap + Escape for mobile sidebar
@@ -119,6 +134,20 @@ export function ChatContainer() {
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
   }, [sidebarState, closeSidebar])
+
+  // Move focus into sidebar on open, restore to trigger on close
+  useEffect(() => {
+    if (sidebarState === "open" && sidebarPanelRef.current) {
+      const first = sidebarPanelRef.current.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      first?.focus()
+    }
+    if (sidebarState === "closed" && triggerRef.current) {
+      triggerRef.current.focus()
+      triggerRef.current = null
+    }
+  }, [sidebarState])
 
   const handleProductClick = useCallback((product: Product) => {
     setDrawerProduct(product)

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -229,7 +229,7 @@ export function ChatContainer() {
         </div>
 
         {/* Messages */}
-        <div className="relative flex-1 overflow-y-auto">
+        <div className="relative flex-1 overflow-y-auto overflow-x-hidden">
           {/* Atmospheric layers */}
           <div
             className="pointer-events-none absolute inset-0 opacity-[0.015]"

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -10,6 +10,8 @@ import { ChatLoadingIndicator } from "./chat-loading-indicator"
 import { ProductDetailDrawer } from "./product-detail-drawer"
 import { ConversationSidebar } from "./conversation-sidebar"
 import { useEffect, useMemo, useRef, useState, useCallback } from "react"
+import { format, isToday, isYesterday } from "date-fns"
+import { de } from "date-fns/locale"
 import { Menu } from "lucide-react"
 import { CombIcon } from "@/components/ui/comb-icon"
 import { Icon } from "@/components/ui/icon"
@@ -138,9 +140,26 @@ export function ChatContainer() {
         </div>
 
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="relative flex-1 overflow-y-auto">
+          {/* Atmospheric layers */}
+          <div
+            className="pointer-events-none absolute inset-0 opacity-[0.015]"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+              backgroundRepeat: "repeat",
+              backgroundSize: "256px 256px",
+            }}
+          />
+          <div
+            className="pointer-events-none absolute left-1/2 top-0 h-[300px] w-[120%] -translate-x-1/2"
+            style={{
+              background:
+                "radial-gradient(ellipse at 50% 0%, rgba(var(--brand-plum-rgb), 0.03), transparent 70%)",
+            }}
+          />
+
           {isEmpty ? (
-            <div className="flex h-full flex-col items-center justify-center px-4">
+            <div className="relative z-[1] flex h-full flex-col items-center justify-center px-4">
               <div className="animate-scale-in mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary">
                 <CombIcon className="h-8 w-8 text-primary-foreground" />
               </div>
@@ -170,19 +189,45 @@ export function ChatContainer() {
               </div>
             </div>
           ) : (
-            <div className="mx-auto max-w-3xl space-y-4 p-4">
-              {messages.map((msg) => {
+            <div className="relative z-[1] mx-auto max-w-3xl space-y-4 p-4">
+              {messages.map((msg, idx) => {
                 // Don't render empty assistant placeholder — streaming indicator handles it
                 if (msg.role === "assistant" && !msg.content) return null
 
+                // Date separator: show when date changes from previous message
+                let dateSeparator: React.ReactNode = null
+                if (msg.created_at) {
+                  const msgDate = new Date(msg.created_at)
+                  const prevMsg = idx > 0 ? messages[idx - 1] : null
+                  const prevDate = prevMsg?.created_at ? new Date(prevMsg.created_at) : null
+                  const dateChanged =
+                    !prevDate || msgDate.toDateString() !== prevDate.toDateString()
+                  if (dateChanged) {
+                    const label = isToday(msgDate)
+                      ? "Heute"
+                      : isYesterday(msgDate)
+                        ? "Gestern"
+                        : format(msgDate, "dd. MMM", { locale: de })
+                    dateSeparator = (
+                      <div className="flex items-center gap-3 py-2">
+                        <div className="h-px flex-1 bg-border" />
+                        <span className="type-caption text-muted-foreground">{label}</span>
+                        <div className="h-px flex-1 bg-border" />
+                      </div>
+                    )
+                  }
+                }
+
                 return (
-                  <ChatMessage
-                    key={msg.id}
-                    message={msg}
-                    hairProfile={hairProfile}
-                    onProductClick={handleProductClick}
-                    isNew={newMessageIds.has(msg.id)}
-                  />
+                  <div key={msg.id}>
+                    {dateSeparator}
+                    <ChatMessage
+                      message={msg}
+                      hairProfile={hairProfile}
+                      onProductClick={handleProductClick}
+                      isNew={newMessageIds.has(msg.id)}
+                    />
+                  </div>
                 )
               })}
 

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -34,7 +34,8 @@ export function ChatContainer() {
   const { hairProfile } = useHairProfile()
   const suggestedPrompts = useMemo(() => generateSuggestedPrompts(hairProfile), [hairProfile])
 
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [sidebarState, setSidebarState] = useState<"closed" | "open" | "closing">("closed")
+  const sidebarPanelRef = useRef<HTMLDivElement>(null)
   const [drawerProduct, setDrawerProduct] = useState<Product | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -81,6 +82,44 @@ export function ChatContainer() {
     }
   }, [messages, hasNewMessages])
 
+  const openSidebar = useCallback(() => setSidebarState("open"), [])
+  const closeSidebar = useCallback(() => setSidebarState("closing"), [])
+
+  // Focus trap + Escape for mobile sidebar
+  useEffect(() => {
+    if (sidebarState !== "open") return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        closeSidebar()
+        return
+      }
+
+      if (e.key !== "Tab") return
+      const panel = sidebarPanelRef.current
+      if (!panel) return
+
+      const focusable = panel.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      )
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [sidebarState, closeSidebar])
+
   const handleProductClick = useCallback((product: Product) => {
     setDrawerProduct(product)
     setDrawerOpen(true)
@@ -107,17 +146,37 @@ export function ChatContainer() {
       </div>
 
       {/* Mobile Sidebar Overlay */}
-      {sidebarOpen && (
-        <div className="fixed inset-0 z-50 flex md:hidden">
-          <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)} />
-          <div className="relative w-72">
+      {sidebarState !== "closed" && (
+        <div
+          className="fixed inset-0 z-50 flex md:hidden"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Unterhaltungen"
+        >
+          <div
+            className={`absolute inset-0 bg-black/50 ${
+              sidebarState === "closing"
+                ? "animate-[backdropFadeOut_0.25s_ease_both]"
+                : "animate-[backdropFadeIn_0.25s_ease_both]"
+            }`}
+            onClick={closeSidebar}
+          />
+          <div
+            ref={sidebarPanelRef}
+            className={`relative w-72 ${
+              sidebarState === "closing" ? "animate-slide-out-left" : "animate-slide-in-left"
+            }`}
+            onAnimationEnd={() => {
+              if (sidebarState === "closing") setSidebarState("closed")
+            }}
+          >
             <ConversationSidebar
               conversations={conversations}
               currentId={currentConversationId}
               onSelect={loadConversation}
               onNew={startNewConversation}
               onDelete={deleteConversation}
-              onClose={() => setSidebarOpen(false)}
+              onClose={closeSidebar}
               isMobile
             />
           </div>
@@ -129,12 +188,13 @@ export function ChatContainer() {
         {/* Mobile header */}
         <div className="flex items-center gap-2 border-b p-3 md:hidden">
           <button
-            onClick={() => setSidebarOpen(true)}
+            onClick={openSidebar}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent"
+            aria-label="Unterhaltungen öffnen"
           >
             <Menu className="h-5 w-5" />
           </button>
-          <span className="text-sm font-medium">
+          <span className="type-body-sm font-medium">
             {currentConversationId ? "Chat" : "Neuer Chat"}
           </span>
         </div>
@@ -167,7 +227,7 @@ export function ChatContainer() {
                 {greeting}
               </h2>
               <p
-                className="animate-fade-in-up mb-8 max-w-md text-center text-sm text-muted-foreground"
+                className="animate-fade-in-up mb-8 max-w-md text-center type-body-sm text-muted-foreground"
                 style={{ animationDelay: "250ms" }}
               >
                 Frag mich alles rund ums Thema Haare — von Pflege-Tipps bis Produktempfehlungen!
@@ -177,7 +237,7 @@ export function ChatContainer() {
                   <button
                     key={prompt.text}
                     onClick={() => sendMessage(prompt.text)}
-                    className="animate-fade-in-up flex items-start gap-2.5 rounded-xl border px-4 py-3 text-left text-sm transition-all duration-200 hover:border-primary/40 hover:bg-accent hover:shadow-sm hover:-translate-y-0.5"
+                    className="animate-fade-in-up flex items-start gap-2.5 rounded-xl border px-4 py-3 text-left type-body-sm transition-all duration-200 hover:border-primary/40 hover:bg-accent hover:shadow-sm hover:-translate-y-0.5"
                     style={{ animationDelay: `${350 + index * 80}ms` }}
                   >
                     {prompt.icon && (

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -40,7 +40,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
   }
 
   return (
-    <div className="border-t bg-background p-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+    <div className="bg-background p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-[0_-2px_12px_rgba(0,0,0,0.04)]">
       <div className="flex items-end gap-2">
         {/* Text input */}
         <textarea
@@ -62,7 +62,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           onClick={handleSubmit}
           disabled={disabled || !message.trim()}
           aria-label="Nachricht senden"
-          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[12px] bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/90 disabled:opacity-50"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[12px] bg-secondary text-secondary-foreground transition-all duration-150 hover:bg-secondary/90 hover:shadow-[0_2px_12px_rgba(var(--brand-coral-rgb),0.25)] active:scale-95 disabled:opacity-50"
         >
           <Send className="h-5 w-5" />
         </button>

--- a/src/components/chat/chat-loading-indicator.tsx
+++ b/src/components/chat/chat-loading-indicator.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { CombIcon } from "@/components/ui/comb-icon"
+
 const LOADING_MESSAGES = [
   "Durchkämmen...",
   "Föhnen...",
@@ -12,29 +14,6 @@ const LOADING_MESSAGES = [
   "Nachschlagen...",
   "Formulieren...",
 ]
-
-function CombIcon() {
-  return (
-    <svg
-      className="h-4 w-4 animate-comb-sway text-muted-foreground"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      {/* Handle */}
-      <rect x="3" y="4" width="4" height="16" rx="1" />
-      {/* Teeth */}
-      <line x1="7" y1="6" x2="21" y2="6" />
-      <line x1="7" y1="9" x2="21" y2="9" />
-      <line x1="7" y1="12" x2="21" y2="12" />
-      <line x1="7" y1="15" x2="21" y2="15" />
-      <line x1="7" y1="18" x2="21" y2="18" />
-    </svg>
-  )
-}
 
 function pickRandomMessage() {
   return LOADING_MESSAGES[Math.floor(Math.random() * LOADING_MESSAGES.length)]
@@ -49,7 +28,7 @@ export function ChatLoadingIndicator() {
         HC
       </div>
       <div className="flex items-center gap-2 rounded-2xl bg-muted px-4 py-2.5">
-        <CombIcon />
+        <CombIcon className="animate-comb-sway text-muted-foreground" />
         <span className="text-sm text-muted-foreground">{message}</span>
       </div>
     </div>

--- a/src/components/chat/chat-loading-indicator.tsx
+++ b/src/components/chat/chat-loading-indicator.tsx
@@ -29,7 +29,7 @@ export function ChatLoadingIndicator() {
       </div>
       <div className="flex items-center gap-2 rounded-2xl bg-muted px-4 py-2.5">
         <CombIcon className="animate-comb-sway text-muted-foreground" />
-        <span className="text-sm text-muted-foreground">{message}</span>
+        <span className="type-body-sm text-muted-foreground">{message}</span>
       </div>
     </div>
   )

--- a/src/components/chat/chat-loading-indicator.tsx
+++ b/src/components/chat/chat-loading-indicator.tsx
@@ -44,7 +44,7 @@ export function ChatLoadingIndicator() {
   const message = pickRandomMessage()
 
   return (
-    <div className="flex gap-3">
+    <div className="flex gap-3 animate-fade-in-up-fast">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
         HC
       </div>

--- a/src/components/chat/chat-loading-indicator.tsx
+++ b/src/components/chat/chat-loading-indicator.tsx
@@ -24,8 +24,8 @@ export function ChatLoadingIndicator() {
 
   return (
     <div className="flex gap-3 animate-fade-in-up-fast">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
-        HC
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-[0_2px_8px_rgba(var(--brand-plum-rgb),0.25)]">
+        <CombIcon className="h-4 w-4 text-primary-foreground" />
       </div>
       <div className="flex items-center gap-2 rounded-2xl bg-muted px-4 py-2.5">
         <CombIcon className="animate-comb-sway text-muted-foreground" />

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -308,7 +308,7 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
             }`}
           >
             {isUser ? (
-              <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+              <p className="type-body-sm whitespace-pre-wrap">{message.content}</p>
             ) : (
               <div className="prose prose-sm max-w-none">
                 <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
@@ -321,7 +321,7 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
 
         {/* Sources footer */}
         {sources.length > 0 && (
-          <details className="text-xs text-muted-foreground px-1">
+          <details className="type-caption text-muted-foreground px-1">
             <summary className="cursor-pointer hover:text-foreground transition-colors">
               {sources.length} {sources.length === 1 ? "Quelle" : "Quellen"}
             </summary>

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -15,7 +15,7 @@ import { ProductPopover } from "./product-popover"
  */
 function renumberCitations(
   content: string,
-  sources: CitationSource[]
+  sources: CitationSource[],
 ): { content: string; sources: CitationSource[] } {
   if (sources.length === 0) return { content, sources }
 
@@ -73,16 +73,15 @@ interface ChatMessageProps {
   message: Message
   hairProfile: HairProfile | null
   onProductClick?: (product: Product) => void
+  /** True for messages appended during this session (not history loads) */
+  isNew?: boolean
 }
 
 /**
  * Splits a text string on [N] markers and interleaves CitationBadge components
  * for any N that exists in the sourceMap.
  */
-function renderWithCitations(
-  text: string,
-  sourceMap: Map<number, CitationSource>
-): ReactNode[] {
+function renderWithCitations(text: string, sourceMap: Map<number, CitationSource>): ReactNode[] {
   const parts = text.split(/\[(\d+)\]/g)
   const result: ReactNode[] = []
 
@@ -113,7 +112,7 @@ function renderWithProductMentions(
   nodes: ReactNode[],
   productMap: Map<string, Product>,
   hairProfile: HairProfile | null,
-  onProductClick?: (product: Product) => void
+  onProductClick?: (product: Product) => void,
 ): ReactNode[] {
   if (productMap.size === 0 || !onProductClick) return nodes
 
@@ -126,9 +125,7 @@ function renderWithProductMentions(
     }
 
     // Try to find product names in text, sorted by length (longest first to avoid partial matches)
-    const names = Array.from(productMap.keys()).sort(
-      (a, b) => b.length - a.length
-    )
+    const names = Array.from(productMap.keys()).sort((a, b) => b.length - a.length)
     let remaining = node
     let key = 0
 
@@ -170,7 +167,7 @@ function renderWithProductMentions(
           >
             {matchedName}
           </button>
-        </ProductPopover>
+        </ProductPopover>,
       )
 
       remaining = remaining.slice(earliest + matchedName.length)
@@ -191,7 +188,7 @@ function processChildren(
   sourceMap: Map<number, CitationSource>,
   productMap: Map<string, Product>,
   hairProfile: HairProfile | null,
-  onProductClick?: (product: Product) => void
+  onProductClick?: (product: Product) => void,
 ): ReactNode {
   if (typeof children === "string") {
     const cited = renderWithCitations(children, sourceMap)
@@ -216,7 +213,7 @@ function processChildren(
         sourceMap,
         productMap,
         hairProfile,
-        onProductClick
+        onProductClick,
       )
       // Clone the element with processed children
       return { ...element, props: { ...element.props, children: processed } }
@@ -225,12 +222,12 @@ function processChildren(
   return children
 }
 
-export function ChatMessage({ message, hairProfile, onProductClick }: ChatMessageProps) {
+export function ChatMessage({ message, hairProfile, onProductClick, isNew }: ChatMessageProps) {
   const isUser = message.role === "user"
 
   const { content: renumberedContent, sources } = useMemo(
     () => renumberCitations(message.content ?? "", message.rag_context?.sources ?? []),
-    [message.content, message.rag_context?.sources]
+    [message.content, message.rag_context?.sources],
   )
 
   const sourceMap = new Map(sources.map((s) => [s.index, s]))
@@ -257,16 +254,12 @@ export function ChatMessage({ message, hairProfile, onProductClick }: ChatMessag
     ? {
         p({ children }) {
           return (
-            <p>
-              {processChildren(children, sourceMap, productMap, hairProfile, onProductClick)}
-            </p>
+            <p>{processChildren(children, sourceMap, productMap, hairProfile, onProductClick)}</p>
           )
         },
         li({ children }) {
           return (
-            <li>
-              {processChildren(children, sourceMap, productMap, hairProfile, onProductClick)}
-            </li>
+            <li>{processChildren(children, sourceMap, productMap, hairProfile, onProductClick)}</li>
           )
         },
         strong({ children }) {
@@ -278,9 +271,7 @@ export function ChatMessage({ message, hairProfile, onProductClick }: ChatMessag
         },
         em({ children }) {
           return (
-            <em>
-              {processChildren(children, sourceMap, productMap, hairProfile, onProductClick)}
-            </em>
+            <em>{processChildren(children, sourceMap, productMap, hairProfile, onProductClick)}</em>
           )
         },
       }
@@ -289,40 +280,31 @@ export function ChatMessage({ message, hairProfile, onProductClick }: ChatMessag
   return (
     <div
       data-testid={isUser ? "message-user" : "message-assistant"}
-      className={`flex gap-3 ${isUser ? "flex-row-reverse" : "flex-row"}`}
+      className={`flex gap-3 ${isUser ? "flex-row-reverse" : "flex-row"}${isNew ? " animate-fade-in-up-fast" : ""}`}
     >
       {/* Avatar */}
       <div
         className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-          isUser
-            ? "bg-primary text-primary-foreground"
-            : "bg-primary text-primary-foreground"
+          isUser ? "bg-primary text-primary-foreground" : "bg-primary text-primary-foreground"
         }`}
       >
         {isUser ? "Du" : "HC"}
       </div>
 
       {/* Content */}
-      <div
-        className={`max-w-[80%] space-y-2 ${isUser ? "items-end" : "items-start"}`}
-      >
+      <div className={`max-w-[80%] space-y-2 ${isUser ? "items-end" : "items-start"}`}>
         {/* Text content */}
         {message.content && (
           <div
             className={`rounded-2xl px-4 py-2.5 ${
-              isUser
-                ? "bg-primary text-primary-foreground"
-                : "bg-muted text-foreground"
+              isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
             }`}
           >
             {isUser ? (
               <p className="text-sm whitespace-pre-wrap">{message.content}</p>
             ) : (
               <div className="prose prose-sm max-w-none">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={markdownComponents}
-                >
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                   {renumberedContent}
                 </ReactMarkdown>
               </div>

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -8,6 +8,7 @@ import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { CitationBadge } from "./citation-badge"
 import { ProductPopover } from "./product-popover"
+import { CombIcon } from "@/components/ui/comb-icon"
 
 /**
  * Renumbers [N] citation markers in content so they appear as [1], [2], [3]
@@ -285,18 +286,22 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
       {/* Avatar */}
       <div
         className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
-          isUser ? "bg-primary text-primary-foreground" : "bg-primary text-primary-foreground"
+          isUser
+            ? "bg-secondary text-secondary-foreground"
+            : "bg-primary text-primary-foreground shadow-[0_2px_8px_rgba(var(--brand-plum-rgb),0.25)]"
         }`}
       >
-        {isUser ? "Du" : "HC"}
+        {isUser ? "Du" : <CombIcon className="h-4 w-4 text-primary-foreground" />}
       </div>
 
       {/* Content */}
-      <div className={`max-w-[80%] space-y-2 ${isUser ? "items-end" : "items-start"}`}>
+      <div
+        className={`flex max-w-[80%] flex-col space-y-2 ${isUser ? "items-end" : "items-start"}`}
+      >
         {/* Text content */}
         {message.content && (
           <div
-            className={`rounded-2xl px-4 py-2.5 ${
+            className={`rounded-2xl px-4 py-2.5 shadow-sm ${
               isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
             }`}
           >

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useMemo, useRef, type ReactNode } from "react"
+import { format } from "date-fns"
 import posthog from "posthog-js"
 import type { Message, CitationSource, Product, HairProfile } from "@/lib/types"
 import type { Components } from "react-markdown"
@@ -332,6 +333,13 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
               ))}
             </ul>
           </details>
+        )}
+
+        {/* Timestamp */}
+        {message.created_at && (
+          <span className="type-caption text-muted-foreground px-1">
+            {format(new Date(message.created_at), "HH:mm")}
+          </span>
         )}
       </div>
     </div>

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -10,6 +10,7 @@ import remarkGfm from "remark-gfm"
 import { CitationBadge } from "./citation-badge"
 import { ProductPopover } from "./product-popover"
 import { CombIcon } from "@/components/ui/comb-icon"
+import { ProductCard } from "./product-card"
 
 /**
  * Renumbers [N] citation markers in content so they appear as [1], [2], [3]
@@ -333,6 +334,29 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
               ))}
             </ul>
           </details>
+        )}
+
+        {/* Product recommendation cards */}
+        {products.length > 0 && onProductClick && (
+          <div className="flex flex-col gap-1.5 pt-1">
+            {products.slice(0, 3).map((p, i) => (
+              <div
+                key={p.id}
+                className="animate-fade-in-up-fast"
+                style={{ animationDelay: `${i * 100}ms` }}
+              >
+                <ProductCard product={p} onClick={onProductClick} />
+              </div>
+            ))}
+            {products.length > 3 && (
+              <button
+                type="button"
+                className="type-caption text-primary hover:underline text-left px-1"
+              >
+                +{products.length - 3} weitere Empfehlungen
+              </button>
+            )}
+          </div>
         )}
 
         {/* Timestamp */}

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useRef, type ReactNode } from "react"
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { format } from "date-fns"
 import posthog from "posthog-js"
 import type { Message, CitationSource, Product, HairProfile } from "@/lib/types"
@@ -250,6 +250,9 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
     }
   }, [products.length])
 
+  const [showAllProducts, setShowAllProducts] = useState(false)
+  const visibleProducts = showAllProducts ? products : products.slice(0, 3)
+
   const hasEnhancements = sources.length > 0 || productMap.size > 0
 
   // Build custom markdown components that inject citation badges + product mentions
@@ -289,7 +292,7 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
       <div
         className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
           isUser
-            ? "bg-secondary text-secondary-foreground"
+            ? "bg-secondary text-[var(--brand-plum-darkest)]"
             : "bg-primary text-primary-foreground shadow-[0_2px_8px_rgba(var(--brand-plum-rgb),0.25)]"
         }`}
       >
@@ -339,7 +342,7 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
         {/* Product recommendation cards */}
         {products.length > 0 && onProductClick && (
           <div className="flex flex-col gap-1.5 pt-1">
-            {products.slice(0, 3).map((p, i) => (
+            {visibleProducts.map((p, i) => (
               <div
                 key={p.id}
                 className="animate-fade-in-up-fast"
@@ -348,9 +351,10 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
                 <ProductCard product={p} onClick={onProductClick} />
               </div>
             ))}
-            {products.length > 3 && (
+            {products.length > 3 && !showAllProducts && (
               <button
                 type="button"
+                onClick={() => setShowAllProducts(true)}
                 className="type-caption text-primary hover:underline text-left px-1"
               >
                 +{products.length - 3} weitere Empfehlungen

--- a/src/components/chat/conversation-sidebar.tsx
+++ b/src/components/chat/conversation-sidebar.tsx
@@ -93,6 +93,11 @@ export function ConversationSidebar({
                       e.stopPropagation()
                       onDelete(conv.id)
                     }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.stopPropagation()
+                      }
+                    }}
                     className="shrink-0 rounded p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive md:p-1"
                     aria-label="Unterhaltung löschen"
                   >

--- a/src/components/chat/conversation-sidebar.tsx
+++ b/src/components/chat/conversation-sidebar.tsx
@@ -57,55 +57,58 @@ export function ConversationSidebar({
           </p>
         ) : (
           <ul className="space-y-1">
-            {conversations.map((conv) => (
-              <li key={conv.id}>
-                <div
-                  role="button"
-                  tabIndex={0}
-                  className={`group flex items-center gap-2 rounded-lg px-3 py-2 type-body-sm transition-colors cursor-pointer ${
-                    currentId === conv.id
-                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                      : "text-sidebar-foreground hover:bg-sidebar-accent/50"
-                  }`}
-                  onClick={() => {
-                    onSelect(conv.id)
-                    if (isMobile && onClose) onClose()
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault()
-                      onSelect(conv.id)
-                      if (isMobile && onClose) onClose()
-                    }
-                  }}
-                >
-                  <MessageCircle className="h-4 w-4 shrink-0 opacity-60" />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate type-body-sm">{conv.title || "Neue Unterhaltung"}</p>
-                    <p className="type-caption opacity-60">
-                      {format(new Date(conv.updated_at), "dd. MMM", {
-                        locale: de,
-                      })}
-                    </p>
-                  </div>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onDelete(conv.id)
-                    }}
+            {conversations.map((conv) => {
+              function selectConversation() {
+                onSelect(conv.id)
+                if (isMobile && onClose) onClose()
+              }
+
+              return (
+                <li key={conv.id}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className={`group flex items-center gap-2 rounded-lg px-3 py-2 type-body-sm transition-colors cursor-pointer ${
+                      currentId === conv.id
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                        : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+                    }`}
+                    onClick={selectConversation}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
-                        e.stopPropagation()
+                        e.preventDefault()
+                        selectConversation()
                       }
                     }}
-                    className="shrink-0 rounded p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive md:p-1"
-                    aria-label="Unterhaltung löschen"
                   >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              </li>
-            ))}
+                    <MessageCircle className="h-4 w-4 shrink-0 opacity-60" />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate type-body-sm">{conv.title || "Neue Unterhaltung"}</p>
+                      <p className="type-caption opacity-60">
+                        {format(new Date(conv.updated_at), "dd. MMM", {
+                          locale: de,
+                        })}
+                      </p>
+                    </div>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onDelete(conv.id)
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.stopPropagation()
+                        }
+                      }}
+                      className="shrink-0 rounded p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive md:p-1"
+                      aria-label="Unterhaltung löschen"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </li>
+              )
+            })}
           </ul>
         )}
       </nav>

--- a/src/components/chat/conversation-sidebar.tsx
+++ b/src/components/chat/conversation-sidebar.tsx
@@ -28,14 +28,12 @@ export function ConversationSidebar({
     <div className="flex h-full flex-col border-r bg-sidebar">
       {/* Header */}
       <div className="flex items-center justify-between border-b p-4">
-        <h2 className="text-sm font-semibold text-sidebar-foreground">
-          Unterhaltungen
-        </h2>
+        <h2 className="type-body-sm font-semibold text-sidebar-foreground">Unterhaltungen</h2>
         <div className="flex items-center gap-1">
           <button
             onClick={onNew}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
-            title="Neue Unterhaltung"
+            aria-label="Neue Unterhaltung"
           >
             <Plus className="h-4 w-4" />
           </button>
@@ -43,6 +41,7 @@ export function ConversationSidebar({
             <button
               onClick={onClose}
               className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
+              aria-label="Seitenleiste schließen"
             >
               <X className="h-4 w-4" />
             </button>
@@ -51,51 +50,60 @@ export function ConversationSidebar({
       </div>
 
       {/* Conversation list */}
-      <div className="flex-1 overflow-y-auto p-2">
+      <nav aria-label="Unterhaltungen" className="flex-1 overflow-y-auto p-2">
         {conversations.length === 0 ? (
-          <p className="px-2 py-4 text-center text-xs text-muted-foreground">
+          <p className="px-2 py-4 text-center type-caption text-muted-foreground">
             Noch keine Unterhaltungen
           </p>
         ) : (
-          <div className="space-y-1">
+          <ul className="space-y-1">
             {conversations.map((conv) => (
-              <div
-                key={conv.id}
-                className={`group flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors cursor-pointer ${
-                  currentId === conv.id
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-sidebar-foreground hover:bg-sidebar-accent/50"
-                }`}
-                onClick={() => {
-                  onSelect(conv.id)
-                  if (isMobile && onClose) onClose()
-                }}
-              >
-                <MessageCircle className="h-4 w-4 shrink-0 opacity-60" />
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm">
-                    {conv.title || "Neue Unterhaltung"}
-                  </p>
-                  <p className="text-xs opacity-60">
-                    {format(new Date(conv.updated_at), "dd. MMM", {
-                      locale: de,
-                    })}
-                  </p>
-                </div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onDelete(conv.id)
+              <li key={conv.id}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className={`group flex items-center gap-2 rounded-lg px-3 py-2 type-body-sm transition-colors cursor-pointer ${
+                    currentId === conv.id
+                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+                  }`}
+                  onClick={() => {
+                    onSelect(conv.id)
+                    if (isMobile && onClose) onClose()
                   }}
-                  className="shrink-0 rounded p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive md:p-1"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      onSelect(conv.id)
+                      if (isMobile && onClose) onClose()
+                    }
+                  }}
                 >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </div>
+                  <MessageCircle className="h-4 w-4 shrink-0 opacity-60" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate type-body-sm">{conv.title || "Neue Unterhaltung"}</p>
+                    <p className="type-caption opacity-60">
+                      {format(new Date(conv.updated_at), "dd. MMM", {
+                        locale: de,
+                      })}
+                    </p>
+                  </div>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onDelete(conv.id)
+                    }}
+                    className="shrink-0 rounded p-1.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 hover:bg-destructive/10 hover:text-destructive md:p-1"
+                    aria-label="Unterhaltung löschen"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </li>
             ))}
-          </div>
+          </ul>
         )}
-      </div>
+      </nav>
     </div>
   )
 }

--- a/src/components/chat/product-card.tsx
+++ b/src/components/chat/product-card.tsx
@@ -9,7 +9,7 @@ interface ProductCardProps {
 /** Maps product.category to the icon name in our icon system. */
 function categoryIconName(category: string | null): IconName {
   if (!category) return "product-shampoo"
-  const mapped = `product-${category.replace("_", "-")}` as IconName
+  const mapped = `product-${category.replaceAll("_", "-")}` as IconName
   // Check if the mapped name is a valid icon; fall back otherwise.
   const validIcons: IconName[] = [
     "product-shampoo",

--- a/src/components/chat/product-card.tsx
+++ b/src/components/chat/product-card.tsx
@@ -1,0 +1,67 @@
+import type { Product } from "@/lib/types"
+import { Icon, type IconName } from "@/components/ui/icon"
+
+interface ProductCardProps {
+  product: Product
+  onClick: (product: Product) => void
+}
+
+/** Maps product.category to the icon name in our icon system. */
+function categoryIconName(category: string | null): IconName {
+  if (!category) return "product-shampoo"
+  const mapped = `product-${category.replace("_", "-")}` as IconName
+  // Check if the mapped name is a valid icon; fall back otherwise.
+  const validIcons: IconName[] = [
+    "product-shampoo",
+    "product-conditioner",
+    "product-oil",
+    "product-mask",
+    "product-leave-in",
+    "product-peeling",
+    "product-dry-shampoo",
+    "product-bond-builder",
+    "product-deep-cleansing",
+  ]
+  return validIcons.includes(mapped) ? mapped : "product-shampoo"
+}
+
+/** Formats a number as German-style price: `12,99 €` */
+function formatPrice(price: number): string {
+  return `${price.toFixed(2).replace(".", ",")} €`
+}
+
+export function ProductCard({ product, onClick }: ProductCardProps) {
+  const iconName = categoryIconName(product.category)
+  const topReason = product.recommendation_meta?.top_reasons?.[0]
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(product)}
+      className="flex w-full cursor-pointer items-center gap-3 rounded-xl border border-border bg-card p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
+    >
+      {/* Category icon */}
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[var(--brand-plum-ice)]">
+        <Icon name={iconName} size={18} className="text-primary" />
+      </div>
+
+      {/* Product info */}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[13px] font-semibold text-[var(--text-heading)]">
+          {product.name}
+        </p>
+        {product.brand && (
+          <p className="truncate text-[11px] text-[var(--text-caption)]">{product.brand}</p>
+        )}
+        {topReason && <p className="mt-0.5 truncate text-[11px] text-primary">{topReason}</p>}
+      </div>
+
+      {/* Price */}
+      {product.price_eur != null && (
+        <span className="shrink-0 font-mono text-[12px] font-medium text-[var(--text-heading)]">
+          {formatPrice(product.price_eur)}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -69,19 +69,19 @@ export function Header() {
       {menuOpen && (
         <div className="border-t bg-background p-4 md:hidden">
           <nav className="flex flex-col gap-1">
-            <MobileNavLink href="/chat" current={pathname} onClick={() => setMenuOpen(false)}>
+            <NavLink href="/chat" current={pathname} onClick={() => setMenuOpen(false)} mobile>
               <MessageCircle className="mr-2 h-4 w-4" />
               Chat
-            </MobileNavLink>
-            <MobileNavLink href="/profile" current={pathname} onClick={() => setMenuOpen(false)}>
+            </NavLink>
+            <NavLink href="/profile" current={pathname} onClick={() => setMenuOpen(false)} mobile>
               <User className="mr-2 h-4 w-4" />
               Profil
-            </MobileNavLink>
+            </NavLink>
             {profile?.is_admin && (
-              <MobileNavLink href="/admin" current={pathname} onClick={() => setMenuOpen(false)}>
+              <NavLink href="/admin" current={pathname} onClick={() => setMenuOpen(false)} mobile>
                 <Shield className="mr-2 h-4 w-4" />
                 Admin
-              </MobileNavLink>
+              </NavLink>
             )}
             <button
               onClick={() => {
@@ -103,36 +103,14 @@ export function Header() {
 function NavLink({
   href,
   current,
-  children,
-}: {
-  href: string
-  current: string
-  children: React.ReactNode
-}) {
-  const isActive = current === href || current.startsWith(href + "/")
-  return (
-    <Link
-      href={href}
-      className={`inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-        isActive
-          ? "bg-accent text-accent-foreground"
-          : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      }`}
-    >
-      {children}
-    </Link>
-  )
-}
-
-function MobileNavLink({
-  href,
-  current,
   onClick,
+  mobile,
   children,
 }: {
   href: string
   current: string
-  onClick: () => void
+  onClick?: () => void
+  mobile?: boolean
   children: React.ReactNode
 }) {
   const isActive = current === href || current.startsWith(href + "/")
@@ -140,7 +118,7 @@ function MobileNavLink({
     <Link
       href={href}
       onClick={onClick}
-      className={`inline-flex items-center rounded-md px-3 py-3 text-sm font-medium transition-colors ${
+      className={`inline-flex items-center rounded-md px-3 ${mobile ? "py-3" : "py-2"} text-sm font-medium transition-colors ${
         isActive
           ? "bg-accent text-accent-foreground"
           : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -17,9 +17,14 @@ export function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-40 relative bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-gradient-to-r after:from-transparent after:via-primary/20 after:to-transparent">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4">
         <Link href="/chat" className="flex items-center gap-2">
+          <div className="flex items-center gap-[3px]">
+            <span className="h-3.5 w-[3px] rounded-sm bg-primary" />
+            <span className="h-3.5 w-[3px] rounded-sm bg-primary/60" />
+            <span className="h-3.5 w-[3px] rounded-sm bg-primary/30" />
+          </div>
           <span className="font-header text-2xl tracking-wide text-[var(--text-heading)]">
             Hair Concierge
           </span>

--- a/src/components/ui/comb-icon.tsx
+++ b/src/components/ui/comb-icon.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils"
+
+interface CombIconProps {
+  className?: string
+}
+
+export function CombIcon({ className }: CombIconProps) {
+  return (
+    <svg
+      className={cn("h-4 w-4", className)}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Handle */}
+      <rect x="3" y="4" width="4" height="16" rx="1" />
+      {/* Teeth */}
+      <line x1="7" y1="6" x2="21" y2="6" />
+      <line x1="7" y1="9" x2="21" y2="9" />
+      <line x1="7" y1="12" x2="21" y2="12" />
+      <line x1="7" y1="15" x2="21" y2="15" />
+      <line x1="7" y1="18" x2="21" y2="18" />
+    </svg>
+  )
+}

--- a/src/components/ui/comb-icon.tsx
+++ b/src/components/ui/comb-icon.tsx
@@ -14,6 +14,7 @@ export function CombIcon({ className }: CombIconProps) {
       strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
+      aria-hidden="true"
     >
       {/* Handle */}
       <rect x="3" y="4" width="4" height="16" rx="1" />

--- a/src/lib/suggested-prompts.ts
+++ b/src/lib/suggested-prompts.ts
@@ -1,38 +1,65 @@
 import type { HairProfile, HairTexture, Concern, Goal } from "@/lib/types"
 import { HAIR_TEXTURE_ADJECTIVE, HAIR_THICKNESS_ADJECTIVE } from "@/lib/vocabulary"
+import type { IconName } from "@/components/ui/icon"
 
-const FALLBACK_PROMPTS = [
-  "Welche Routine empfiehlst du für lockiges Haar?",
-  "Was hilft gegen Spliss?",
-  "Kannst du mir ein gutes Shampoo empfehlen?",
-  "Wie bekomme ich mehr Volumen?",
+export interface SuggestedPrompt {
+  text: string
+  icon?: IconName
+}
+
+const FALLBACK_PROMPTS: SuggestedPrompt[] = [
+  { text: "Welche Routine empfiehlst du für lockiges Haar?", icon: "hair-curly" },
+  { text: "Was hilft gegen Spliss?", icon: "goal-split-ends" },
+  { text: "Kannst du mir ein gutes Shampoo empfehlen?", icon: "product-shampoo" },
+  { text: "Wie bekomme ich mehr Volumen?", icon: "goal-volume" },
 ]
 
 /* ── Slot 1: Template prompts (one picked based on available profile data) ── */
 
-function getTemplatePrompts(profile: HairProfile): string[] {
-  const prompts: string[] = []
+const TEXTURE_ICON: Record<HairTexture, IconName> = {
+  straight: "hair-straight",
+  wavy: "hair-wavy",
+  curly: "hair-curly",
+  coily: "hair-coily",
+}
+
+function getTemplatePrompts(profile: HairProfile): SuggestedPrompt[] {
+  const prompts: SuggestedPrompt[] = []
   const ht = profile.hair_texture
   const tx = profile.thickness
 
   if (ht && tx) {
-    prompts.push(
-      `Welche Pflegeroutine passt am besten zu meinem ${HAIR_TEXTURE_ADJECTIVE[ht]}, ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar?`,
-    )
-    prompts.push(
-      `Was sind die besten Produkte für ${HAIR_TEXTURE_ADJECTIVE[ht]} und ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar?`,
-    )
+    prompts.push({
+      text: `Welche Pflegeroutine passt am besten zu meinem ${HAIR_TEXTURE_ADJECTIVE[ht]}, ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar?`,
+      icon: TEXTURE_ICON[ht],
+    })
+    prompts.push({
+      text: `Was sind die besten Produkte für ${HAIR_TEXTURE_ADJECTIVE[ht]} und ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar?`,
+      icon: TEXTURE_ICON[ht],
+    })
   }
   if (ht) {
-    prompts.push(`Welche Pflegeroutine empfiehlst du für ${HAIR_TEXTURE_ADJECTIVE[ht]} Haar?`)
-    prompts.push(`Wie style ich ${HAIR_TEXTURE_ADJECTIVE[ht]} Haar am besten?`)
+    prompts.push({
+      text: `Welche Pflegeroutine empfiehlst du für ${HAIR_TEXTURE_ADJECTIVE[ht]} Haar?`,
+      icon: TEXTURE_ICON[ht],
+    })
+    prompts.push({
+      text: `Wie style ich ${HAIR_TEXTURE_ADJECTIVE[ht]} Haar am besten?`,
+      icon: TEXTURE_ICON[ht],
+    })
   }
   if (tx) {
-    prompts.push(`Worauf sollte ich bei ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar besonders achten?`)
+    prompts.push({
+      text: `Worauf sollte ich bei ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar besonders achten?`,
+      icon: "product-shampoo",
+    })
   }
 
   // Always have at least one generic template
-  prompts.push("Welche Pflegeroutine würdest du mir persönlich empfehlen?")
+  prompts.push({
+    text: "Welche Pflegeroutine würdest du mir persönlich empfehlen?",
+    icon: "product-shampoo",
+  })
 
   return prompts
 }
@@ -41,6 +68,7 @@ function getTemplatePrompts(profile: HairProfile): string[] {
 
 interface PoolPrompt {
   text: string
+  icon?: IconName
   concerns?: Concern[]
   goals?: Goal[]
   hairTextures?: HairTexture[]
@@ -48,36 +76,109 @@ interface PoolPrompt {
 
 const POOL_PROMPTS: PoolPrompt[] = [
   // Concern-based
-  { text: "Meine Haare sind so trocken — welche Pflege hilft wirklich?", concerns: ["dryness"] },
-  { text: "Was kann ich gegen Spliss an den Spitzen tun?", concerns: ["split_ends"] },
-  { text: "Wie werde ich Schuppen endlich los?", concerns: ["dandruff"] },
-  { text: "Meine Kopfhaut fettet so schnell nach — was hilft?", concerns: ["oily_scalp"] },
-  { text: "Wie kann ich Haarausfall vorbeugen?", concerns: ["hair_loss"] },
+  {
+    text: "Meine Haare sind so trocken — welche Pflege hilft wirklich?",
+    icon: "goal-moisture",
+    concerns: ["dryness"],
+  },
+  {
+    text: "Was kann ich gegen Spliss an den Spitzen tun?",
+    icon: "goal-split-ends",
+    concerns: ["split_ends"],
+  },
+  {
+    text: "Wie werde ich Schuppen endlich los?",
+    icon: "scalp-dry",
+    concerns: ["dandruff"],
+  },
+  {
+    text: "Meine Kopfhaut fettet so schnell nach — was hilft?",
+    icon: "scalp-oily",
+    concerns: ["oily_scalp"],
+  },
+  {
+    text: "Wie kann ich Haarausfall vorbeugen?",
+    icon: "goal-growth",
+    concerns: ["hair_loss"],
+  },
   {
     text: "Mein Haar ist durch Färben strapaziert — wie repariere ich es?",
+    icon: "goal-color-protection",
     concerns: ["hair_damage", "colored"],
   },
-  { text: "Was hilft wirklich gegen Frizz?", concerns: ["frizz"] },
-  { text: "Mein Haar wird immer dünner — welche Produkte stärken es?", concerns: ["thinning"] },
-  { text: "Wie schütze ich meine Haarfarbe vor dem Verblassen?", concerns: ["colored"] },
+  { text: "Was hilft wirklich gegen Frizz?", icon: "goal-frizz", concerns: ["frizz"] },
+  {
+    text: "Mein Haar wird immer dünner — welche Produkte stärken es?",
+    icon: "goal-growth",
+    concerns: ["thinning"],
+  },
+  {
+    text: "Wie schütze ich meine Haarfarbe vor dem Verblassen?",
+    icon: "goal-color-protection",
+    concerns: ["colored"],
+  },
 
   // Goal-based
-  { text: "Wie bekomme ich mehr Volumen in meine Haare?", goals: ["volume"] },
-  { text: "Was kann ich tun, damit mein Haar schneller wächst?" },
-  { text: "Wie definiere ich meine Locken am besten?", goals: ["curl_definition"] },
-  { text: "Welche Produkte sorgen für mehr Glanz?", goals: ["shine"] },
-  { text: "Wie bringe ich mehr Feuchtigkeit in mein Haar?", goals: ["moisture"] },
-  { text: "Was hilft für eine gesunde Kopfhaut?", goals: ["healthy_scalp"] },
-  { text: "Wie bekomme ich meine Haare gesünder?", goals: ["healthier_hair"] },
-  { text: "Wie reduziere ich Frizz dauerhaft?", goals: ["less_frizz"] },
-  { text: "Wie schütze ich meine Farbe am besten?", goals: ["color_protection"] },
-  { text: "Was hilft wirklich gegen Spliss und abgebrochene Spitzen?", goals: ["less_split_ends"] },
+  {
+    text: "Wie bekomme ich mehr Volumen in meine Haare?",
+    icon: "goal-volume",
+    goals: ["volume"],
+  },
+  { text: "Was kann ich tun, damit mein Haar schneller wächst?", icon: "goal-growth" },
+  {
+    text: "Wie definiere ich meine Locken am besten?",
+    icon: "hair-curly",
+    goals: ["curl_definition"],
+  },
+  { text: "Welche Produkte sorgen für mehr Glanz?", icon: "goal-shine", goals: ["shine"] },
+  {
+    text: "Wie bringe ich mehr Feuchtigkeit in mein Haar?",
+    icon: "goal-moisture",
+    goals: ["moisture"],
+  },
+  {
+    text: "Was hilft für eine gesunde Kopfhaut?",
+    icon: "goal-scalp-health",
+    goals: ["healthy_scalp"],
+  },
+  {
+    text: "Wie bekomme ich meine Haare gesünder?",
+    icon: "goal-repair",
+    goals: ["healthier_hair"],
+  },
+  { text: "Wie reduziere ich Frizz dauerhaft?", icon: "goal-frizz", goals: ["less_frizz"] },
+  {
+    text: "Wie schütze ich meine Farbe am besten?",
+    icon: "goal-color-protection",
+    goals: ["color_protection"],
+  },
+  {
+    text: "Was hilft wirklich gegen Spliss und abgebrochene Spitzen?",
+    icon: "goal-split-ends",
+    goals: ["less_split_ends"],
+  },
 
   // Hair-texture-based
-  { text: "Wie style ich Locken ohne Hitze?", hairTextures: ["curly", "coily"] },
-  { text: "Wie pflege ich welliges Haar, ohne es zu beschweren?", hairTextures: ["wavy"] },
-  { text: "Welche Leave-in-Produkte eignen sich für glattes Haar?", hairTextures: ["straight"] },
-  { text: "Welche Schlafschutz-Routine eignet sich für Locken?", hairTextures: ["curly", "coily"] },
+  {
+    text: "Wie style ich Locken ohne Hitze?",
+    icon: "hair-curly",
+    hairTextures: ["curly", "coily"],
+  },
+  {
+    text: "Wie pflege ich welliges Haar, ohne es zu beschweren?",
+    icon: "hair-wavy",
+    hairTextures: ["wavy"],
+  },
+  {
+    text: "Welche Leave-in-Produkte eignen sich für glattes Haar?",
+    icon: "hair-straight",
+    hairTextures: ["straight"],
+  },
+  {
+    text: "Welche Schlafschutz-Routine eignet sich für Locken?",
+    icon: "hair-curly",
+    hairTextures: ["curly", "coily"],
+  },
 ]
 
 function shuffle<T>(arr: T[]): T[] {
@@ -103,7 +204,7 @@ function matchesProfile(prompt: PoolPrompt, profile: HairProfile): boolean {
 
 /* ── Main export ── */
 
-export function generateSuggestedPrompts(profile: HairProfile | null): string[] {
+export function generateSuggestedPrompts(profile: HairProfile | null): SuggestedPrompt[] {
   if (
     !profile ||
     (!profile.hair_texture &&
@@ -121,16 +222,16 @@ export function generateSuggestedPrompts(profile: HairProfile | null): string[] 
   // Slots 2-4: pick 3 from the filtered pool
   const matched = POOL_PROMPTS.filter((p) => matchesProfile(p, profile))
   const pool = matched.length >= 3 ? matched : [...matched, ...POOL_PROMPTS]
-  const unique = shuffle(pool).filter((p) => p.text !== template)
+  const unique = shuffle(pool).filter((p) => p.text !== template.text)
 
   // Deduplicate
-  const seen = new Set<string>([template])
-  const picked: string[] = []
+  const seen = new Set<string>([template.text])
+  const picked: SuggestedPrompt[] = []
   for (const p of unique) {
     if (picked.length >= 3) break
     if (!seen.has(p.text)) {
       seen.add(p.text)
-      picked.push(p.text)
+      picked.push({ text: p.text, icon: p.icon })
     }
   }
 


### PR DESCRIPTION
## Summary

- Message entrance animations with new-message tracking (only new messages animate, not history)
- CombIcon avatars for assistant, coral avatars for user, bubble shadows
- Suggested prompt icons from existing 165-icon registry + stagger + hover personality
- Chat atmosphere (noise texture + plum gradient glow)
- HH:mm timestamps + date group separators (Heute/Gestern)
- Inline product recommendation cards below messages (category icon, brand, price, match reason)
- Sidebar slide animation + focus trap + Escape-to-close
- Semantic nav/ul/button structure replacing div onClick
- Typography system adoption (type-* classes) with iOS zoom preservation
- Custom scrollbar + plum selection color
- Header brand mark + gradient divider
- prefers-reduced-motion fallback for all animations
- WCAG AA contrast fix on user avatar

## Test plan

- [ ] Visual check on mobile (375px) + desktop (1440px)
- [ ] Send a message — entrance animation plays, product cards render if recommendations present
- [ ] Mobile sidebar — slides in/out, focus trapped, Escape closes
- [ ] Keyboard nav — Tab through conversation list, Enter/Space to select
- [ ] iOS — chat input does NOT zoom on focus
- [ ] Reduced motion — disable animations in OS settings, verify no animations play

🤖 Generated with [Claude Code](https://claude.com/claude-code)