### PR TITLE
fix: prevent scalp quiz selection border from being clipped

### DIFF
--- a/src/components/quiz/quiz-scalp-question.tsx
+++ b/src/components/quiz/quiz-scalp-question.tsx
@@ -182,7 +182,7 @@ export function QuizScalpQuestion() {
                 maxHeight: isCollapsed ? 0 : 500,
                 opacity: isCollapsed ? 0 : 1,
                 marginTop: isCollapsed ? 0 : i > 0 ? 12 : 0,
-                overflow: "hidden",
+                overflow: isCollapsed ? "hidden" : "visible",
                 transition: "max-height 300ms ease, opacity 200ms ease, margin-top 300ms ease",
               }}
             >


### PR DESCRIPTION
## Summary
- Fixed purple selection border being cut off on the scalp type quiz step (step 6/6)
- Root cause: `overflow: "hidden"` on the wrapper div clipped the `scale-[1.015]` transform applied to active cards
- Changed to `overflow: isCollapsed ? "hidden" : "visible"` so the collapse animation still works while the border renders fully

## Test plan
- [ ] Navigate to quiz step 6 (scalp type)
- [ ] Select a scalp type option — purple border should be fully visible (no clipping)
- [ ] Verify collapse animation still works when proceeding to the gate/condition sub-steps
- [ ] Compare with step 5 (chemical treatment) — borders should look identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)