### PR TITLE
feat: universal goals grid for onboarding with pick-up-to-5 limit

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -25,7 +25,7 @@ import {
   TOWEL_MATERIAL_OPTIONS,
   TOWEL_TECHNIQUE_OPTIONS,
 } from "@/lib/vocabulary"
-import { deriveOnboardingGoals } from "@/lib/onboarding/goal-flow"
+import { deriveVolumeFromGoals } from "@/lib/onboarding/goal-flow"
 import {
   PROFILE_FIELD_CONFIG,
   PROFILE_JOURNEY_STEPS,
@@ -72,7 +72,7 @@ type ProfileFormData = {
 
 type StructuredField = ProfileFieldConfig & { value: ProfileFieldValue }
 
-const EDITABLE_GOAL_OPTIONS = GOAL_OPTIONS.filter((option) => option.value !== "volume")
+const EDITABLE_GOAL_OPTIONS = GOAL_OPTIONS
 
 const HEAT_PROTECTION_OPTIONS = [
   { value: "yes", label: "Ja" },
@@ -100,7 +100,7 @@ function createFormData(profile: HairProfile | null): ProfileFormData {
     thickness: profile?.thickness || "",
     density: profile?.density || "",
     concerns: profile?.concerns || [],
-    desired_volume: profile?.desired_volume || (storedGoals.includes("volume") ? "more" : ""),
+    desired_volume: profile?.desired_volume || "",
     wash_frequency: profile?.wash_frequency || "",
     heat_styling: profile?.heat_styling || "",
     styling_tools: profile?.styling_tools || [],
@@ -113,7 +113,7 @@ function createFormData(profile: HairProfile | null): ProfileFormData {
     post_wash_actions: profile?.post_wash_actions || [],
     current_routine_products: profile?.current_routine_products || [],
     products_used: profile?.products_used || "",
-    goals: storedGoals.filter((goal) => goal !== "volume"),
+    goals: storedGoals,
     additional_notes: profile?.additional_notes || "",
   }
 }
@@ -403,10 +403,8 @@ export default function ProfilePage() {
     setSaving(true)
 
     try {
-      const desiredVolume = formData.desired_volume
-        ? (formData.desired_volume as NonNullable<HairProfile["desired_volume"]>)
-        : null
-      const derivedGoals = deriveOnboardingGoals(formData.goals as Goal[], desiredVolume)
+      const goals = formData.goals as Goal[]
+      const derivedVolume = deriveVolumeFromGoals(goals)
 
       const payload = {
         user_id: user.id,
@@ -414,7 +412,7 @@ export default function ProfilePage() {
         thickness: formData.thickness || null,
         density: formData.density || null,
         concerns: formData.concerns,
-        desired_volume: desiredVolume,
+        desired_volume: derivedVolume,
         wash_frequency: formData.wash_frequency || null,
         heat_styling: formData.heat_styling || null,
         styling_tools: formData.styling_tools,
@@ -427,7 +425,7 @@ export default function ProfilePage() {
         post_wash_actions: formData.post_wash_actions,
         current_routine_products: formData.current_routine_products,
         products_used: formData.products_used || null,
-        goals: derivedGoals,
+        goals,
         additional_notes: formData.additional_notes || null,
         updated_at: new Date().toISOString(),
       }
@@ -603,21 +601,31 @@ export default function ProfilePage() {
           <div className="flex flex-wrap gap-2">
             {EDITABLE_GOAL_OPTIONS.map((option) => {
               const active = formData.goals.includes(option.value)
+              const atMax = !active && formData.goals.length >= 5
               return (
                 <button
                   key={option.value}
                   type="button"
+                  disabled={atMax}
                   onClick={() =>
-                    setFormData((current) => ({
-                      ...current,
-                      goals: toggleArrayItem(current.goals, option.value),
-                    }))
+                    setFormData((current) => {
+                      if (current.goals.includes(option.value)) {
+                        return { ...current, goals: current.goals.filter((g) => g !== option.value) }
+                      }
+                      if (current.goals.length >= 5) return current
+                      let next = [...current.goals]
+                      if (option.value === "volume") next = next.filter((g) => g !== "less_volume")
+                      if (option.value === "less_volume") next = next.filter((g) => g !== "volume")
+                      next.push(option.value)
+                      return { ...current, goals: next }
+                    })
                   }
                   className={cn(
                     "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
                     active
                       ? "border-primary bg-primary/10 text-primary"
                       : "border-border hover:bg-muted",
+                    atMax && "opacity-40 cursor-not-allowed",
                   )}
                 >
                   {option.label}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -8,7 +8,7 @@ import { useToast } from "@/providers/toast-provider"
 import { createClient } from "@/lib/supabase/client"
 import {
   CONCERN_OPTIONS,
-  DESIRED_VOLUME_OPTIONS,
+
   GOAL_OPTIONS,
   HEAT_STYLING_OPTIONS,
   POST_WASH_ACTION_OPTIONS,
@@ -560,14 +560,6 @@ export default function ProfilePage() {
 
   function renderInlineEditor(field: StructuredField) {
     switch (field.key) {
-      case "desired_volume":
-        return (
-          <SegmentedControl
-            options={DESIRED_VOLUME_OPTIONS}
-            value={formData.desired_volume}
-            onChange={(value) => setFormData((current) => ({ ...current, desired_volume: value }))}
-          />
-        )
       case "concerns":
         return (
           <div className="flex flex-wrap gap-2">

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -17,7 +17,7 @@ import {
   mapProductChecklistToRoutineProducts,
   reconcileDiffusor,
 } from "@/lib/onboarding/backward-compat"
-import { deriveOnboardingGoals } from "@/lib/onboarding/goal-flow"
+import { deriveVolumeFromGoals } from "@/lib/onboarding/goal-flow"
 import type { ProductFrequency } from "@/lib/vocabulary"
 import type { HairTexture, DesiredVolume } from "@/lib/vocabulary"
 import type { Goal } from "@/lib/vocabulary"
@@ -204,7 +204,15 @@ export function OnboardingFlow({
         store.setUsesHeatProtection(hairProfile.uses_heat_protection as boolean)
       }
       if (Array.isArray(hairProfile.goals)) {
-        store.setSelectedGoals(hairProfile.goals as string[])
+        const goals = hairProfile.goals as string[]
+        // Legacy resume: translate desired_volume into goal selection
+        if (hairProfile.desired_volume === "more" && !goals.includes("volume")) {
+          goals.push("volume")
+        }
+        if (hairProfile.desired_volume === "less" && !goals.includes("less_volume")) {
+          goals.push("less_volume")
+        }
+        store.setSelectedGoals(goals)
       }
       if (hairProfile.desired_volume) {
         store.setDesiredVolume(hairProfile.desired_volume as DesiredVolume)
@@ -457,16 +465,14 @@ export function OnboardingFlow({
           }
 
           case "goals": {
-            const derivedGoals = deriveOnboardingGoals(
-              state.selectedGoals as Goal[],
-              state.desiredVolume,
-            )
+            const goals = state.selectedGoals as Goal[]
+            const desiredVolume = deriveVolumeFromGoals(goals)
             const routineProducts = mapProductChecklistToRoutineProducts(
               state.allSelectedProducts(),
             )
             await saveHairProfile({
-              goals: derivedGoals,
-              desired_volume: state.desiredVolume,
+              goals,
+              desired_volume: desiredVolume,
               current_routine_products: routineProducts,
             })
             await supabase.from("profiles").update({ onboarding_completed: true }).eq("id", userId)
@@ -542,7 +548,12 @@ export function OnboardingFlow({
     if (selectedGoals.includes(goal)) {
       setSelectedGoals(selectedGoals.filter((g) => g !== goal))
     } else {
-      setSelectedGoals([...selectedGoals, goal])
+      if (selectedGoals.length >= 5) return
+      let next = [...selectedGoals]
+      if (goal === "volume") next = next.filter((g) => g !== "less_volume")
+      if (goal === "less_volume") next = next.filter((g) => g !== "volume")
+      next.push(goal)
+      setSelectedGoals(next)
     }
   }, [])
 
@@ -804,9 +815,7 @@ export function OnboardingFlow({
           <GoalsScreen
             hairTexture={(hairProfile?.hair_texture as HairTexture) ?? null}
             selectedGoals={store.selectedGoals}
-            desiredVolume={store.desiredVolume}
             onGoalToggle={toggleGoal}
-            onVolumeChange={(vol) => store.setDesiredVolume(vol)}
             onContinue={() => handleStepComplete("goals")}
             onBack={() => store.goBack()}
             isSaving={savingStep === "goals"}

--- a/src/components/onboarding/screens/goals-screen.tsx
+++ b/src/components/onboarding/screens/goals-screen.tsx
@@ -1,46 +1,30 @@
 "use client"
 
 import { ArrowLeft } from "lucide-react"
-import { QuizOptionCard } from "@/components/quiz/quiz-option-card"
-import { getOnboardingGoalCards } from "@/lib/onboarding/goal-flow"
-import { DESIRED_VOLUME_LABELS } from "@/lib/types"
-import type { IconName } from "@/components/ui/icon"
-import type { HairTexture, DesiredVolume } from "@/lib/vocabulary"
-
-const VOLUME_ICONS: Record<DesiredVolume, IconName> = {
-  less: "goal-smoothness",
-  balanced: "result-balance",
-  more: "goal-volume",
-}
-
-const VOLUME_DESCRIPTIONS: Record<DesiredVolume, string> = {
-  less: "Ruhiger, glatter und kompakter im Fall.",
-  balanced: "Natürlich, kontrolliert und ohne Extreme.",
-  more: "Mehr Fülle, Lift und sichtbare Bewegung.",
-}
+import { cn } from "@/lib/utils"
+import { getOrderedGoals, getGoalLabel } from "@/lib/onboarding/goal-flow"
+import type { HairTexture } from "@/lib/vocabulary"
 
 interface GoalsScreenProps {
   hairTexture: HairTexture | null
   selectedGoals: string[]
-  desiredVolume: DesiredVolume | null
   onGoalToggle: (goal: string) => void
-  onVolumeChange: (vol: DesiredVolume) => void
   onContinue: () => void
   onBack: () => void
   isSaving?: boolean
+  maxGoals?: number
 }
 
 export function GoalsScreen({
   hairTexture,
   selectedGoals,
-  desiredVolume,
   onGoalToggle,
-  onVolumeChange,
   onContinue,
   onBack,
   isSaving,
+  maxGoals = 5,
 }: GoalsScreenProps) {
-  const goals = hairTexture ? getOnboardingGoalCards(hairTexture) : []
+  const goals = hairTexture ? getOrderedGoals(hairTexture) : []
 
   return (
     <div>
@@ -58,79 +42,63 @@ export function GoalsScreen({
       </h1>
 
       <p
-        className="animate-fade-in-up text-sm text-[var(--text-sub)] mb-8"
+        className="animate-fade-in-up text-sm text-[var(--text-sub)] mb-1"
         style={{ animationDelay: "50ms" }}
       >
-        Erst das Wunsch-Volumen, dann die Details, die dir sonst noch wichtig sind.
+        Waehle bis zu {maxGoals} Ziele.
       </p>
 
-      {/* Volume picker */}
-      <div className="mb-8 animate-fade-in-up" style={{ animationDelay: "100ms" }}>
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <h2 className="font-header text-2xl leading-tight text-foreground">
-            Wie viel Volumen willst du?
-          </h2>
-          <span className="rounded-full border border-[var(--brand-plum)]/30 bg-[var(--brand-plum)]/10 px-2.5 py-1 text-[11px] font-semibold tracking-[0.14em] text-[var(--brand-plum)]">
-            PFLICHT
-          </span>
-        </div>
-        <div className="space-y-3">
-          {(["less", "balanced", "more"] as const).map((value, i) => (
-            <QuizOptionCard
-              key={value}
-              icon={VOLUME_ICONS[value]}
-              label={DESIRED_VOLUME_LABELS[value]}
-              description={VOLUME_DESCRIPTIONS[value]}
-              active={desiredVolume === value}
-              disabled={isSaving}
-              onClick={() => onVolumeChange(value)}
-              animationDelay={140 + i * 60}
-            />
-          ))}
-        </div>
+      <p
+        className="animate-fade-in-up text-sm text-[var(--text-sub)] mb-8"
+        style={{ animationDelay: "70ms" }}
+      >
+        {selectedGoals.length} / {maxGoals} gewaehlt
+      </p>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+        {goals.map((goal, i) => {
+          const isSelected = selectedGoals.includes(goal)
+          const isDisabled = isSaving || (!isSelected && selectedGoals.length >= maxGoals)
+
+          return (
+            <button
+              key={goal}
+              onClick={() => onGoalToggle(goal)}
+              disabled={isDisabled}
+              className={cn(
+                "quiz-card flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-all",
+                "animate-fade-in-up",
+                isSelected && "quiz-card-active",
+                !isSelected && selectedGoals.length >= maxGoals && "opacity-40 cursor-not-allowed",
+              )}
+              style={{ animationDelay: `${100 + i * 50}ms` }}
+            >
+              <span className="text-center">{getGoalLabel(goal, hairTexture!)}</span>
+              {isSelected && (
+                <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-plum)] text-primary-foreground">
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M2.5 6L5 8.5L9.5 4"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              )}
+            </button>
+          )
+        })}
       </div>
-
-      {/* Goal cards */}
-      {goals.length > 0 && (
-        <>
-          <div className="mb-3 animate-fade-in-up" style={{ animationDelay: "340ms" }}>
-            <h2 className="font-header text-2xl leading-tight text-foreground mb-2">
-              Was ist dir außerdem wichtig?
-            </h2>
-            <p className="text-sm text-[var(--text-sub)]">
-              Optional. Diese Auswahl hilft beim ersten Plan.
-            </p>
-          </div>
-
-          <div className="space-y-3 mb-8">
-            {goals.map((goal, i) => (
-              <QuizOptionCard
-                key={goal.key}
-                icon={goal.icon}
-                label={goal.label}
-                description={goal.description}
-                active={selectedGoals.includes(goal.key)}
-                disabled={isSaving}
-                onClick={() => onGoalToggle(goal.key)}
-                animationDelay={380 + i * 80}
-              />
-            ))}
-          </div>
-        </>
-      )}
 
       <div
         className="animate-fade-in-up"
-        style={{ animationDelay: `${380 + goals.length * 80 + 60}ms` }}
+        style={{ animationDelay: `${100 + goals.length * 50 + 60}ms` }}
       >
-        {!desiredVolume && (
-          <p className="mb-3 text-sm text-secondary">
-            Bitte wähle zuerst aus, wie viel Volumen du dir wünschst.
-          </p>
-        )}
         <button
           onClick={onContinue}
-          disabled={!desiredVolume || isSaving}
+          disabled={selectedGoals.length < 1 || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
           {isSaving ? "Speichern..." : "Weiter"}

--- a/src/components/onboarding/screens/goals-screen.tsx
+++ b/src/components/onboarding/screens/goals-screen.tsx
@@ -45,14 +45,14 @@ export function GoalsScreen({
         className="animate-fade-in-up text-sm text-[var(--text-sub)] mb-1"
         style={{ animationDelay: "50ms" }}
       >
-        Waehle bis zu {maxGoals} Ziele.
+        Wähle bis zu {maxGoals} Ziele.
       </p>
 
       <p
         className="animate-fade-in-up text-sm text-[var(--text-sub)] mb-8"
         style={{ animationDelay: "70ms" }}
       >
-        {selectedGoals.length} / {maxGoals} gewaehlt
+        {selectedGoals.length} / {maxGoals} gewählt
       </p>
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
@@ -66,27 +66,32 @@ export function GoalsScreen({
               onClick={() => onGoalToggle(goal)}
               disabled={isDisabled}
               className={cn(
-                "quiz-card flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-all",
+                "quiz-card flex items-center justify-center gap-2 px-3 py-3 text-sm font-medium transition-all",
                 "animate-fade-in-up",
                 isSelected && "quiz-card-active",
                 !isSelected && selectedGoals.length >= maxGoals && "opacity-40 cursor-not-allowed",
               )}
               style={{ animationDelay: `${100 + i * 50}ms` }}
             >
-              <span className="text-center">{getGoalLabel(goal, hairTexture!)}</span>
-              {isSelected && (
-                <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-plum)] text-primary-foreground">
-                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                    <path
-                      d="M2.5 6L5 8.5L9.5 4"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-              )}
+              <span className="text-center leading-tight">{getGoalLabel(goal, hairTexture!)}</span>
+              <div
+                className={cn(
+                  "flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-opacity",
+                  isSelected
+                    ? "bg-[var(--brand-plum)] text-primary-foreground opacity-100"
+                    : "opacity-0",
+                )}
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path
+                    d="M2.5 6L5 8.5L9.5 4"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
             </button>
           )
         })}

--- a/src/lib/onboarding/goal-flow.ts
+++ b/src/lib/onboarding/goal-flow.ts
@@ -1,19 +1,9 @@
-import type { HairTexture, Goal, DesiredVolume } from "@/lib/vocabulary"
-import { ONBOARDING_GOALS } from "@/lib/vocabulary/onboarding-goals"
+import type { Goal, DesiredVolume } from "@/lib/vocabulary"
 
-export function getOnboardingGoalCards(hairTexture: HairTexture) {
-  return ONBOARDING_GOALS[hairTexture]
-}
+export { getOrderedGoals, getGoalLabel } from "@/lib/vocabulary/onboarding-goals"
 
-export function deriveOnboardingGoals(
-  secondaryGoals: Goal[],
-  desiredVolume: DesiredVolume | null
-): Goal[] {
-  const derived = new Set<Goal>(secondaryGoals)
-
-  if (desiredVolume === "more") {
-    derived.add("volume")
-  }
-
-  return [...derived]
+export function deriveVolumeFromGoals(goals: Goal[]): DesiredVolume {
+  if (goals.includes("volume")) return "more"
+  if (goals.includes("less_volume")) return "less"
+  return "balanced"
 }

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -232,7 +232,7 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
     displayMode: "badges",
     editMode: "inline",
     getValue: (profile) => {
-      const goals = profile?.goals?.filter((goal) => goal !== "volume") ?? []
+      const goals = profile?.goals ?? []
       return goals.length ? goals.map((goal) => GOAL_LABELS[goal] ?? goal) : null
     },
   },

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -215,7 +215,7 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
     sectionKey: "goals",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "inline",
+    editMode: "read_only",
     getValue: (profile) => {
       const fallback =
         profile?.desired_volume ?? (profile?.goals?.includes("volume") ? "more" : null)

--- a/src/lib/vocabulary/concerns-goals.ts
+++ b/src/lib/vocabulary/concerns-goals.ts
@@ -46,7 +46,7 @@ export type Goal = (typeof GOALS)[number]
 
 export const GOAL_LABELS: Record<Goal, string> = {
   volume: "Mehr Volumen",
-  healthier_hair: "Gesuenderes Haar",
+  healthier_hair: "Gesünderes Haar",
   less_frizz: "Weniger Frizz",
   color_protection: "Farbschutz",
   moisture: "Mehr Feuchtigkeit",
@@ -55,7 +55,7 @@ export const GOAL_LABELS: Record<Goal, string> = {
   curl_definition: "Locken-Definition",
   less_split_ends: "Weniger Spliss",
   less_volume: "Weniger Volumen",
-  strengthen: "Haare staerken",
+  strengthen: "Haare stärken",
   anti_breakage: "Anti-Haarbruch",
 }
 

--- a/src/lib/vocabulary/concerns-goals.ts
+++ b/src/lib/vocabulary/concerns-goals.ts
@@ -38,6 +38,9 @@ export const GOALS = [
   "shine",
   "curl_definition",
   "less_split_ends",
+  "less_volume",
+  "strengthen",
+  "anti_breakage",
 ] as const
 export type Goal = (typeof GOALS)[number]
 
@@ -51,6 +54,9 @@ export const GOAL_LABELS: Record<Goal, string> = {
   shine: "Mehr Glanz",
   curl_definition: "Locken-Definition",
   less_split_ends: "Weniger Spliss",
+  less_volume: "Weniger Volumen",
+  strengthen: "Haare staerken",
+  anti_breakage: "Anti-Haarbruch",
 }
 
 export const GOAL_OPTIONS = GOALS.map((value) => ({

--- a/src/lib/vocabulary/index.ts
+++ b/src/lib/vocabulary/index.ts
@@ -79,27 +79,19 @@ export {
   ROUTINE_PRODUCT_LABELS,
   ROUTINE_PRODUCT_OPTIONS,
 } from "../leave-in/constants"
-export type {
-  PostWashAction,
-  RoutinePreference,
-  RoutineProduct,
-} from "../leave-in/constants"
+export type { PostWashAction, RoutinePreference, RoutineProduct } from "../leave-in/constants"
 
-export {
-  SOURCE_TYPES,
-  SOURCE_TYPE_LABELS,
-} from "./source-labels"
+export { SOURCE_TYPES, SOURCE_TYPE_LABELS } from "./source-labels"
 export type { SourceType } from "./source-labels"
 
-export {
-  ERR_UNAUTHORIZED,
-  ERR_FORBIDDEN,
-  ERR_INVALID_DATA,
-  fehler,
-} from "./errors"
+export { ERR_UNAUTHORIZED, ERR_FORBIDDEN, ERR_INVALID_DATA, fehler } from "./errors"
 
-export { ONBOARDING_GOALS } from "./onboarding-goals"
-export type { OnboardingGoal } from "./onboarding-goals"
+export {
+  TEXTURE_GOAL_PRIORITY,
+  GOAL_LABEL_OVERRIDES,
+  getOrderedGoals,
+  getGoalLabel,
+} from "./onboarding-goals"
 
 export {
   PRODUCT_FREQUENCIES,

--- a/src/lib/vocabulary/onboarding-goals.ts
+++ b/src/lib/vocabulary/onboarding-goals.ts
@@ -1,129 +1,39 @@
 import type { Goal } from "./concerns-goals"
+import { GOALS, GOAL_LABELS } from "./concerns-goals"
 import type { HairTexture } from "./hair-types"
-import type { IconName } from "@/components/ui/icon"
 
-export interface OnboardingGoal {
-  key: Goal
-  label: string
-  description: string
-  icon: IconName
+export const TEXTURE_GOAL_PRIORITY: Record<HairTexture, Goal[]> = {
+  straight: ["volume", "shine", "less_frizz", "healthy_scalp", "less_split_ends"],
+  wavy: ["less_frizz", "curl_definition", "moisture", "shine", "volume"],
+  curly: ["curl_definition", "moisture", "less_frizz", "strengthen", "less_split_ends"],
+  coily: ["moisture", "strengthen", "anti_breakage", "healthy_scalp", "healthier_hair"],
 }
 
-export const ONBOARDING_GOALS: Record<HairTexture, OnboardingGoal[]> = {
-  straight: [
-    {
-      key: "healthy_scalp",
-      label: "Weniger schnell nachfetten",
-      description: "Längere Frische zwischen den Wäschen",
-      icon: "goal-less-washing",
-    },
-    {
-      key: "less_frizz",
-      label: "Anti-Frizz & Geschmeidigkeit",
-      description: "Glatter Fall ohne Kräuselung",
-      icon: "goal-smoothness",
-    },
-    {
-      key: "shine",
-      label: "Mehr Glanz",
-      description: "Sichtbar glänzenderes, ruhigeres Finish",
-      icon: "goal-shine",
-    },
-    {
-      key: "less_split_ends",
-      label: "Weniger Spliss",
-      description: "Gesunde Spitzen, weniger Haarbruch",
-      icon: "goal-split-ends",
-    },
-  ],
-  wavy: [
-    {
-      key: "curl_definition",
-      label: "Wellen-Definition",
-      description: "Gleichmäßige, sichtbare Wellen",
-      icon: "goal-definition",
-    },
-    {
-      key: "moisture",
-      label: "Leichte Feuchtigkeit",
-      description: "Hydration ohne Beschwerung",
-      icon: "goal-moisture",
-    },
-    {
-      key: "shine",
-      label: "Mehr Glanz",
-      description: "Glänzenderes, gesünder wirkendes Haar",
-      icon: "goal-shine",
-    },
-    {
-      key: "less_frizz",
-      label: "Weniger Frizz",
-      description: "Kontrolle ohne Beschwerung",
-      icon: "goal-frizz",
-    },
-    {
-      key: "less_split_ends",
-      label: "Weniger Spliss",
-      description: "Gesunde Spitzen, weniger Haarbruch",
-      icon: "goal-split-ends",
-    },
-  ],
-  curly: [
-    {
-      key: "curl_definition",
-      label: "Locken-Clumping",
-      description: "Definierte Lockenbündel statt Frizz",
-      icon: "goal-definition",
-    },
-    {
-      key: "moisture",
-      label: "Intensive Feuchtigkeit",
-      description: "Tiefenwirksame Pflege für trockene Locken",
-      icon: "goal-moisture",
-    },
-    {
-      key: "shine",
-      label: "Mehr Glanz",
-      description: "Mehr Reflexion und weniger stumpfer Look",
-      icon: "goal-shine",
-    },
-    {
-      key: "less_split_ends",
-      label: "Weniger Spliss",
-      description: "Gesunde Spitzen, weniger Haarbruch",
-      icon: "goal-split-ends",
-    },
-    {
-      key: "less_frizz",
-      label: "Weniger Frizz",
-      description: "Kontrolle und Definition statt Kräuselung",
-      icon: "goal-frizz",
-    },
-  ],
-  coily: [
-    {
-      key: "moisture",
-      label: "Feuchtigkeit versiegeln",
-      description: "Feuchtigkeit einschließen und bewahren",
-      icon: "goal-moisture",
-    },
-    {
-      key: "healthy_scalp",
-      label: "Kopfhaut beruhigen",
-      description: "Reizfreie, ausgeglichene Kopfhaut",
-      icon: "goal-scalp-health",
-    },
-    {
-      key: "healthier_hair",
-      label: "Gesünderes Haar",
-      description: "Mehr Widerstandsfähigkeit und weniger Haarbruch",
-      icon: "goal-repair",
-    },
-    {
-      key: "less_split_ends",
-      label: "Weniger Spliss",
-      description: "Gesunde Spitzen, weniger Haarbruch",
-      icon: "goal-split-ends",
-    },
-  ],
+export const GOAL_LABEL_OVERRIDES: Record<HairTexture, Partial<Record<Goal, string>>> = {
+  straight: {
+    healthy_scalp: "Weniger schnell nachfetten",
+    less_frizz: "Anti-Frizz & Geschmeidigkeit",
+  },
+  wavy: {
+    curl_definition: "Wellen-Definition",
+    moisture: "Leichte Feuchtigkeit",
+  },
+  curly: {
+    curl_definition: "Locken-Clumping",
+    moisture: "Intensive Feuchtigkeit",
+  },
+  coily: {
+    moisture: "Feuchtigkeit versiegeln",
+    healthy_scalp: "Kopfhaut beruhigen",
+  },
+}
+
+export function getOrderedGoals(texture: HairTexture): Goal[] {
+  const priority = TEXTURE_GOAL_PRIORITY[texture]
+  const rest = GOALS.filter((g) => !priority.includes(g))
+  return [...priority, ...rest]
+}
+
+export function getGoalLabel(goal: Goal, texture: HairTexture): string {
+  return GOAL_LABEL_OVERRIDES[texture]?.[goal] ?? GOAL_LABELS[goal]
 }

--- a/tests/onboarding-goal-flow.test.ts
+++ b/tests/onboarding-goal-flow.test.ts
@@ -1,30 +1,64 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import {
-  deriveOnboardingGoals,
-  getOnboardingGoalCards,
-} from "../src/lib/onboarding/goal-flow"
+import { deriveVolumeFromGoals } from "../src/lib/onboarding/goal-flow"
+import { getOrderedGoals, getGoalLabel } from "../src/lib/vocabulary/onboarding-goals"
+import { GOALS } from "../src/lib/vocabulary/concerns-goals"
 
-test("desired volume 'more' adds the volume goal", () => {
-  const goals = deriveOnboardingGoals(["shine", "healthy_scalp"], "more")
+// --- deriveVolumeFromGoals ---
 
-  assert.deepEqual(goals, ["shine", "healthy_scalp", "volume"])
+test("volume goal derives desired_volume 'more'", () => {
+  assert.equal(deriveVolumeFromGoals(["shine", "volume"]), "more")
 })
 
-test("desired volume 'less' and 'balanced' do not inject the volume goal", () => {
-  assert.deepEqual(deriveOnboardingGoals(["shine"], "less"), ["shine"])
-  assert.deepEqual(
-    deriveOnboardingGoals(["healthy_scalp"], "balanced"),
-    ["healthy_scalp"]
-  )
+test("less_volume goal derives desired_volume 'less'", () => {
+  assert.equal(deriveVolumeFromGoals(["less_volume", "moisture"]), "less")
 })
 
-test("straight onboarding cards are unique and no longer use the old volume chip", () => {
-  const straightGoals = getOnboardingGoalCards("straight")
-  const keys = straightGoals.map((goal) => goal.key)
+test("no volume goal derives desired_volume 'balanced'", () => {
+  assert.equal(deriveVolumeFromGoals(["shine", "healthy_scalp"]), "balanced")
+})
 
-  assert.deepEqual(keys, ["healthy_scalp", "less_frizz", "shine", "less_split_ends"])
-  assert.equal(new Set(keys).size, keys.length)
-  assert.ok(!keys.includes("volume"))
+test("empty goals derives desired_volume 'balanced'", () => {
+  assert.equal(deriveVolumeFromGoals([]), "balanced")
+})
+
+// --- getOrderedGoals ---
+
+test("getOrderedGoals returns all goals with no duplicates", () => {
+  for (const texture of ["straight", "wavy", "curly", "coily"] as const) {
+    const ordered = getOrderedGoals(texture)
+    assert.equal(ordered.length, GOALS.length, `${texture}: expected ${GOALS.length} goals`)
+    assert.equal(new Set(ordered).size, ordered.length, `${texture}: has duplicates`)
+  }
+})
+
+test("getOrderedGoals puts priority goals first for straight", () => {
+  const ordered = getOrderedGoals("straight")
+  assert.deepEqual(ordered.slice(0, 5), ["volume", "shine", "less_frizz", "healthy_scalp", "less_split_ends"])
+})
+
+test("getOrderedGoals puts priority goals first for curly", () => {
+  const ordered = getOrderedGoals("curly")
+  assert.deepEqual(ordered.slice(0, 5), ["curl_definition", "moisture", "less_frizz", "strengthen", "less_split_ends"])
+})
+
+test("getOrderedGoals puts priority goals first for coily", () => {
+  const ordered = getOrderedGoals("coily")
+  assert.deepEqual(ordered.slice(0, 5), ["moisture", "strengthen", "anti_breakage", "healthy_scalp", "healthier_hair"])
+})
+
+// --- getGoalLabel ---
+
+test("getGoalLabel returns override when it exists", () => {
+  assert.equal(getGoalLabel("curl_definition", "curly"), "Locken-Clumping")
+  assert.equal(getGoalLabel("curl_definition", "wavy"), "Wellen-Definition")
+  assert.equal(getGoalLabel("moisture", "coily"), "Feuchtigkeit versiegeln")
+  assert.equal(getGoalLabel("healthy_scalp", "straight"), "Weniger schnell nachfetten")
+})
+
+test("getGoalLabel returns default label when no override", () => {
+  assert.equal(getGoalLabel("volume", "curly"), "Mehr Volumen")
+  assert.equal(getGoalLabel("shine", "coily"), "Mehr Glanz")
+  assert.equal(getGoalLabel("anti_breakage", "straight"), "Anti-Haarbruch")
 })

--- a/tests/profile-page-smoke.spec.ts
+++ b/tests/profile-page-smoke.spec.ts
@@ -109,8 +109,8 @@ test.describe.serial("Profile page smoke", () => {
     await memorySwitch.click()
     await expect(memorySwitch).toHaveAttribute("aria-checked", "false")
 
-    const volumeCard = page.locator('[role="button"]').filter({ hasText: "Gewünschtes Volumen" })
-    await volumeCard.first().click()
+    const goalsCard = page.locator('[role="button"]').filter({ hasText: "Weitere Ziele" })
+    await goalsCard.first().click()
     await expect(page.getByRole("button", { name: "Haar-Check aktualisieren" })).toBeVisible()
     await expect(page.getByText("Du bearbeitest dein Profil")).toBeVisible()
 
@@ -120,13 +120,12 @@ test.describe.serial("Profile page smoke", () => {
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
     await expect(page.getByRole("button", { name: "Speichern" })).toBeVisible()
 
-    await page.getByRole("radio", { name: /^Mehr$/ }).click()
     await page.getByRole("radio", { name: "Alle 2-3 Tage" }).click()
     await page.getByRole("button", { name: "Speichern" }).click()
 
     const washCard = page.locator("div.rounded-xl").filter({ hasText: "Wasch-Häufigkeit" })
 
-    await expect(volumeCard.first()).toContainText("Mehr")
+    await expect(goalsCard.first()).toContainText("Mehr Glanz")
     await expect(washCard.first()).toContainText("Alle 2-3 Tage")
 
     const routineProductsCard = page

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -80,6 +80,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
 
     if (!userId) return
 
+    await admin.from("user_product_usage").delete().eq("user_id", userId)
     await admin.from("hair_profiles").delete().eq("user_id", userId)
     await admin.from("profiles").delete().eq("id", userId)
     await admin.auth.admin.deleteUser(userId)
@@ -198,50 +199,72 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.locator('input[type="password"]:visible').fill(password)
       await page.getByRole("button", { name: /^Anmelden$/ }).click()
 
-      // Should land on goals page
-      await page.waitForURL(/\/onboarding\/goals(\?.*)?$/, {
+      // Should land on onboarding (single-page flow)
+      await page.waitForURL(/\/onboarding(\?.*)?$/, {
         timeout: 30_000,
         waitUntil: "domcontentloaded",
       })
-      await expect(
-        page.getByText("Wie viel Volumen willst du?", { exact: false })
-      ).toBeVisible()
     })
 
-    await test.step("Complete goals, profile, routine and verify database state", async () => {
-      // Goals page: select volume, secondary goal, routine preference
-      await page
-        .getByRole("button", {
-          name: /^MEHR Mehr Fuelle, Lift und sichtbare Bewegung\.$/,
-        })
-        .click()
-      await page.getByRole("button", { name: /Mehr Glanz/i }).click()
-      await page.getByRole("button", { name: /Ausgewogen/i }).click()
-      await page.getByRole("button", { name: /WEITER ZUM PROFIL/i }).click()
+    await test.step("Complete onboarding flow through goals and verify database state", async () => {
+      // Welcome screen
+      await expect(page.getByRole("button", { name: /LOS GEHT/i })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /LOS GEHT/i }).click()
 
-      // Profile page: select density
-      await page.waitForURL(/\/onboarding\/profile(\?.*)?$/, {
-        timeout: 30_000,
-        waitUntil: "domcontentloaded",
-      })
-      await expect(
-        page.getByText("Wie dicht ist dein", { exact: false })
-      ).toBeVisible()
-      await page.getByRole("button", { name: /Mittlere Dichte/i }).click()
-      await page.getByRole("button", { name: /^WEITER$/ }).click()
-
-      // Routine page: select wash frequency, products, post-wash actions
-      await page.waitForURL(/\/onboarding\/routine(\?.*)?$/, {
-        timeout: 30_000,
-        waitUntil: "domcontentloaded",
-      })
-      await expect(
-        page.getByText("Wie oft waeschst du deine Haare regelmaessig?", { exact: false })
-      ).toBeVisible()
-      await page.getByRole("button", { name: /^Alle 2-3 Tage$/ }).click()
+      // Products basics: select Conditioner
+      await expect(page.getByText("Deine Basis-Produkte", { exact: false })).toBeVisible({ timeout: 10_000 })
       await page.getByRole("button", { name: /^Conditioner$/i }).click()
+      await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+      // Products extras: skip
+      await expect(page.getByText("Weitere Produkte", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /Nichts davon/i }).click()
+
+      // Product drilldown: conditioner — select a frequency
+      await expect(page.getByText("Dein Conditioner", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /1-2x pro Woche/i }).click()
+      await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+      // Heat tools: skip (no heat tools)
+      await expect(page.getByText("Welche Hitzetools nutzt du?", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /Nichts davon/i }).click()
+
+      // Interstitial: continue
+      await expect(page.getByText("Fast geschafft!", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+      // Towel material: select Frottee (single-select, auto-advances)
+      await expect(page.getByText("Womit trocknest du dein Haar?", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /Frottee-Handtuch/i }).click()
+
+      // Towel technique: select Rubbeln (single-select, auto-advances)
+      await expect(page.getByText("Wie trocknest du?", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /^Rubbeln$/i }).click()
+
+      // Drying method: select Lufttrocknen (multi-select, needs Weiter)
+      await expect(page.getByText("Wie trocknest du dein Haar?", { exact: false })).toBeVisible({ timeout: 10_000 })
       await page.getByRole("button", { name: /Lufttrocknen/i }).click()
-      await page.getByRole("button", { name: /PROFIL ABSCHLIESSEN/i }).click()
+      await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+      // Brush type: select Grobzinkiger Kamm (single-select, auto-advances)
+      await expect(page.getByText("Welche Bürste", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /Grobzinkiger Kamm/i }).click()
+
+      // Night protection: skip
+      await expect(page.getByText("Wie schützt du dein Haar nachts?", { exact: false })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /Nichts davon/i }).click()
+
+      // Goals page: select goals from the chip grid
+      await expect(
+        page.getByText("Deine Haarziele", { exact: false })
+      ).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /Mehr Volumen/i }).click()
+      await page.getByRole("button", { name: /Mehr Glanz/i }).click()
+      await page.getByRole("button", { name: /^Weiter$/ }).click()
+
+      // Celebration popup
+      await expect(page.getByRole("button", { name: /ZUM CHAT/i })).toBeVisible({ timeout: 10_000 })
+      await page.getByRole("button", { name: /ZUM CHAT/i }).click()
 
       // Should land on chat
       await page.waitForURL("**/chat", { timeout: 30_000 })
@@ -281,14 +304,11 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       expect(hairProfile).toMatchObject({
         hair_texture: "wavy",
         thickness: "normal",
-        density: "medium",
         cuticle_condition: "slightly_rough",
         protein_moisture_balance: "stretches_stays",
         scalp_type: "dry",
         scalp_condition: "dry_flakes",
         desired_volume: "more",
-        routine_preference: "balanced",
-        wash_frequency: "every_2_3_days",
       })
       expect(hairProfile?.chemical_treatment).toEqual(["colored", "bleached"])
       expect(hairProfile?.goals).toEqual(expect.arrayContaining(["shine", "volume"]))
@@ -309,14 +329,11 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       expect(initialProfile).toMatchObject({
         hair_texture: "wavy",
         thickness: "normal",
-        density: "medium",
         cuticle_condition: "slightly_rough",
         protein_moisture_balance: "stretches_stays",
         scalp_type: "dry",
         scalp_condition: "dry_flakes",
         desired_volume: "more",
-        routine_preference: "balanced",
-        wash_frequency: "every_2_3_days",
       })
       expect(initialProfile?.chemical_treatment).toEqual(["colored", "bleached"])
       expect(initialProfile?.goals).toEqual(expect.arrayContaining(["shine", "volume"]))
@@ -392,14 +409,12 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.locator('input[type="password"]:visible').fill(password)
       await page.getByRole("button", { name: /^Anmelden$/ }).click()
 
-      // Should land on goals page
-      await page.waitForURL(/\/onboarding\/goals(\?.*)?$/, {
+      // Returning user with completed onboarding: lead is linked during the
+      // /onboarding server-side load, then redirect to /chat since onboarding_completed is true
+      await page.waitForURL("**/chat", {
         timeout: 30_000,
         waitUntil: "domcontentloaded",
       })
-      await expect(
-        page.getByText("Wie viel Volumen willst du?", { exact: false })
-      ).toBeVisible()
     })
 
     await test.step("Verify the latest lead links and diagnostics are overwritten", async () => {
@@ -441,15 +456,12 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       expect(hairProfile).toMatchObject({
         hair_texture: "straight",
         thickness: "fine",
-        density: "medium",
         cuticle_condition: "smooth",
         protein_moisture_balance: "snaps",
         scalp_type: "oily",
         scalp_condition: "none",
-        // Goals and routine data from first run remain (user hasn't re-submitted these pages)
+        // Goals and onboarding data from first run remain (user hasn't re-submitted onboarding)
         desired_volume: "more",
-        routine_preference: "balanced",
-        wash_frequency: "every_2_3_days",
       })
       expect(hairProfile?.chemical_treatment).toEqual(["natural"])
       // Goals stay from first run since user didn't re-save goals page


### PR DESCRIPTION
## Summary

- Replaces the restrictive texture-specific goal picker (4-5 goals + mandatory volume picker) with a universal multi-select chip grid showing all 12 goals
- Goals are sorted by texture relevance (priority goals first), with texture-specific German labels (e.g. "Locken-Clumping" for curly, "Wellen-Definition" for wavy)
- Adds 3 new goals: `less_volume` ("Weniger Volumen"), `strengthen` ("Haare stärken"), `anti_breakage` ("Anti-Haarbruch")
- Volume folded into the grid as mutually exclusive "Mehr Volumen" / "Weniger Volumen" chips, with backward-compatible `desired_volume` derivation
- Pick up to 5 limit with live counter and disabled state for overflow chips
- Profile page updated: volume field now read-only (derived from goals), inline goals editor enforces max-5 and mutual exclusion

## Test plan

- [x] `npm run ci:verify` passes (typecheck + lint + build)
- [x] 10/10 unit tests pass (`tests/onboarding-goal-flow.test.ts`)
- [x] Codex whole-branch review — findings addressed
- [x] Visual check on dev server — umlauts correct, chip sizing stable, checkmarks render properly
- [ ] E2E test: `npx playwright test tests/quiz-onboarding-e2e.spec.ts`
- [ ] E2E test: `npx playwright test tests/profile-page-smoke.spec.ts`
- [ ] Verify legacy resume: user with existing `desired_volume` sees correct chip pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)