### PR TITLE
[codex] refine tiefenreinigung reset logic

### DIFF
--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -106,7 +106,7 @@ function formatUserProfile(
   if (!profile) {
     return appendMemoryContext(
       "Kein Haarprofil vorhanden. Frage den Nutzer nach seinen Haardetails, wenn relevant.",
-      memoryContext
+      memoryContext,
     )
   }
 
@@ -122,22 +122,30 @@ function formatUserProfile(
     parts.push(`Haardichte: ${HAIR_DENSITY_LABELS[profile.density] ?? profile.density}`)
   }
   if (profile.concerns.length > 0) {
-    parts.push(`Probleme/Bedenken: ${profile.concerns.map((c) => CONCERN_LABELS[c] ?? c).join(", ")}`)
+    parts.push(
+      `Probleme/Bedenken: ${profile.concerns.map((c) => CONCERN_LABELS[c] ?? c).join(", ")}`,
+    )
   }
   if (profile.goals.length > 0) {
     parts.push(`Ziele: ${profile.goals.map((g) => GOAL_LABELS[g] ?? g).join(", ")}`)
   }
   if (profile.desired_volume) {
-    parts.push(`Gewuenschtes Volumen: ${DESIRED_VOLUME_LABELS[profile.desired_volume] ?? profile.desired_volume}`)
+    parts.push(
+      `Gewuenschtes Volumen: ${DESIRED_VOLUME_LABELS[profile.desired_volume] ?? profile.desired_volume}`,
+    )
   }
   if (profile.wash_frequency) {
-    parts.push(`Waschfrequenz: ${WASH_FREQUENCY_LABELS[profile.wash_frequency] ?? profile.wash_frequency}`)
+    parts.push(
+      `Waschfrequenz: ${WASH_FREQUENCY_LABELS[profile.wash_frequency] ?? profile.wash_frequency}`,
+    )
   }
   if (profile.heat_styling) {
     parts.push(`Hitzestyling: ${HEAT_STYLING_LABELS[profile.heat_styling] ?? profile.heat_styling}`)
   }
   if (profile.styling_tools.length > 0) {
-    parts.push(`Styling-Tools: ${profile.styling_tools.map((t) => STYLING_TOOL_LABELS[t] ?? t).join(", ")}`)
+    parts.push(
+      `Styling-Tools: ${profile.styling_tools.map((t) => STYLING_TOOL_LABELS[t] ?? t).join(", ")}`,
+    )
   }
   if ((profile.post_wash_actions ?? []).length > 0) {
     parts.push(`Nach dem Waschen: ${(profile.post_wash_actions ?? []).join(", ")}`)
@@ -146,7 +154,9 @@ function formatUserProfile(
     parts.push(`Aktuelle Routine-Produkte: ${(profile.current_routine_products ?? []).join(", ")}`)
   }
   if (profile.cuticle_condition) {
-    parts.push(`Kutikula-Zustand: ${CUTICLE_CONDITION_LABELS[profile.cuticle_condition] ?? profile.cuticle_condition}`)
+    parts.push(
+      `Kutikula-Zustand: ${CUTICLE_CONDITION_LABELS[profile.cuticle_condition] ?? profile.cuticle_condition}`,
+    )
   }
   if (profile.protein_moisture_balance) {
     parts.push(`Protein-Feuchtigkeits-Balance: ${profile.protein_moisture_balance}`)
@@ -155,28 +165,42 @@ function formatUserProfile(
     parts.push(`Kopfhaut-Typ: ${SCALP_TYPE_LABELS[profile.scalp_type] ?? profile.scalp_type}`)
   }
   if (profile.scalp_condition && profile.scalp_condition !== "none") {
-    parts.push(`Kopfhaut-Beschwerden: ${SCALP_CONDITION_LABELS[profile.scalp_condition] ?? profile.scalp_condition}`)
+    parts.push(
+      `Kopfhaut-Beschwerden: ${SCALP_CONDITION_LABELS[profile.scalp_condition] ?? profile.scalp_condition}`,
+    )
   }
   if (profile.chemical_treatment?.length > 0) {
-    parts.push(`Chemische Behandlung: ${profile.chemical_treatment.map((t) => CHEMICAL_TREATMENT_LABELS[t] ?? t).join(", ")}`)
+    parts.push(
+      `Chemische Behandlung: ${profile.chemical_treatment.map((t) => CHEMICAL_TREATMENT_LABELS[t] ?? t).join(", ")}`,
+    )
   }
   if (profile.mechanical_stress_factors?.length > 0) {
-    parts.push(`Mechanische Belastung: ${profile.mechanical_stress_factors.map((f) => MECHANICAL_STRESS_FACTOR_LABELS[f] ?? f).join(", ")}`)
+    parts.push(
+      `Mechanische Belastung: ${profile.mechanical_stress_factors.map((f) => MECHANICAL_STRESS_FACTOR_LABELS[f] ?? f).join(", ")}`,
+    )
   }
   if (profile.towel_material) {
-    parts.push(`Handtuch: ${TOWEL_MATERIAL_LABELS[profile.towel_material] ?? profile.towel_material}`)
+    parts.push(
+      `Handtuch: ${TOWEL_MATERIAL_LABELS[profile.towel_material] ?? profile.towel_material}`,
+    )
   }
   if (profile.towel_technique) {
-    parts.push(`Trocknungstechnik: ${TOWEL_TECHNIQUE_LABELS[profile.towel_technique] ?? profile.towel_technique}`)
+    parts.push(
+      `Trocknungstechnik: ${TOWEL_TECHNIQUE_LABELS[profile.towel_technique] ?? profile.towel_technique}`,
+    )
   }
   if (profile.drying_method?.length > 0) {
-    parts.push(`Trocknungsmethode: ${profile.drying_method.map((d) => DRYING_METHOD_LABELS[d] ?? d).join(", ")}`)
+    parts.push(
+      `Trocknungsmethode: ${profile.drying_method.map((d) => DRYING_METHOD_LABELS[d] ?? d).join(", ")}`,
+    )
   }
   if (profile.brush_type) {
     parts.push(`Bürste: ${BRUSH_TYPE_LABELS[profile.brush_type] ?? profile.brush_type}`)
   }
   if (profile.night_protection?.length > 0) {
-    parts.push(`Nachtschutz: ${profile.night_protection.map((n) => NIGHT_PROTECTION_LABELS[n] ?? n).join(", ")}`)
+    parts.push(
+      `Nachtschutz: ${profile.night_protection.map((n) => NIGHT_PROTECTION_LABELS[n] ?? n).join(", ")}`,
+    )
   }
   if (profile.uses_heat_protection) {
     parts.push("Verwendet Hitzeschutz: Ja")
@@ -188,19 +212,21 @@ function formatUserProfile(
     parts.push(`Zusaetzliche Infos: ${profile.additional_notes}`)
   }
 
-  let result = parts.length > 0
-    ? parts.join("\n")
-    : "Haarprofil angelegt, aber noch keine Details eingetragen."
+  let result =
+    parts.length > 0
+      ? parts.join("\n")
+      : "Haarprofil angelegt, aber noch keine Details eingetragen."
 
-  const effectiveMemory =
-    memoryContext === undefined ? profile.conversation_memory : memoryContext
+  const effectiveMemory = memoryContext === undefined ? profile.conversation_memory : memoryContext
   if (effectiveMemory) {
     result = appendMemoryContext(result, effectiveMemory)
   }
 
   if (clarificationQuestions && clarificationQuestions.length > 0) {
-    result += "\n\n(HINWEIS: Stelle zuerst gezielte Rueckfragen, um die Situation zu verstehen. Nenne dabei KEINE konkreten Produktnamen — auch nicht die Produkte aus der Datenbank unten. Produktempfehlungen kommen erst, wenn du genug Kontext hast."
-    result += "\n\nStelle insbesondere diese Fragen (in deinem eigenen Stil, nicht woertlich kopieren):"
+    result +=
+      "\n\n(HINWEIS: Stelle zuerst gezielte Rueckfragen, um die Situation zu verstehen. Nenne dabei KEINE konkreten Produktnamen — auch nicht die Produkte aus der Datenbank unten. Produktempfehlungen kommen erst, wenn du genug Kontext hast."
+    result +=
+      "\n\nStelle insbesondere diese Fragen (in deinem eigenen Stil, nicht woertlich kopieren):"
     for (const q of clarificationQuestions) {
       result += `\n- ${q}`
     }
@@ -218,7 +244,7 @@ function formatShampooProfile(
   if (!profile) {
     return appendMemoryContext(
       "Kein Shampoo-Profil vorhanden. Frage nur nach Haardicke, Kopfhaut-Typ und Kopfhaut-Beschwerden.",
-      memoryContext
+      memoryContext,
     )
   }
 
@@ -238,19 +264,21 @@ function formatShampooProfile(
     parts.push(`Kopfhaut-Beschwerden: ${scalpConditionLabel}`)
   }
 
-  let result = parts.length > 0
-    ? parts.join("\n")
-    : "Shampoo-Profil angelegt, aber die drei Pflichtfelder fehlen noch."
+  let result =
+    parts.length > 0
+      ? parts.join("\n")
+      : "Shampoo-Profil angelegt, aber die drei Pflichtfelder fehlen noch."
 
-  const effectiveMemory =
-    memoryContext === undefined ? profile.conversation_memory : memoryContext
+  const effectiveMemory = memoryContext === undefined ? profile.conversation_memory : memoryContext
   if (effectiveMemory) {
     result = appendMemoryContext(result, effectiveMemory)
   }
 
   if (clarificationQuestions && clarificationQuestions.length > 0) {
-    result += "\n\n(HINWEIS: Shampoo-Klaerungsrunde. Stelle AUSSCHLIESSLICH Rueckfragen zu den fehlenden Shampoo-Feldern."
-    result += "\nNenne KEINE Produkte und stelle KEINE weiteren Fragen zu Routine, Zielen, Haarstruktur, Waschfrequenz oder anderen Produkten."
+    result +=
+      "\n\n(HINWEIS: Shampoo-Klaerungsrunde. Stelle AUSSCHLIESSLICH Rueckfragen zu den fehlenden Shampoo-Feldern."
+    result +=
+      "\nNenne KEINE Produkte und stelle KEINE weiteren Fragen zu Routine, Zielen, Haarstruktur, Waschfrequenz oder anderen Produkten."
     if (clarificationQuestions.length === 1) {
       result += "\nStelle genau diese eine Rueckfrage:"
     } else {
@@ -277,9 +305,7 @@ function formatRagContext(chunks: ContentChunk[]): string {
   return chunks
     .map((chunk, i) => {
       const label = SOURCE_TYPE_LABELS[chunk.source_type] ?? chunk.source_type
-      const source = chunk.source_name
-        ? ` (${label} – ${chunk.source_name})`
-        : ` (${label})`
+      const source = chunk.source_name ? ` (${label} – ${chunk.source_name})` : ` (${label})`
       return `[${i + 1}]${source}:\n${chunk.content}`
     })
     .join("\n\n")
@@ -321,7 +347,9 @@ function formatMaskDecision(maskDecision?: MaskDecision): string {
 
   if (maskDecision.needs_mask) {
     if (maskDecision.need_strength > 0) {
-      const strengthLabel = MASK_STRENGTH_LABELS[String(maskDecision.need_strength)] ?? String(maskDecision.need_strength)
+      const strengthLabel =
+        MASK_STRENGTH_LABELS[String(maskDecision.need_strength)] ??
+        String(maskDecision.need_strength)
       parts.push(`- Staerke: ${strengthLabel}`)
     }
     if (maskDecision.mask_type) {
@@ -336,7 +364,7 @@ function formatMaskDecision(maskDecision?: MaskDecision): string {
     parts.push(
       `- Aktive Signale: ${maskDecision.active_signals
         .map((signal) => MASK_SIGNAL_LABELS[signal] ?? signal)
-        .join(", ")}`
+        .join(", ")}`,
     )
   }
 
@@ -356,26 +384,36 @@ function formatShampooDecision(shampooDecision?: ShampooDecision): string {
   parts.push(`- Profil ausreichend: ${shampooDecision.eligible ? "ja" : "nein"}`)
 
   if (shampooDecision.matched_profile.thickness) {
-    parts.push(`- Haardicke: ${HAIR_THICKNESS_LABELS[shampooDecision.matched_profile.thickness] ?? shampooDecision.matched_profile.thickness}`)
+    parts.push(
+      `- Haardicke: ${HAIR_THICKNESS_LABELS[shampooDecision.matched_profile.thickness] ?? shampooDecision.matched_profile.thickness}`,
+    )
   }
   if (shampooDecision.matched_profile.scalp_type) {
-    parts.push(`- Kopfhaut-Typ: ${SCALP_TYPE_LABELS[shampooDecision.matched_profile.scalp_type] ?? shampooDecision.matched_profile.scalp_type}`)
+    parts.push(
+      `- Kopfhaut-Typ: ${SCALP_TYPE_LABELS[shampooDecision.matched_profile.scalp_type] ?? shampooDecision.matched_profile.scalp_type}`,
+    )
   }
   if (shampooDecision.matched_profile.scalp_condition) {
-    parts.push(`- Kopfhaut-Beschwerden: ${SCALP_CONDITION_LABELS[shampooDecision.matched_profile.scalp_condition] ?? shampooDecision.matched_profile.scalp_condition}`)
+    parts.push(
+      `- Kopfhaut-Beschwerden: ${SCALP_CONDITION_LABELS[shampooDecision.matched_profile.scalp_condition] ?? shampooDecision.matched_profile.scalp_condition}`,
+    )
   }
   if (shampooDecision.matched_bucket) {
-    parts.push(`- Shampoo-Bucket: ${SHAMPOO_BUCKET_LABELS[shampooDecision.matched_bucket] ?? shampooDecision.matched_bucket}`)
+    parts.push(
+      `- Shampoo-Bucket: ${SHAMPOO_BUCKET_LABELS[shampooDecision.matched_bucket] ?? shampooDecision.matched_bucket}`,
+    )
   }
   if (shampooDecision.matched_concern_code) {
     parts.push(`- Wissensbasis-Fokus: ${shampooDecision.matched_concern_code}`)
   }
   if (shampooDecision.secondary_bucket) {
-    parts.push(`- Basis-Shampoo-Bucket (Rotation): ${SHAMPOO_BUCKET_LABELS[shampooDecision.secondary_bucket] ?? shampooDecision.secondary_bucket}`)
+    parts.push(
+      `- Basis-Shampoo-Bucket (Rotation): ${SHAMPOO_BUCKET_LABELS[shampooDecision.secondary_bucket] ?? shampooDecision.secondary_bucket}`,
+    )
   }
   if (shampooDecision.matched_profile.scalp_condition === "dry_flakes") {
     parts.push(
-      "- Hinweis: Trockene Schuppen ordnen wir dem trockenen Shampoo-Bucket zu. Wenn die Schueppchen nach 4-6 Wochen nicht besser werden, empfehlen wir einen Dermatologen aufzusuchen."
+      "- Hinweis: Trockene Schuppen ordnen wir dem trockenen Shampoo-Bucket zu. Wenn die Schueppchen nach 4-6 Wochen nicht besser werden, empfehlen wir einen Dermatologen aufzusuchen.",
     )
   }
 
@@ -383,7 +421,7 @@ function formatShampooDecision(shampooDecision?: ShampooDecision): string {
     parts.push(
       `- Fehlende Felder: ${shampooDecision.missing_profile_fields
         .map((field) => SHAMPOO_FIELD_LABELS[field] ?? field)
-        .join(", ")}`
+        .join(", ")}`,
     )
   } else if (shampooDecision.no_catalog_match) {
     parts.push("- Katalogstatus: kein exakter Shampoo-Match fuer dieses Profil vorhanden")
@@ -433,22 +471,34 @@ function formatConditionerDecision(conditionerDecision?: ConditionerDecision): s
   parts.push(`- Profil ausreichend: ${conditionerDecision.eligible ? "ja" : "nein"}`)
 
   if (conditionerDecision.matched_profile.thickness) {
-    parts.push(`- Haardicke: ${HAIR_THICKNESS_LABELS[conditionerDecision.matched_profile.thickness] ?? conditionerDecision.matched_profile.thickness}`)
+    parts.push(
+      `- Haardicke: ${HAIR_THICKNESS_LABELS[conditionerDecision.matched_profile.thickness] ?? conditionerDecision.matched_profile.thickness}`,
+    )
   }
   if (conditionerDecision.matched_profile.density) {
-    parts.push(`- Haardichte: ${HAIR_DENSITY_LABELS[conditionerDecision.matched_profile.density] ?? conditionerDecision.matched_profile.density}`)
+    parts.push(
+      `- Haardichte: ${HAIR_DENSITY_LABELS[conditionerDecision.matched_profile.density] ?? conditionerDecision.matched_profile.density}`,
+    )
   }
   if (conditionerDecision.matched_profile.protein_moisture_balance) {
-    parts.push(`- Zugtest: ${PROTEIN_MOISTURE_LABELS[conditionerDecision.matched_profile.protein_moisture_balance] ?? conditionerDecision.matched_profile.protein_moisture_balance}`)
+    parts.push(
+      `- Zugtest: ${PROTEIN_MOISTURE_LABELS[conditionerDecision.matched_profile.protein_moisture_balance] ?? conditionerDecision.matched_profile.protein_moisture_balance}`,
+    )
   }
   if (conditionerDecision.matched_balance_need) {
-    parts.push(`- Pflegefokus: ${CONDITIONER_BALANCE_LABELS[conditionerDecision.matched_balance_need]}`)
+    parts.push(
+      `- Pflegefokus: ${CONDITIONER_BALANCE_LABELS[conditionerDecision.matched_balance_need]}`,
+    )
   }
   if (conditionerDecision.matched_weight) {
-    parts.push(`- Erwartetes Gewicht: ${CONDITIONER_WEIGHT_LABELS[conditionerDecision.matched_weight]}`)
+    parts.push(
+      `- Erwartetes Gewicht: ${CONDITIONER_WEIGHT_LABELS[conditionerDecision.matched_weight]}`,
+    )
   }
   if (conditionerDecision.matched_repair_level) {
-    parts.push(`- Repair-Level: ${CONDITIONER_REPAIR_LEVEL_LABELS[conditionerDecision.matched_repair_level]}`)
+    parts.push(
+      `- Repair-Level: ${CONDITIONER_REPAIR_LEVEL_LABELS[conditionerDecision.matched_repair_level]}`,
+    )
   }
   if (conditionerDecision.matched_concern_code) {
     parts.push(`- Wissensbasis-Fokus: ${conditionerDecision.matched_concern_code}`)
@@ -458,7 +508,7 @@ function formatConditionerDecision(conditionerDecision?: ConditionerDecision): s
     parts.push(
       `- Fehlende Felder: ${conditionerDecision.missing_profile_fields
         .map((field) => CONDITIONER_FIELD_LABELS[field] ?? field)
-        .join(", ")}`
+        .join(", ")}`,
     )
   } else if (conditionerDecision.no_catalog_match) {
     parts.push("- Katalogstatus: kein exakter Conditioner-Match fuer dieses Profil vorhanden")
@@ -467,7 +517,9 @@ function formatConditionerDecision(conditionerDecision?: ConditionerDecision): s
   }
 
   if (!conditionerDecision.used_density) {
-    parts.push("- Hinweis: Die Haardichte fehlt noch, deshalb bleibt das Produktgewicht vorerst ein Soft-Signal.")
+    parts.push(
+      "- Hinweis: Die Haardichte fehlt noch, deshalb bleibt das Produktgewicht vorerst ein Soft-Signal.",
+    )
   }
 
   return parts.join("\n")
@@ -480,22 +532,32 @@ function formatLeaveInDecision(leaveInDecision?: LeaveInDecision): string {
   parts.push(`- Profil ausreichend: ${leaveInDecision.eligible ? "ja" : "nein"}`)
 
   if (leaveInDecision.matched_profile.hair_texture) {
-    parts.push(`- Haarmuster: ${HAIR_TEXTURE_LABELS[leaveInDecision.matched_profile.hair_texture] ?? leaveInDecision.matched_profile.hair_texture}`)
+    parts.push(
+      `- Haarmuster: ${HAIR_TEXTURE_LABELS[leaveInDecision.matched_profile.hair_texture] ?? leaveInDecision.matched_profile.hair_texture}`,
+    )
   }
   if (leaveInDecision.matched_profile.thickness) {
-    parts.push(`- Haardicke: ${HAIR_THICKNESS_LABELS[leaveInDecision.matched_profile.thickness] ?? leaveInDecision.matched_profile.thickness}`)
+    parts.push(
+      `- Haardicke: ${HAIR_THICKNESS_LABELS[leaveInDecision.matched_profile.thickness] ?? leaveInDecision.matched_profile.thickness}`,
+    )
   }
   if (leaveInDecision.matched_profile.density) {
-    parts.push(`- Haardichte: ${HAIR_DENSITY_LABELS[leaveInDecision.matched_profile.density] ?? leaveInDecision.matched_profile.density}`)
+    parts.push(
+      `- Haardichte: ${HAIR_DENSITY_LABELS[leaveInDecision.matched_profile.density] ?? leaveInDecision.matched_profile.density}`,
+    )
   }
   if (leaveInDecision.need_bucket) {
     parts.push(`- Pflegefokus: ${LEAVE_IN_NEED_BUCKET_LABELS[leaveInDecision.need_bucket]}`)
   }
   if (leaveInDecision.styling_context) {
-    parts.push(`- Styling-Kontext: ${LEAVE_IN_STYLING_CONTEXT_LABELS[leaveInDecision.styling_context]}`)
+    parts.push(
+      `- Styling-Kontext: ${LEAVE_IN_STYLING_CONTEXT_LABELS[leaveInDecision.styling_context]}`,
+    )
   }
   if (leaveInDecision.conditioner_relationship) {
-    parts.push(`- Conditioner-Rolle: ${LEAVE_IN_CONDITIONER_RELATIONSHIP_LABELS[leaveInDecision.conditioner_relationship]}`)
+    parts.push(
+      `- Conditioner-Rolle: ${LEAVE_IN_CONDITIONER_RELATIONSHIP_LABELS[leaveInDecision.conditioner_relationship]}`,
+    )
   }
   if (leaveInDecision.matched_weight) {
     parts.push(`- Erwartetes Gewicht: ${LEAVE_IN_WEIGHT_LABELS[leaveInDecision.matched_weight]}`)
@@ -505,7 +567,7 @@ function formatLeaveInDecision(leaveInDecision?: LeaveInDecision): string {
     parts.push(
       `- Fehlende Felder: ${leaveInDecision.missing_profile_fields
         .map((field) => LEAVE_IN_FIELD_LABELS[field] ?? field)
-        .join(", ")}`
+        .join(", ")}`,
     )
   } else if (leaveInDecision.no_catalog_match) {
     parts.push("- Katalogstatus: kein exakter Leave-in-Match fuer dieses Profil vorhanden")
@@ -523,7 +585,9 @@ function formatOilDecision(oilDecision?: OilDecision): string {
   parts.push(`- Profil ausreichend: ${oilDecision.eligible ? "ja" : "nein"}`)
 
   if (oilDecision.matched_profile.thickness) {
-    parts.push(`- Haardicke: ${HAIR_THICKNESS_LABELS[oilDecision.matched_profile.thickness] ?? oilDecision.matched_profile.thickness}`)
+    parts.push(
+      `- Haardicke: ${HAIR_THICKNESS_LABELS[oilDecision.matched_profile.thickness] ?? oilDecision.matched_profile.thickness}`,
+    )
   }
   if (oilDecision.matched_subtype) {
     parts.push(`- Oel-Typ: ${OIL_SUBTYPE_LABELS[oilDecision.matched_subtype]}`)
@@ -532,17 +596,21 @@ function formatOilDecision(oilDecision?: OilDecision): string {
     parts.push(`- Anwendung: ${OIL_USE_MODE_LABELS[oilDecision.use_mode]}`)
   }
   if (oilDecision.adjunct_scalp_support) {
-    parts.push("- Kopfhaut-Hinweis: Oel nur als unterstuetzende Zusatzpflege einordnen, nicht als primaeren Behandlungsweg.")
+    parts.push(
+      "- Kopfhaut-Hinweis: Oel nur als unterstuetzende Zusatzpflege einordnen, nicht als primaeren Behandlungsweg.",
+    )
   }
 
   if (!oilDecision.eligible) {
     parts.push(
       `- Fehlende Felder: ${oilDecision.missing_profile_fields
         .map((field) => OIL_FIELD_LABELS[field] ?? field)
-        .join(", ")}`
+        .join(", ")}`,
     )
   } else if (oilDecision.no_recommendation && oilDecision.no_recommendation_reason) {
-    parts.push(`- Kein Oel empfohlen: ${OIL_NO_RECOMMENDATION_LABELS[oilDecision.no_recommendation_reason]}`)
+    parts.push(
+      `- Kein Oel empfohlen: ${OIL_NO_RECOMMENDATION_LABELS[oilDecision.no_recommendation_reason]}`,
+    )
   } else if (oilDecision.no_catalog_match) {
     parts.push("- Katalogstatus: kein exakter Oel-Match fuer Haardicke und Oel-Typ vorhanden")
   } else {
@@ -558,19 +626,23 @@ function formatRoutinePlan(routinePlan?: RoutinePlan): string {
   const parts = ["\n\nRoutine-Plan:"]
 
   if (routinePlan.primary_focuses.length > 0) {
-    parts.push(`- Hauptfokus: ${routinePlan.primary_focuses.map((focus) => focus.label).join(", ")}`)
+    parts.push(
+      `- Hauptfokus: ${routinePlan.primary_focuses.map((focus) => focus.label).join(", ")}`,
+    )
   }
 
   if (routinePlan.active_topics.length > 0) {
     parts.push(
       `- Aktive Themen: ${routinePlan.active_topics
         .map((topic) => `${topic.label} (${topic.reason})`)
-        .join(" | ")}`
+        .join(" | ")}`,
     )
   }
 
   if (routinePlan.compare_cwc_owc) {
-    parts.push("- Vergleichsmodus: Erklaere CWC und OWC erst kurz gegeneinander und entscheide dich dann fuer die passendere Variante fuer dieses Profil.")
+    parts.push(
+      "- Vergleichsmodus: Erklaere CWC und OWC erst kurz gegeneinander und entscheide dich dann fuer die passendere Variante fuer dieses Profil.",
+    )
   }
 
   const hasWashProtectionTechnique = routinePlan.sections
@@ -580,7 +652,7 @@ function formatRoutinePlan(routinePlan?: RoutinePlan): string {
   parts.push(
     hasWashProtectionTechnique
       ? "- Niveau: Hohe Ebene fuer alle Slots; nur bei CWC/OWC sind kompakte nummerierte Wash-Day-Schritte erlaubt."
-      : "- Niveau: Hohe Ebene, keine Detail-Anwendungsschritte."
+      : "- Niveau: Hohe Ebene, keine Detail-Anwendungsschritte.",
   )
 
   for (const section of routinePlan.sections) {
@@ -606,20 +678,18 @@ function formatRoutinePlan(routinePlan?: RoutinePlan): string {
         parts.push(
           `  Angehaengte Produkte: ${(slot.attached_products ?? [])
             .map((product) => {
-              const name = product.brand
-                ? `${product.name} von ${product.brand}`
-                : product.name
+              const name = product.brand ? `${product.name} von ${product.brand}` : product.name
               const reasons = product.recommendation_meta?.top_reasons?.slice(0, 2).join(" | ")
               return reasons ? `${name} (${reasons})` : name
             })
-            .join(" ; ")}`
+            .join(" ; ")}`,
         )
       }
     }
   }
 
   parts.push(
-    "\nWICHTIG: Folge dieser Struktur. Erklaere pro Slot erst die Routine-Logik und den Fit zum Profil. Nenne bereits angehaengte Produkte erst danach und nur direkt beim passenden Slot."
+    "\nWICHTIG: Folge dieser Struktur. Erklaere pro Slot erst die Routine-Logik und den Fit zum Profil. Nenne bereits angehaengte Produkte erst danach und nur direkt beim passenden Slot.",
   )
 
   return parts.join("\n")
@@ -637,21 +707,14 @@ function formatProducts(
   leaveInDecision?: LeaveInDecision,
   oilDecision?: OilDecision,
 ): string {
-  const maskDecisionBlock = productCategory === "mask"
-    ? formatMaskDecision(maskDecision)
-    : ""
-  const shampooDecisionBlock = productCategory === "shampoo"
-    ? formatShampooDecision(shampooDecision)
-    : ""
-  const conditionerDecisionBlock = productCategory === "conditioner"
-    ? formatConditionerDecision(conditionerDecision)
-    : ""
-  const leaveInDecisionBlock = productCategory === "leave_in"
-    ? formatLeaveInDecision(leaveInDecision)
-    : ""
-  const oilDecisionBlock = productCategory === "oil"
-    ? formatOilDecision(oilDecision)
-    : ""
+  const maskDecisionBlock = productCategory === "mask" ? formatMaskDecision(maskDecision) : ""
+  const shampooDecisionBlock =
+    productCategory === "shampoo" ? formatShampooDecision(shampooDecision) : ""
+  const conditionerDecisionBlock =
+    productCategory === "conditioner" ? formatConditionerDecision(conditionerDecision) : ""
+  const leaveInDecisionBlock =
+    productCategory === "leave_in" ? formatLeaveInDecision(leaveInDecision) : ""
+  const oilDecisionBlock = productCategory === "oil" ? formatOilDecision(oilDecision) : ""
   const categoryDecisionBlock =
     shampooDecisionBlock ||
     conditionerDecisionBlock ||
@@ -692,7 +755,11 @@ function formatProducts(
       return `${categoryDecisionBlock}\n\nWICHTIG: Frage nur nach den fehlenden Oel-Feldern. Klaere ausschliesslich Haardicke und Oel-Zweck. Nenne keine Produkte und behandle das NICHT als Katalog-No-Match.`
     }
 
-    if (productCategory === "oil" && oilDecision?.no_recommendation && oilDecision.no_recommendation_reason) {
+    if (
+      productCategory === "oil" &&
+      oilDecision?.no_recommendation &&
+      oilDecision.no_recommendation_reason
+    ) {
       return `${categoryDecisionBlock}\n\nWICHTIG: Sage klar, dass aktuell kein Oel empfohlen wird. Begruende das nur mit dem Oel-Entscheidungsblock. Nenne KEINE konkreten Oele und improvisiere keinen Therapie-Oel-Ersatz.`
     }
 
@@ -716,14 +783,17 @@ function formatProducts(
         parts.push(`  Score: ${meta.score.toFixed(1)}`)
 
         if (meta.category === "mask") {
-          const strengthLabel = MASK_STRENGTH_LABELS[String(meta.need_strength)] ?? String(meta.need_strength)
+          const strengthLabel =
+            MASK_STRENGTH_LABELS[String(meta.need_strength)] ?? String(meta.need_strength)
           const maskTypeLabel = MASK_TYPE_LABELS[meta.mask_type] ?? meta.mask_type
           parts.push(`  Staerke: ${strengthLabel}`)
           parts.push(`  Typ: ${maskTypeLabel}`)
         }
 
         if (meta.category === "shampoo") {
-          const shampooRole = (p as unknown as Record<string, unknown>).shampoo_role as string | undefined
+          const shampooRole = (p as unknown as Record<string, unknown>).shampoo_role as
+            | string
+            | undefined
           if (shampooRole === "treatment") {
             parts.push("  Rolle: Behandlungs-Shampoo (Anti-Schuppen)")
           } else if (shampooRole === "daily") {
@@ -734,10 +804,14 @@ function formatProducts(
               meta.matched_profile.thickness,
               meta.matched_profile.scalp_type,
               meta.matched_profile.scalp_condition,
-            ].filter(Boolean).join(" | ")}`
+            ]
+              .filter(Boolean)
+              .join(" | ")}`,
           )
           if (meta.matched_bucket) {
-            parts.push(`  Shampoo-Bucket: ${SHAMPOO_BUCKET_LABELS[meta.matched_bucket] ?? meta.matched_bucket}`)
+            parts.push(
+              `  Shampoo-Bucket: ${SHAMPOO_BUCKET_LABELS[meta.matched_bucket] ?? meta.matched_bucket}`,
+            )
           }
           if (meta.matched_concern_code) {
             parts.push(`  Kopfhaut-Fokus: ${meta.matched_concern_code}`)
@@ -748,12 +822,16 @@ function formatProducts(
           parts.push(
             `  Match-Profil: ${[
               meta.matched_profile.thickness
-                ? HAIR_THICKNESS_LABELS[meta.matched_profile.thickness] ?? meta.matched_profile.thickness
+                ? (HAIR_THICKNESS_LABELS[meta.matched_profile.thickness] ??
+                  meta.matched_profile.thickness)
                 : null,
               meta.matched_profile.density
-                ? HAIR_DENSITY_LABELS[meta.matched_profile.density] ?? meta.matched_profile.density
+                ? (HAIR_DENSITY_LABELS[meta.matched_profile.density] ??
+                  meta.matched_profile.density)
                 : null,
-            ].filter(Boolean).join(" | ")}`
+            ]
+              .filter(Boolean)
+              .join(" | ")}`,
           )
           if (meta.matched_balance_need) {
             parts.push(`  Pflegefokus: ${CONDITIONER_BALANCE_LABELS[meta.matched_balance_need]}`)
@@ -762,7 +840,9 @@ function formatProducts(
             parts.push(`  Gewicht: ${CONDITIONER_WEIGHT_LABELS[meta.matched_weight]}`)
           }
           if (meta.matched_repair_level) {
-            parts.push(`  Repair-Level: ${CONDITIONER_REPAIR_LEVEL_LABELS[meta.matched_repair_level]}`)
+            parts.push(
+              `  Repair-Level: ${CONDITIONER_REPAIR_LEVEL_LABELS[meta.matched_repair_level]}`,
+            )
           }
         }
 
@@ -770,24 +850,33 @@ function formatProducts(
           parts.push(
             `  Match-Profil: ${[
               meta.matched_profile.hair_texture
-                ? HAIR_TEXTURE_LABELS[meta.matched_profile.hair_texture] ?? meta.matched_profile.hair_texture
+                ? (HAIR_TEXTURE_LABELS[meta.matched_profile.hair_texture] ??
+                  meta.matched_profile.hair_texture)
                 : null,
               meta.matched_profile.thickness
-                ? HAIR_THICKNESS_LABELS[meta.matched_profile.thickness] ?? meta.matched_profile.thickness
+                ? (HAIR_THICKNESS_LABELS[meta.matched_profile.thickness] ??
+                  meta.matched_profile.thickness)
                 : null,
               meta.matched_profile.density
-                ? HAIR_DENSITY_LABELS[meta.matched_profile.density] ?? meta.matched_profile.density
+                ? (HAIR_DENSITY_LABELS[meta.matched_profile.density] ??
+                  meta.matched_profile.density)
                 : null,
-            ].filter(Boolean).join(" | ")}`
+            ]
+              .filter(Boolean)
+              .join(" | ")}`,
           )
           if (meta.need_bucket) {
             parts.push(`  Pflegefokus: ${LEAVE_IN_NEED_BUCKET_LABELS[meta.need_bucket]}`)
           }
           if (meta.styling_context) {
-            parts.push(`  Styling-Kontext: ${LEAVE_IN_STYLING_CONTEXT_LABELS[meta.styling_context]}`)
+            parts.push(
+              `  Styling-Kontext: ${LEAVE_IN_STYLING_CONTEXT_LABELS[meta.styling_context]}`,
+            )
           }
           if (meta.conditioner_relationship) {
-            parts.push(`  Conditioner-Rolle: ${LEAVE_IN_CONDITIONER_RELATIONSHIP_LABELS[meta.conditioner_relationship]}`)
+            parts.push(
+              `  Conditioner-Rolle: ${LEAVE_IN_CONDITIONER_RELATIONSHIP_LABELS[meta.conditioner_relationship]}`,
+            )
           }
           if (meta.matched_weight) {
             parts.push(`  Gewicht: ${LEAVE_IN_WEIGHT_LABELS[meta.matched_weight]}`)
@@ -798,9 +887,12 @@ function formatProducts(
           parts.push(
             `  Match-Profil: ${[
               meta.matched_profile.thickness
-                ? HAIR_THICKNESS_LABELS[meta.matched_profile.thickness] ?? meta.matched_profile.thickness
+                ? (HAIR_THICKNESS_LABELS[meta.matched_profile.thickness] ??
+                  meta.matched_profile.thickness)
                 : null,
-            ].filter(Boolean).join(" | ")}`
+            ]
+              .filter(Boolean)
+              .join(" | ")}`,
           )
           if (meta.matched_subtype) {
             parts.push(`  Oel-Typ: ${OIL_SUBTYPE_LABELS[meta.matched_subtype]}`)
@@ -827,8 +919,9 @@ function formatProducts(
     })
     .join("\n")
 
-  const header = (productCategory && PRODUCT_SECTION_HEADERS[productCategory])
-    ?? "Passende Produkte aus unserer Datenbank"
+  const header =
+    (productCategory && PRODUCT_SECTION_HEADERS[productCategory]) ??
+    "Passende Produkte aus unserer Datenbank"
 
   return `${categoryDecisionBlock}\n\n${header}:\n${productList}\n\nWICHTIG: Verwende die EXAKTEN Produktnamen (wie oben geschrieben) wenn du sie erwaehst — die Namen werden in der App als klickbare Links dargestellt.`
 }
@@ -880,7 +973,7 @@ Wenn du Oel-Empfehlungen gibst:
 6. Begruende den Fit danach nur ueber Oel-Typ, Haardicke und die Anwendungslogik aus den Metadaten.
 7. Wenn Kopfhautthemen mitlaufen, ordne natuerliche Oele nur als unterstuetzende Zusatzpflege ein. Stelle sie NICHT als primaeren Behandlungsweg fuer Schuppen, gereizte Kopfhaut oder Haarwachstum dar.
 8. Wenn der Nutzer gezielt ein Therapie-Oel oder eine spezifische Oelmischung sucht und diese nicht im Katalog ist, sage das ehrlich statt einen Ersatz zu erfinden.`,
- routine: `
+  routine: `
 
 ## Routine-Antworten:
 Wenn ein Routine-Plan vorhanden ist:
@@ -896,8 +989,14 @@ Wenn ein Routine-Plan vorhanden ist:
 10. Bei Kopfhautthemen bleibe konservativ und nicht-medizinisch.
 11. Wenn Bond Builder relevant ist: Olaplex No. 0+3, K18 Molecular Repair Leave-in und Epres gehoeren zu den wenigen Produkten mit nachgewiesener Bond-Technologie. Viele Produkte mit "Bond" im Namen pflegen nur die Oberflaeche, reparieren aber nicht die innere Haarstruktur. Das sind Technologie-Beispiele, keine Produktempfehlungen.
 12. Nenne bei Bond Builder den Unterschied zwischen Laengs- und Querverbindungen nur, wenn der Routine-Plan das vorgibt. Erfinde keine eigene K18-vs-Olaplex-Logik.
-13. Wenn der Routine-Plan Vergleichsmodus fuer CWC/OWC signalisiert, erklaere erst kurz den Unterschied beider Methoden, waehle dann die passendere Option fuer dieses Profil und fuehre nur mit dieser Variante weiter.
-14. Wenn Buersten & Tools relevant sind, bleibe bei Funktionslogik und Sicherheitsregeln: Slip beim Entwirren, von unten nach oben arbeiten, sanfter Druck auf der Kopfhaut und keine improvisierten Marken- oder Tool-Empfehlungen.`,
+13. Wenn Tiefenreinigung aktiv ist, unterscheide sauber zwischen Kopfhaut-Tiefenreinigung, Haar-Reset und Hard Reset. Erklaere nur die Slots, die im Routine-Plan wirklich aktiv sind.
+14. Stelle Tiefenreinigung nie als universellen Pflichtschritt, taegliche Empfehlung oder "Detox fuer alle" dar. Sie ist immer bedarfsgetrieben.
+15. Wenn Tiefenreinigung fuer die Laengen aktiv ist, erwaehne die Anschluss-Pflege klar: danach Conditioner oder Maske.
+16. Bei Schuppen, deutlichem Juckreiz oder gereizter Kopfhaut bleibe extra konservativ und rahme Tiefenreinigung nicht als primaeren Loesungsweg; erfinde keine medizinischen Aussagen.
+17. Nenne keine DIY-Scrubs, Zucker-/Salz-Mischungen oder vereinfachte Heuristiken wie "klar = tiefenreinigend", "mehr Tenside = besser" oder "Sulfate = automatisch richtig".
+18. Wenn trockene Kopfhaut als Gegenpol erwaehnt wird, ordne Hair Oiling hoechstens als sanfte Zusatzpflege ein - nie als eigentlichen Reinigungsweg.
+19. Wenn der Routine-Plan Vergleichsmodus fuer CWC/OWC signalisiert, erklaere erst kurz den Unterschied beider Methoden, waehle dann die passendere Option fuer dieses Profil und fuehre nur mit dieser Variante weiter.
+20. Wenn Buersten & Tools relevant sind, bleibe bei Funktionslogik und Sicherheitsregeln: Slip beim Entwirren, von unten nach oben arbeiten, sanfter Druck auf der Kopfhaut und keine improvisierten Marken- oder Tool-Empfehlungen.`,
   mask: `
 
 ## Masken-Empfehlungen:
@@ -934,9 +1033,10 @@ export function buildSystemPrompt(
     prompt += CATEGORY_REASONING_PROMPTS[productCategory]
   }
 
-  const userProfileContext = productCategory === "shampoo"
-    ? formatShampooProfile(hairProfile, clarificationQuestions, memoryContext)
-    : formatUserProfile(hairProfile, clarificationQuestions, memoryContext)
+  const userProfileContext =
+    productCategory === "shampoo"
+      ? formatShampooProfile(hairProfile, clarificationQuestions, memoryContext)
+      : formatUserProfile(hairProfile, clarificationQuestions, memoryContext)
 
   prompt = prompt.replace("{{USER_PROFILE}}", userProfileContext)
 
@@ -945,7 +1045,12 @@ export function buildSystemPrompt(
     ragContext += formatRoutinePlan(routinePlan)
   }
   if (
-    (products || maskDecision || shampooDecision || conditionerDecision || leaveInDecision || oilDecision) &&
+    (products ||
+      maskDecision ||
+      shampooDecision ||
+      conditionerDecision ||
+      leaveInDecision ||
+      oilDecision) &&
     !(productCategory === "routine" && routinePlan)
   ) {
     ragContext += formatProducts(
@@ -971,9 +1076,7 @@ export function buildSystemPrompt(
  * @param params - All inputs needed to build the prompt and generate a response
  * @returns A ReadableStream of text deltas from the model
  */
-export async function synthesizeResponse(
-  params: SynthesizeParams
-): Promise<SynthesisResult> {
+export async function synthesizeResponse(params: SynthesizeParams): Promise<SynthesisResult> {
   const {
     userMessage,
     conversationHistory,

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -7,7 +7,10 @@ import {
   WASH_FREQUENCY_LABELS,
 } from "@/lib/vocabulary"
 import { CONDITIONER_REPAIR_LEVEL_LABELS } from "@/lib/conditioner/constants"
-import { LEAVE_IN_NEED_BUCKET_LABELS, LEAVE_IN_STYLING_CONTEXT_LABELS } from "@/lib/leave-in/constants"
+import {
+  LEAVE_IN_NEED_BUCKET_LABELS,
+  LEAVE_IN_STYLING_CONTEXT_LABELS,
+} from "@/lib/leave-in/constants"
 import {
   buildBrushToolsSlot,
   hasBrushToolsNeed,
@@ -65,6 +68,65 @@ const CLARIFY_TERMS = [
   "hard water",
 ]
 
+const SCALP_TERMS = ["kopfhaut", "ansatz", "ansaetze", "scalp"]
+
+const SCALP_CLARIFY_TERMS = [
+  "nachfetten",
+  "fettig",
+  "oelig",
+  "oily roots",
+  "talg",
+  "dry shampoo",
+  "trockenshampoo",
+]
+
+const HARD_WATER_TERMS = [
+  "hartes wasser",
+  "hard water",
+  "kalk",
+  "mineralablagerung",
+  "mineral build up",
+  "mineral buildup",
+]
+
+const SWIMMING_TERMS = ["chlor", "chlorwasser", "pool", "schwimmen", "schwimmbad", "swimming"]
+
+const CO_WASH_TERMS = [
+  "co-wash",
+  "cowash",
+  "co wash",
+  "nur conditioner",
+  "nur spuelung",
+  "nur spulung",
+]
+
+const HAIR_RESET_TERMS = [
+  "wachsig",
+  "waxy",
+  "ueberpflegt",
+  "uberpflegt",
+  "coated",
+  "belegt",
+  "produktrotation",
+  "product rotation",
+  "zu viele produkte",
+  "nichts zieht mehr ein",
+  "ueberlagert",
+  "uberlagert",
+]
+
+const HARD_RESET_TERMS = [
+  "hard reset",
+  "wachsig",
+  "waxy",
+  "ueberpflegt",
+  "uberpflegt",
+  "nichts zieht mehr ein",
+  "zu viele produkte",
+]
+
+const SENSITIVE_SCALP_TERMS = ["juck", "itch", "schuppen", "seborr", "seb derm"]
+
 const OILING_TERMS = [
   "hair oiling",
   "hairoiling",
@@ -77,13 +139,7 @@ const OILING_TERMS = [
   "oiling routine",
 ]
 
-const BOND_BUILDER_TERMS = [
-  "bond builder",
-  "bond repair",
-  "olaplex",
-  "k18",
-  "bonding",
-]
+const BOND_BUILDER_TERMS = ["bond builder", "bond repair", "olaplex", "k18", "bonding"]
 
 const REFRESH_TERMS = [
   "lockenrefresh",
@@ -95,18 +151,9 @@ const REFRESH_TERMS = [
   "naechster tag",
 ]
 
-const CWC_TERMS = [
-  "cwc",
-  "cwc methode",
-  "conditioner wash conditioner",
-]
+const CWC_TERMS = ["cwc", "cwc methode", "conditioner wash conditioner"]
 
-const OWC_TERMS = [
-  "owc",
-  "owc methode",
-  "oel waschen conditioner",
-  "oil wash conditioner",
-]
+const OWC_TERMS = ["owc", "owc methode", "oel waschen conditioner", "oil wash conditioner"]
 
 const CWC_OWC_COMPARISON_TERMS = [
   "cwc oder owc",
@@ -216,24 +263,109 @@ function hasBetweenWashDays(washFrequency: HairProfile["wash_frequency"]): boole
   return washFrequency !== null && washFrequency !== "daily"
 }
 
-function hasBuildupSignals(profile: HairProfile | null, normalizedMessage: string): boolean {
-  const heavyProductCount = (profile?.current_routine_products ?? []).filter((entry) =>
-    HEAVY_ROUTINE_PRODUCTS.has(entry)
-  ).length
+function getCombinedRoutineText(profile: HairProfile | null, normalizedMessage: string): string {
   const productText = normalizeText(profile?.products_used ?? "")
-  const combinedText = `${normalizedMessage} ${productText}`.trim()
-  const usesHairOiling = (profile?.current_routine_products ?? []).includes("oil") || includesAny(combinedText, OILING_TERMS)
+  return `${normalizedMessage} ${productText}`.trim()
+}
+
+function countHeavyRoutineProducts(profile: HairProfile | null): number {
+  return (profile?.current_routine_products ?? []).filter((entry) =>
+    HEAVY_ROUTINE_PRODUCTS.has(entry),
+  ).length
+}
+
+function hasHairOilingUsage(profile: HairProfile | null, combinedText: string): boolean {
+  return (
+    (profile?.current_routine_products ?? []).includes("oil") ||
+    includesAny(combinedText, OILING_TERMS)
+  )
+}
+
+function hasSensitiveScalpSignals(profile: HairProfile | null, combinedText: string): boolean {
+  return (
+    profile?.scalp_condition === "irritated" ||
+    profile?.scalp_condition === "dry_flakes" ||
+    profile?.scalp_condition === "dandruff" ||
+    includesAny(combinedText, SENSITIVE_SCALP_TERMS)
+  )
+}
+
+function hasScalpClarifySignals(profile: HairProfile | null, normalizedMessage: string): boolean {
+  const combinedText = getCombinedRoutineText(profile, normalizedMessage)
+  const explicitScalpClarify =
+    includesAny(normalizedMessage, CLARIFY_TERMS) && includesAny(combinedText, SCALP_TERMS)
 
   return (
-    includesAny(normalizedMessage, CLARIFY_TERMS) ||
+    explicitScalpClarify ||
     profile?.scalp_type === "oily" ||
     (profile?.concerns ?? []).includes("oily_scalp") ||
-    (profile?.goals ?? []).includes("volume") ||
-    heavyProductCount >= 2 ||
-    usesHairOiling ||
-    includesAny(combinedText, HEAVY_STYLING_TERMS) ||
+    includesAny(combinedText, SCALP_CLARIFY_TERMS)
+  )
+}
+
+function hasHairResetSignals(profile: HairProfile | null, normalizedMessage: string): boolean {
+  const heavyProductCount = countHeavyRoutineProducts(profile)
+  const combinedText = getCombinedRoutineText(profile, normalizedMessage)
+  const explicitHairReset =
+    includesAny(normalizedMessage, CLARIFY_TERMS) && !includesAny(combinedText, SCALP_TERMS)
+  const hasHardWaterExposure = includesAny(combinedText, HARD_WATER_TERMS)
+  const hasSwimmingExposure = includesAny(combinedText, SWIMMING_TERMS)
+  const hasCoWashBurden = includesAny(combinedText, CO_WASH_TERMS)
+  const hasHairOiling = hasHairOilingUsage(profile, combinedText)
+  const hasHeavyStyling = includesAny(combinedText, HEAVY_STYLING_TERMS)
+  const hasOverloadLanguage =
     includesAny(combinedText, UNDERPERFORMING_ROUTINE_TERMS) ||
-    includesAny(combinedText, WASH_LESS_TERMS)
+    includesAny(combinedText, HAIR_RESET_TERMS)
+  const hasLowWashBurden =
+    includesAny(combinedText, WASH_LESS_TERMS) &&
+    (heavyProductCount >= 2 || hasHeavyStyling || hasHairOiling)
+  const hasVolumeSupportedReset =
+    (profile?.goals ?? []).includes("volume") &&
+    (heavyProductCount >= 1 ||
+      hasHeavyStyling ||
+      hasOverloadLanguage ||
+      hasHardWaterExposure ||
+      hasSwimmingExposure ||
+      hasCoWashBurden)
+
+  return (
+    explicitHairReset ||
+    hasHardWaterExposure ||
+    hasSwimmingExposure ||
+    hasCoWashBurden ||
+    hasOverloadLanguage ||
+    heavyProductCount >= 2 ||
+    hasHairOiling ||
+    hasHeavyStyling ||
+    hasLowWashBurden ||
+    hasVolumeSupportedReset
+  )
+}
+
+function hasHardResetSignals(profile: HairProfile | null, normalizedMessage: string): boolean {
+  const heavyProductCount = countHeavyRoutineProducts(profile)
+  const combinedText = getCombinedRoutineText(profile, normalizedMessage)
+  const hasHardWaterExposure = includesAny(combinedText, HARD_WATER_TERMS)
+  const hasSwimmingExposure = includesAny(combinedText, SWIMMING_TERMS)
+  const hasCoWashBurden = includesAny(combinedText, CO_WASH_TERMS)
+  const hasHairOiling = hasHairOilingUsage(profile, combinedText)
+  const hasHeavyStyling = includesAny(combinedText, HEAVY_STYLING_TERMS)
+  const hasHardResetLanguage =
+    includesAny(combinedText, HARD_RESET_TERMS) || includesAny(combinedText, HAIR_RESET_TERMS)
+  const overloadCount = [
+    heavyProductCount >= 2,
+    hasHairOiling,
+    hasHeavyStyling,
+    hasHardWaterExposure,
+    hasSwimmingExposure,
+    hasCoWashBurden,
+  ].filter(Boolean).length
+
+  return (
+    hasHardResetLanguage ||
+    heavyProductCount >= 3 ||
+    (heavyProductCount >= 2 && hasHeavyStyling) ||
+    overloadCount >= 3
   )
 }
 
@@ -323,9 +455,7 @@ function deriveBondBuilderSeverity(profile: HairProfile | null): "moderate" | "s
 }
 
 function hasOilWeightRisk(profile: HairProfile | null): boolean {
-  return (
-    (profile?.thickness === "fine" && profile?.density === "high")
-  )
+  return profile?.thickness === "fine" && profile?.density === "high"
 }
 
 function hasFrequentWashNeed(washFrequency: HairProfile["wash_frequency"]): boolean {
@@ -337,34 +467,21 @@ function hasMechanicalStressNeed(profile: HairProfile | null): boolean {
 }
 
 function hasWashProtectionNeed(profile: HairProfile | null): boolean {
-  return (
-    hasDrynessDamageSignals(profile) ||
-    hasMechanicalStressNeed(profile)
-  )
+  return hasDrynessDamageSignals(profile) || hasMechanicalStressNeed(profile)
 }
 
 function hasStrongDrynessDamageCluster(profile: HairProfile | null): boolean {
   const concerns = new Set(profile?.concerns ?? [])
 
-  return (
-    concerns.has("dryness") ||
-    concerns.has("hair_damage") ||
-    concerns.has("split_ends")
-  )
+  return concerns.has("dryness") || concerns.has("hair_damage") || concerns.has("split_ends")
 }
 
-function countOwcSupportSignals(
-  profile: HairProfile | null,
-  context: RoutineContext,
-): number {
+function countOwcSupportSignals(profile: HairProfile | null, context: RoutineContext): number {
   const treatments = new Set(profile?.chemical_treatment ?? [])
   let count = 0
 
   if (treatments.has("colored") || treatments.has("bleached")) count++
-  if (
-    profile?.cuticle_condition === "rough" ||
-    profile?.cuticle_condition === "slightly_rough"
-  ) {
+  if (profile?.cuticle_condition === "rough" || profile?.cuticle_condition === "slightly_rough") {
     count++
   }
   if (hasStrongDrynessDamageCluster(profile)) count++
@@ -375,17 +492,10 @@ function countOwcSupportSignals(
 }
 
 function hasOwcProactiveBlock(context: RoutineContext): boolean {
-  return (
-    context.has_oil_weight_risk ||
-    context.scalp_type === "oily" ||
-    context.has_buildup_signals
-  )
+  return context.has_oil_weight_risk || context.scalp_type === "oily" || context.has_buildup_signals
 }
 
-function hasOwcFit(
-  profile: HairProfile | null,
-  context: RoutineContext,
-): boolean {
+function hasOwcFit(profile: HairProfile | null, context: RoutineContext): boolean {
   if (!context.has_wash_protection_need) return false
 
   switch (profile?.hair_texture) {
@@ -529,11 +639,12 @@ function getExplicitTopicIds(message: string): RoutineTopicId[] {
   return topics
 }
 
-export function deriveRoutineContext(
-  profile: HairProfile | null,
-  message: string,
-): RoutineContext {
+export function deriveRoutineContext(profile: HairProfile | null, message: string): RoutineContext {
   const normalizedMessage = normalizeText(message)
+  const combinedText = getCombinedRoutineText(profile, normalizedMessage)
+  const hasScalpClarify = hasScalpClarifySignals(profile, normalizedMessage)
+  const hasHairReset = hasHairResetSignals(profile, normalizedMessage)
+  const hasSensitiveScalp = hasSensitiveScalpSignals(profile, combinedText)
   const explicitTopicIds = getExplicitTopicIds(message)
   const primaryFocuses = buildPrimaryFocuses(profile, explicitTopicIds)
   const organizerComplete =
@@ -546,8 +657,7 @@ export function deriveRoutineContext(
     Boolean(profile?.scalp_type) ||
     (profile?.current_routine_products?.length ?? 0) > 0
   const inventoryComplete =
-    (profile?.current_routine_products?.length ?? 0) > 0 ||
-    Boolean(profile?.products_used?.trim())
+    (profile?.current_routine_products?.length ?? 0) > 0 || Boolean(profile?.products_used?.trim())
 
   return {
     hair_texture: profile?.hair_texture ?? null,
@@ -572,7 +682,11 @@ export function deriveRoutineContext(
     cadence_complete: cadenceComplete,
     inventory_complete: inventoryComplete,
     has_between_wash_days: hasBetweenWashDays(profile?.wash_frequency ?? null),
-    has_buildup_signals: hasBuildupSignals(profile, normalizedMessage),
+    has_buildup_signals: hasScalpClarify || hasHairReset,
+    has_scalp_clarify_signals: hasScalpClarify,
+    has_hair_reset_signals: hasHairReset,
+    has_hard_reset_signals: hasHardResetSignals(profile, normalizedMessage) && !hasSensitiveScalp,
+    has_sensitive_scalp_signals: hasSensitiveScalp,
     has_dryness_damage_signals: hasDrynessDamageSignals(profile),
     has_damage_signals: hasDamageSignals(profile),
     has_bond_builder_signals: hasBondBuilderSignals(profile),
@@ -612,9 +726,10 @@ function hasProactiveHairOilingFit(context: RoutineContext): boolean {
 
 function hasScalpHairOilingFit(context: RoutineContext): boolean {
   return (
-    context.scalp_type === "dry" ||
-    context.scalp_condition === "dry_flakes" ||
-    context.scalp_condition === "dandruff"
+    context.scalp_type === "dry" &&
+    context.scalp_condition !== "dry_flakes" &&
+    context.scalp_condition !== "dandruff" &&
+    context.scalp_condition !== "irritated"
   )
 }
 
@@ -627,12 +742,7 @@ export function activateRoutineTopics(
   const activations: RoutineTopicActivation[] = []
   const seen = new Set<RoutineTopicId>()
 
-  const push = (
-    id: RoutineTopicId,
-    reason: string,
-    priority: number,
-    instructionOnly: boolean,
-  ) => {
+  const push = (id: RoutineTopicId, reason: string, priority: number, instructionOnly: boolean) => {
     if (seen.has(id)) return
     seen.add(id)
     activations.push(createTopicActivation(id, reason, priority, instructionOnly))
@@ -640,29 +750,21 @@ export function activateRoutineTopics(
 
   const baseTopicId = getBaseRoutineTopicId(profile)
   if (baseTopicId) {
-    push(
-      baseTopicId,
-      "Das Haarmuster legt die Grundstruktur der Routine fest.",
-      10,
-      false,
-    )
+    push(baseTopicId, "Das Haarmuster legt die Grundstruktur der Routine fest.", 10, false)
   }
 
   const explicit = new Set(context.explicit_topic_ids)
   const washProtectionSelection = selectWashProtectionTopic(profile, context, message)
 
-  if (
-    explicit.has("tiefenreinigung") ||
-    context.has_buildup_signals
-  ) {
-    push(
-      "tiefenreinigung",
-      explicit.has("tiefenreinigung")
-        ? "Die Frage zielt direkt auf Build-up oder Tiefenreinigung."
-        : "Kopfhaut- oder Build-up-Signale sprechen fuer einen gelegentlichen Reset.",
-      30,
-      true,
-    )
+  if (explicit.has("tiefenreinigung") || context.has_buildup_signals) {
+    const clarifyReason = explicit.has("tiefenreinigung")
+      ? "Die Frage zielt direkt auf Build-up oder Tiefenreinigung."
+      : context.has_scalp_clarify_signals && context.has_hair_reset_signals
+        ? "Kopfhaut- und Rueckstands-Signale sprechen fuer einen gezielten Reset."
+        : context.has_scalp_clarify_signals
+          ? "Kopfhaut- und Sebum-Signale sprechen fuer eine gezielte Kopfhaut-Tiefenreinigung."
+          : "Rueckstaende, Produktueberlagerung oder Mineralien sprechen fuer einen gezielten Reset."
+    push("tiefenreinigung", clarifyReason, 30, true)
   }
 
   if (
@@ -718,11 +820,9 @@ export function activateRoutineTopics(
 
   if (
     explicit.has("lockenrefresh") ||
-    (
-      context.has_between_wash_days &&
+    (context.has_between_wash_days &&
       context.hair_texture !== null &&
-      CURLY_TEXTURES.has(context.hair_texture)
-    )
+      CURLY_TEXTURES.has(context.hair_texture))
   ) {
     push(
       "lockenrefresh",
@@ -737,8 +837,7 @@ export function activateRoutineTopics(
   if (washProtectionSelection.topicId) {
     const topicId = washProtectionSelection.topicId
     const explicitRequest =
-      (topicId === "cwc" && explicit.has("cwc")) ||
-      (topicId === "owc" && explicit.has("owc"))
+      (topicId === "cwc" && explicit.has("cwc")) || (topicId === "owc" && explicit.has("owc"))
 
     let reason: string
     if (washProtectionSelection.compareMode) {
@@ -766,7 +865,7 @@ export function buildRoutineClarificationQuestions(
 
   if (!context.organizer_complete) {
     questions.push(
-      "Was soll deine Routine gerade vor allem leisten - weniger Frizz, mehr Feuchtigkeit, Definition, Reparatur oder eher etwas fuer die Kopfhaut?"
+      "Was soll deine Routine gerade vor allem leisten - weniger Frizz, mehr Feuchtigkeit, Definition, Reparatur oder eher etwas fuer die Kopfhaut?",
     )
   }
 
@@ -776,7 +875,7 @@ export function buildRoutineClarificationQuestions(
 
   if (!context.inventory_complete) {
     questions.push(
-      "Welche Schritte sind aktuell schon fest in deiner Routine - Shampoo, Conditioner, Leave-in, Maske oder Oel?"
+      "Welche Schritte sind aktuell schon fest in deiner Routine - Shampoo, Conditioner, Leave-in, Maske oder Oel?",
     )
   }
 
@@ -787,11 +886,17 @@ export function buildRoutineClarificationQuestions(
   return questions.slice(0, 3)
 }
 
-function hasCurrentProduct(profile: HairProfile | null, product: HairProfile["current_routine_products"][number]): boolean {
+function hasCurrentProduct(
+  profile: HairProfile | null,
+  product: HairProfile["current_routine_products"][number],
+): boolean {
   return (profile?.current_routine_products ?? []).includes(product)
 }
 
-function buildSectionSummary(phase: RoutinePlanSection["phase"], profile: HairProfile | null): string {
+function buildSectionSummary(
+  phase: RoutinePlanSection["phase"],
+  profile: HairProfile | null,
+): string {
   if (phase === "base_wash") {
     const washLabel = profile?.wash_frequency
       ? (WASH_FREQUENCY_LABELS[profile.wash_frequency] ?? profile.wash_frequency)
@@ -806,7 +911,10 @@ function buildSectionSummary(phase: RoutinePlanSection["phase"], profile: HairPr
   return "Das sind optionale oder gelegentliche Bausteine, die nur bei Bedarf dazukommen."
 }
 
-function pushSlot(sections: Map<RoutinePlanSection["phase"], RoutineSlotAdvice[]>, slot: RoutineSlotAdvice): void {
+function pushSlot(
+  sections: Map<RoutinePlanSection["phase"], RoutineSlotAdvice[]>,
+  slot: RoutineSlotAdvice,
+): void {
   sections.set(slot.phase, [...(sections.get(slot.phase) ?? []), slot])
 }
 
@@ -848,6 +956,130 @@ function buildCwcTechniqueSlot(): RoutineSlotAdvice {
     product_linkable: false,
     product_query: null,
     attachment_priority: 92,
+  }
+}
+
+function buildScalpClarifySlot(
+  context: RoutineContext,
+  shampooPresent: boolean,
+): RoutineSlotAdvice {
+  const rationale = [
+    "Hier geht es primaer um Talg, Kopfhaut-Rueckstaende und schnell belegte Ansaetze - nicht um einen Voll-Reset fuer die Laengen.",
+    context.has_sensitive_scalp_signals
+      ? "Bei sensibler Kopfhaut lieber sanft und gezielt reinigen statt die Intensitaet hochzuziehen."
+      : "Wenn der Ansatz schnell nachfettet oder Dry-Shampoo-Reste sitzen, kann punktuell auch ein sanftes Scalp-Exfoliant vor der Waesche sinnvoll sein.",
+  ]
+
+  const caveats = context.has_sensitive_scalp_signals
+    ? [
+        "Bei juckender, schuppiger oder gereizter Kopfhaut eher konservativ bleiben und bevorzugt ein gezieltes Kopfhaut-Shampoo priorisieren.",
+      ]
+    : []
+
+  return {
+    id: "occasional-scalp-clarify",
+    kind: "instruction",
+    phase: "occasional",
+    label: "Kopfhaut-Tiefenreinigung",
+    action: shampooPresent ? "adjust" : "add",
+    category: null,
+    cadence:
+      context.scalp_type === "oily"
+        ? "alle 1-2 Wochen nach Bedarf"
+        : "punktuell bei belegtem Ansatz",
+    rationale,
+    caveats,
+    topic_ids: ["tiefenreinigung"],
+    product_linkable: false,
+    product_query: null,
+    attachment_priority: 95,
+  }
+}
+
+function buildHairResetSlot(params: {
+  context: RoutineContext
+  shampooPresent: boolean
+  bondBuilderDriven: boolean
+  educational: boolean
+}): RoutineSlotAdvice {
+  const { context, shampooPresent, bondBuilderDriven, educational } = params
+
+  const rationale = bondBuilderDriven
+    ? [
+        "Bond Builder brauchen saubere Haarstruktur - Rueckstaende koennen die Aufnahme blockieren.",
+        "Vor Bond Builder ist ein Haar-Reset oft sinnvoller als noch mehr Produkt auf ueberlagerte Laengen zu schichten.",
+        "Danach immer Conditioner oder Maske einplanen, damit die Laengen nicht stumpf bleiben.",
+      ]
+    : educational
+      ? [
+          "Tiefenreinigung ist ein gezielter Reset fuer Rueckstaende auf Haar und Kopfhaut, kein Pflichtschritt fuer jede Routine.",
+          "Fuer die Laengen wird sie vor allem dann spannend, wenn Produkte, Mineralien oder Poolwasser die Haare schwer oder stumpf machen.",
+          "Danach immer Conditioner oder Maske einplanen, damit die Laengen wieder geschmeidig werden.",
+        ]
+      : [
+          "Hier geht es vor allem um Rueckstaende auf Laengen und Spitzen - etwa durch Leave-ins, Oele, Styling, Mineralien oder Poolwasser.",
+          "Ein Haar-Reset schafft wieder eine saubere Basis, wenn sich die Haare wachsig, belegt oder ueberpflegt anfuehlen.",
+          "Danach immer Conditioner oder Maske einplanen, damit die Laengen nicht stumpf bleiben.",
+        ]
+
+  rationale.push(
+    "Auf sauberem Haar greifen Pflege oder farbauffrischende Produkte oft gleichmaessiger - das ist ein Bonus, kein Pflichtargument.",
+  )
+
+  const caveats = context.has_sensitive_scalp_signals
+    ? [
+        "Die Kopfhaut wirkt eher sensibel - deshalb gezielt reinigen und die Intensitaet nicht unnoetig hochziehen.",
+      ]
+    : []
+
+  return {
+    id: "occasional-hair-reset",
+    kind: "instruction",
+    phase: "occasional",
+    label: "Haar-Reset / Tiefenreinigung",
+    action: shampooPresent ? "adjust" : "add",
+    category: null,
+    cadence: educational
+      ? "bei deutlichem Build-up nach Bedarf"
+      : "alle 2-3 Wochen oder bei Build-up",
+    rationale,
+    caveats,
+    topic_ids: ["tiefenreinigung"],
+    product_linkable: false,
+    product_query: null,
+    attachment_priority: 96,
+  }
+}
+
+function buildHardResetSlot(context: RoutineContext): RoutineSlotAdvice {
+  const caveats = [
+    "Nur fuer echte Ueberlagerung - nicht als Standard fuer jede Waesche etablieren.",
+  ]
+
+  if (context.has_sensitive_scalp_signals) {
+    caveats.push(
+      "Bei schuppiger, trockener oder gereizter Kopfhaut lieber beim normalen Haar-Reset bleiben.",
+    )
+  }
+
+  return {
+    id: "occasional-hard-reset",
+    kind: "instruction",
+    phase: "occasional",
+    label: "Hard Reset",
+    action: "add",
+    category: null,
+    cadence: "selten und nur bei deutlicher Ueberlagerung",
+    rationale: [
+      "Das ist die Eskalationsstufe fuer wirklich belegte, wachsig wirkende oder deutlich ueberpflegte Haare.",
+      "Wenn viele Produkte rotieren oder kaum noch etwas sauber einzieht, kann punktuell ein staerkerer Reset sinnvoll sein.",
+      "Danach immer Conditioner oder Maske einplanen, damit die Haare nicht quietschig oder stumpf bleiben.",
+    ],
+    caveats,
+    topic_ids: ["tiefenreinigung"],
+    product_linkable: false,
+    product_query: null,
+    attachment_priority: 97,
   }
 }
 
@@ -896,11 +1128,15 @@ function buildOwcTechniqueSlot(
   ]
 
   if (profile?.hair_texture === "straight") {
-    caveats.unshift("OWC ist bei glattem Haar meist nicht die erste Wahl und eher ein gezielter Test als ein Default.")
+    caveats.unshift(
+      "OWC ist bei glattem Haar meist nicht die erste Wahl und eher ein gezielter Test als ein Default.",
+    )
   }
 
   if (context.has_oil_weight_risk) {
-    caveats.push("Das Profil hat ein hoeheres Beschwerungsrisiko — lieber mit minimaler Menge starten.")
+    caveats.push(
+      "Das Profil hat ein hoeheres Beschwerungsrisiko — lieber mit minimaler Menge starten.",
+    )
   }
 
   return {
@@ -947,7 +1183,12 @@ function buildRoutineSlots(
   const leaveInPresent = hasCurrentProduct(profile, "leave_in")
   const maskPresent = hasCurrentProduct(profile, "mask")
   const oilPresent = hasCurrentProduct(profile, "oil")
-  const { shampoo: shampooDecision, conditioner: conditionerDecision, leave_in: leaveInDecision, mask: maskDecision } = decisionContext
+  const {
+    shampoo: shampooDecision,
+    conditioner: conditionerDecision,
+    leave_in: leaveInDecision,
+    mask: maskDecision,
+  } = decisionContext
 
   pushSlot(sections, {
     id: "base-shampoo",
@@ -967,7 +1208,8 @@ function buildRoutineSlots(
     ],
     caveats: [],
     topic_ids: activations[0] ? [activations[0].id] : [],
-    product_linkable: !shampooPresent && shampooDecision.eligible && Boolean(shampooDecision.matched_bucket),
+    product_linkable:
+      !shampooPresent && shampooDecision.eligible && Boolean(shampooDecision.matched_bucket),
     product_query: "Ich suche ein Shampoo fuer meine regulaeren Waschtage.",
     attachment_priority: 50,
   })
@@ -975,29 +1217,29 @@ function buildRoutineSlots(
   const conditionerReasons = ["Conditioner bleibt der feste Pflegeanker nach jeder Waesche."]
   if (conditionerDecision.matched_balance_need) {
     conditionerReasons.push(
-      `Der Conditioner sollte vor allem ${conditionerDecision.matched_balance_need === "balanced"
-        ? "ausgewogen pflegen"
-        : conditionerDecision.matched_balance_need === "moisture"
-          ? "mehr Feuchtigkeit liefern"
-          : "mehr Struktur und Repair geben"}.`
+      `Der Conditioner sollte vor allem ${
+        conditionerDecision.matched_balance_need === "balanced"
+          ? "ausgewogen pflegen"
+          : conditionerDecision.matched_balance_need === "moisture"
+            ? "mehr Feuchtigkeit liefern"
+            : "mehr Struktur und Repair geben"
+      }.`,
     )
   }
   if (conditionerDecision.matched_repair_level) {
     conditionerReasons.push(
-      `Der Repair-Fokus liegt eher bei ${CONDITIONER_REPAIR_LEVEL_LABELS[conditionerDecision.matched_repair_level]}.`
+      `Der Repair-Fokus liegt eher bei ${CONDITIONER_REPAIR_LEVEL_LABELS[conditionerDecision.matched_repair_level]}.`,
     )
   }
 
-  const conditionerAction: RoutineSlotAction =
-    conditionerPresent
-      ? (
-        conditionerDecision.matched_balance_need && conditionerDecision.matched_balance_need !== "balanced"
-          ? "upgrade"
-          : conditionerDecision.matched_repair_level === "high"
-            ? "upgrade"
-            : "keep"
-      )
-      : "add"
+  const conditionerAction: RoutineSlotAction = conditionerPresent
+    ? conditionerDecision.matched_balance_need &&
+      conditionerDecision.matched_balance_need !== "balanced"
+      ? "upgrade"
+      : conditionerDecision.matched_repair_level === "high"
+        ? "upgrade"
+        : "keep"
+    : "add"
 
   pushSlot(sections, {
     id: "base-conditioner",
@@ -1086,21 +1328,19 @@ function buildRoutineSlots(
 
   if (shouldUseLeaveIn || leaveInPresent) {
     const leaveInAction: RoutineSlotAction =
-      !shouldUseLeaveIn && leaveInPresent
-        ? "avoid"
-        : leaveInPresent
-          ? "adjust"
-          : "add"
+      !shouldUseLeaveIn && leaveInPresent ? "avoid" : leaveInPresent ? "adjust" : "add"
 
-    const leaveInReasons = ["Ein Leave-in oder Finish-Schritt macht die Routine nach dem Waschen runder."]
+    const leaveInReasons = [
+      "Ein Leave-in oder Finish-Schritt macht die Routine nach dem Waschen runder.",
+    ]
     if (leaveInDecision.need_bucket) {
       leaveInReasons.push(
-        `Der Schwerpunkt liegt eher auf ${LEAVE_IN_NEED_BUCKET_LABELS[leaveInDecision.need_bucket]}.`
+        `Der Schwerpunkt liegt eher auf ${LEAVE_IN_NEED_BUCKET_LABELS[leaveInDecision.need_bucket]}.`,
       )
     }
     if (leaveInDecision.styling_context) {
       leaveInReasons.push(
-        `Der Finish-Schritt soll vor allem fuer ${LEAVE_IN_STYLING_CONTEXT_LABELS[leaveInDecision.styling_context]} passen.`
+        `Der Finish-Schritt soll vor allem fuer ${LEAVE_IN_STYLING_CONTEXT_LABELS[leaveInDecision.styling_context]} passen.`,
       )
     }
 
@@ -1116,10 +1356,10 @@ function buildRoutineSlots(
       caveats: [],
       topic_ids: activeTopicIds.has("lockenrefresh")
         ? ["lockenrefresh"]
-        : (activations[0] ? [activations[0].id] : []),
-      product_linkable:
-        leaveInAction === "add" &&
-        leaveInDecision.eligible,
+        : activations[0]
+          ? [activations[0].id]
+          : [],
+      product_linkable: leaveInAction === "add" && leaveInDecision.eligible,
       product_query: "Ich suche ein Leave-in fuer meine Routine nach dem Waschen.",
       attachment_priority: 10,
     })
@@ -1140,9 +1380,15 @@ function buildRoutineSlots(
     const refreshCaveats: string[] = []
 
     if (hasRefreshDrynessNeed(profile)) {
-      refreshRationale.splice(2, 0, "Bei Bedarf vorher etwas Leave-In in trockene Laengen einarbeiten (siehe Leave-In-Slot).")
+      refreshRationale.splice(
+        2,
+        0,
+        "Bei Bedarf vorher etwas Leave-In in trockene Laengen einarbeiten (siehe Leave-In-Slot).",
+      )
       if (profile?.thickness === "fine") {
-        refreshCaveats.push("Bei feinem Haar reicht oft schon ein minimaler Tropfen Leave-In, damit die Locken nicht beschwert werden.")
+        refreshCaveats.push(
+          "Bei feinem Haar reicht oft schon ein minimaler Tropfen Leave-In, damit die Locken nicht beschwert werden.",
+        )
       }
     }
 
@@ -1173,27 +1419,21 @@ function buildRoutineSlots(
       kind: "product_slot",
       phase: "occasional",
       label: "Maske / Kur",
-      action: !maskDecision.needs_mask
-        ? "avoid"
-        : maskPresent
-          ? "adjust"
-          : "add",
+      action: !maskDecision.needs_mask ? "avoid" : maskPresent ? "adjust" : "add",
       category: "mask",
-      cadence: maskDecision.needs_mask ? buildMaskCadence(maskDecision.need_strength) : "vorerst nicht fest einplanen",
+      cadence: maskDecision.needs_mask
+        ? buildMaskCadence(maskDecision.need_strength)
+        : "vorerst nicht fest einplanen",
       rationale: maskDecision.needs_mask
         ? [
-          "Eine Maske bleibt Zusatzpflege und wird nur bei echtem Bedarf fest eingeplant.",
-          maskDecision.mask_type
-            ? `Der Fokus liegt eher auf ${MASK_TYPE_LABELS[maskDecision.mask_type] ?? maskDecision.mask_type}.`
-            : "Die Maske wird ueber Bedarf und Vertraeglichkeit gesteuert.",
-        ]
-        : [
-          "Aktuell sprechen die Profilsignale nicht fuer eine feste Masken-Rolle in der Routine.",
-        ],
+            "Eine Maske bleibt Zusatzpflege und wird nur bei echtem Bedarf fest eingeplant.",
+            maskDecision.mask_type
+              ? `Der Fokus liegt eher auf ${MASK_TYPE_LABELS[maskDecision.mask_type] ?? maskDecision.mask_type}.`
+              : "Die Maske wird ueber Bedarf und Vertraeglichkeit gesteuert.",
+          ]
+        : ["Aktuell sprechen die Profilsignale nicht fuer eine feste Masken-Rolle in der Routine."],
       caveats: [],
-      topic_ids: activeTopicIds.has("bond_builder")
-        ? ["bond_builder"]
-        : [],
+      topic_ids: activeTopicIds.has("bond_builder") ? ["bond_builder"] : [],
       product_linkable: !maskPresent && maskDecision.needs_mask && Boolean(maskDecision.mask_type),
       product_query: "Ich suche eine Maske fuer meine Routine.",
       attachment_priority: 30,
@@ -1202,34 +1442,31 @@ function buildRoutineSlots(
 
   if (activeTopicIds.has("tiefenreinigung")) {
     const bondBuilderDriven = activeTopicIds.has("bond_builder")
-    pushSlot(sections, {
-      id: "occasional-clarify",
-      kind: "instruction",
-      phase: "occasional",
-      label: "Tiefenreinigung / Reset",
-      action: shampooPresent ? "adjust" : "add",
-      category: null,
-      cadence: context.scalp_type === "oily" ? "alle 1-2 Wochen nach Bedarf" : "alle 2-3 Wochen oder bei Build-up",
-      rationale: bondBuilderDriven
-        ? [
-          "Bond Builder brauchen saubere Haarstruktur — Rueckstaende blockieren die Aufnahme.",
-          "Tiefenreinigung vor dem Bond Builder sorgt fuer maximale Wirkung.",
-        ]
-        : [
-          "Tiefenreinigung ist ein gezielter Reset und kein Pflichtschritt fuer jede Waesche.",
-          "Sie wird vor allem dann relevant, wenn Kopfhaut, Build-up oder Produktueberlagerung die Routine schwerer machen.",
-        ],
-      caveats: (
-        context.scalp_condition === "irritated" ||
-        context.scalp_condition === "dry_flakes"
+    const educationalClarify =
+      context.explicit_topic_ids.includes("tiefenreinigung") &&
+      !context.has_scalp_clarify_signals &&
+      !context.has_hair_reset_signals &&
+      !bondBuilderDriven
+
+    if (context.has_scalp_clarify_signals) {
+      pushSlot(sections, buildScalpClarifySlot(context, shampooPresent))
+    }
+
+    if (context.has_hair_reset_signals || bondBuilderDriven || educationalClarify) {
+      pushSlot(
+        sections,
+        buildHairResetSlot({
+          context,
+          shampooPresent,
+          bondBuilderDriven,
+          educational: educationalClarify,
+        }),
       )
-        ? ["Bei gereizter oder trockener Kopfhaut vorsichtig bleiben und nicht ueberziehen."]
-        : [],
-      topic_ids: ["tiefenreinigung"],
-      product_linkable: false,
-      product_query: null,
-      attachment_priority: 95,
-    })
+    }
+
+    if (context.has_hard_reset_signals) {
+      pushSlot(sections, buildHardResetSlot(context))
+    }
   }
 
   if ((activeTopicIds.has("hair_oiling") || oilPresent) && activeWashProtectionTopic !== "owc") {
@@ -1243,21 +1480,25 @@ function buildRoutineSlots(
     const oilRationale = [
       "Hair Oiling bleibt ein optionaler Pre-Wash-Baustein und keine Pflicht fuer jede Routine.",
       hasScalpHairOilingFit(context)
-        ? "Es kann sowohl die Kopfhautbalance unterstuetzen als auch Laengen und Spitzen vor der Waesche schuetzen."
+        ? "Es kann trockene, nicht entzuendliche Kopfhaut sanft unterstuetzen und gleichzeitig Laengen und Spitzen vor der Waesche schuetzen."
         : "Es ist vor allem dann sinnvoll, wenn Trockenheit oder Oberflaechenschaeden ein Thema sind.",
     ]
     if (oilActive) {
       oilRationale.push(
-        "Wichtig beim Auswaschen: Shampoo zuerst auf trockenes Haar auftragen, dann erst mit Wasser ausspuelen."
+        "Wichtig beim Auswaschen: Shampoo zuerst auf trockenes Haar auftragen, dann erst mit Wasser ausspuelen.",
       )
     }
 
     const oilCaveats: string[] = []
     if (context.scalp_condition === "irritated") {
-      oilCaveats.push("Bei stark gereizter Kopfhaut eher sanft bleiben und die Routine nicht ueberladen.")
+      oilCaveats.push(
+        "Bei stark gereizter Kopfhaut eher sanft bleiben und die Routine nicht ueberladen.",
+      )
     }
     if (oilActive) {
-      oilCaveats.push("Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.")
+      oilCaveats.push(
+        "Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.",
+      )
     }
 
     pushSlot(sections, {
@@ -1306,30 +1547,37 @@ function buildRoutineSlots(
       const treatments = new Set(profile?.chemical_treatment ?? [])
       const hasChemical = treatments.has("bleached") || treatments.has("colored")
 
-      const bondRationale: string[] = severity === "severe"
-        ? [
-          "Die Kombination aus K18 und Olaplex kann die Reparatur deutlich verstaerken — K18 fuer Laengsverbindungen, Olaplex fuer Querverbindungen.",
-        ]
-        : hasChemical
+      const bondRationale: string[] =
+        severity === "severe"
           ? [
-            "Bond Builder kann hier gezielt unterstuetzen.",
-            "Bei chemischer Belastung kann Olaplex (Querverbindungen) besonders sinnvoll sein.",
-          ]
-          : [
-            "Bond Builder kann hier gezielt unterstuetzen.",
-            "Bei allgemeiner Schaedigung ohne Chemie ist K18 (Laengsverbindungen) oft der bessere Einstieg.",
-          ]
+              "Die Kombination aus K18 und Olaplex kann die Reparatur deutlich verstaerken — K18 fuer Laengsverbindungen, Olaplex fuer Querverbindungen.",
+            ]
+          : hasChemical
+            ? [
+                "Bond Builder kann hier gezielt unterstuetzen.",
+                "Bei chemischer Belastung kann Olaplex (Querverbindungen) besonders sinnvoll sein.",
+              ]
+            : [
+                "Bond Builder kann hier gezielt unterstuetzen.",
+                "Bei allgemeiner Schaedigung ohne Chemie ist K18 (Laengsverbindungen) oft der bessere Einstieg.",
+              ]
 
       const bondCaveats: string[] = [
         "Zu haeufige Anwendung kann das Haar steif und sproede machen — Pausen einhalten.",
       ]
 
       if (profile?.protein_moisture_balance === "snaps") {
-        bondCaveats.push("Die Haare reissen aktuell leicht — ein professionelles Beratungsgespraech kann hier zusaetzlich helfen.")
+        bondCaveats.push(
+          "Die Haare reissen aktuell leicht — ein professionelles Beratungsgespraech kann hier zusaetzlich helfen.",
+        )
       } else if (profile?.protein_moisture_balance === "stretches_stays") {
-        bondCaveats.push("Bond Builder und Protein koennen parallel laufen, solange die Haare noch ueberdehnt sind.")
+        bondCaveats.push(
+          "Bond Builder und Protein koennen parallel laufen, solange die Haare noch ueberdehnt sind.",
+        )
       } else if (profile?.protein_moisture_balance === "stretches_bounces") {
-        bondCaveats.push("Die Haare sind aktuell stabil — Protein-Behandlungen dazu sind nicht mehr noetig, Feuchtigkeit reicht.")
+        bondCaveats.push(
+          "Die Haare sind aktuell stabil — Protein-Behandlungen dazu sind nicht mehr noetig, Feuchtigkeit reicht.",
+        )
       }
 
       pushSlot(sections, {
@@ -1391,10 +1639,7 @@ export function buildRoutinePlan(
   }
 }
 
-export function buildRoutineRetrievalSubqueries(
-  message: string,
-  plan: RoutinePlan,
-): string[] {
+export function buildRoutineRetrievalSubqueries(message: string, plan: RoutinePlan): string[] {
   const focusSummary = plan.primary_focuses
     .filter((focus) => !(focus.kind === "topic" && (focus.code === "cwc" || focus.code === "owc")))
     .slice(0, 2)
@@ -1409,9 +1654,7 @@ export function buildRoutineRetrievalSubqueries(
   }
 
   for (const topic of plan.active_topics) {
-    const query = focusSummary
-      ? `${topic.label} ${focusSummary}`
-      : topic.label
+    const query = focusSummary ? `${topic.label} ${focusSummary}` : topic.label
     queries.add(query)
   }
 
@@ -1428,10 +1671,7 @@ export function buildRoutineRetrievalSubqueries(
 export function getRoutineAutofillSlots(plan: RoutinePlan): RoutineSlotAdvice[] {
   return plan.sections
     .flatMap((section) => section.slots)
-    .filter((slot) =>
-      slot.product_linkable &&
-      (slot.action === "add" || slot.action === "upgrade")
-    )
+    .filter((slot) => slot.product_linkable && (slot.action === "add" || slot.action === "upgrade"))
     .sort((a, b) => a.attachment_priority - b.attachment_priority)
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,11 +38,7 @@ import type {
   ConditionerWeight,
   ConditionerRepairLevel,
 } from "@/lib/conditioner/constants"
-import type {
-  OilNoRecommendationReason,
-  OilSubtype,
-  OilUseMode,
-} from "@/lib/oil/constants"
+import type { OilNoRecommendationReason, OilSubtype, OilUseMode } from "@/lib/oil/constants"
 import type { ShampooBucket, ShampooBucketPair } from "@/lib/shampoo/constants"
 
 export type {
@@ -290,7 +286,11 @@ export interface OilRecommendationMetadata extends BaseRecommendationMetadata {
 
 export type MaskType = "protein" | "moisture" | "performance"
 export type MaskNeedStrength = 1 | 2 | 3
-export type MaskSignal = "chemical_treatment" | "heat_styling" | "protein_moisture_balance" | "mechanical_stress"
+export type MaskSignal =
+  | "chemical_treatment"
+  | "heat_styling"
+  | "protein_moisture_balance"
+  | "mechanical_stress"
 
 export interface MaskRecommendationMetadata extends BaseRecommendationMetadata {
   category: "mask"
@@ -421,6 +421,10 @@ export interface RoutineContext {
   inventory_complete: boolean
   has_between_wash_days: boolean
   has_buildup_signals: boolean
+  has_scalp_clarify_signals: boolean
+  has_hair_reset_signals: boolean
+  has_hard_reset_signals: boolean
+  has_sensitive_scalp_signals: boolean
   has_dryness_damage_signals: boolean
   has_damage_signals: boolean
   has_bond_builder_signals: boolean
@@ -647,11 +651,11 @@ export interface ContentChunk {
 }
 
 export interface CitationSource {
-  index: number          // 1-based, matches [1] markers
-  source_type: string    // "book", "product_list", etc.
-  label: string          // German: "Fachbuch", "Produktmatrix"
+  index: number // 1-based, matches [1] markers
+  source_type: string // "book", "product_list", etc.
+  label: string // German: "Fachbuch", "Produktmatrix"
   source_name: string | null
-  snippet: string        // First ~200 chars of chunk content
+  snippet: string // First ~200 chars of chunk content
 }
 
 export type IntentType =
@@ -663,7 +667,14 @@ export type IntentType =
   | "general_chat"
   | "followup"
 
-export type ProductCategory = "shampoo" | "conditioner" | "mask" | "oil" | "leave_in" | "routine" | null
+export type ProductCategory =
+  | "shampoo"
+  | "conditioner"
+  | "mask"
+  | "oil"
+  | "leave_in"
+  | "routine"
+  | null
 
 export type RetrievalMode = "faq" | "hybrid" | "hybrid_plus_graph" | "product_sql_plus_hybrid"
 
@@ -686,13 +697,21 @@ export interface RouterDecision {
   retrieval_mode: RetrievalMode
   needs_clarification: boolean
   clarification_reason?: string
-  slot_completeness: number          // 0–1
+  slot_completeness: number // 0–1
   confidence: number
-  policy_overrides: string[]         // e.g. ["low_confidence", "missing_slots"]
+  policy_overrides: string[] // e.g. ["low_confidence", "missing_slots"]
 }
 
 export interface ChatSSEEvent {
-  type: "conversation_id" | "content_delta" | "product_recommendations" | "sources" | "confidence" | "retrieval_debug" | "done" | "error"
+  type:
+    | "conversation_id"
+    | "content_delta"
+    | "product_recommendations"
+    | "sources"
+    | "confidence"
+    | "retrieval_debug"
+    | "done"
+    | "error"
   data: unknown
 }
 

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -49,7 +49,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
 }
 
 function createRoutineClassification(
-  overrides: Partial<ClassificationResult> = {}
+  overrides: Partial<ClassificationResult> = {},
 ): ClassificationResult {
   return {
     intent: "routine_help",
@@ -94,7 +94,8 @@ test.describe("Routine planner", () => {
     const plan = buildRoutinePlan(profile, "Welche Routine empfiehlst du gegen Frizz?")
     const activeTopics = plan.active_topics.map((topic) => topic.label)
     const baseSlots = plan.sections.find((section) => section.phase === "base_wash")?.slots ?? []
-    const maintenanceSlots = plan.sections.find((section) => section.phase === "maintenance")?.slots ?? []
+    const maintenanceSlots =
+      plan.sections.find((section) => section.phase === "maintenance")?.slots ?? []
 
     expect(activeTopics).toContain("Locken & Wellen")
     expect(activeTopics).toContain("Lockenrefresh")
@@ -115,38 +116,113 @@ test.describe("Routine planner", () => {
         hair_texture: "curly",
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Meine Locken sehen am naechsten Tag schnell platt aus."
+      "Meine Locken sehen am naechsten Tag schnell platt aus.",
     )
 
     expect(topics.map((topic) => topic.id)).toEqual(
-      expect.arrayContaining(["routine_locken", "lockenrefresh"])
+      expect.arrayContaining(["routine_locken", "lockenrefresh"]),
     )
   })
 
-  test("oily scalp or heavy inventory activates tiefenreinigung", () => {
-    const topics = activateRoutineTopics(
+  test("oily scalp activates a dedicated scalp clarify slot without forcing hair reset", () => {
+    const plan = buildRoutinePlan(
       createProfile({
         scalp_type: "oily",
-        current_routine_products: ["shampoo", "conditioner", "leave_in", "oil"],
+        current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Meine Routine fuehlt sich schnell beschwert an."
+      "Meine Kopfhaut fettet schnell nach.",
     )
 
-    expect(topics.map((topic) => topic.id)).toContain("tiefenreinigung")
+    const topicIds = plan.active_topics.map((topic) => topic.id)
+    const scalpClarifySlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-scalp-clarify")
+    const hairResetSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-hair-reset")
+
+    expect(topicIds).toContain("tiefenreinigung")
+    expect(scalpClarifySlot?.label).toBe("Kopfhaut-Tiefenreinigung")
+    expect(hairResetSlot).toBeUndefined()
   })
 
-  test("heavy styling or volume signals can proactively surface tiefenreinigung", () => {
+  test("volume goal alone does not activate tiefenreinigung", () => {
     const topics = activateRoutineTopics(
       createProfile({
         scalp_type: "balanced",
         goals: ["volume"],
         current_routine_products: ["shampoo", "conditioner"],
-        products_used: "Ich nutze oft Trockenshampoo, Gel und ein Silikon-Serum.",
       }),
-      "Meine Haare fuehlen sich schnell ueberlagert an und ich will mehr Volumen."
+      "Ich will einfach nur mehr Volumen.",
     )
 
-    expect(topics.map((topic) => topic.id)).toContain("tiefenreinigung")
+    expect(topics.map((topic) => topic.id)).not.toContain("tiefenreinigung")
+  })
+
+  test("hard water exposure activates hair reset and its aftercare guidance", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        scalp_type: "balanced",
+        current_routine_products: ["shampoo", "conditioner"],
+        products_used: "Ich habe hartes Wasser und meine Haare werden schnell stumpf.",
+      }),
+      "Welche Routine passt zu mir?",
+    )
+
+    const hairResetSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-hair-reset")
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("tiefenreinigung")
+    expect(hairResetSlot?.label).toBe("Haar-Reset / Tiefenreinigung")
+    expect(hairResetSlot?.rationale.some((line) => line.includes("Conditioner oder Maske"))).toBe(
+      true,
+    )
+  })
+
+  test("chlorine and product overload escalate to hard reset", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        current_routine_products: ["shampoo", "conditioner", "leave_in", "mask", "oil"],
+        products_used: "Ich schwimme oft im Chlorwasser, nutze Gel und viele Produkte in Rotation.",
+      }),
+      "Meine Haare fuehlen sich wachsig und beschwert an.",
+    )
+
+    const hairResetSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-hair-reset")
+    const hardResetSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-hard-reset")
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("tiefenreinigung")
+    expect(hairResetSlot).toBeDefined()
+    expect(hardResetSlot?.label).toBe("Hard Reset")
+    expect(hardResetSlot?.rationale.some((line) => line.includes("Conditioner oder Maske"))).toBe(
+      true,
+    )
+  })
+
+  test("sensitive scalp suppresses hard reset even with overload signals", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        scalp_condition: "dry_flakes",
+        current_routine_products: ["shampoo", "conditioner", "leave_in", "mask", "oil"],
+        products_used: "Ich schwimme oft im Chlorwasser und meine Haare fuehlen sich wachsig an.",
+      }),
+      "Meine Haare fuehlen sich beschwert an.",
+    )
+
+    const hairResetSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-hair-reset")
+    const hardResetSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "occasional-hard-reset")
+
+    expect(hairResetSlot).toBeDefined()
+    expect(hardResetSlot).toBeUndefined()
   })
 
   test("damage signals activate bond builder and upgrade the conditioner slot", () => {
@@ -192,7 +268,7 @@ test.describe("Routine planner", () => {
         cuticle_condition: "rough",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Ich suche eine Routine fuer trockene Laengen."
+      "Ich suche eine Routine fuer trockene Laengen.",
     )
 
     expect(topics.map((topic) => topic.id)).toContain("hair_oiling")
@@ -207,11 +283,14 @@ test.describe("Routine planner", () => {
 
     const topics = activateRoutineTopics(
       profile,
-      "Meine Kopfhaut fettet schnell nach. Welche Routine passt?"
+      "Meine Kopfhaut fettet schnell nach. Welche Routine passt?",
     )
     expect(topics.map((topic) => topic.id)).not.toContain("hair_oiling")
 
-    const plan = buildRoutinePlan(profile, "Meine Kopfhaut fettet schnell nach. Welche Routine passt?")
+    const plan = buildRoutinePlan(
+      profile,
+      "Meine Kopfhaut fettet schnell nach. Welche Routine passt?",
+    )
     const oilSlot = plan.sections
       .flatMap((section) => section.slots)
       .find((slot) => slot.id === "occasional-oil")
@@ -225,22 +304,23 @@ test.describe("Routine planner", () => {
         goals: ["healthy_scalp"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     expect(topics.map((topic) => topic.id)).not.toContain("hair_oiling")
   })
 
-  test("dandruff still activates hair oiling via scalp fit", () => {
+  test("dandruff does not auto-activate hair oiling or tiefenreinigung", () => {
     const topics = activateRoutineTopics(
       createProfile({
         scalp_condition: "dandruff",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
-    expect(topics.map((topic) => topic.id)).toContain("hair_oiling")
+    expect(topics.map((topic) => topic.id)).not.toContain("hair_oiling")
+    expect(topics.map((topic) => topic.id)).not.toContain("tiefenreinigung")
   })
 
   test("active oiling slot includes wash-out rationale and essential oil caveat", () => {
@@ -253,7 +333,7 @@ test.describe("Routine planner", () => {
         cuticle_condition: "rough",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Ich suche eine Routine fuer trockene Laengen."
+      "Ich suche eine Routine fuer trockene Laengen.",
     )
 
     const oilSlot = plan.sections
@@ -261,8 +341,12 @@ test.describe("Routine planner", () => {
       .find((slot) => slot.id === "occasional-oil")
 
     expect(oilSlot?.action).toBe("add")
-    expect(oilSlot?.rationale.some((line) => line.includes("Shampoo zuerst auf trockenes Haar"))).toBe(true)
-    expect(oilSlot?.caveats).toContain("Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.")
+    expect(
+      oilSlot?.rationale.some((line) => line.includes("Shampoo zuerst auf trockenes Haar")),
+    ).toBe(true)
+    expect(oilSlot?.caveats).toContain(
+      "Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.",
+    )
   })
 
   test("avoid oiling slot does not include wash-out rationale or essential oil caveat", () => {
@@ -270,7 +354,7 @@ test.describe("Routine planner", () => {
       createProfile({
         current_routine_products: ["shampoo", "conditioner", "oil"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const oilSlot = plan.sections
@@ -278,8 +362,12 @@ test.describe("Routine planner", () => {
       .find((slot) => slot.id === "occasional-oil")
 
     expect(oilSlot?.action).toBe("avoid")
-    expect(oilSlot?.rationale.every((line) => !line.includes("Shampoo zuerst auf trockenes Haar"))).toBe(true)
-    expect(oilSlot?.caveats).not.toContain("Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.")
+    expect(
+      oilSlot?.rationale.every((line) => !line.includes("Shampoo zuerst auf trockenes Haar")),
+    ).toBe(true)
+    expect(oilSlot?.caveats).not.toContain(
+      "Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.",
+    )
   })
 
   test("irritated scalp gets both irritation caveat and essential oil caveat on active oiling", () => {
@@ -294,7 +382,7 @@ test.describe("Routine planner", () => {
         cuticle_condition: "rough",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Ich suche eine Routine fuer trockene Laengen."
+      "Ich suche eine Routine fuer trockene Laengen.",
     )
 
     const oilSlot = plan.sections
@@ -302,8 +390,12 @@ test.describe("Routine planner", () => {
       .find((slot) => slot.id === "occasional-oil")
 
     expect(oilSlot?.caveats).toHaveLength(2)
-    expect(oilSlot?.caveats).toContain("Bei stark gereizter Kopfhaut eher sanft bleiben und die Routine nicht ueberladen.")
-    expect(oilSlot?.caveats).toContain("Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.")
+    expect(oilSlot?.caveats).toContain(
+      "Bei stark gereizter Kopfhaut eher sanft bleiben und die Routine nicht ueberladen.",
+    )
+    expect(oilSlot?.caveats).toContain(
+      "Aetherische Oele (z.B. Rosmarin, Teebaum) nie pur auftragen — immer mit einem Basisoel verduennen.",
+    )
   })
 
   test("leave-in activates independently of hair oiling", () => {
@@ -314,7 +406,7 @@ test.describe("Routine planner", () => {
         scalp_type: "balanced",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const leaveInSlot = plan.sections
@@ -334,7 +426,7 @@ test.describe("Routine planner", () => {
         chemical_treatment: ["colored"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine hilft gegen trockene Laengen?"
+      "Welche Routine hilft gegen trockene Laengen?",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
@@ -359,7 +451,7 @@ test.describe("Routine planner", () => {
         chemical_treatment: ["natural"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Meine welligen Haare haben Frizz."
+      "Meine welligen Haare haben Frizz.",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
@@ -375,7 +467,7 @@ test.describe("Routine planner", () => {
         chemical_treatment: ["colored"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Meine welligen Haare sind trocken und strapaziert."
+      "Meine welligen Haare sind trocken und strapaziert.",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
@@ -393,7 +485,7 @@ test.describe("Routine planner", () => {
         mechanical_stress_factors: ["rough_brushing"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu meinen Locken, wenn sie sich an Waschtagen schnell verhaken?"
+      "Welche Routine passt zu meinen Locken, wenn sie sich an Waschtagen schnell verhaken?",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
@@ -423,11 +515,13 @@ test.describe("Routine planner", () => {
         cuticle_condition: "rough",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu meinen Locken?"
+      "Welche Routine passt zu meinen Locken?",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).not.toContain("owc")
-    expect(plan.sections.flatMap((section) => section.slots).find((slot) => slot.id === "base-owc-oil")).toBeUndefined()
+    expect(
+      plan.sections.flatMap((section) => section.slots).find((slot) => slot.id === "base-owc-oil"),
+    ).toBeUndefined()
   })
 
   test("explicit OWC ask with oil-weight risk keeps the slot but disables oil product matching", () => {
@@ -440,7 +534,7 @@ test.describe("Routine planner", () => {
         cuticle_condition: "rough",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Soll ich OWC testen?"
+      "Soll ich OWC testen?",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
@@ -462,10 +556,7 @@ test.describe("Routine planner", () => {
       current_routine_products: ["shampoo", "conditioner"],
     })
 
-    const plan = buildRoutinePlan(
-      profile,
-      "Was ist der Unterschied zwischen CWC und OWC?"
-    )
+    const plan = buildRoutinePlan(profile, "Was ist der Unterschied zwischen CWC und OWC?")
     const prompt = buildSystemPrompt(
       profile,
       [createChunk()],
@@ -482,7 +573,7 @@ test.describe("Routine planner", () => {
     )
     const subqueries = buildRoutineRetrievalSubqueries(
       "Was ist der Unterschied zwischen CWC und OWC?",
-      plan
+      plan,
     )
 
     expect(plan.compare_cwc_owc).toBe(true)
@@ -505,7 +596,7 @@ test.describe("Routine planner", () => {
         mechanical_stress_factors: [],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Was ist die CWC Methode?"
+      "Was ist die CWC Methode?",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
@@ -531,7 +622,7 @@ test.describe("Routine planner", () => {
         mechanical_stress_factors: [],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Was ist der Unterschied zwischen CWC und OWC?"
+      "Was ist der Unterschied zwischen CWC und OWC?",
     )
 
     expect(plan.compare_cwc_owc).toBe(true)
@@ -561,7 +652,7 @@ test.describe("Routine planner", () => {
         mechanical_stress_factors: ["rough_brushing"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu meinen Locken?"
+      "Welche Routine passt zu meinen Locken?",
     )
 
     expect(plan.active_topics.map((topic) => topic.id)).toContain("owc")
@@ -583,7 +674,7 @@ test.describe("Routine planner", () => {
       createProfile({
         current_routine_products: ["shampoo", "conditioner", "mask"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
     const maskSlot = maskPlan.sections
       .flatMap((section) => section.slots)
@@ -604,7 +695,7 @@ test.describe("Routine planner", () => {
         scalp_type: null,
         current_routine_products: [],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     expect(routerDecision.needs_clarification).toBe(true)
@@ -622,7 +713,7 @@ test.describe("Routine planner", () => {
         current_routine_products: [],
         products_used: null,
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     expect(routerDecision.needs_clarification).toBe(true)
@@ -639,7 +730,7 @@ test.describe("Routine planner", () => {
         wash_frequency: "every_2_3_days",
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     expect(routerDecision.needs_clarification).toBe(false)
@@ -653,18 +744,20 @@ test.describe("Routine planner", () => {
         goals: ["less_frizz"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
-      "Welche Routine empfiehlst du fuer welliges Haar mit Frizz?"
+      "Welche Routine empfiehlst du fuer welliges Haar mit Frizz?",
     )
 
     const subqueries = buildRoutineRetrievalSubqueries(
       "Welche Routine empfiehlst du fuer welliges Haar mit Frizz?",
-      plan
+      plan,
     )
     const autofillSlots = getRoutineAutofillSlots(plan)
 
     expect(subqueries.some((query) => query.includes("Locken & Wellen"))).toBe(true)
     expect(autofillSlots.length).toBeGreaterThan(0)
-    expect(autofillSlots.every((slot) => slot.action === "add" || slot.action === "upgrade")).toBe(true)
+    expect(autofillSlots.every((slot) => slot.action === "add" || slot.action === "upgrade")).toBe(
+      true,
+    )
   })
 
   test("routine context keeps organizer and cadence signals independent from routine_preference", () => {
@@ -674,7 +767,7 @@ test.describe("Routine planner", () => {
         goals: ["less_frizz"],
         routine_preference: "minimal",
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     expect(context.organizer_complete).toBe(true)
@@ -688,7 +781,9 @@ test.describe("Routine planner", () => {
     })
 
     test("detects Mousse/Schaum", () => {
-      expect(detectStylingProductKind("Ich nutze einen Locken-Schaum von Schwarzkopf")).toBe("Mousse")
+      expect(detectStylingProductKind("Ich nutze einen Locken-Schaum von Schwarzkopf")).toBe(
+        "Mousse",
+      )
       expect(detectStylingProductKind("Mousse von Cantu")).toBe("Mousse")
     })
 
@@ -729,7 +824,7 @@ test.describe("Routine planner", () => {
         products_used: "Balea Styling Gel",
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
@@ -737,7 +832,9 @@ test.describe("Routine planner", () => {
       .find((slot) => slot.id === "maintenance-refresh")
 
     expect(refreshSlot).toBeDefined()
-    expect(refreshSlot?.rationale.some((line) => line.includes("dein Gel vom letzten Waschtag"))).toBe(true)
+    expect(
+      refreshSlot?.rationale.some((line) => line.includes("dein Gel vom letzten Waschtag")),
+    ).toBe(true)
   })
 
   test("refresh slot uses generic product echo when products_used has no styling match", () => {
@@ -747,14 +844,18 @@ test.describe("Routine planner", () => {
         products_used: null,
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
       .flatMap((section) => section.slots)
       .find((slot) => slot.id === "maintenance-refresh")
 
-    expect(refreshSlot?.rationale.some((line) => line.includes("dasselbe Styling-Produkt vom letzten Waschtag"))).toBe(true)
+    expect(
+      refreshSlot?.rationale.some((line) =>
+        line.includes("dasselbe Styling-Produkt vom letzten Waschtag"),
+      ),
+    ).toBe(true)
   })
 
   test("refresh slot adds leave-in cross-reference for dry/damaged hair", () => {
@@ -765,7 +866,7 @@ test.describe("Routine planner", () => {
         cuticle_condition: "rough",
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
@@ -784,7 +885,7 @@ test.describe("Routine planner", () => {
         concerns: ["dryness"],
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
@@ -804,7 +905,7 @@ test.describe("Routine planner", () => {
         chemical_treatment: ["natural"],
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
@@ -821,7 +922,7 @@ test.describe("Routine planner", () => {
         hair_texture: "curly",
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
@@ -842,7 +943,7 @@ test.describe("Routine planner", () => {
         goals: [],
         current_routine_products: ["shampoo", "conditioner", "leave_in"],
       }),
-      "Welche Routine passt zu mir?"
+      "Welche Routine passt zu mir?",
     )
 
     const refreshSlot = plan.sections
@@ -879,6 +980,10 @@ test.describe("Routine planner", () => {
     expect(prompt).toContain("Maske / Kur: gerade eher weniger geeignet")
     expect(prompt).toContain("Begruende pro relevantem Slot erst kurz den Fit zum Profil")
     expect(prompt).toContain("ordne sie direkt dem gerade erklaerten Slot")
+    expect(prompt).toContain(
+      "unterscheide sauber zwischen Kopfhaut-Tiefenreinigung, Haar-Reset und Hard Reset",
+    )
+    expect(prompt).toContain("Tiefenreinigung nie als universellen Pflichtschritt")
     expect(prompt).not.toContain("Routine-Detailgrad")
   })
 
@@ -890,7 +995,7 @@ test.describe("Routine planner", () => {
           cuticle_condition: "smooth",
           concerns: [],
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       expect(topics.map((topic) => topic.id)).not.toContain("bond_builder")
@@ -903,7 +1008,7 @@ test.describe("Routine planner", () => {
           cuticle_condition: "rough",
           concerns: [],
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       expect(topics.map((topic) => topic.id)).toContain("bond_builder")
@@ -918,7 +1023,7 @@ test.describe("Routine planner", () => {
           concerns: [],
           chemical_treatment: ["natural"],
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       expect(topics.map((topic) => topic.id)).toContain("bond_builder")
@@ -932,7 +1037,7 @@ test.describe("Routine planner", () => {
           concerns: [],
           heat_styling: "never",
         }),
-        "Was ist ein Bond Builder?"
+        "Was ist ein Bond Builder?",
       )
 
       const bondSlot = plan.sections
@@ -956,15 +1061,19 @@ test.describe("Routine planner", () => {
           cuticle_condition: "rough",
           concerns: ["hair_damage"],
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const bondSlot = plan.sections
         .flatMap((section) => section.slots)
         .find((slot) => slot.id === "occasional-bond-builder")
 
-      expect(bondSlot?.rationale.some((line) => line.includes("Kombination aus K18 und Olaplex"))).toBe(true)
-      expect(bondSlot?.caveats.some((line) => line.includes("professionelles Beratungsgespraech"))).toBe(true)
+      expect(
+        bondSlot?.rationale.some((line) => line.includes("Kombination aus K18 und Olaplex")),
+      ).toBe(true)
+      expect(
+        bondSlot?.caveats.some((line) => line.includes("professionelles Beratungsgespraech")),
+      ).toBe(true)
     })
 
     test("moderate + chemical treatment leans Olaplex", () => {
@@ -975,14 +1084,16 @@ test.describe("Routine planner", () => {
           concerns: [],
           protein_moisture_balance: "stretches_bounces",
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const bondSlot = plan.sections
         .flatMap((section) => section.slots)
         .find((slot) => slot.id === "occasional-bond-builder")
 
-      expect(bondSlot?.rationale.some((line) => line.includes("Olaplex (Querverbindungen)"))).toBe(true)
+      expect(bondSlot?.rationale.some((line) => line.includes("Olaplex (Querverbindungen)"))).toBe(
+        true,
+      )
     })
 
     test("moderate + no chemical treatment leans K18", () => {
@@ -993,25 +1104,26 @@ test.describe("Routine planner", () => {
           concerns: ["hair_damage"],
           protein_moisture_balance: "stretches_bounces",
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const bondSlot = plan.sections
         .flatMap((section) => section.slots)
         .find((slot) => slot.id === "occasional-bond-builder")
 
-      expect(bondSlot?.rationale.some((line) => line.includes("K18 (Laengsverbindungen)"))).toBe(true)
+      expect(bondSlot?.rationale.some((line) => line.includes("K18 (Laengsverbindungen)"))).toBe(
+        true,
+      )
     })
 
     test("bond builder co-activates tiefenreinigung", () => {
-      const topics = activateRoutineTopics(
-        createProfile({
-          cuticle_condition: "rough",
-          concerns: ["hair_damage"],
-          chemical_treatment: ["bleached"],
-        }),
-        "Welche Routine passt zu mir?"
-      )
+      const profile = createProfile({
+        cuticle_condition: "rough",
+        concerns: ["hair_damage"],
+        chemical_treatment: ["bleached"],
+      })
+      const topics = activateRoutineTopics(profile, "Welche Routine passt zu mir?")
+      const plan = buildRoutinePlan(profile, "Welche Routine passt zu mir?")
 
       const topicIds = topics.map((topic) => topic.id)
       expect(topicIds).toContain("bond_builder")
@@ -1019,6 +1131,11 @@ test.describe("Routine planner", () => {
 
       const tiefenreinigung = topics.find((topic) => topic.id === "tiefenreinigung")
       expect(tiefenreinigung?.reason).toContain("Rueckstaende")
+
+      const hairResetSlot = plan.sections
+        .flatMap((section) => section.slots)
+        .find((slot) => slot.id === "occasional-hair-reset")
+      expect(hairResetSlot?.rationale.some((line) => line.includes("Bond Builder"))).toBe(true)
     })
 
     test("repair fatigue caveat is always present on bond builder slot", () => {
@@ -1027,7 +1144,7 @@ test.describe("Routine planner", () => {
           cuticle_condition: "rough",
           concerns: ["hair_damage"],
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const bondSlot = plan.sections
@@ -1044,7 +1161,7 @@ test.describe("Routine planner", () => {
           concerns: ["hair_damage"],
           protein_moisture_balance: "stretches_stays",
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const stretchesSlot = stretchesPlan.sections
@@ -1059,7 +1176,7 @@ test.describe("Routine planner", () => {
           concerns: ["hair_damage"],
           protein_moisture_balance: "stretches_bounces",
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const balancedSlot = balancedPlan.sections
@@ -1105,7 +1222,7 @@ test.describe("Routine planner", () => {
           concerns: [],
           heat_styling: "never",
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       expect(topics.map((topic) => topic.id)).toContain("bond_builder")
@@ -1133,7 +1250,7 @@ test.describe("Routine planner", () => {
     test("explicit brush question activates brush_tools", () => {
       const topics = activateRoutineTopics(
         createProfile(),
-        "Welche Buerste ist fuer nasses Entwirren am besten?"
+        "Welche Buerste ist fuer nasses Entwirren am besten?",
       )
 
       expect(topics.map((topic) => topic.id)).toContain("brush_tools")
@@ -1145,7 +1262,7 @@ test.describe("Routine planner", () => {
           brush_type: "paddle",
           mechanical_stress_factors: ["rough_brushing"],
         }),
-        "Welche Routine passt zu mir?"
+        "Welche Routine passt zu mir?",
       )
 
       const topicIds = plan.active_topics.map((topic) => topic.id)
@@ -1156,7 +1273,9 @@ test.describe("Routine planner", () => {
       expect(topicIds).toContain("brush_tools")
       expect(brushSlot?.action).toBe("adjust")
       expect(brushSlot?.rationale.some((line) => line.includes("von unten nach oben"))).toBe(true)
-      expect(brushSlot?.rationale.some((line) => line.includes("Paddle- und Rundbuersten"))).toBe(true)
+      expect(brushSlot?.rationale.some((line) => line.includes("Paddle- und Rundbuersten"))).toBe(
+        true,
+      )
     })
 
     test("scalp-sensitive profiles get gentle scalp tool caveats", () => {
@@ -1165,7 +1284,7 @@ test.describe("Routine planner", () => {
           scalp_condition: "irritated",
           concerns: ["hair_loss"],
         }),
-        "Welches Tool passt fuer Kopfhautserum und Scalp Brush?"
+        "Welches Tool passt fuer Kopfhautserum und Scalp Brush?",
       )
 
       const brushSlot = plan.sections
@@ -1173,8 +1292,12 @@ test.describe("Routine planner", () => {
         .find((slot) => slot.id === "maintenance-brush-tools")
 
       expect(brushSlot?.rationale.some((line) => line.includes("Applikatorflasche"))).toBe(true)
-      expect(brushSlot?.caveats.some((line) => line.includes("gereizter oder schuppiger Kopfhaut"))).toBe(true)
-      expect(brushSlot?.caveats.some((line) => line.includes("Haarausfall oder Ausduennung"))).toBe(true)
+      expect(
+        brushSlot?.caveats.some((line) => line.includes("gereizter oder schuppiger Kopfhaut")),
+      ).toBe(true)
+      expect(brushSlot?.caveats.some((line) => line.includes("Haarausfall oder Ausduennung"))).toBe(
+        true,
+      )
     })
 
     test("curl refresh tool questions surface the spray-bottle hint", () => {
@@ -1183,7 +1306,7 @@ test.describe("Routine planner", () => {
           hair_texture: "curly",
           wash_frequency: "every_2_3_days",
         }),
-        "Brauche ich eine Spruehflasche fuer meinen Lockenrefresh?"
+        "Brauche ich eine Spruehflasche fuer meinen Lockenrefresh?",
       )
 
       const brushSlot = plan.sections


### PR DESCRIPTION
## What changed

This ports the current Tiefenreinigung refinement work onto a fresh branch from `main` and keeps the change scoped to the live routine/planner path.

- refines routine detection so Tiefenreinigung is split into `Kopfhaut-Tiefenreinigung`, `Haar-Reset`, and `Hard Reset`
- suppresses over-aggressive reset behavior for sensitive or dandruff-prone scalp profiles
- adds routine prompt guardrails so chat responses stay conservative and avoid generic "detox for everyone" framing
- extends routine planner coverage for oily scalp, hard water, product overload, and sensitive scalp cases

## Why it changed

The old worktree had useful uncommitted improvements, but they were sitting on top of stale branch history. Production also treated several different clarify/reset situations too broadly. This lifts the useful logic onto current `main` without carrying over the stale branch state.

## User impact

Users asking about clarify/reset routines should get more targeted guidance:

- oily scalp can surface a scalp-specific clarify slot without forcing a full hair reset
- hard water / mineral buildup can trigger a length-focused reset with aftercare
- true overload can escalate to a hard reset
- sensitive scalp keeps the logic more conservative

## Root cause

The existing routine logic grouped multiple Tiefenreinigung scenarios together and the response prompt did not clearly constrain how the assistant should talk about them.

## Validation

- `npm run typecheck`
- manual planner smoke checks with `npx tsx` covering:
  - oily scalp -> scalp clarify only
  - hard water -> hair reset
  - overload -> hair reset + hard reset
  - sensitive scalp -> no hard reset

## Notes

I did not run the repo's full automated spec suite here. Direct `vitest` execution in this environment does not currently resolve the repo's `@/` path aliases without extra test runner setup, so validation focused on typecheck plus direct planner execution.
