### PR TITLE
fix: onboarding save-step UX, volume picker, mobile sidebar nav

### DIFF
--- a/src/components/chat/conversation-sidebar.tsx
+++ b/src/components/chat/conversation-sidebar.tsx
@@ -31,7 +31,10 @@ export function ConversationSidebar({
         <h2 className="type-body-sm font-semibold text-sidebar-foreground">Unterhaltungen</h2>
         <div className="flex items-center gap-1">
           <button
-            onClick={onNew}
+            onClick={() => {
+              onNew()
+              if (isMobile && onClose) onClose()
+            }}
             className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
             aria-label="Neue Unterhaltung"
           >

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -160,6 +160,13 @@ export function OnboardingFlow({
   const savingStepsRef = useRef<Set<OnboardingStep>>(new Set())
   const stepSaveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
+  // Clean up debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(stepSaveTimerRef.current)
+    }
+  }, [])
+
   // ── Initialization: hydrate store from server data ──
 
   useEffect(() => {

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -155,8 +155,10 @@ export function OnboardingFlow({
   const { toast } = useToast()
   const store = useOnboardingStore()
   const [hydrated, setHydrated] = useState(false)
+  const [savingStep, setSavingStep] = useState<OnboardingStep | null>(null)
   const initRef = useRef(false)
-  const savingRef = useRef(false)
+  const savingStepsRef = useRef<Set<OnboardingStep>>(new Set())
+  const stepSaveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   // ── Initialization: hydrate store from server data ──
 
@@ -308,13 +310,9 @@ export function OnboardingFlow({
 
   const handleStepComplete = useCallback(
     async (completedStep: OnboardingStep) => {
-      if (savingRef.current) return
-      savingRef.current = true
-
-      // Safety net: auto-reset after 10s in case a save hangs
-      const safetyTimeout = setTimeout(() => {
-        savingRef.current = false
-      }, 10000)
+      if (savingStepsRef.current.has(completedStep)) return
+      savingStepsRef.current.add(completedStep)
+      setSavingStep(completedStep)
 
       try {
         const state = useOnboardingStore.getState()
@@ -482,15 +480,22 @@ export function OnboardingFlow({
         // Advance the store
         state.goNext()
 
-        // Save the new step (after goNext)
+        // Persist step progress in background (non-blocking).
+        // Debounce so rapid step transitions only write the latest step,
+        // preventing an older in-flight request from overwriting a newer one.
+        clearTimeout(stepSaveTimerRef.current)
         const nextStep = useOnboardingStore.getState().currentStep
-        await saveOnboardingStep(nextStep)
+        stepSaveTimerRef.current = setTimeout(() => {
+          saveOnboardingStep(nextStep).catch((err) => {
+            console.error("Failed to persist onboarding step:", err)
+          })
+        }, 50)
       } catch (err) {
         console.error("Failed to save onboarding step:", err)
         toast({ title: "Fehler beim Speichern. Bitte versuche es erneut.", variant: "destructive" })
       } finally {
-        clearTimeout(safetyTimeout)
-        savingRef.current = false
+        savingStepsRef.current.delete(completedStep)
+        setSavingStep(null)
       }
     },
     [userId, router, toast, saveProductUsage, saveHairProfile, saveOnboardingStep],
@@ -614,6 +619,7 @@ export function OnboardingFlow({
             onToggle={toggleBasicProduct}
             onContinue={() => handleStepComplete("products_basics")}
             onBack={() => store.goBack()}
+            isSaving={savingStep === "products_basics"}
           />
         )
 
@@ -632,6 +638,7 @@ export function OnboardingFlow({
               store.setSelectedExtraProducts([])
               handleStepComplete("products_extras")
             }}
+            isSaving={savingStep === "products_extras"}
           />
         )
 
@@ -671,6 +678,7 @@ export function OnboardingFlow({
               store.setSelectedHeatTools([])
               handleStepComplete("heat_tools")
             }}
+            isSaving={savingStep === "heat_tools"}
           />
         )
 
@@ -745,6 +753,7 @@ export function OnboardingFlow({
             onToggle={toggleDryingMethod}
             onContinue={() => handleStepComplete("drying_method")}
             onBack={() => store.goBack()}
+            isSaving={savingStep === "drying_method"}
           />
         )
 
@@ -777,6 +786,7 @@ export function OnboardingFlow({
               store.setNightProtection([])
               handleStepComplete("night_protection")
             }}
+            isSaving={savingStep === "night_protection"}
           />
         )
 
@@ -790,6 +800,7 @@ export function OnboardingFlow({
             onVolumeChange={(vol) => store.setDesiredVolume(vol)}
             onContinue={() => handleStepComplete("goals")}
             onBack={() => store.goBack()}
+            isSaving={savingStep === "goals"}
           />
         )
 

--- a/src/components/onboarding/screens/goals-screen.tsx
+++ b/src/components/onboarding/screens/goals-screen.tsx
@@ -4,7 +4,20 @@ import { ArrowLeft } from "lucide-react"
 import { QuizOptionCard } from "@/components/quiz/quiz-option-card"
 import { getOnboardingGoalCards } from "@/lib/onboarding/goal-flow"
 import { DESIRED_VOLUME_LABELS } from "@/lib/types"
+import type { IconName } from "@/components/ui/icon"
 import type { HairTexture, DesiredVolume } from "@/lib/vocabulary"
+
+const VOLUME_ICONS: Record<DesiredVolume, IconName> = {
+  less: "goal-smoothness",
+  balanced: "result-balance",
+  more: "goal-volume",
+}
+
+const VOLUME_DESCRIPTIONS: Record<DesiredVolume, string> = {
+  less: "Ruhiger, glatter und kompakter im Fall.",
+  balanced: "Natuerlich, kontrolliert und ohne Extreme.",
+  more: "Mehr Fuelle, Lift und sichtbare Bewegung.",
+}
 
 interface GoalsScreenProps {
   hairTexture: HairTexture | null
@@ -14,6 +27,7 @@ interface GoalsScreenProps {
   onVolumeChange: (vol: DesiredVolume) => void
   onContinue: () => void
   onBack: () => void
+  isSaving?: boolean
 }
 
 export function GoalsScreen({
@@ -24,6 +38,7 @@ export function GoalsScreen({
   onVolumeChange,
   onContinue,
   onBack,
+  isSaving,
 }: GoalsScreenProps) {
   const goals = hairTexture ? getOnboardingGoalCards(hairTexture) : []
 
@@ -31,8 +46,9 @@ export function GoalsScreen({
     <div>
       <button
         onClick={onBack}
+        disabled={isSaving}
         aria-label="Zurück"
-        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2"
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2 disabled:opacity-40"
       >
         <ArrowLeft className="h-5 w-5" />
       </button>
@@ -58,32 +74,19 @@ export function GoalsScreen({
             PFLICHT
           </span>
         </div>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          {(["less", "balanced", "more"] as const).map((value, i) => {
-            const active = desiredVolume === value
-            return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => onVolumeChange(value)}
-                className={`rounded-2xl border px-4 py-4 text-left transition-all duration-200 ${
-                  active
-                    ? "border-[var(--brand-plum)] bg-[var(--brand-plum)]/15 text-foreground shadow-[0_0_0_1px_rgba(var(--brand-plum-rgb),0.18)]"
-                    : "border-border bg-muted text-foreground/75 hover:border-border hover:bg-muted"
-                }`}
-                style={{ animationDelay: `${140 + i * 60}ms` }}
-              >
-                <div className="mb-2 text-xs font-semibold tracking-[0.16em] text-[var(--brand-plum)]">
-                  {DESIRED_VOLUME_LABELS[value].toUpperCase()}
-                </div>
-                <div className="text-sm leading-relaxed">
-                  {value === "less" && "Ruhiger, glatter und kompakter im Fall."}
-                  {value === "balanced" && "Natuerlich, kontrolliert und ohne Extreme."}
-                  {value === "more" && "Mehr Fuelle, Lift und sichtbare Bewegung."}
-                </div>
-              </button>
-            )
-          })}
+        <div className="space-y-3">
+          {(["less", "balanced", "more"] as const).map((value, i) => (
+            <QuizOptionCard
+              key={value}
+              icon={VOLUME_ICONS[value]}
+              label={DESIRED_VOLUME_LABELS[value]}
+              description={VOLUME_DESCRIPTIONS[value]}
+              active={desiredVolume === value}
+              disabled={isSaving}
+              onClick={() => onVolumeChange(value)}
+              animationDelay={140 + i * 60}
+            />
+          ))}
         </div>
       </div>
 
@@ -107,6 +110,7 @@ export function GoalsScreen({
                 label={goal.label}
                 description={goal.description}
                 active={selectedGoals.includes(goal.key)}
+                disabled={isSaving}
                 onClick={() => onGoalToggle(goal.key)}
                 animationDelay={380 + i * 80}
               />
@@ -126,10 +130,10 @@ export function GoalsScreen({
         )}
         <button
           onClick={onContinue}
-          disabled={!desiredVolume}
+          disabled={!desiredVolume || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Weiter
+          {isSaving ? "Speichern..." : "Weiter"}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/heat-tools-screen.tsx
+++ b/src/components/onboarding/screens/heat-tools-screen.tsx
@@ -21,6 +21,7 @@ interface HeatToolsScreenProps {
   onContinue: () => void
   onBack: () => void
   onNone: () => void
+  isSaving?: boolean
 }
 
 export function HeatToolsScreen({
@@ -29,6 +30,7 @@ export function HeatToolsScreen({
   onContinue,
   onBack,
   onNone,
+  isSaving,
 }: HeatToolsScreenProps) {
   const hasSelection = selected.length > 0
 
@@ -36,8 +38,9 @@ export function HeatToolsScreen({
     <div>
       <button
         onClick={onBack}
+        disabled={isSaving}
         aria-label="Zurück"
-        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2"
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2 disabled:opacity-40"
       >
         <ArrowLeft className="h-5 w-5" />
       </button>
@@ -60,6 +63,7 @@ export function HeatToolsScreen({
             icon={HEAT_TOOL_ICONS[option.value] ?? "heat-tool"}
             label={option.label}
             active={selected.includes(option.value)}
+            disabled={isSaving}
             onClick={() => onToggle(option.value)}
             animationDelay={100 + i * 60}
           />
@@ -73,7 +77,8 @@ export function HeatToolsScreen({
         <button
           type="button"
           onClick={onNone}
-          className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+          disabled={isSaving}
+          className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground disabled:opacity-40"
         >
           Nichts davon
         </button>
@@ -85,10 +90,10 @@ export function HeatToolsScreen({
       >
         <button
           onClick={onContinue}
-          disabled={!hasSelection}
+          disabled={!hasSelection || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Weiter
+          {isSaving ? "Speichern..." : "Weiter"}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/multi-select-screen.tsx
+++ b/src/components/onboarding/screens/multi-select-screen.tsx
@@ -14,6 +14,7 @@ interface MultiSelectScreenProps {
   onBack: () => void
   noneLabel?: string
   onNone?: () => void
+  isSaving?: boolean
 }
 
 export function MultiSelectScreen({
@@ -26,6 +27,7 @@ export function MultiSelectScreen({
   onBack,
   noneLabel,
   onNone,
+  isSaving,
 }: MultiSelectScreenProps) {
   const hasSelection = selected.length > 0
 
@@ -33,8 +35,9 @@ export function MultiSelectScreen({
     <div>
       <button
         onClick={onBack}
+        disabled={isSaving}
         aria-label="Zurück"
-        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2"
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2 disabled:opacity-40"
       >
         <ArrowLeft className="h-5 w-5" />
       </button>
@@ -59,6 +62,7 @@ export function MultiSelectScreen({
             icon={option.icon}
             label={option.label}
             active={selected.includes(option.value)}
+            disabled={isSaving}
             onClick={() => onToggle(option.value)}
             animationDelay={100 + i * 60}
           />
@@ -73,7 +77,8 @@ export function MultiSelectScreen({
           <button
             type="button"
             onClick={onNone}
-            className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+            disabled={isSaving}
+            className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground disabled:opacity-40"
           >
             {noneLabel}
           </button>
@@ -86,10 +91,10 @@ export function MultiSelectScreen({
       >
         <button
           onClick={onContinue}
-          disabled={!hasSelection}
+          disabled={!hasSelection || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Weiter
+          {isSaving ? "Speichern..." : "Weiter"}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/product-checklist-screen.tsx
+++ b/src/components/onboarding/screens/product-checklist-screen.tsx
@@ -14,6 +14,7 @@ interface ProductChecklistScreenProps {
   onBack: () => void
   noneLabel?: string
   onNone?: () => void
+  isSaving?: boolean
 }
 
 export function ProductChecklistScreen({
@@ -26,6 +27,7 @@ export function ProductChecklistScreen({
   onBack,
   noneLabel,
   onNone,
+  isSaving,
 }: ProductChecklistScreenProps) {
   const hasSelection = selected.length > 0
 
@@ -33,8 +35,9 @@ export function ProductChecklistScreen({
     <div>
       <button
         onClick={onBack}
+        disabled={isSaving}
         aria-label="Zurück"
-        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2"
+        className="flex min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground hover:text-foreground transition-colors mb-2 disabled:opacity-40"
       >
         <ArrowLeft className="h-5 w-5" />
       </button>
@@ -57,6 +60,7 @@ export function ProductChecklistScreen({
             icon={option.icon}
             label={option.label}
             active={selected.includes(option.value)}
+            disabled={isSaving}
             onClick={() => onToggle(option.value)}
             animationDelay={100 + i * 60}
           />
@@ -71,7 +75,8 @@ export function ProductChecklistScreen({
           <button
             type="button"
             onClick={onNone}
-            className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+            disabled={isSaving}
+            className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground disabled:opacity-40"
           >
             {noneLabel}
           </button>
@@ -84,10 +89,10 @@ export function ProductChecklistScreen({
       >
         <button
           onClick={onContinue}
-          disabled={!hasSelection}
+          disabled={!hasSelection || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Weiter
+          {isSaving ? "Speichern..." : "Weiter"}
         </button>
       </div>
     </div>

--- a/src/components/quiz/quiz-card.tsx
+++ b/src/components/quiz/quiz-card.tsx
@@ -6,21 +6,31 @@ interface QuizCardProps {
   children: React.ReactNode
   className?: string
   active?: boolean
+  disabled?: boolean
   onClick?: () => void
 }
 
-export function QuizCard({ children, className, active, onClick }: QuizCardProps) {
+export function QuizCard({ children, className, active, disabled, onClick }: QuizCardProps) {
+  const interactive = onClick && !disabled
   return (
     <div
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      onClick={onClick}
-      onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") onClick() } : undefined}
+      role={interactive ? "button" : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      aria-disabled={disabled || undefined}
+      onClick={interactive ? onClick : undefined}
+      onKeyDown={
+        interactive
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") onClick()
+            }
+          : undefined
+      }
       className={cn(
         "quiz-card transition-all duration-200",
         active && "quiz-card-active scale-[1.015]",
-        onClick && "cursor-pointer",
-        className
+        interactive && "cursor-pointer",
+        disabled && "opacity-60 pointer-events-none",
+        className,
       )}
     >
       {children}

--- a/src/components/quiz/quiz-option-card.tsx
+++ b/src/components/quiz/quiz-option-card.tsx
@@ -8,6 +8,7 @@ interface QuizOptionCardProps {
   label: string
   description?: string
   active: boolean
+  disabled?: boolean
   onClick: () => void
   animationDelay?: number
 }
@@ -17,12 +18,13 @@ export function QuizOptionCard({
   label,
   description,
   active,
+  disabled,
   onClick,
   animationDelay = 0,
 }: QuizOptionCardProps) {
   return (
     <div className="animate-fade-in-up" style={{ animationDelay: `${animationDelay}ms` }}>
-      <QuizCard active={active} onClick={onClick}>
+      <QuizCard active={active} disabled={disabled} onClick={onClick}>
         <div className="flex items-start gap-3">
           <Icon name={icon} size={24} className="text-primary mt-0.5 shrink-0" />
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- **Onboarding save steps**: Debounced step persistence to prevent race conditions on rapid transitions. Added `isSaving` state to all onboarding screens — buttons disable and show "Speichern..." during save.
- **HAI-65 — Volume picker**: Replaced low-contrast custom buttons with `QuizOptionCard` components (white→plum active state, checkmarks, scale animation) matching every other quiz screen.
- **HAI-59 — Mobile chat sidebar**: Plus button now closes the sidebar on mobile after starting a new chat, matching the existing pattern used when selecting a conversation.

## Test plan
- [ ] Onboarding: step through flow, verify buttons show "Speichern..." briefly and disable during save
- [ ] Goals screen: volume options render as QuizOptionCards with clear selected/unselected states
- [ ] Mobile chat: open sidebar → tap plus → sidebar closes and empty chat appears
- [ ] Mobile chat: open sidebar → tap conversation → sidebar still closes (regression)
- [ ] Mobile chat: open sidebar → tap X → sidebar still closes (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)