### PR TITLE
feat: add langfuse quality loop for production chat

### DIFF
--- a/docs/chat-quality-review-rubric.md
+++ b/docs/chat-quality-review-rubric.md
@@ -1,0 +1,272 @@
+# Chat Quality Review Rubric
+
+This rubric is the shared quality language for reviewing `production-chat-turn` traces in Langfuse.
+
+Use it for:
+
+- manual review of thumbs-down traces
+- sampled review of zero-feedback and thumbs-up traces
+- deciding whether the next fix belongs in classification, rules, retrieval, or synthesis
+- keeping human review aligned with the eval harness metrics
+
+The current automated eval rubric already uses the same score names:
+
+- `groundedness`
+- `recommendation_relevance`
+- `clarification_quality`
+- `overclaim_risk`
+- `internal_eval_quality`
+
+## Review goal
+
+When you review a chat trace, do not ask only "was this answer good?"
+
+Ask these two questions:
+
+1. Was the answer helpful and safe for this user and this question?
+2. Which layer most likely caused the failure?
+
+The second question matters most, because the fix depends on the failure layer:
+
+- wrong intent/category -> classification or router logic
+- unnecessary or weak follow-up questions -> clarification rules or classifier prompt
+- weak or irrelevant context -> retrieval logic or source selection
+- right ingredients but poor final answer -> system prompt / synthesis behavior
+- unsupported certainty or hair/scalp overreach -> synthesis prompt, guardrails, or rule constraints
+
+## Fast review flow
+
+For each trace:
+
+1. Read the user message, profile summary, and final assistant output.
+2. Check whether the assistant should have answered directly or asked a clarifying question.
+3. Inspect the router decision, retrieval mode, sources, and matched products.
+4. Score the trace on the four core dimensions below.
+5. Assign one primary failure bucket.
+6. Add one short action note describing what should change next.
+
+Keep each review short. The goal is pattern detection, not perfect prose.
+
+## Scoring rubric
+
+Score each dimension on a `0.0` to `1.0` scale.
+
+Suggested anchors:
+
+- `1.0` = clearly strong
+- `0.7` = usable but imperfect
+- `0.5` = mixed / borderline
+- `0.3` = weak
+- `0.0` = clearly poor
+
+For `overclaim_risk`, lower is better.
+
+### `groundedness`
+
+Question:
+Is the answer meaningfully tied to the actual user question, known profile facts, and available sources?
+
+High score:
+
+- uses known profile/context correctly
+- stays within what the system actually knows
+- reflects retrieval evidence or explicit known facts
+- does not invent product facts, diagnoses, or user attributes
+
+Low score:
+
+- generic advice that ignores known context
+- claims not supported by sources or profile
+- product suggestions with no clear evidence path
+- contradictory use of known user/profile data
+
+Hair Concierge red flags:
+
+- citing needs that were never mentioned
+- recommending a category that was not actually asked for
+- acting as if the model "knows" scalp/hair conditions that were never established
+
+### `recommendation_relevance`
+
+Question:
+Did the answer actually solve the user’s problem in a way that fits their profile and intent?
+
+High score:
+
+- addresses the real question directly
+- recommendations match the category/need
+- advice is specific enough to be actionable
+- if products are suggested, they are meaningfully differentiated
+
+Low score:
+
+- vague generic advice instead of the requested help
+- wrong category or wrong level of specificity
+- answers a nearby question instead of the asked one
+- gives recommendations that conflict with profile constraints
+
+Hair Concierge red flags:
+
+- generic “use conditioner/oil” answers when the user asked for concrete leave-in recommendations
+- repeating broad hair-care tips instead of selecting among available products
+- suggesting heavy or mismatched products despite profile signals
+
+### `clarification_quality`
+
+Question:
+Was the system’s choice to clarify or answer directly the right one, and was it done well?
+
+High score:
+
+- asks only when the missing info really blocks a useful answer
+- asks a small number of targeted questions
+- questions are specific and easy to answer
+- when clarification is not needed, the answer is direct and not evasive
+- after repeated vague turns, gives a best-effort answer instead of looping forever
+
+Low score:
+
+- asks unnecessary follow-up questions
+- asks broad, lazy, or repetitive questions
+- asks too many questions at once
+- avoids answering despite enough context
+- gives a direct answer when crucial information is missing
+
+Hair Concierge red flags:
+
+- asking for routine/history when the user asked a simple general-care question
+- asking multiple generic profile questions that do not unblock a product choice
+- continued clarification after the cap should have forced a best-effort answer
+
+### `overclaim_risk`
+
+Question:
+How much risk is there that the answer sounds more certain, specific, or medically grounded than the system can support?
+
+Low risk (`0.0` to `0.3`):
+
+- language is appropriately careful
+- uncertainty is acknowledged where needed
+- cosmetic guidance stays cosmetic
+- medically adjacent issues are framed conservatively
+
+High risk (`0.7` to `1.0`):
+
+- strong claims without support
+- diagnostic tone for scalp or hair-loss issues
+- product certainty that is not evidence-based
+- implying guaranteed outcomes
+- authoritative wording that outruns the available context
+
+Hair Concierge red flags:
+
+- “this is definitely because…”
+- “you need this product”
+- medical-sounding scalp explanations without evidence or referral guidance
+- product claims not grounded in your own source material
+
+## Primary failure bucket
+
+After scoring, assign one primary bucket.
+
+Use these buckets consistently:
+
+- `classification`
+  - wrong intent
+  - wrong product category
+  - wrong direct-answer vs clarification decision
+- `retrieval`
+  - weak sources
+  - wrong retrieval mode
+  - missing or irrelevant context
+- `rules`
+  - deterministic business logic produced the wrong product set or wrong clarification path
+- `synthesis`
+  - final wording was vague, generic, too long, not grounded, or overconfident despite decent inputs
+- `policy/safety`
+  - medically adjacent overreach, unsupported certainty, or unsafe framing
+
+Only choose one primary bucket per trace. If multiple things are wrong, choose the earliest failure that most likely caused the rest.
+
+## Review note template
+
+Use short notes in this structure:
+
+```text
+Verdict: weak
+Primary bucket: synthesis
+Why: Retrieval found relevant leave-in context, but the final answer stayed generic and asked broad follow-up questions instead of giving category-specific options.
+Next change: tighten synthesis prompt to prefer best-effort concrete recommendations when retrieval confidence is sufficient.
+```
+
+## Triage rules
+
+Prioritize traces in this order:
+
+1. thumbs down + high overclaim risk
+2. thumbs down + wrong category / wrong clarification behavior
+3. zero-feedback samples with obviously weak quality
+4. thumbs up samples, to understand what “good” looks like
+
+Do not overreact to a single trace. Wait for a pattern:
+
+- `3-5` similar failures in the same bucket is enough to start a targeted fix
+- fix one layer at a time
+- rerun evals before and after the change
+
+## What to change based on the bucket
+
+If the main issue is `classification`:
+
+- review intent prompt
+- review router thresholds
+- inspect clarification trigger logic
+
+If the main issue is `retrieval`:
+
+- inspect subqueries
+- inspect source ranking
+- inspect retrieval mode choice
+- verify the right internal content exists at all
+
+If the main issue is `rules`:
+
+- inspect deterministic category logic
+- inspect profile slot requirements
+- inspect product scoring or eligibility rules
+
+If the main issue is `synthesis`:
+
+- tighten the main system prompt
+- make answer structure more explicit
+- reduce generic filler
+- require stronger grounding to retrieved evidence and profile facts
+
+If the main issue is `policy/safety`:
+
+- soften certainty
+- add stronger “do not diagnose” framing
+- separate cosmetic advice from medically adjacent advice more clearly
+
+## Weekly operating rhythm
+
+Suggested lightweight rhythm:
+
+- `2-3x` per week: review the newest thumbs-down traces
+- weekly: sample a few zero-feedback traces
+- weekly: sample a few thumbs-up traces to preserve wins
+- before prompt or rule changes: run `npm run test:chat:langfuse`
+- after changes: compare `internal_eval_quality`, `groundedness`, `recommendation_relevance`, `clarification_quality`, `overclaim_risk`, and `user_feedback`
+
+## Phase-1 success definition
+
+For phase 1, quality is improving if you can see:
+
+- fewer thumbs-down traces caused by the same repeated bucket
+- stronger `internal_eval_quality`
+- stronger `groundedness`
+- stronger `recommendation_relevance`
+- better `clarification_quality`
+- lower `overclaim_risk`
+
+The main goal is not perfect scores. It is learning which component to tune next with confidence.

--- a/docs/langfuse-quality-loop.md
+++ b/docs/langfuse-quality-loop.md
@@ -1,0 +1,178 @@
+# Langfuse Quality Loop
+
+This repo now has a phase-1 Langfuse integration for the production chat path.
+
+## What is live in the app
+
+- One Langfuse trace per chat turn, grouped by conversation ID as the session ID.
+- Child observations for the major pipeline stages:
+  - context loading
+  - intent classification
+  - routing
+  - retrieval
+  - product selection
+  - synthesis
+  - memory extraction
+- Prompt linkage for the production chat prompts:
+  - chat system prompt
+  - intent classifier prompt
+  - conversation title prompt
+  - memory extraction prompt
+- Prompt fallback behavior if Langfuse is unavailable or a label is missing.
+- Dual-write trace persistence in Supabase via `conversation_turn_traces`.
+- Assistant-message thumbs up/down feedback stored locally and sent to Langfuse scores.
+- Eval harness publishing into Langfuse experiments.
+
+## Required environment variables
+
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+- `LANGFUSE_BASE_URL`
+- `LANGFUSE_RELEASE`
+
+Optional:
+
+- `LANGFUSE_PROMPT_LABEL`
+- `LANGFUSE_TRACING_ENVIRONMENT`
+- `LANGFUSE_EVAL_PUBLISH`
+
+Use your Langfuse EU cloud base URL for `LANGFUSE_BASE_URL`.
+
+## Prompt workflow
+
+The repo keeps prompt fallbacks in code and treats Langfuse as the runtime source of truth.
+
+1. Sync the repo prompts into Langfuse:
+
+```bash
+npm run langfuse:sync-prompts
+```
+
+2. Review or relabel the synced versions in Langfuse.
+
+3. Production chat reads by label. If that fetch fails, the app falls back to the in-repo prompt text and marks the trace as fallback-backed.
+
+Use `--dry-run` to preview prompt changes:
+
+```bash
+npm run langfuse:sync-prompts -- --dry-run
+```
+
+## Eval workflow
+
+Run the normal harness without publishing:
+
+```bash
+npm run test:chat:judge
+```
+
+Publish the run into Langfuse:
+
+```bash
+npm run test:chat:langfuse
+```
+
+Useful flags:
+
+- `--scenario <id>`
+- `--base-url <url>`
+- `--langfuse-run-name <name>`
+- `--langfuse-experiment-name <name>`
+
+The Langfuse experiment stores:
+
+- assertion pass rate
+- scenario-specific judge score
+- groundedness
+- recommendation relevance
+- clarification quality
+- overclaim risk
+- internal eval quality
+
+`internal_eval_quality` is the phase-1 headline KPI. It blends deterministic assertion pass rate, rubric scores, and the scenario-specific expectation judge when present.
+
+## Dataset seeding
+
+Seed the two baseline datasets:
+
+```bash
+npm run langfuse:seed-datasets
+```
+
+Default datasets:
+
+- `hair-concierge-curated-chat-evals`
+- `hair-concierge-production-chat-triage`
+
+The production dataset samples recent traced conversations from Supabase using:
+
+- thumbs down traces
+- zero-feedback traces
+- thumbs up traces
+
+Helpful flags:
+
+- `--since-days 30`
+- `--negative-limit 50`
+- `--zero-feedback-limit 25`
+- `--positive-limit 10`
+- `--fetch-limit 500`
+
+## Review queue setup
+
+Create the manual review score configs and annotation queues:
+
+```bash
+npm run langfuse:setup-review-queues
+```
+
+Queues created by default:
+
+- `HC Thumbs Down Review`
+- `HC No Feedback Sample`
+- `HC Thumbs Up Sample`
+- `HC Prompt Change Review`
+
+If your Langfuse plan only allows a single annotation queue, the setup script will automatically reuse the first available queue for all review buckets instead of failing. In that case, treat that one queue as your shared manual review inbox.
+
+To focus the prompt-change queue on specific prompt versions:
+
+```bash
+npm run langfuse:setup-review-queues -- --prompt-versions 12,13
+```
+
+Use the shared review rubric in [docs/chat-quality-review-rubric.md](/Users/nick/AI_work/hair_conscierge/.worktrees/langfuse-quality-loop/docs/chat-quality-review-rubric.md:1) so manual review, thumbs feedback, and eval metrics stay aligned.
+
+## Privacy and masking
+
+Before trace data leaves the app, the Langfuse OTEL exporter applies masking in `src/lib/langfuse/masking.ts`.
+
+Sent raw:
+
+- structured hair-profile enums and booleans
+- routing metadata such as `intent`, `product_category`, `retrieval_mode`, and `needs_clarification`
+- prompt name, version, label, and fallback status
+- release and environment dimensions
+- user feedback and eval scores
+
+Masked:
+
+- email-like strings
+- phone-like strings
+- metadata keys such as `email`, `name`, `first_name`, `last_name`, and `phone`
+
+Aggressively redacted:
+
+- `additional_notes`
+- `memory_context`
+- `conversation_memory`
+- `notes`
+- `free_text`
+
+This keeps quality-relevant structured context visible while reducing direct identifier leakage.
+
+## Operational notes
+
+- Keep the current Supabase trace tables and admin trace UI. They are still the source of repo-local debugging context.
+- Langfuse is the quality analysis layer on top: prompt versions, experiments, review queues, and cross-run comparison.
+- Release gating is still manual in phase 1. Use Langfuse traces, experiments, and queues to make ship decisions, but do not hard-block CI on these scores yet.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,11 @@
 import * as Sentry from "@sentry/nextjs"
+import { ensureLangfuseTracing, isLangfuseConfigured } from "@/lib/langfuse/client"
 
 export async function register() {
+  if (process.env.NEXT_RUNTIME !== "edge" && isLangfuseConfigured()) {
+    ensureLangfuseTracing()
+  }
+
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
     tracesSampleRate: 0.1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "hair-concierge",
       "version": "0.1.0",
       "dependencies": {
+        "@langfuse/client": "^5.1.0",
+        "@langfuse/openai": "^5.1.0",
+        "@langfuse/otel": "^5.1.0",
+        "@langfuse/tracing": "^5.1.0",
+        "@opentelemetry/sdk-node": "^0.214.0",
         "@sentry/nextjs": "^10.48.0",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -1622,6 +1627,37 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
@@ -1819,6 +1855,82 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@langfuse/client": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/client/-/client-5.1.0.tgz",
+      "integrity": "sha512-czZxxr/9ROaTTjD5vn1qo7WxcGi4zkXGwDvNHgQKrihi6SBBsFapv7v4EtxBhwyXq339C7QyVPWDw55+Cgx9Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.1.0",
+        "@langfuse/tracing": "^5.1.0",
+        "mustache": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.1.0.tgz",
+      "integrity": "sha512-yFvC67HBtrY4B3tyzF8+RJaIqK79LBVXtAgtmEc2vhpKauecvSW0zevRnRynFX+ajUHqi9TN7tnD91FJszFLgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/openai": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/openai/-/openai-5.1.0.tgz",
+      "integrity": "sha512-tVk7RopuGRzlaNAJgFUEY2HadaeDxbDiraYvFne3GsyB1B/1WnmocXeH2v33Eh6FHJF/MhpBerXxzBq4AYtTOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.1.0",
+        "@langfuse/tracing": "^5.1.0"
+      }
+    },
+    "node_modules/@langfuse/otel": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.1.0.tgz",
+      "integrity": "sha512-pvaXgZHMHqjsRjn+Gs5amrrq61w0Rxz1OChmLr2FfQzlymNl7+MxSXsWBj5dZQlufGbhyG+LT3wdx3MV8aLXHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.1"
+      }
+    },
+    "node_modules/@langfuse/tracing": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.1.0.tgz",
+      "integrity": "sha512-ScwYnQzqLZOaMPZkCsWizx139eb02GI8tD5yxs5XVjGNGZxKdw1DfRPTIONSlOhaAYCY9ILGTJdkqAtNTzsbRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -2227,6 +2339,37 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.214.0.tgz",
+      "integrity": "sha512-Q+awuEwxhETwIAXuxHvIY5ZMEP0ZqvxLTi9kclrkyVJppEUXYL3Bhiw3jYrxdHYMh0Y0tVInQH9FEZ1aMinvLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/configuration/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
@@ -2254,6 +2397,141 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.214.0.tgz",
+      "integrity": "sha512-SwmFRwO8mi6nndzbsjPgSFg7qy1WeNHRFD+s6uCsdiUDUt3+yzI2qiHE3/ub2f37+/CbeGcG+Ugc8Gwr6nu2Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/sdk-logs": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
       "version": "0.208.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
@@ -2271,6 +2549,1051 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.214.0.tgz",
+      "integrity": "sha512-IWAVvCO1TlpotRjFmhQFz9RSfQy5BsLtDRBtptSrXZRwfyRPpuql/RMe5zdmu0Gxl3ERDFwOzOqkf3bwy7Jzcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.214.0.tgz",
+      "integrity": "sha512-0NGxWHVYHgbp51SEzmsP+Hdups81eRs229STcSWHo3WO0aqY6RpJ9csxfyEtFgaNrBDv6UfOh0je4ss/ROS6XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-Tx/59RmjBgkXJ3qnsD04rpDrVWL53LU/czpgLJh+Ab98nAroe91I7vZ3uGN9mxwPS0jsZEnmqmHygVwB2vRMlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.214.0.tgz",
+      "integrity": "sha512-pJIcghFGhx3VSCgP5U+yZx+OMNj0t+ttnhC8IjL5Wza7vWIczctF6t3AGcVQffi2dEqX+ZHANoBwoPR8y6RMKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.214.0.tgz",
+      "integrity": "sha512-4TGYoZKebUWVuYkV6r5wS2dUF4zH7EbWFw/Uqz1ZM1tGHQeFT9wzHGXq3iSIXMUrwu5jRdxjfMaXrYejPu2kpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.214.0.tgz",
+      "integrity": "sha512-FWRZ7AWoTryYhthralHkfXUuyO3l7cRsnr49WcDio1orl2a7KxT8aDZdwQtV1adzoUvZ9Gfo+IstElghCS4zfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.214.0.tgz",
+      "integrity": "sha512-ON0spYWb2yAdQ9b+ItNyK0c6qdtcs+0eVR4YFJkhJL7agfT8sHFg0e5EesauSRiTHPZHiDobI92k77q0lwAmqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.6.1.tgz",
+      "integrity": "sha512-km2/hD3inLTqtLnUAHDGz7ZP/VOyZNslrC/iN66x4jkmpckwlONW54LRPNI6fm09/musDtZga9EWsxgwnjGUlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -2683,6 +4006,139 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-IDP6zcyA24RhNZ289MP6eToIZcinlmirHjX8v3zKCQ2ZhPpt5cGwkN91tCth337lqHIgWcTy90uKRiX/SzALDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.208.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
@@ -2718,6 +4174,66 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.6.1.tgz",
+      "integrity": "sha512-Dvz9TA6cPqIbxolSzQ5x9br6iQlqdGhVYrm+oYc7pfJ7LaVXz8F0XIqhWbnKB5YvfZ6SUmabBUUxnvHs/9uhxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.6.1.tgz",
+      "integrity": "sha512-kKFMxBcjBZAC1vBch5mtZ/dJQvcAEKWga+c+q5iGgRLPIE6Mc649zEwMaCIQCzalziMJQiyUadFYMHmELB7AFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -2825,6 +4341,179 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.214.0.tgz",
+      "integrity": "sha512-gl2XvQBJuPjhGcw9SsnQO5qxChAPMuGRPFaD8lqtF+Cey91NgGUQ0sio2vlDFOSm3JOLzc44vL+OAfx1dXuZjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/configuration": "0.214.0",
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.214.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.214.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.214.0",
+        "@opentelemetry/exporter-prometheus": "0.214.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.214.0",
+        "@opentelemetry/exporter-zipkin": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/propagator-b3": "2.6.1",
+        "@opentelemetry/propagator-jaeger": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "@opentelemetry/sdk-trace-node": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-9qv2Tl/Hq6qc5pJCbzFJnzA0uvlb9DgM70yGJPYf3bA5LlLkRCpcn81i4JbcIH4grlQIWY6A+W7YG0LLvS1BAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/sdk-logs": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
@@ -2849,6 +4538,55 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
+      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -5815,7 +7553,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6429,6 +8166,87 @@
       "version": "0.0.1",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -6470,7 +8288,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -6481,7 +8298,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -7919,6 +9735,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -9394,6 +11219,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -10500,6 +12331,15 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "funding": [
@@ -11551,6 +13391,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -14128,6 +15977,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "license": "ISC"
@@ -14136,7 +15994,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -14148,6 +16005,24 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
@@ -14155,6 +16030,65 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,18 @@
     "test:qa": "playwright test qa-validation",
     "test:chat": "tsx scripts/eval-chat/run.ts --skip-judge",
     "test:chat:judge": "tsx scripts/eval-chat/run.ts",
+    "test:chat:langfuse": "tsx scripts/eval-chat/run.ts --langfuse-publish",
+    "langfuse:sync-prompts": "tsx scripts/langfuse/sync-prompts.ts",
+    "langfuse:seed-datasets": "tsx scripts/langfuse/seed-datasets.ts",
+    "langfuse:setup-review-queues": "tsx scripts/langfuse/setup-review-queues.ts",
     "prepare": "husky"
   },
   "dependencies": {
+    "@langfuse/client": "^5.1.0",
+    "@langfuse/openai": "^5.1.0",
+    "@langfuse/otel": "^5.1.0",
+    "@langfuse/tracing": "^5.1.0",
+    "@opentelemetry/sdk-node": "^0.214.0",
     "@sentry/nextjs": "^10.48.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",

--- a/scripts/eval-chat/client.ts
+++ b/scripts/eval-chat/client.ts
@@ -14,8 +14,7 @@ const MAX_CHUNK_SIZE = 3180
 
 // ── Base64URL encoding (matches @supabase/ssr) ───────────────────────────
 
-const TO_BASE64URL =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".split("")
+const TO_BASE64URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".split("")
 
 function stringToBase64URL(str: string): string {
   const base64: string[] = []
@@ -84,9 +83,7 @@ function buildAuthCookies(sessionJSON: string): string {
     remaining = remaining.slice(head.length)
   }
 
-  return chunks
-    .map((value, i) => `${COOKIE_NAME}.${i}=${encodeURIComponent(value)}`)
-    .join("; ")
+  return chunks.map((value, i) => `${COOKIE_NAME}.${i}=${encodeURIComponent(value)}`).join("; ")
 }
 
 // ── Test user management ─────────────────────────────────────────────────
@@ -110,13 +107,12 @@ export async function createTestSession(
   const email = `eval-chat-${Date.now()}@test.hairconscierge.dev`
   const password = "eval-test-password-2026"
 
-  const { data: userData, error: createErr } =
-    await admin.auth.admin.createUser({
-      email,
-      password,
-      email_confirm: true,
-      user_metadata: { full_name: "Eval Test User" },
-    })
+  const { data: userData, error: createErr } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { full_name: "Eval Test User" },
+  })
 
   if (createErr || !userData.user) {
     throw new Error(`Failed to create test user: ${createErr?.message}`)
@@ -136,8 +132,10 @@ export async function createTestSession(
     auth: { autoRefreshToken: false, persistSession: false },
   })
 
-  const { data: signInData, error: signInErr } =
-    await anonClient.auth.signInWithPassword({ email, password })
+  const { data: signInData, error: signInErr } = await anonClient.auth.signInWithPassword({
+    email,
+    password,
+  })
 
   if (signInErr || !signInData.session) {
     throw new Error(`Failed to sign in test user: ${signInErr?.message}`)
@@ -179,10 +177,7 @@ export async function upsertHairProfile(
   })
 }
 
-export async function clearConversations(
-  admin: SupabaseClient,
-  userId: string,
-): Promise<void> {
+export async function clearConversations(admin: SupabaseClient, userId: string): Promise<void> {
   const { data: conversations } = await admin
     .from("conversations")
     .select("id")
@@ -224,6 +219,9 @@ export async function sendMessage(
     const text = await response.text().catch(() => "(empty body)")
     return {
       conversation_id: null,
+      assistant_message_id: null,
+      langfuse_trace_id: null,
+      langfuse_trace_url: null,
       content: "",
       done_data: null,
       sources: [],
@@ -236,6 +234,9 @@ export async function sendMessage(
   // Parse SSE stream
   const result: SSEResult = {
     conversation_id: null,
+    assistant_message_id: null,
+    langfuse_trace_id: null,
+    langfuse_trace_url: null,
     content: "",
     done_data: null,
     sources: [],
@@ -264,6 +265,9 @@ export async function sendMessage(
           case "conversation_id":
             result.conversation_id = event.data
             break
+          case "langfuse_trace":
+            result.langfuse_trace_id = event.data?.trace_id ?? null
+            break
           case "content_delta":
             result.content += event.data
             break
@@ -272,6 +276,11 @@ export async function sendMessage(
             break
           case "sources":
             result.sources = event.data
+            break
+          case "assistant_message":
+            result.assistant_message_id = event.data?.id ?? null
+            result.langfuse_trace_id = event.data?.langfuse_trace_id ?? result.langfuse_trace_id
+            result.langfuse_trace_url = event.data?.langfuse_trace_url ?? null
             break
           case "done":
             result.done_data = event.data
@@ -291,8 +300,7 @@ export async function sendMessage(
     try {
       const event = JSON.parse(buffer.slice(6))
       if (event.type === "done") result.done_data = event.data
-      if (event.type === "error")
-        result.error = event.data?.message ?? "Unknown SSE error"
+      if (event.type === "error") result.error = event.data?.message ?? "Unknown SSE error"
     } catch {
       // ignore
     }
@@ -308,13 +316,19 @@ export async function fetchLatestAssistantMessage(
   admin: SupabaseClient,
   conversationId: string,
 ): Promise<{
+  id: string
   content: string | null
   product_recommendations: unknown[] | null
   rag_context: { sources?: unknown[]; category_decision?: unknown } | null
+  langfuse_trace_id: string | null
+  langfuse_trace_url: string | null
+  user_feedback_score: number | null
 } | null> {
   const { data } = await admin
     .from("messages")
-    .select("content, product_recommendations, rag_context")
+    .select(
+      "id, content, product_recommendations, rag_context, langfuse_trace_id, langfuse_trace_url, user_feedback_score",
+    )
     .eq("conversation_id", conversationId)
     .eq("role", "assistant")
     .order("created_at", { ascending: false })

--- a/scripts/eval-chat/judge.ts
+++ b/scripts/eval-chat/judge.ts
@@ -3,7 +3,13 @@
  */
 
 import OpenAI from "openai"
-import type { SSEResult, JudgeSpec, JudgeVerdict, HairProfileOverrides } from "./types"
+import type {
+  SSEResult,
+  JudgeSpec,
+  JudgeVerdict,
+  HairProfileOverrides,
+  QualityRubricResult,
+} from "./types"
 
 let _openai: OpenAI | null = null
 function getOpenAI(): OpenAI {
@@ -11,6 +17,23 @@ function getOpenAI(): OpenAI {
     _openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
   }
   return _openai
+}
+
+async function runJsonJudge<T>(prompt: string, fallback: T): Promise<T> {
+  try {
+    const response = await getOpenAI().chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: prompt }],
+      response_format: { type: "json_object" },
+      temperature: 0,
+      max_tokens: 500,
+    })
+
+    const raw = response.choices[0]?.message?.content?.trim() ?? ""
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
 }
 
 export async function runJudge(
@@ -59,30 +82,86 @@ ${spec.expected_behavior}
 Antworte NUR mit validem JSON:
 {"verdict": "pass" oder "fail", "score": 0.0-1.0, "reasoning": "Kurze Begruendung", "issues": ["Problem 1", "Problem 2"]}`
 
-  try {
-    const response = await getOpenAI().chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [{ role: "user", content: prompt }],
-      response_format: { type: "json_object" },
-      temperature: 0,
-      max_tokens: 300,
-    })
+  const parsed = await runJsonJudge<Partial<JudgeVerdict>>(prompt, {
+    verdict: "fail",
+    score: 0,
+    reasoning: "Judge error",
+    issues: ["LLM judge call failed"],
+  })
 
-    const raw = response.choices[0]?.message?.content?.trim() ?? ""
-    const parsed = JSON.parse(raw)
+  return {
+    verdict: parsed.verdict === "pass" ? "pass" : "fail",
+    score: typeof parsed.score === "number" ? parsed.score : 0,
+    reasoning: parsed.reasoning ?? "",
+    issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+  }
+}
 
-    return {
-      verdict: parsed.verdict === "pass" ? "pass" : "fail",
-      score: typeof parsed.score === "number" ? parsed.score : 0,
-      reasoning: parsed.reasoning ?? "",
-      issues: Array.isArray(parsed.issues) ? parsed.issues : [],
-    }
-  } catch (error) {
-    return {
-      verdict: "fail",
-      score: 0,
-      reasoning: `Judge error: ${error instanceof Error ? error.message : String(error)}`,
-      issues: ["LLM judge call failed"],
-    }
+function clampScore(value: unknown, defaultValue = 0): number {
+  if (typeof value !== "number" || Number.isNaN(value)) return defaultValue
+  return Math.max(0, Math.min(1, value))
+}
+
+export async function runQualityRubric(
+  message: string,
+  sse: SSEResult,
+  profile: HairProfileOverrides,
+  conversationContext?: string,
+): Promise<QualityRubricResult> {
+  const profileSummary = Object.entries(profile)
+    .filter(([, v]) => v !== null && v !== undefined)
+    .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : v}`)
+    .join("\n")
+
+  const metadataSummary = sse.done_data
+    ? Object.entries(sse.done_data)
+        .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+        .join("\n")
+    : "(no done event)"
+
+  const prompt = `Du bist ein strenger Qualitaetspruefer fuer den deutschen Haarpflege-Chatbot Hair Concierge.
+Bewerte die Antwort entlang eines festen Rubrik-Schemas und antworte NUR mit validem JSON.
+
+## Nutzernachricht
+${message}
+${conversationContext ? `\n## Gespraechsverlauf\n${conversationContext}` : ""}
+
+## Haarprofil
+${profileSummary}
+
+## Assistent-Antwort
+${sse.content.slice(0, 3000)}
+
+## Router- und SSE-Metadaten
+${metadataSummary}
+
+## Rubrik
+- groundedness: 0.0-1.0. Wie gut ist die Antwort an vorhandenen Kontext, Quellen und bekannte Profildaten gebunden?
+- recommendation_relevance: 0.0-1.0. Wie gut passt die Empfehlung oder Beratung zur Nutzerfrage und zum Profil?
+- clarification_quality: 0.0-1.0. Wenn Rueckfragen noetig waeren: wie gut wurden sie gestellt? Wenn keine Rueckfragen noetig sind: war die Antwort passend direkt und nicht unnoetig ausweichend?
+- overclaim_risk: 0.0-1.0. 0.0 = praktisch kein Risiko fuer ueberzogene oder ungestuetzte Behauptungen. 1.0 = hohes Risiko fuer Overclaiming.
+- overall_quality: 0.0-1.0. Gesamteindruck unter Beruecksichtigung aller Faktoren.
+
+Antworte NUR mit JSON:
+{"groundedness":0.0,"recommendation_relevance":0.0,"clarification_quality":0.0,"overclaim_risk":0.0,"overall_quality":0.0,"summary":"kurz","issues":["issue 1"]}`
+
+  const parsed = await runJsonJudge<Partial<QualityRubricResult>>(prompt, {
+    groundedness: 0,
+    recommendation_relevance: 0,
+    clarification_quality: 0,
+    overclaim_risk: 1,
+    overall_quality: 0,
+    summary: "Judge error",
+    issues: ["LLM rubric judge failed"],
+  })
+
+  return {
+    groundedness: clampScore(parsed.groundedness),
+    recommendation_relevance: clampScore(parsed.recommendation_relevance),
+    clarification_quality: clampScore(parsed.clarification_quality),
+    overclaim_risk: clampScore(parsed.overclaim_risk, 1),
+    overall_quality: clampScore(parsed.overall_quality),
+    summary: parsed.summary ?? "",
+    issues: Array.isArray(parsed.issues) ? parsed.issues : [],
   }
 }

--- a/scripts/eval-chat/langfuse.ts
+++ b/scripts/eval-chat/langfuse.ts
@@ -1,0 +1,272 @@
+import { LangfuseClient } from "@langfuse/client"
+import type {
+  EvalScenario,
+  LangfuseExperimentSummary,
+  QualityRubricResult,
+  ScenarioResult,
+  TurnResult,
+} from "./types"
+
+interface PublishEvalExperimentParams {
+  baseUrl: string
+  scenarios: EvalScenario[]
+  results: ScenarioResult[]
+  skipJudge: boolean
+  experimentName: string
+  runName?: string
+}
+
+interface EvalExperimentItem {
+  input: {
+    scenario_id: string
+    scenario_name: string
+    turn_index: number
+    message: string
+    hair_profile: EvalScenario["hair_profile"]
+    base_url: string
+  }
+  expectedOutput: {
+    expected_behavior: string | null
+  }
+  metadata: {
+    live_trace_id: string | null
+    live_trace_url: string | null
+    conversation_id: string | null
+    assistant_message_id: string | null
+    assertion_failures: number
+    assertion_count: number
+    turn_passed: boolean
+    judge_score: number | null
+    rubric: QualityRubricResult | null
+    latency_ms: number
+    source_count: number
+    product_count: number
+  }
+  output: {
+    assistant_response: string
+    done_data: Record<string, unknown> | null
+    error: string | null
+  }
+}
+
+function isConfigured(): boolean {
+  return Boolean(
+    process.env.LANGFUSE_PUBLIC_KEY &&
+    process.env.LANGFUSE_SECRET_KEY &&
+    process.env.LANGFUSE_BASE_URL,
+  )
+}
+
+function getClient(): LangfuseClient {
+  if (!isConfigured()) {
+    throw new Error(
+      "Langfuse env vars missing. Set LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL.",
+    )
+  }
+
+  return new LangfuseClient({
+    publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+    secretKey: process.env.LANGFUSE_SECRET_KEY,
+    baseUrl: process.env.LANGFUSE_BASE_URL,
+  })
+}
+
+function buildItems(
+  baseUrl: string,
+  scenarios: EvalScenario[],
+  results: ScenarioResult[],
+): EvalExperimentItem[] {
+  const scenariosById = new Map(scenarios.map((scenario) => [scenario.id, scenario]))
+  const items: EvalExperimentItem[] = []
+
+  for (const scenarioResult of results) {
+    const scenario = scenariosById.get(scenarioResult.id)
+    if (!scenario) continue
+
+    for (const turnResult of scenarioResult.turns) {
+      const scenarioTurn = scenario.turns[turnResult.turn_index - 1]
+      const assertionFailures = turnResult.assertions.filter(
+        (assertion) => !assertion.passed,
+      ).length
+
+      items.push({
+        input: {
+          scenario_id: scenario.id,
+          scenario_name: scenario.name,
+          turn_index: turnResult.turn_index,
+          message: turnResult.message,
+          hair_profile: scenario.hair_profile,
+          base_url: baseUrl,
+        },
+        expectedOutput: {
+          expected_behavior: scenarioTurn?.judge?.expected_behavior ?? null,
+        },
+        metadata: {
+          live_trace_id: turnResult.sse_result.langfuse_trace_id,
+          live_trace_url: turnResult.sse_result.langfuse_trace_url,
+          conversation_id: turnResult.sse_result.conversation_id,
+          assistant_message_id: turnResult.sse_result.assistant_message_id,
+          assertion_failures: assertionFailures,
+          assertion_count: turnResult.assertions.length,
+          turn_passed: turnResult.all_passed,
+          judge_score: turnResult.judge_result?.score ?? null,
+          rubric: turnResult.quality_rubric,
+          latency_ms: turnResult.sse_result.latency_ms,
+          source_count: turnResult.sse_result.sources.length,
+          product_count: turnResult.sse_result.products.length,
+        },
+        output: {
+          assistant_response: turnResult.sse_result.content,
+          done_data: turnResult.sse_result.done_data,
+          error: turnResult.sse_result.error,
+        },
+      })
+    }
+  }
+
+  return items
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+function buildInternalEvalQuality(turn: TurnResult): number {
+  const assertionPassRate =
+    turn.assertions.length === 0
+      ? Number(turn.all_passed)
+      : turn.assertions.filter((assertion) => assertion.passed).length / turn.assertions.length
+
+  const rubric = turn.quality_rubric
+  const rubricQuality = rubric
+    ? average([
+        rubric.groundedness,
+        rubric.recommendation_relevance,
+        rubric.clarification_quality,
+        1 - rubric.overclaim_risk,
+        rubric.overall_quality,
+      ])
+    : assertionPassRate
+
+  const expectationScore = turn.judge_result?.score ?? rubricQuality
+
+  return average([assertionPassRate, rubricQuality, expectationScore])
+}
+
+export async function publishEvalExperiment(
+  params: PublishEvalExperimentParams,
+): Promise<LangfuseExperimentSummary> {
+  const { baseUrl, scenarios, results, skipJudge, experimentName, runName } = params
+  const langfuse = getClient()
+  const items = buildItems(baseUrl, scenarios, results)
+
+  const turnByKey = new Map<string, TurnResult>()
+  for (const scenario of results) {
+    for (const turn of scenario.turns) {
+      turnByKey.set(`${scenario.id}:${turn.turn_index}`, turn)
+    }
+  }
+  const outputByKey = new Map(
+    items.map((item) => [`${item.input.scenario_id}:${item.input.turn_index}`, item.output]),
+  )
+
+  const experiment = await langfuse.experiment.run<
+    EvalExperimentItem["input"],
+    EvalExperimentItem["expectedOutput"],
+    EvalExperimentItem["metadata"]
+  >({
+    name: experimentName,
+    runName,
+    description: "Production chat regression run published from the local eval harness.",
+    metadata: {
+      base_url: baseUrl,
+      release: process.env.LANGFUSE_RELEASE ?? process.env.VERCEL_GIT_COMMIT_SHA ?? "local",
+      skip_judge: skipJudge,
+      scenario_count: scenarios.length,
+      turn_count: items.length,
+    },
+    data: items,
+    task: async (item) => {
+      const experimentItem = item as EvalExperimentItem
+
+      return {
+        input: experimentItem.input,
+        expected_output: experimentItem.expectedOutput,
+        metadata: experimentItem.metadata,
+        output:
+          outputByKey.get(
+            `${experimentItem.input.scenario_id}:${experimentItem.input.turn_index}`,
+          ) ?? null,
+      }
+    },
+    evaluators: [
+      async ({ input, metadata, output }) => {
+        const turn = turnByKey.get(`${input.scenario_id}:${input.turn_index}`)
+        const quality = turn ? buildInternalEvalQuality(turn) : 0
+        return {
+          name: "internal_eval_quality",
+          value: quality,
+          comment:
+            turn?.quality_rubric?.summary ??
+            `assertion_failures=${metadata?.assertion_failures ?? 0}`,
+          metadata: output?.metadata,
+        }
+      },
+      async ({ metadata }) => ({
+        name: "assertion_pass_rate",
+        value:
+          !metadata || metadata.assertion_count === 0
+            ? Number(metadata?.turn_passed ?? 0)
+            : (metadata.assertion_count - metadata.assertion_failures) / metadata.assertion_count,
+      }),
+      async ({ metadata }) => ({
+        name: "scenario_expectation_score",
+        value: metadata?.judge_score ?? 0,
+      }),
+      async ({ metadata }) => ({
+        name: "groundedness",
+        value: metadata?.rubric?.groundedness ?? 0,
+      }),
+      async ({ metadata }) => ({
+        name: "recommendation_relevance",
+        value: metadata?.rubric?.recommendation_relevance ?? 0,
+      }),
+      async ({ metadata }) => ({
+        name: "clarification_quality",
+        value: metadata?.rubric?.clarification_quality ?? 0,
+      }),
+      async ({ metadata }) => ({
+        name: "overclaim_risk",
+        value: metadata?.rubric?.overclaim_risk ?? 0,
+      }),
+      async ({ metadata }) => ({
+        name: "turn_passed",
+        value: metadata?.turn_passed ? 1 : 0,
+        dataType: "BOOLEAN" as const,
+      }),
+    ],
+    runEvaluators: [
+      async ({ itemResults }) => {
+        const qualityScores = itemResults
+          .flatMap((result) => result.evaluations)
+          .filter((evaluation) => evaluation.name === "internal_eval_quality")
+          .map((evaluation) => (typeof evaluation.value === "number" ? evaluation.value : 0))
+
+        return {
+          name: "internal_eval_quality_average",
+          value: average(qualityScores),
+        }
+      },
+    ],
+  })
+
+  await langfuse.flush()
+
+  return {
+    experiment_id: experiment.experimentId,
+    run_name: experiment.runName,
+    dataset_run_id: experiment.datasetRunId,
+    dataset_run_url: experiment.datasetRunUrl,
+  }
+}

--- a/scripts/eval-chat/report.ts
+++ b/scripts/eval-chat/report.ts
@@ -4,12 +4,13 @@
 
 import fs from "fs"
 import path from "path"
-import type { EvalReport, ScenarioResult } from "./types"
+import type { EvalReport, LangfuseExperimentSummary, ScenarioResult } from "./types"
 
 export function buildReport(
   scenarios: ScenarioResult[],
   baseUrl: string,
   startTime: number,
+  langfuseExperiment: LangfuseExperimentSummary | null = null,
 ): EvalReport {
   const totalAssertions = scenarios.reduce(
     (sum, s) => sum + s.turns.reduce((ts, t) => ts + t.assertions.length, 0),
@@ -25,6 +26,7 @@ export function buildReport(
     timestamp: new Date().toISOString(),
     base_url: baseUrl,
     duration_ms: Date.now() - startTime,
+    langfuse_experiment: langfuseExperiment,
     summary: {
       total_scenarios: scenarios.length,
       passed: scenarios.filter((s) => s.passed).length,
@@ -60,6 +62,12 @@ export function printSummary(report: EvalReport): void {
     `  Assertions: ${summary.total_assertions - summary.assertion_failures}/${summary.total_assertions} passed`,
   )
   console.log(`  Duration: ${(report.duration_ms / 1000).toFixed(1)}s`)
+  if (report.langfuse_experiment) {
+    console.log(`  Langfuse run: ${report.langfuse_experiment.run_name}`)
+    if (report.langfuse_experiment.dataset_run_url) {
+      console.log(`  Langfuse URL: ${report.langfuse_experiment.dataset_run_url}`)
+    }
+  }
   console.log("")
 
   for (const scenario of scenarios) {

--- a/scripts/eval-chat/run.ts
+++ b/scripts/eval-chat/run.ts
@@ -14,13 +14,10 @@ import path from "path"
 // ── Load .env.local (same pattern as eval-retrieval.ts) ──────────────────
 const envPath = path.join(process.cwd(), ".env.local")
 if (fs.existsSync(envPath)) {
-  for (const line of fs
-    .readFileSync(envPath, "utf-8")
-    .replace(/\r/g, "")
-    .split("\n")) {
+  for (const line of fs.readFileSync(envPath, "utf-8").replace(/\r/g, "").split("\n")) {
     const match = line.match(/^([^#=]+)=(.*)$/)
     if (match && !process.env[match[1].trim()]) {
-      process.env[match[1].trim()] = match[2].trim()
+      process.env[match[1].trim()] = match[2].trim().replace(/^"(.*)"$/, "$1")
     }
   }
 }
@@ -29,17 +26,18 @@ import { SCENARIOS } from "./fixtures"
 import {
   createTestSession,
   upsertHairProfile,
-  clearConversations,
   sendMessage,
   fetchLatestAssistantMessage,
 } from "./client"
 import { runMetadataAssertions, runContentAssertions } from "./assertions"
-import { runJudge } from "./judge"
+import { runJudge, runQualityRubric } from "./judge"
+import { publishEvalExperiment } from "./langfuse"
 import { buildReport, writeReport, printSummary } from "./report"
 import type {
   ScenarioResult,
   TurnResult,
   AssertionResult,
+  LangfuseExperimentSummary,
 } from "./types"
 
 // ── CLI args ─────────────────────────────────────────────────────────────
@@ -49,6 +47,9 @@ function parseArgs() {
   let baseUrl = "http://localhost:3000"
   let scenarioFilter: string | null = null
   let skipJudge = false
+  let langfusePublish = process.env.LANGFUSE_EVAL_PUBLISH === "1"
+  let langfuseRunName: string | null = null
+  let langfuseExperimentName = "Hair Concierge Chat Eval"
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--base-url" && args[i + 1]) {
@@ -57,16 +58,36 @@ function parseArgs() {
       scenarioFilter = args[++i]
     } else if (args[i] === "--skip-judge") {
       skipJudge = true
+    } else if (args[i] === "--langfuse-publish") {
+      langfusePublish = true
+    } else if (args[i] === "--langfuse-run-name" && args[i + 1]) {
+      langfuseRunName = args[++i]
+    } else if (args[i] === "--langfuse-experiment-name" && args[i + 1]) {
+      langfuseExperimentName = args[++i]
     }
   }
 
-  return { baseUrl, scenarioFilter, skipJudge }
+  return {
+    baseUrl,
+    scenarioFilter,
+    skipJudge,
+    langfusePublish,
+    langfuseRunName,
+    langfuseExperimentName,
+  }
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────
 
 async function main() {
-  const { baseUrl, scenarioFilter, skipJudge } = parseArgs()
+  const {
+    baseUrl,
+    scenarioFilter,
+    skipJudge,
+    langfusePublish,
+    langfuseRunName,
+    langfuseExperimentName,
+  } = parseArgs()
   const startTime = Date.now()
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -80,9 +101,7 @@ async function main() {
     process.exit(1)
   }
 
-  const scenarios = scenarioFilter
-    ? SCENARIOS.filter((s) => s.id === scenarioFilter)
-    : SCENARIOS
+  const scenarios = scenarioFilter ? SCENARIOS.filter((s) => s.id === scenarioFilter) : SCENARIOS
 
   if (scenarios.length === 0) {
     console.error(`No scenario found with id "${scenarioFilter}"`)
@@ -94,16 +113,13 @@ async function main() {
   )
 
   const results: ScenarioResult[] = []
+  let langfuseExperiment: LangfuseExperimentSummary | null = null
 
   for (const scenario of scenarios) {
     console.log(`\n--- ${scenario.id}: ${scenario.name} ---`)
 
     // Fresh user per scenario (isolates state)
-    const session = await createTestSession(
-      supabaseUrl,
-      serviceRoleKey,
-      anonKey,
-    )
+    const session = await createTestSession(supabaseUrl, serviceRoleKey, anonKey)
 
     try {
       await upsertHairProfile(session.admin, session.userId, scenario.hair_profile)
@@ -147,10 +163,7 @@ async function main() {
         if (conversationId && sse.content.length > 0) {
           // Small delay to let async persistence complete
           await new Promise((r) => setTimeout(r, 1000))
-          const dbMsg = await fetchLatestAssistantMessage(
-            session.admin,
-            conversationId,
-          )
+          const dbMsg = await fetchLatestAssistantMessage(session.admin, conversationId)
           if (dbMsg) {
             const dbSourceCount = dbMsg.rag_context?.sources
               ? (dbMsg.rag_context.sources as unknown[]).length
@@ -182,9 +195,7 @@ async function main() {
             sse,
             turn.judge,
             scenario.hair_profile,
-            conversationHistory.length > 0
-              ? conversationHistory.join("\n")
-              : undefined,
+            conversationHistory.length > 0 ? conversationHistory.join("\n") : undefined,
           )
 
           assertions.push({
@@ -196,6 +207,15 @@ async function main() {
           })
         }
 
+        const qualityRubric = skipJudge
+          ? null
+          : await runQualityRubric(
+              turn.message,
+              sse,
+              scenario.hair_profile,
+              conversationHistory.length > 0 ? conversationHistory.join("\n") : undefined,
+            )
+
         const allPassed = assertions.every((a) => a.passed)
         const failCount = assertions.filter((a) => !a.passed).length
 
@@ -206,9 +226,7 @@ async function main() {
 
         if (!allPassed) {
           for (const f of assertions.filter((a) => !a.passed)) {
-            console.log(
-              `      [${f.tier}] ${f.name}: expected ${f.expected}, got ${f.actual}`,
-            )
+            console.log(`      [${f.tier}] ${f.name}: expected ${f.expected}, got ${f.actual}`)
           }
         }
 
@@ -218,15 +236,14 @@ async function main() {
           sse_result: sse,
           assertions,
           judge_result: judgeResult,
+          quality_rubric: qualityRubric,
           all_passed: allPassed,
         })
 
         // Build conversation context for judge
         conversationHistory.push(`Nutzer: ${turn.message}`)
         if (sse.content) {
-          conversationHistory.push(
-            `Assistent: ${sse.content.slice(0, 200)}`,
-          )
+          conversationHistory.push(`Assistent: ${sse.content.slice(0, 200)}`)
         }
       }
 
@@ -242,8 +259,31 @@ async function main() {
     }
   }
 
+  if (langfusePublish) {
+    try {
+      langfuseExperiment = await publishEvalExperiment({
+        baseUrl,
+        scenarios,
+        results,
+        skipJudge,
+        experimentName: langfuseExperimentName,
+        runName: langfuseRunName ?? undefined,
+      })
+      console.log(
+        `Langfuse experiment published: ${langfuseExperiment.run_name} (${langfuseExperiment.experiment_id})`,
+      )
+      if (langfuseExperiment.dataset_run_url) {
+        console.log(`Langfuse URL: ${langfuseExperiment.dataset_run_url}`)
+      }
+    } catch (error) {
+      console.error(
+        `Failed to publish Langfuse experiment: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
   // Write report
-  const report = buildReport(results, baseUrl, startTime)
+  const report = buildReport(results, baseUrl, startTime, langfuseExperiment)
   const reportPath = writeReport(report)
   printSummary(report)
   console.log(`Report: ${reportPath}`)

--- a/scripts/eval-chat/types.ts
+++ b/scripts/eval-chat/types.ts
@@ -73,6 +73,9 @@ export interface EvalScenario {
 
 export interface SSEResult {
   conversation_id: string | null
+  assistant_message_id: string | null
+  langfuse_trace_id: string | null
+  langfuse_trace_url: string | null
   content: string
   done_data: Record<string, unknown> | null
   sources: unknown[]
@@ -96,12 +99,23 @@ export interface JudgeVerdict {
   issues: string[]
 }
 
+export interface QualityRubricResult {
+  groundedness: number
+  recommendation_relevance: number
+  clarification_quality: number
+  overclaim_risk: number
+  overall_quality: number
+  summary: string
+  issues: string[]
+}
+
 export interface TurnResult {
   turn_index: number
   message: string
   sse_result: SSEResult
   assertions: AssertionResult[]
   judge_result: JudgeVerdict | null
+  quality_rubric: QualityRubricResult | null
   all_passed: boolean
 }
 
@@ -112,10 +126,18 @@ export interface ScenarioResult {
   turns: TurnResult[]
 }
 
+export interface LangfuseExperimentSummary {
+  experiment_id: string
+  run_name: string
+  dataset_run_id?: string
+  dataset_run_url?: string
+}
+
 export interface EvalReport {
   timestamp: string
   base_url: string
   duration_ms: number
+  langfuse_experiment?: LangfuseExperimentSummary | null
   summary: {
     total_scenarios: number
     passed: number

--- a/scripts/langfuse/seed-datasets.ts
+++ b/scripts/langfuse/seed-datasets.ts
@@ -1,0 +1,175 @@
+import type { FetchedDataset } from "@langfuse/client"
+import { SCENARIOS } from "../eval-chat/fixtures"
+import {
+  fetchProductionTraceCandidates,
+  getLangfuseClientOrThrow,
+  getSupabaseAdminClientOrThrow,
+  loadLocalEnv,
+  parseArgs,
+  readNumberArg,
+  readStringArg,
+} from "./shared"
+
+async function ensureDataset(name: string, description: string): Promise<FetchedDataset> {
+  const langfuse = getLangfuseClientOrThrow()
+
+  try {
+    return await langfuse.dataset.get(name)
+  } catch {
+    await langfuse.api.datasets.create({
+      name,
+      description,
+      metadata: {
+        source: "hair-concierge",
+      },
+    })
+    return langfuse.dataset.get(name)
+  }
+}
+
+async function seedCuratedDataset(datasetName: string): Promise<void> {
+  const langfuse = getLangfuseClientOrThrow()
+  const dataset = await ensureDataset(
+    datasetName,
+    "Curated Hair Concierge regression cases sourced from scripts/eval-chat/fixtures.ts",
+  )
+  const existingIds = new Set(dataset.items.map((item) => item.id))
+  let created = 0
+
+  for (const scenario of SCENARIOS) {
+    const previousTurns: string[] = []
+
+    for (let turnIndex = 0; turnIndex < scenario.turns.length; turnIndex += 1) {
+      const turn = scenario.turns[turnIndex]
+      const itemId = `${scenario.id}-turn-${turnIndex + 1}`
+
+      if (existingIds.has(itemId)) {
+        previousTurns.push(turn.message)
+        continue
+      }
+
+      await langfuse.api.datasetItems.create({
+        id: itemId,
+        datasetName,
+        input: {
+          message: turn.message,
+          prior_turn_messages: previousTurns,
+          hair_profile: scenario.hair_profile,
+        },
+        expectedOutput:
+          turn.judge?.expected_behavior ??
+          "Match deterministic metadata assertions and content heuristics.",
+        metadata: {
+          source: "curated_eval_fixture",
+          scenario_id: scenario.id,
+          scenario_name: scenario.name,
+          turn_index: turnIndex + 1,
+          metadata_assertions: turn.metadata ?? null,
+          content_assertions: turn.content ?? null,
+        },
+      })
+
+      created += 1
+      previousTurns.push(turn.message)
+    }
+  }
+
+  console.log(
+    `Curated dataset ${datasetName}: ${created} item(s) created, ${existingIds.size} already existed`,
+  )
+}
+
+async function seedProductionDataset(
+  datasetName: string,
+  params: {
+    sinceDays: number
+    negativeLimit: number
+    zeroFeedbackLimit: number
+    positiveLimit: number
+    fetchLimit: number
+  },
+): Promise<void> {
+  const langfuse = getLangfuseClientOrThrow()
+  const supabase = getSupabaseAdminClientOrThrow()
+  const dataset = await ensureDataset(
+    datasetName,
+    "Sampled production chat traces for triage, annotation, and offline review.",
+  )
+  const existingIds = new Set(dataset.items.map((item) => item.id))
+  const candidates = await fetchProductionTraceCandidates(
+    supabase,
+    params.sinceDays,
+    params.fetchLimit,
+  )
+
+  const negatives = candidates
+    .filter((candidate) => candidate.feedbackScore === -1)
+    .slice(0, params.negativeLimit)
+  const zeroFeedback = candidates
+    .filter((candidate) => candidate.feedbackScore === null)
+    .slice(0, params.zeroFeedbackLimit)
+  const positives = candidates
+    .filter((candidate) => candidate.feedbackScore === 1)
+    .slice(0, params.positiveLimit)
+  const selection = [...negatives, ...zeroFeedback, ...positives]
+  let created = 0
+
+  for (const candidate of selection) {
+    const itemId = `trace-${candidate.langfuseTraceId}`
+    if (existingIds.has(itemId)) continue
+
+    await langfuse.api.datasetItems.create({
+      id: itemId,
+      datasetName,
+      sourceTraceId: candidate.langfuseTraceId,
+      input: {
+        user_message: candidate.userMessage,
+        conversation_id: candidate.conversationId,
+      },
+      metadata: {
+        source: "production_trace",
+        created_at: candidate.createdAt,
+        feedback_score: candidate.feedbackScore,
+        intent: candidate.intent,
+        product_category: candidate.productCategory,
+        retrieval_mode: candidate.retrievalMode,
+        needs_clarification: candidate.needsClarification,
+        prompt_version: candidate.promptVersion,
+        prompt_label: candidate.promptLabel,
+        prompt_is_fallback: candidate.promptIsFallback,
+        assistant_preview: candidate.assistantContent.slice(0, 1000),
+      },
+    })
+    created += 1
+  }
+
+  console.log(
+    `Production dataset ${datasetName}: ${created} item(s) created from ${selection.length} sampled traces`,
+  )
+}
+
+async function main() {
+  loadLocalEnv()
+
+  const args = parseArgs(process.argv.slice(2))
+  const curatedDatasetName =
+    readStringArg(args, "--curated-name", "hair-concierge-curated-chat-evals") ??
+    "hair-concierge-curated-chat-evals"
+  const productionDatasetName =
+    readStringArg(args, "--production-name", "hair-concierge-production-chat-triage") ??
+    "hair-concierge-production-chat-triage"
+
+  await seedCuratedDataset(curatedDatasetName)
+  await seedProductionDataset(productionDatasetName, {
+    sinceDays: readNumberArg(args, "--since-days", 30),
+    negativeLimit: readNumberArg(args, "--negative-limit", 50),
+    zeroFeedbackLimit: readNumberArg(args, "--zero-feedback-limit", 25),
+    positiveLimit: readNumberArg(args, "--positive-limit", 10),
+    fetchLimit: readNumberArg(args, "--fetch-limit", 500),
+  })
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/scripts/langfuse/setup-review-queues.ts
+++ b/scripts/langfuse/setup-review-queues.ts
@@ -1,0 +1,242 @@
+import type { ScoreConfig } from "@langfuse/core"
+import {
+  fetchProductionTraceCandidates,
+  getLangfuseClientOrThrow,
+  getSupabaseAdminClientOrThrow,
+  loadLocalEnv,
+  parseArgs,
+  readNumberArg,
+  readStringArg,
+} from "./shared"
+
+const SCORE_CONFIGS = [
+  {
+    name: "hc_manual_review_pass",
+    dataType: "BOOLEAN" as const,
+    description: "Overall manual review decision for a production chat trace.",
+  },
+  {
+    name: "hc_review_groundedness",
+    dataType: "NUMERIC" as const,
+    minValue: 0,
+    maxValue: 1,
+    description: "Manual review score for grounding quality.",
+  },
+  {
+    name: "hc_review_recommendation_relevance",
+    dataType: "NUMERIC" as const,
+    minValue: 0,
+    maxValue: 1,
+    description: "Manual review score for recommendation relevance.",
+  },
+  {
+    name: "hc_review_clarification_quality",
+    dataType: "NUMERIC" as const,
+    minValue: 0,
+    maxValue: 1,
+    description: "Manual review score for clarification quality.",
+  },
+  {
+    name: "hc_review_overclaim_risk",
+    dataType: "NUMERIC" as const,
+    minValue: 0,
+    maxValue: 1,
+    description: "Manual review score for overclaim risk. Lower is better.",
+  },
+] as const
+
+async function ensureScoreConfigs(): Promise<ScoreConfig[]> {
+  const langfuse = getLangfuseClientOrThrow()
+  const existing = await langfuse.api.scoreConfigs.get({ limit: 100 })
+  const configsByName = new Map(existing.data.map((config) => [config.name, config]))
+  const ensured: ScoreConfig[] = []
+
+  for (const config of SCORE_CONFIGS) {
+    const current = configsByName.get(config.name)
+    if (current && !current.isArchived) {
+      ensured.push(current)
+      continue
+    }
+
+    const created = await langfuse.api.scoreConfigs.create(config)
+    ensured.push(created)
+  }
+
+  return ensured
+}
+
+async function listAllQueues() {
+  const langfuse = getLangfuseClientOrThrow()
+  const queues = []
+  let page = 1
+
+  while (true) {
+    const response = await langfuse.api.annotationQueues.listQueues({ page, limit: 100 })
+    queues.push(...response.data)
+    if (page >= response.meta.totalPages) break
+    page += 1
+  }
+
+  return queues
+}
+
+async function ensureQueue(
+  name: string,
+  description: string,
+  scoreConfigIds: string[],
+  fallbackQueue?: { id: string; name: string } | null,
+): Promise<{ id: string; name: string }> {
+  const langfuse = getLangfuseClientOrThrow()
+  const existing = (await listAllQueues()).find((queue) => queue.name === name)
+  if (existing) {
+    return { id: existing.id, name: existing.name }
+  }
+
+  try {
+    const created = await langfuse.api.annotationQueues.createQueue({
+      name,
+      description,
+      scoreConfigIds,
+    })
+
+    return { id: created.id, name: created.name }
+  } catch (error) {
+    const statusCode =
+      error && typeof error === "object" && "statusCode" in error
+        ? (error as { statusCode?: number }).statusCode
+        : undefined
+
+    if (statusCode === 405 && fallbackQueue) {
+      console.log(
+        `Queue limit reached on current Langfuse plan. Reusing "${fallbackQueue.name}" for "${name}".`,
+      )
+      return fallbackQueue
+    }
+
+    throw error
+  }
+}
+
+async function listQueueObjectIds(queueId: string): Promise<Set<string>> {
+  const langfuse = getLangfuseClientOrThrow()
+  const objectIds = new Set<string>()
+  let page = 1
+
+  while (true) {
+    const response = await langfuse.api.annotationQueues.listQueueItems(queueId, {
+      page,
+      limit: 100,
+    })
+
+    for (const item of response.data) {
+      objectIds.add(item.objectId)
+    }
+
+    if (page >= response.meta.totalPages) break
+    page += 1
+  }
+
+  return objectIds
+}
+
+async function addMissingQueueItems(queueId: string, traceIds: string[]): Promise<number> {
+  const langfuse = getLangfuseClientOrThrow()
+  const existingIds = await listQueueObjectIds(queueId)
+  let created = 0
+
+  for (const traceId of traceIds) {
+    if (existingIds.has(traceId)) continue
+
+    await langfuse.api.annotationQueues.createQueueItem(queueId, {
+      objectId: traceId,
+      objectType: "TRACE",
+    })
+    created += 1
+  }
+
+  return created
+}
+
+async function main() {
+  loadLocalEnv()
+
+  const args = parseArgs(process.argv.slice(2))
+  const sinceDays = readNumberArg(args, "--since-days", 30)
+  const negativeLimit = readNumberArg(args, "--negative-limit", 50)
+  const zeroFeedbackLimit = readNumberArg(args, "--zero-feedback-limit", 25)
+  const positiveLimit = readNumberArg(args, "--positive-limit", 10)
+  const fetchLimit = readNumberArg(args, "--fetch-limit", 500)
+  const promptVersions = (readStringArg(args, "--prompt-versions", "") ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => Number.isFinite(value))
+
+  const supabase = getSupabaseAdminClientOrThrow()
+  const candidates = await fetchProductionTraceCandidates(supabase, sinceDays, fetchLimit)
+  const scoreConfigs = await ensureScoreConfigs()
+  const scoreConfigIds = scoreConfigs.map((config) => config.id)
+  const existingQueues = await listAllQueues()
+  let fallbackQueue: { id: string; name: string } | null =
+    existingQueues.length > 0 ? { id: existingQueues[0].id, name: existingQueues[0].name } : null
+
+  const queues = [
+    {
+      name: "HC Thumbs Down Review",
+      description: "All recent traces with explicit negative user feedback.",
+      traceIds: candidates
+        .filter((candidate) => candidate.feedbackScore === -1)
+        .slice(0, negativeLimit)
+        .map((candidate) => candidate.langfuseTraceId),
+    },
+    {
+      name: "HC No Feedback Sample",
+      description: "Sample of recent traces without explicit user feedback.",
+      traceIds: candidates
+        .filter((candidate) => candidate.feedbackScore === null)
+        .slice(0, zeroFeedbackLimit)
+        .map((candidate) => candidate.langfuseTraceId),
+    },
+    {
+      name: "HC Thumbs Up Sample",
+      description: "Sample of recent positively rated traces for contrast review.",
+      traceIds: candidates
+        .filter((candidate) => candidate.feedbackScore === 1)
+        .slice(0, positiveLimit)
+        .map((candidate) => candidate.langfuseTraceId),
+    },
+    {
+      name: "HC Prompt Change Review",
+      description:
+        "Recent traces tied to the current prompt rollout. Use --prompt-versions to target specific versions.",
+      traceIds: candidates
+        .filter((candidate) =>
+          promptVersions.length > 0
+            ? candidate.promptVersion !== null && promptVersions.includes(candidate.promptVersion)
+            : candidate.promptIsFallback === false && candidate.promptVersion !== null,
+        )
+        .slice(0, zeroFeedbackLimit)
+        .map((candidate) => candidate.langfuseTraceId),
+    },
+  ]
+
+  for (const queue of queues) {
+    const ensuredQueue = await ensureQueue(
+      queue.name,
+      queue.description,
+      scoreConfigIds,
+      fallbackQueue,
+    )
+    fallbackQueue = ensuredQueue
+    const created = await addMissingQueueItems(ensuredQueue.id, queue.traceIds)
+    console.log(
+      `${queue.name} -> ${ensuredQueue.name}: ${created} new item(s), ${queue.traceIds.length} requested`,
+    )
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/scripts/langfuse/shared.ts
+++ b/scripts/langfuse/shared.ts
@@ -1,0 +1,183 @@
+import fs from "fs"
+import path from "path"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import { LangfuseClient } from "@langfuse/client"
+
+export interface ProductionTraceCandidate {
+  langfuseTraceId: string
+  createdAt: string
+  feedbackScore: number | null
+  conversationId: string | null
+  userMessage: string
+  assistantContent: string
+  intent: string | null
+  productCategory: string | null
+  retrievalMode: string | null
+  needsClarification: boolean | null
+  promptVersion: number | null
+  promptLabel: string | null
+  promptIsFallback: boolean | null
+}
+
+export function loadLocalEnv(): void {
+  const envPath = path.join(process.cwd(), ".env.local")
+  if (!fs.existsSync(envPath)) return
+
+  for (const line of fs.readFileSync(envPath, "utf-8").replace(/\r/g, "").split("\n")) {
+    const match = line.match(/^([^#=]+)=(.*)$/)
+    if (match && !process.env[match[1].trim()]) {
+      process.env[match[1].trim()] = match[2].trim().replace(/^"(.*)"$/, "$1")
+    }
+  }
+}
+
+export function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing ${name}. Add it to your environment or .env.local.`)
+  }
+  return value
+}
+
+export function getLangfuseClientOrThrow(): LangfuseClient {
+  return new LangfuseClient({
+    publicKey: requireEnv("LANGFUSE_PUBLIC_KEY"),
+    secretKey: requireEnv("LANGFUSE_SECRET_KEY"),
+    baseUrl: requireEnv("LANGFUSE_BASE_URL"),
+  })
+}
+
+export function getSupabaseAdminClientOrThrow(): SupabaseClient {
+  return createClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: { autoRefreshToken: false, persistSession: false },
+    },
+  )
+}
+
+export function getPromptLabel(): string {
+  return (
+    process.env.LANGFUSE_PROMPT_LABEL ??
+    (process.env.NODE_ENV === "production" ? "production" : "staging")
+  )
+}
+
+export function parseArgs(argv: string[]): Map<string, string | true> {
+  const parsed = new Map<string, string | true>()
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (!token.startsWith("--")) continue
+
+    const next = argv[index + 1]
+    if (next && !next.startsWith("--")) {
+      parsed.set(token, next)
+      index += 1
+    } else {
+      parsed.set(token, true)
+    }
+  }
+
+  return parsed
+}
+
+export function readStringArg(
+  args: Map<string, string | true>,
+  name: string,
+  fallback?: string,
+): string | undefined {
+  const value = args.get(name)
+  if (typeof value === "string") return value
+  return fallback
+}
+
+export function readNumberArg(
+  args: Map<string, string | true>,
+  name: string,
+  fallback: number,
+): number {
+  const value = args.get(name)
+  if (typeof value !== "string") return fallback
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export function hasFlag(args: Map<string, string | true>, name: string): boolean {
+  return args.has(name)
+}
+
+export async function fetchProductionTraceCandidates(
+  supabase: SupabaseClient,
+  sinceDays: number,
+  fetchLimit: number,
+): Promise<ProductionTraceCandidate[]> {
+  const sinceIso = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: traceRows, error: traceError } = await supabase
+    .from("conversation_turn_traces")
+    .select("assistant_message_id, langfuse_trace_id, created_at, trace")
+    .gte("created_at", sinceIso)
+    .not("langfuse_trace_id", "is", null)
+    .eq("status", "completed")
+    .order("created_at", { ascending: false })
+    .limit(fetchLimit)
+
+  if (traceError) {
+    throw new Error(`Failed to load production traces: ${traceError.message}`)
+  }
+
+  const assistantMessageIds = (traceRows ?? [])
+    .map((row) => row.assistant_message_id)
+    .filter((value): value is string => typeof value === "string")
+
+  const feedbackByMessageId = new Map<string, number | null>()
+  if (assistantMessageIds.length > 0) {
+    const { data: messageRows, error: messageError } = await supabase
+      .from("messages")
+      .select("id, user_feedback_score")
+      .in("id", assistantMessageIds)
+
+    if (messageError) {
+      throw new Error(`Failed to load assistant feedback rows: ${messageError.message}`)
+    }
+
+    for (const row of messageRows ?? []) {
+      feedbackByMessageId.set(row.id, row.user_feedback_score ?? null)
+    }
+  }
+
+  return (traceRows ?? [])
+    .map((row) => {
+      const trace = row.trace as Record<string, any> | null
+      if (!trace || typeof row.langfuse_trace_id !== "string") return null
+
+      return {
+        langfuseTraceId: row.langfuse_trace_id,
+        createdAt: row.created_at,
+        feedbackScore:
+          typeof row.assistant_message_id === "string"
+            ? (feedbackByMessageId.get(row.assistant_message_id) ?? null)
+            : null,
+        conversationId: trace.conversation_id ?? null,
+        userMessage: trace.user_message ?? "",
+        assistantContent: trace.response?.assistant_content ?? "",
+        intent: trace.intent ?? null,
+        productCategory: trace.product_category ?? null,
+        retrievalMode: trace.router_decision?.retrieval_mode ?? null,
+        needsClarification:
+          typeof trace.router_decision?.needs_clarification === "boolean"
+            ? trace.router_decision.needs_clarification
+            : null,
+        promptVersion: trace.prompt_refs?.synthesis?.version ?? null,
+        promptLabel: trace.prompt_refs?.synthesis?.label ?? null,
+        promptIsFallback:
+          typeof trace.prompt_refs?.synthesis?.is_fallback === "boolean"
+            ? trace.prompt_refs.synthesis.is_fallback
+            : null,
+      }
+    })
+    .filter((value): value is ProductionTraceCandidate => Boolean(value))
+}

--- a/scripts/langfuse/sync-prompts.ts
+++ b/scripts/langfuse/sync-prompts.ts
@@ -1,0 +1,100 @@
+import {
+  INTENT_CLASSIFICATION_PROMPT,
+  MEMORY_EXTRACTION_JSON_PROMPT,
+  SYSTEM_PROMPT,
+  TITLE_GENERATION_PROMPT,
+} from "../../src/lib/rag/prompts"
+import {
+  loadLocalEnv,
+  getLangfuseClientOrThrow,
+  getPromptLabel,
+  parseArgs,
+  hasFlag,
+} from "./shared"
+
+const LANGFUSE_PROMPTS = [
+  {
+    name: "hair-concierge-chat-system",
+    fallback: SYSTEM_PROMPT,
+  },
+  {
+    name: "hair-concierge-intent-classifier",
+    fallback: INTENT_CLASSIFICATION_PROMPT,
+  },
+  {
+    name: "hair-concierge-title-generator",
+    fallback: TITLE_GENERATION_PROMPT,
+  },
+  {
+    name: "hair-concierge-memory-extraction",
+    fallback: MEMORY_EXTRACTION_JSON_PROMPT,
+  },
+] as const
+
+async function main() {
+  loadLocalEnv()
+
+  const args = parseArgs(process.argv.slice(2))
+  const dryRun = hasFlag(args, "--dry-run")
+  const label = getPromptLabel()
+  const langfuse = getLangfuseClientOrThrow()
+  const commitMessage = `sync from repo (${process.env.LANGFUSE_RELEASE ?? new Date().toISOString()})`
+
+  for (const prompt of LANGFUSE_PROMPTS) {
+    try {
+      const existing = await langfuse.prompt.get(prompt.name, {
+        type: "text",
+        label,
+        maxRetries: 1,
+      })
+      if (existing.prompt === prompt.fallback) {
+        console.log(
+          `skip  ${prompt.name} (label=${label}, version=${existing.promptResponse.version})`,
+        )
+        continue
+      }
+
+      if (dryRun) {
+        console.log(`would update ${prompt.name} for label ${label}`)
+        continue
+      }
+
+      const created = await langfuse.prompt.create({
+        name: prompt.name,
+        type: "text",
+        prompt: prompt.fallback,
+        labels: [label],
+        tags: ["hair-concierge", "production-chat"],
+        commitMessage,
+      })
+
+      console.log(
+        `update ${prompt.name} -> version ${created.promptResponse.version} (label=${label})`,
+      )
+      continue
+    } catch {
+      if (dryRun) {
+        console.log(`would create ${prompt.name} for label ${label}`)
+        continue
+      }
+
+      const created = await langfuse.prompt.create({
+        name: prompt.name,
+        type: "text",
+        prompt: prompt.fallback,
+        labels: [label],
+        tags: ["hair-concierge", "production-chat"],
+        commitMessage,
+      })
+
+      console.log(
+        `create ${prompt.name} -> version ${created.promptResponse.version} (label=${label})`,
+      )
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,6 +6,10 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "outDir": "./dist",
     "rootDir": "."
   },

--- a/src/app/admin/conversations/[id]/page.tsx
+++ b/src/app/admin/conversations/[id]/page.tsx
@@ -14,6 +14,10 @@ interface MessageRow {
   content: string | null
   created_at: string
   rag_context?: MessageRagContext | null
+  langfuse_trace_id?: string | null
+  langfuse_trace_url?: string | null
+  user_feedback_score?: -1 | 1 | null
+  user_feedback_at?: string | null
 }
 
 interface ConversationDetail {
@@ -71,7 +75,9 @@ function TraceBadge({
         : "bg-muted text-muted-foreground border-border"
 
   return (
-    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${className}`}>
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${className}`}
+    >
       {label}
     </span>
   )
@@ -97,9 +103,17 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
           <span className="text-xs text-muted-foreground">
             Gesamt: {formatDuration(totalLatency)}
           </span>
-          <span className="text-xs text-muted-foreground">
-            Request: {trace.request_id}
-          </span>
+          <span className="text-xs text-muted-foreground">Request: {trace.request_id}</span>
+          {traceRecord.langfuse_trace_url ? (
+            <a
+              href={traceRecord.langfuse_trace_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-primary underline underline-offset-2"
+            >
+              Langfuse
+            </a>
+          ) : null}
         </div>
       </summary>
 
@@ -133,9 +147,7 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
 
           <div className="rounded-lg border bg-card p-3">
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Produkte</p>
-            <p className="mt-1 font-medium text-foreground">
-              {matchedProducts.length} gematcht
-            </p>
+            <p className="mt-1 font-medium text-foreground">{matchedProducts.length} gematcht</p>
             <p className="mt-1 text-xs text-muted-foreground">
               Routine-Plan: {trace.decision_context.should_plan_routine ? "ja" : "nein"}
             </p>
@@ -196,9 +208,7 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
           <div className="rounded-lg border bg-card p-3">
             <p className="text-xs text-muted-foreground">
               Subqueries:{" "}
-              {trace.retrieval.subqueries.length > 0
-                ? trace.retrieval.subqueries.join(" | ")
-                : "—"}
+              {trace.retrieval.subqueries.length > 0 ? trace.retrieval.subqueries.join(" | ") : "—"}
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
               Metadata-Filter:{" "}
@@ -223,9 +233,7 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
                         Score: {chunk.weighted_similarity.toFixed(4)}
                       </span>
                       {chunk.source_name ? (
-                        <span className="text-xs text-muted-foreground">
-                          {chunk.source_name}
-                        </span>
+                        <span className="text-xs text-muted-foreground">{chunk.source_name}</span>
                       ) : null}
                     </div>
                     <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">
@@ -244,7 +252,9 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
           </p>
           <div className="rounded-lg border bg-card p-3">
             {matchedProducts.length === 0 ? (
-              <p className="text-xs text-muted-foreground">Keine Produktmatches fuer diesen Turn.</p>
+              <p className="text-xs text-muted-foreground">
+                Keine Produktmatches fuer diesen Turn.
+              </p>
             ) : (
               <div className="space-y-2">
                 {matchedProducts.map((product) => (
@@ -278,6 +288,11 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
             <p className="text-xs text-muted-foreground">
               Modell: {trace.prompt.model} · Temperatur: {trace.prompt.temperature}
             </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Prompt: {trace.prompt.prompt_ref.name} · Version:{" "}
+              {trace.prompt.prompt_ref.version ?? "fallback"} · Label:{" "}
+              {trace.prompt.prompt_ref.label}
+            </p>
             <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-background p-3 text-xs text-foreground">
               {trace.prompt.system_prompt}
             </pre>
@@ -289,7 +304,10 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
             </p>
             <div className="max-h-72 space-y-2 overflow-auto">
               {trace.prompt.messages.map((message, index) => (
-                <div key={`${message.role}-${index}`} className="rounded-md border bg-background p-3">
+                <div
+                  key={`${message.role}-${index}`}
+                  className="rounded-md border bg-background p-3"
+                >
                   <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     {message.role}
                   </p>
@@ -308,12 +326,16 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
               Entscheidungskontext
             </p>
             <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-background p-3 text-xs text-foreground">
-              {JSON.stringify({
-                classification: trace.classification,
-                router_decision: trace.router_decision,
-                category_decision: trace.decision_context.category_decision,
-                routine_plan: trace.decision_context.routine_plan,
-              }, null, 2)}
+              {JSON.stringify(
+                {
+                  classification: trace.classification,
+                  router_decision: trace.router_decision,
+                  category_decision: trace.decision_context.category_decision,
+                  routine_plan: trace.decision_context.routine_plan,
+                },
+                null,
+                2,
+              )}
             </pre>
           </div>
 
@@ -322,12 +344,16 @@ function TraceCard({ traceRecord }: { traceRecord: ConversationTurnTrace }) {
               Profil Snapshot
             </p>
             <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-md bg-background p-3 text-xs text-foreground">
-              {JSON.stringify({
-                hair_profile_snapshot: trace.hair_profile_snapshot,
-                memory_context: trace.memory_context,
-                response: trace.response,
-                error: trace.error,
-              }, null, 2)}
+              {JSON.stringify(
+                {
+                  hair_profile_snapshot: trace.hair_profile_snapshot,
+                  memory_context: trace.memory_context,
+                  response: trace.response,
+                  error: trace.error,
+                },
+                null,
+                2,
+              )}
             </pre>
           </div>
         </div>
@@ -353,8 +379,7 @@ export default function AdminConversationDetailPage() {
         }
         setData(await res.json())
       } catch (err: unknown) {
-        const message =
-          err instanceof Error ? err.message : fehler("Laden", "der Konversation")
+        const message = err instanceof Error ? err.message : fehler("Laden", "der Konversation")
         toast({ title: message, variant: "destructive" })
       } finally {
         setLoading(false)
@@ -377,7 +402,7 @@ export default function AdminConversationDetailPage() {
 
   const orphanTraces = useMemo(
     () => (data?.traces ?? []).filter((trace) => !trace.assistant_message_id),
-    [data?.traces]
+    [data?.traces],
   )
 
   if (loading) {
@@ -411,12 +436,10 @@ export default function AdminConversationDetailPage() {
 
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-bold">
-              {conversation.title || "Konversation"}
-            </h1>
+            <h1 className="text-2xl font-bold">{conversation.title || "Konversation"}</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              {chatUser?.full_name || "Unbekannt"} ({chatUser?.email}) ·{" "}
-              {messages.length} Nachrichten · {formatDateTime(conversation.created_at)}
+              {chatUser?.full_name || "Unbekannt"} ({chatUser?.email}) · {messages.length}{" "}
+              Nachrichten · {formatDateTime(conversation.created_at)}
             </p>
           </div>
           <div className="rounded-xl border bg-card px-4 py-3 text-sm">
@@ -430,18 +453,14 @@ export default function AdminConversationDetailPage() {
 
       <div className="space-y-4 rounded-xl border bg-card p-4">
         {messages.length === 0 ? (
-          <p className="py-8 text-center text-muted-foreground">
-            Keine Nachrichten vorhanden.
-          </p>
+          <p className="py-8 text-center text-muted-foreground">Keine Nachrichten vorhanden.</p>
         ) : (
           messages.map((msg) => {
             const trace = traceByAssistantMessageId.get(msg.id)
 
             return (
               <div key={msg.id}>
-                <div
-                  className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
-                >
+                <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
                   <div
                     className={`max-w-[85%] rounded-xl px-4 py-3 ${
                       msg.role === "user"
@@ -459,9 +478,7 @@ export default function AdminConversationDetailPage() {
                             ? "Hair Concierge"
                             : "System"}
                       </span>
-                      <span className="text-xs opacity-50">
-                        {formatTime(msg.created_at)}
-                      </span>
+                      <span className="text-xs opacity-50">{formatTime(msg.created_at)}</span>
                     </div>
                     <p className="whitespace-pre-wrap text-sm leading-relaxed">
                       {msg.content || "—"}
@@ -470,6 +487,22 @@ export default function AdminConversationDetailPage() {
                       <p className="mt-2 text-xs opacity-60">
                         Quellen gespeichert: {msg.rag_context.sources.length}
                       </p>
+                    ) : null}
+                    {msg.user_feedback_score ? (
+                      <p className="mt-2 text-xs opacity-60">
+                        Feedback: {msg.user_feedback_score > 0 ? "positiv" : "negativ"}{" "}
+                        {msg.user_feedback_at ? `· ${formatTime(msg.user_feedback_at)}` : ""}
+                      </p>
+                    ) : null}
+                    {msg.langfuse_trace_url ? (
+                      <a
+                        href={msg.langfuse_trace_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="mt-2 inline-block text-xs text-primary underline underline-offset-2"
+                      >
+                        Trace in Langfuse öffnen
+                      </a>
                     ) : null}
                   </div>
                 </div>

--- a/src/app/api/admin/conversations/[id]/route.ts
+++ b/src/app/api/admin/conversations/[id]/route.ts
@@ -3,10 +3,7 @@ import { createAdminClient } from "@/lib/supabase/admin"
 import { ERR_UNAUTHORIZED, ERR_FORBIDDEN, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 
   const supabase = await createClient()
@@ -25,10 +22,7 @@ export async function GET(
     .single()
 
   if (!profile?.is_admin) {
-    return NextResponse.json(
-      { error: ERR_FORBIDDEN },
-      { status: 403 }
-    )
+    return NextResponse.json({ error: ERR_FORBIDDEN }, { status: 403 })
   }
 
   const admin = createAdminClient()
@@ -41,30 +35,28 @@ export async function GET(
     .single()
 
   if (convError || !conversation) {
-    return NextResponse.json(
-      { error: "Konversation nicht gefunden" },
-      { status: 404 }
-    )
+    return NextResponse.json({ error: "Konversation nicht gefunden" }, { status: 404 })
   }
 
   // Fetch messages
   const { data: messages, error: msgError } = await admin
     .from("messages")
-    .select("id, conversation_id, role, content, product_recommendations, rag_context, created_at")
+    .select(
+      "id, conversation_id, role, content, product_recommendations, rag_context, langfuse_trace_id, langfuse_trace_url, user_feedback_score, user_feedback_at, created_at",
+    )
     .eq("conversation_id", id)
     .order("created_at", { ascending: true })
 
   if (msgError) {
-    return NextResponse.json(
-      { error: fehler("Laden", "der Nachrichten") },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: fehler("Laden", "der Nachrichten") }, { status: 500 })
   }
 
   let traces: unknown[] = []
   const { data: traceRows, error: traceError } = await admin
     .from("conversation_turn_traces")
-    .select("id, conversation_id, user_id, user_message_id, assistant_message_id, status, trace, created_at, updated_at")
+    .select(
+      "id, conversation_id, user_id, user_message_id, assistant_message_id, langfuse_trace_id, langfuse_trace_url, status, trace, created_at, updated_at",
+    )
     .eq("conversation_id", id)
     .order("created_at", { ascending: true })
 

--- a/src/app/api/chat/feedback/route.ts
+++ b/src/app/api/chat/feedback/route.ts
@@ -1,0 +1,94 @@
+import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { getLangfuseClient } from "@/lib/openai/client"
+import { ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
+import { NextResponse } from "next/server"
+
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const [{ chatFeedbackSchema }] = await Promise.all([import("@/lib/validators")])
+  const body = await request.json()
+  const parsed = chatFeedbackSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Ungültiges Feedback", details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { message_id, score } = parsed.data
+  const admin = createAdminClient()
+
+  const { data: messageRow, error: messageError } = await admin
+    .from("messages")
+    .select("id, conversation_id, role, langfuse_trace_id, user_feedback_score")
+    .eq("id", message_id)
+    .single()
+
+  if (messageError || !messageRow) {
+    return NextResponse.json({ error: "Nachricht nicht gefunden" }, { status: 404 })
+  }
+
+  if (messageRow.role !== "assistant") {
+    return NextResponse.json({ error: "Feedback nur für Assistant-Nachrichten" }, { status: 400 })
+  }
+
+  const { data: conversationRow, error: conversationError } = await admin
+    .from("conversations")
+    .select("user_id")
+    .eq("id", messageRow.conversation_id)
+    .single()
+
+  if (conversationError || !conversationRow || conversationRow.user_id !== user.id) {
+    return NextResponse.json({ error: fehler("Speichern", "des Feedbacks") }, { status: 403 })
+  }
+
+  if (messageRow.user_feedback_score === score) {
+    return NextResponse.json({ success: true, score, unchanged: true })
+  }
+
+  const feedbackTimestamp = new Date().toISOString()
+  const { error: updateError } = await admin
+    .from("messages")
+    .update({
+      user_feedback_score: score,
+      user_feedback_at: feedbackTimestamp,
+    })
+    .eq("id", message_id)
+
+  if (updateError) {
+    return NextResponse.json({ error: fehler("Speichern", "des Feedbacks") }, { status: 500 })
+  }
+
+  const langfuse = getLangfuseClient()
+  if (langfuse && messageRow.langfuse_trace_id) {
+    langfuse.score.create({
+      id: `chat-feedback-${message_id}`,
+      traceId: messageRow.langfuse_trace_id,
+      name: "user_feedback",
+      value: score > 0 ? 1 : 0,
+      comment: score > 0 ? "thumbs_up" : "thumbs_down",
+      dataType: "BOOLEAN",
+      metadata: {
+        source: "chat_feedback",
+        message_id,
+      },
+    })
+    await langfuse.flush()
+  }
+
+  return NextResponse.json({
+    success: true,
+    score,
+    feedback_at: feedbackTimestamp,
+  })
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,5 +1,15 @@
 import { createClient } from "@/lib/supabase/server"
 import { checkRateLimit, CHAT_RATE_LIMIT } from "@/lib/rate-limit"
+import { propagateAttributes, startObservation } from "@langfuse/tracing"
+import { context as otelContext, trace as otelTrace } from "@opentelemetry/api"
+import {
+  ensureLangfuseTracing,
+  flushLangfuseClient,
+  getLangfuseClient,
+  getLangfuseRelease,
+  resolveLangfuseTraceId,
+} from "@/lib/openai/client"
+import { sanitizeLangfuseText } from "@/lib/langfuse/masking"
 import { ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
 
@@ -10,6 +20,8 @@ async function persistConversationTurnTrace(params: {
   user_id: string
   user_message_id: string | null
   assistant_message_id: string | null
+  langfuse_trace_id: string | null
+  langfuse_trace_url: string | null
   status: "completed" | "failed"
   trace: unknown
 }) {
@@ -51,6 +63,7 @@ export async function POST(request: Request) {
     { extractConversationMemory },
     { buildRetrievalDebugEventData, finalizeChatTurnTrace },
     { chatMessageSchema },
+    { generateConversationTitle },
   ] = await Promise.all([
     import("@/lib/supabase/admin"),
     import("@/lib/rag/pipeline"),
@@ -58,6 +71,7 @@ export async function POST(request: Request) {
     import("@/lib/rag/memory-extractor"),
     import("@/lib/rag/debug-trace"),
     import("@/lib/validators"),
+    import("@/lib/rag/title-generator"),
   ])
 
   const body = await request.json()
@@ -73,11 +87,69 @@ export async function POST(request: Request) {
   const { message, conversation_id } = parsed.data
   const requestId = crypto.randomUUID()
   const requestStart = performance.now()
+  let chatObservation: ReturnType<typeof startObservation> | null = null
 
   try {
+    const admin = createAdminClient()
+    let conversationId = conversation_id ?? null
+
+    if (!conversationId) {
+      const { data: createdConversation, error: conversationError } = await admin
+        .from("conversations")
+        .insert({
+          user_id: user.id,
+          title: null,
+          is_active: true,
+        })
+        .select("id")
+        .single()
+
+      if (conversationError || !createdConversation) {
+        throw new Error(`Failed to create conversation: ${conversationError?.message}`)
+      }
+
+      conversationId = createdConversation.id
+      generateConversationTitle(createdConversation.id, message).catch(() => {})
+    }
+    const activeConversationId = conversationId
+    if (!activeConversationId) {
+      throw new Error("Conversation id missing after creation")
+    }
+
+    ensureLangfuseTracing()
+
+    chatObservation = startObservation(
+      "production-chat-turn",
+      {
+        input: {
+          user_message: sanitizeLangfuseText(message),
+          conversation_id: activeConversationId,
+        },
+        metadata: {
+          feature: "production_chat",
+          request_id: requestId,
+        },
+      },
+      { asType: "chain" },
+    )
+    const activeChatObservation = chatObservation
+    const parentContext = otelTrace.setSpan(otelContext.active(), activeChatObservation.otelSpan)
+    const langfuseTraceId = resolveLangfuseTraceId(activeChatObservation)
+    const traceUrlPromise = langfuseTraceId
+      ? (getLangfuseClient()
+          ?.getTraceUrl(langfuseTraceId)
+          .catch(() => null) ?? null)
+      : null
+
+    if (!langfuseTraceId && getLangfuseClient()) {
+      console.warn("Langfuse trace id unavailable for chat turn", {
+        requestId,
+        conversationId: activeConversationId,
+      })
+    }
+
     const {
       stream,
-      conversationId,
       intent,
       matchedProducts,
       sources,
@@ -85,21 +157,38 @@ export async function POST(request: Request) {
       routerDecision,
       categoryDecision,
       debugTrace,
-    } = await runPipeline({
-      message,
-      conversationId: conversation_id,
-      userId: user.id,
-      requestId,
-    })
+    } = await otelContext.with(parentContext, async () =>
+      propagateAttributes(
+        {
+          userId: user.id,
+          sessionId: activeConversationId,
+          version: getLangfuseRelease(),
+          traceName: "production-chat-turn",
+          tags: ["production-chat"],
+          metadata: {
+            conversation_id: activeConversationId,
+            request_id: requestId,
+            route: "/api/chat",
+          },
+        },
+        async () =>
+          runPipeline({
+            message,
+            conversationId: activeConversationId,
+            userId: user.id,
+            requestId,
+          }),
+      ),
+    )
 
     // Save user message
-    const admin = createAdminClient()
     const { data: userMessageRow, error: userMessageError } = await admin
       .from("messages")
       .insert({
-        conversation_id: conversationId,
+        conversation_id: activeConversationId,
         role: "user",
         content: message,
+        langfuse_trace_id: langfuseTraceId,
       })
       .select("id")
       .single()
@@ -115,7 +204,16 @@ export async function POST(request: Request) {
         // Send conversation ID first
         controller.enqueue(
           encoder.encode(
-            `data: ${JSON.stringify({ type: "conversation_id", data: conversationId })}\n\n`,
+            `data: ${JSON.stringify({ type: "conversation_id", data: activeConversationId })}\n\n`,
+          ),
+        )
+
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "langfuse_trace",
+              data: { trace_id: langfuseTraceId },
+            })}\n\n`,
           ),
         )
 
@@ -146,112 +244,136 @@ export async function POST(request: Request) {
         const streamReadStart = performance.now()
 
         try {
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
+          await otelContext.with(parentContext, async () => {
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) break
 
-            const text = new TextDecoder().decode(value)
-            fullContent += text
+              const text = new TextDecoder().decode(value)
+              fullContent += text
 
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({ type: "content_delta", data: text })}\n\n`),
-            )
-          }
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: "content_delta", data: text })}\n\n`,
+                ),
+              )
+            }
 
-          // Send matched products — suppress during clarification rounds
-          const productsToSend =
-            !routerDecision.needs_clarification && matchedProducts.length > 0
-              ? matchedProducts.slice(0, 3)
-              : []
-          if (productsToSend.length > 0) {
+            const productsToSend =
+              !routerDecision.needs_clarification && matchedProducts.length > 0
+                ? matchedProducts.slice(0, 3)
+                : []
+            const langfuseTraceUrl = traceUrlPromise ? await traceUrlPromise : null
+
+            if (productsToSend.length > 0) {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: "product_recommendations", data: productsToSend })}\n\n`,
+                ),
+              )
+            }
+
+            if (sources.length > 0) {
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify({ type: "sources", data: sources })}\n\n`),
+              )
+            }
+
+            const { data: assistantMessageRow, error: assistantMessageError } = await admin
+              .from("messages")
+              .insert({
+                conversation_id: activeConversationId,
+                role: "assistant",
+                content: fullContent,
+                rag_context: buildAssistantRagContext(sources, categoryDecision),
+                product_recommendations: productsToSend.length > 0 ? productsToSend : null,
+                langfuse_trace_id: langfuseTraceId,
+                langfuse_trace_url: langfuseTraceUrl,
+              })
+              .select("id")
+              .single()
+
+            if (assistantMessageError) {
+              console.error("Failed to save assistant message:", assistantMessageError)
+            }
+
             controller.enqueue(
               encoder.encode(
-                `data: ${JSON.stringify({ type: "product_recommendations", data: productsToSend })}\n\n`,
+                `data: ${JSON.stringify({
+                  type: "assistant_message",
+                  data: {
+                    id: assistantMessageRow?.id ?? null,
+                    langfuse_trace_id: langfuseTraceId,
+                    langfuse_trace_url: langfuseTraceUrl,
+                  },
+                })}\n\n`,
               ),
             )
-          }
 
-          // Send citation sources
-          if (sources.length > 0) {
+            await admin
+              .from("conversations")
+              .update({
+                updated_at: new Date().toISOString(),
+              })
+              .eq("id", activeConversationId)
+
+            extractConversationMemory(activeConversationId, user.id).catch(() => {})
+
+            await admin
+              .from("profiles")
+              .update({
+                message_count_this_month:
+                  (await admin
+                    .from("profiles")
+                    .select("message_count_this_month")
+                    .eq("id", user.id)
+                    .single()
+                    .then((r) => r.data?.message_count_this_month || 0)) + 1,
+              })
+              .eq("id", user.id)
+
+            const completedTrace = finalizeChatTurnTrace(debugTrace, {
+              assistant_content: fullContent,
+              sources,
+              product_count: productsToSend.length,
+              status: "completed",
+              stream_read_ms: Math.round(performance.now() - streamReadStart),
+              total_ms: Math.round(performance.now() - requestStart),
+            })
+
+            persistConversationTurnTrace({
+              conversation_id: activeConversationId,
+              user_id: user.id,
+              user_message_id: userMessageRow?.id ?? null,
+              assistant_message_id: assistantMessageRow?.id ?? null,
+              langfuse_trace_id: langfuseTraceId,
+              langfuse_trace_url: langfuseTraceUrl,
+              status: "completed",
+              trace: completedTrace,
+            }).catch(() => {})
+
+            activeChatObservation.update({
+              output: {
+                status: "completed",
+                product_count: productsToSend.length,
+                assistant_preview: sanitizeLangfuseText(fullContent)?.slice(0, 500),
+              },
+            })
+
             controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({ type: "sources", data: sources })}\n\n`),
+              encoder.encode(
+                `data: ${JSON.stringify({
+                  type: "done",
+                  data: buildDoneEventData({
+                    intent,
+                    retrievalSummary,
+                    routerDecision,
+                    categoryDecision,
+                  }),
+                })}\n\n`,
+              ),
             )
-          }
-
-          // Save assistant message (with products for persistence)
-          const admin = createAdminClient()
-          const { data: assistantMessageRow, error: assistantMessageError } = await admin
-            .from("messages")
-            .insert({
-              conversation_id: conversationId,
-              role: "assistant",
-              content: fullContent,
-              rag_context: buildAssistantRagContext(sources, categoryDecision),
-              product_recommendations: productsToSend.length > 0 ? productsToSend : null,
-            })
-            .select("id")
-            .single()
-
-          if (assistantMessageError) {
-            console.error("Failed to save assistant message:", assistantMessageError)
-          }
-
-          // Update conversation updated_at
-          await admin
-            .from("conversations")
-            .update({
-              updated_at: new Date().toISOString(),
-            })
-            .eq("id", conversationId)
-
-          // Extract conversation memory (fire-and-forget)
-          extractConversationMemory(conversationId, user.id).catch(() => {})
-
-          // Increment user message count
-          await admin
-            .from("profiles")
-            .update({
-              message_count_this_month:
-                (await admin
-                  .from("profiles")
-                  .select("message_count_this_month")
-                  .eq("id", user.id)
-                  .single()
-                  .then((r) => r.data?.message_count_this_month || 0)) + 1,
-            })
-            .eq("id", user.id)
-
-          const completedTrace = finalizeChatTurnTrace(debugTrace, {
-            assistant_content: fullContent,
-            sources,
-            product_count: productsToSend.length,
-            status: "completed",
-            stream_read_ms: Math.round(performance.now() - streamReadStart),
-            total_ms: Math.round(performance.now() - requestStart),
           })
-
-          persistConversationTurnTrace({
-            conversation_id: conversationId,
-            user_id: user.id,
-            user_message_id: userMessageRow?.id ?? null,
-            assistant_message_id: assistantMessageRow?.id ?? null,
-            status: "completed",
-            trace: completedTrace,
-          }).catch(() => {})
-
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({
-                type: "done",
-                data: buildDoneEventData({
-                  intent,
-                  retrievalSummary,
-                  routerDecision,
-                  categoryDecision,
-                }),
-              })}\n\n`,
-            ),
-          )
         } catch (error) {
           controller.enqueue(
             encoder.encode(
@@ -259,6 +381,7 @@ export async function POST(request: Request) {
             ),
           )
 
+          const langfuseTraceUrl = traceUrlPromise ? await traceUrlPromise : null
           const errorMessage = error instanceof Error ? error.message : "Unbekannter Stream-Fehler"
           const failedTrace = finalizeChatTurnTrace(debugTrace, {
             assistant_content: fullContent,
@@ -271,15 +394,29 @@ export async function POST(request: Request) {
           })
 
           persistConversationTurnTrace({
-            conversation_id: conversationId,
+            conversation_id: activeConversationId,
             user_id: user.id,
             user_message_id: userMessageRow?.id ?? null,
             assistant_message_id: null,
+            langfuse_trace_id: langfuseTraceId,
+            langfuse_trace_url: langfuseTraceUrl,
             status: "failed",
             trace: failedTrace,
           }).catch(() => {})
+
+          activeChatObservation.update({
+            output: {
+              status: "failed",
+              assistant_preview: sanitizeLangfuseText(fullContent)?.slice(0, 500),
+            },
+            metadata: {
+              error: errorMessage,
+            },
+          })
         }
 
+        activeChatObservation.end()
+        flushLangfuseClient().catch(() => {})
         controller.close()
       },
     })
@@ -293,6 +430,17 @@ export async function POST(request: Request) {
     })
   } catch (error) {
     console.error("Chat pipeline error:", error)
+    if (chatObservation) {
+      chatObservation.update({
+        output: {
+          status: "failed",
+        },
+        metadata: {
+          error: error instanceof Error ? error.message : "chat_pipeline_error",
+        },
+      })
+      chatObservation.end()
+    }
     return NextResponse.json({ error: fehler("Verarbeitung") }, { status: 500 })
   }
 }

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -25,6 +25,7 @@ export function ChatContainer() {
     conversations,
     currentConversationId,
     sendMessage,
+    submitFeedback,
     loadConversation,
     loadConversations,
     deleteConversation,
@@ -314,6 +315,7 @@ export function ChatContainer() {
                       message={msg}
                       hairProfile={hairProfile}
                       onProductClick={handleProductClick}
+                      onFeedback={submitFeedback}
                       isNew={newMessageIds.has(msg.id)}
                     />
                   </div>

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -5,6 +5,7 @@ import { format } from "date-fns"
 import posthog from "posthog-js"
 import type { Message, CitationSource, Product, HairProfile } from "@/lib/types"
 import type { Components } from "react-markdown"
+import { ThumbsDown, ThumbsUp } from "lucide-react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { CitationBadge } from "./citation-badge"
@@ -76,6 +77,7 @@ interface ChatMessageProps {
   message: Message
   hairProfile: HairProfile | null
   onProductClick?: (product: Product) => void
+  onFeedback?: (messageId: string, score: -1 | 1) => Promise<void>
   /** True for messages appended during this session (not history loads) */
   isNew?: boolean
 }
@@ -225,7 +227,13 @@ function processChildren(
   return children
 }
 
-export function ChatMessage({ message, hairProfile, onProductClick, isNew }: ChatMessageProps) {
+export function ChatMessage({
+  message,
+  hairProfile,
+  onProductClick,
+  onFeedback,
+  isNew,
+}: ChatMessageProps) {
   const isUser = message.role === "user"
 
   const { content: renumberedContent, sources } = useMemo(
@@ -251,6 +259,7 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
   }, [products.length])
 
   const [showAllProducts, setShowAllProducts] = useState(false)
+  const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false)
   const visibleProducts = showAllProducts ? products : products.slice(0, 3)
 
   const hasEnhancements = sources.length > 0 || productMap.size > 0
@@ -365,9 +374,55 @@ export function ChatMessage({ message, hairProfile, onProductClick, isNew }: Cha
 
         {/* Timestamp */}
         {message.created_at && (
-          <span className="type-caption text-muted-foreground px-1">
-            {format(new Date(message.created_at), "HH:mm")}
-          </span>
+          <div className="flex items-center gap-2 px-1">
+            <span className="type-caption text-muted-foreground">
+              {format(new Date(message.created_at), "HH:mm")}
+            </span>
+            {!isUser && onFeedback && !message.id.startsWith("temp-") ? (
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setIsSubmittingFeedback(true)
+                    try {
+                      await onFeedback(message.id, 1)
+                    } finally {
+                      setIsSubmittingFeedback(false)
+                    }
+                  }}
+                  className={`rounded-full p-1 transition-colors ${
+                    message.user_feedback_score === 1
+                      ? "bg-emerald-500/10 text-emerald-700"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                  aria-label="Antwort positiv bewerten"
+                  disabled={isSubmittingFeedback}
+                >
+                  <ThumbsUp className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setIsSubmittingFeedback(true)
+                    try {
+                      await onFeedback(message.id, -1)
+                    } finally {
+                      setIsSubmittingFeedback(false)
+                    }
+                  }}
+                  className={`rounded-full p-1 transition-colors ${
+                    message.user_feedback_score === -1
+                      ? "bg-rose-500/10 text-rose-700"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                  aria-label="Antwort negativ bewerten"
+                  disabled={isSubmittingFeedback}
+                >
+                  <ThumbsDown className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ) : null}
+          </div>
         )}
       </div>
     </div>

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -10,6 +10,7 @@ interface UseChatReturn {
   conversations: Conversation[]
   currentConversationId: string | null
   sendMessage: (content: string) => Promise<void>
+  submitFeedback: (messageId: string, score: -1 | 1) => Promise<void>
   loadConversation: (id: string) => Promise<void>
   loadConversations: () => Promise<void>
   deleteConversation: (id: string) => Promise<void>
@@ -96,6 +97,10 @@ export function useChat(): UseChatReturn {
         product_recommendations: null,
         rag_context: null,
         token_usage: null,
+        langfuse_trace_id: null,
+        langfuse_trace_url: null,
+        user_feedback_score: null,
+        user_feedback_at: null,
         created_at: new Date().toISOString(),
       }
       setMessages((prev) => [...prev, userMessage])
@@ -114,6 +119,10 @@ export function useChat(): UseChatReturn {
         product_recommendations: null,
         rag_context: null,
         token_usage: null,
+        langfuse_trace_id: null,
+        langfuse_trace_url: null,
+        user_feedback_score: null,
+        user_feedback_at: null,
         created_at: new Date().toISOString(),
       }
       setMessages((prev) => [...prev, assistantMessage])
@@ -173,6 +182,19 @@ export function useChat(): UseChatReturn {
                     return updated
                   })
                   break
+                case "langfuse_trace":
+                  setMessages((prev) => {
+                    const updated = [...prev]
+                    const last = updated[updated.length - 1]
+                    if (last?.role === "assistant") {
+                      updated[updated.length - 1] = {
+                        ...last,
+                        langfuse_trace_id: event.data?.trace_id ?? null,
+                      }
+                    }
+                    return updated
+                  })
+                  break
                 case "product_recommendations":
                   setMessages((prev) => {
                     const updated = [...prev]
@@ -181,6 +203,22 @@ export function useChat(): UseChatReturn {
                       updated[updated.length - 1] = {
                         ...last,
                         product_recommendations: event.data,
+                      }
+                    }
+                    return updated
+                  })
+                  break
+                case "assistant_message":
+                  setMessages((prev) => {
+                    const updated = [...prev]
+                    const last = updated[updated.length - 1]
+                    if (last?.role === "assistant") {
+                      updated[updated.length - 1] = {
+                        ...last,
+                        id: event.data?.id ?? last.id,
+                        langfuse_trace_id: event.data?.langfuse_trace_id ?? last.langfuse_trace_id,
+                        langfuse_trace_url:
+                          event.data?.langfuse_trace_url ?? last.langfuse_trace_url,
                       }
                     }
                     return updated
@@ -253,12 +291,63 @@ export function useChat(): UseChatReturn {
     [currentConversationId, isStreaming, loadConversations, messages.length],
   )
 
+  const submitFeedback = useCallback(
+    async (messageId: string, score: -1 | 1) => {
+      const previous = messages
+
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === messageId
+            ? {
+                ...message,
+                user_feedback_score: score,
+                user_feedback_at: new Date().toISOString(),
+              }
+            : message,
+        ),
+      )
+
+      try {
+        const res = await fetch("/api/chat/feedback", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            message_id: messageId,
+            score,
+          }),
+        })
+
+        if (!res.ok) {
+          throw new Error("Feedback konnte nicht gespeichert werden")
+        }
+
+        const data = await res.json()
+        setMessages((prev) =>
+          prev.map((message) =>
+            message.id === messageId
+              ? {
+                  ...message,
+                  user_feedback_score: data.score,
+                  user_feedback_at: data.feedback_at ?? message.user_feedback_at,
+                }
+              : message,
+          ),
+        )
+      } catch (error) {
+        console.error("Fehler beim Speichern des Chat-Feedbacks:", error)
+        setMessages(previous)
+      }
+    },
+    [messages],
+  )
+
   return {
     messages,
     isStreaming,
     conversations,
     currentConversationId,
     sendMessage,
+    submitFeedback,
     loadConversation,
     loadConversations,
     deleteConversation,

--- a/src/lib/langfuse/client.ts
+++ b/src/lib/langfuse/client.ts
@@ -1,0 +1,140 @@
+import OpenAI from "openai"
+import { LangfuseClient } from "@langfuse/client"
+import { observeOpenAI, type LangfuseConfig as LangfuseOpenAIConfig } from "@langfuse/openai"
+import { LangfuseSpanProcessor } from "@langfuse/otel"
+import { NodeSDK } from "@opentelemetry/sdk-node"
+import { maskLangfuseExport } from "./masking"
+
+let openAIInstance: OpenAI | null = null
+let langfuseInstance: LangfuseClient | null | undefined
+
+declare global {
+  var __hairConciergeLangfuseSdk: NodeSDK | undefined
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing ${name} – set it in your .env.local file.`)
+  }
+  return value
+}
+
+export function getRawOpenAI(): OpenAI {
+  if (!openAIInstance) {
+    openAIInstance = new OpenAI({ apiKey: requireEnv("OPENAI_API_KEY") })
+  }
+
+  return openAIInstance
+}
+
+export function isLangfuseConfigured(): boolean {
+  return Boolean(
+    process.env.LANGFUSE_PUBLIC_KEY &&
+    process.env.LANGFUSE_SECRET_KEY &&
+    process.env.LANGFUSE_BASE_URL,
+  )
+}
+
+export function getLangfuseClient(): LangfuseClient | null {
+  if (langfuseInstance !== undefined) {
+    return langfuseInstance
+  }
+
+  if (!isLangfuseConfigured()) {
+    langfuseInstance = null
+    return langfuseInstance
+  }
+
+  langfuseInstance = new LangfuseClient({
+    publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+    secretKey: process.env.LANGFUSE_SECRET_KEY,
+    baseUrl: process.env.LANGFUSE_BASE_URL,
+  })
+
+  return langfuseInstance
+}
+
+export function getLangfusePromptLabel(): string {
+  return (
+    process.env.LANGFUSE_PROMPT_LABEL ??
+    (process.env.NODE_ENV === "production" ? "production" : "staging")
+  )
+}
+
+export function getLangfuseEnvironment(): string {
+  return (
+    process.env.LANGFUSE_TRACING_ENVIRONMENT ??
+    process.env.VERCEL_ENV ??
+    process.env.NODE_ENV ??
+    "development"
+  )
+}
+
+export function getLangfuseRelease(): string {
+  return (
+    process.env.LANGFUSE_RELEASE ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ??
+    "local"
+  )
+}
+
+export function ensureLangfuseTracing(): NodeSDK | null {
+  if (!isLangfuseConfigured()) {
+    return null
+  }
+
+  if (globalThis.__hairConciergeLangfuseSdk) {
+    return globalThis.__hairConciergeLangfuseSdk
+  }
+
+  const sdk = new NodeSDK({
+    spanProcessors: [
+      new LangfuseSpanProcessor({
+        publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+        secretKey: process.env.LANGFUSE_SECRET_KEY,
+        baseUrl: process.env.LANGFUSE_BASE_URL,
+        environment: getLangfuseEnvironment(),
+        release: getLangfuseRelease(),
+        exportMode: "immediate",
+        mask: maskLangfuseExport,
+      }),
+    ],
+  })
+
+  sdk.start()
+  globalThis.__hairConciergeLangfuseSdk = sdk
+
+  return sdk
+}
+
+export function isValidLangfuseTraceId(value: string | null | undefined): value is string {
+  return Boolean(value && /^[0-9a-f]{32}$/i.test(value) && !/^0{32}$/i.test(value))
+}
+
+export function resolveLangfuseTraceId(params: {
+  traceId?: string | null
+  otelSpan?: { spanContext: () => { traceId: string } } | null
+}): string | null {
+  const candidates = [params.traceId, params.otelSpan?.spanContext().traceId]
+
+  for (const candidate of candidates) {
+    if (isValidLangfuseTraceId(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export function getObservedOpenAI(config?: LangfuseOpenAIConfig): OpenAI {
+  return observeOpenAI(getRawOpenAI(), config)
+}
+
+export async function flushLangfuseClient(): Promise<void> {
+  const langfuse = getLangfuseClient()
+  if (!langfuse) return
+
+  await langfuse.flush()
+}

--- a/src/lib/langfuse/masking.ts
+++ b/src/lib/langfuse/masking.ts
@@ -1,0 +1,59 @@
+import type { MaskFunction } from "@langfuse/otel"
+
+const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
+const PHONE_REGEX = /(?:\+?\d{1,3}[\s./-]?)?(?:\(?\d{2,4}\)?[\s./-]?)?\d{3,4}[\s./-]?\d{3,4}\b/g
+
+const REDACTED = "[redacted]"
+const REDACTED_TEXT = "[redacted_sensitive_text]"
+
+const IDENTIFIER_KEYS = new Set([
+  "email",
+  "full_name",
+  "name",
+  "first_name",
+  "last_name",
+  "phone",
+  "telephone",
+])
+
+const SENSITIVE_TEXT_KEYS = new Set([
+  "additional_notes",
+  "memory_context",
+  "conversation_memory",
+  "notes",
+  "free_text",
+])
+
+function maskString(value: string): string {
+  return value.replace(EMAIL_REGEX, REDACTED).replace(PHONE_REGEX, REDACTED)
+}
+
+function maskValue(value: unknown, key?: string): unknown {
+  if (typeof value === "string") {
+    if (key && IDENTIFIER_KEYS.has(key)) return REDACTED
+    if (key && SENSITIVE_TEXT_KEYS.has(key)) return REDACTED_TEXT
+    return maskString(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => maskValue(entry, key))
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        maskValue(entryValue, entryKey),
+      ]),
+    )
+  }
+
+  return value
+}
+
+export const maskLangfuseExport: MaskFunction = ({ data }) => maskValue(data)
+
+export function sanitizeLangfuseText(value: string | null | undefined): string | null {
+  if (!value) return null
+  return maskString(value)
+}

--- a/src/lib/langfuse/prompts.ts
+++ b/src/lib/langfuse/prompts.ts
@@ -1,0 +1,125 @@
+import type { LangfusePromptReference } from "@/lib/types"
+import type { LangfuseConfig as LangfuseOpenAIConfig } from "@langfuse/openai"
+import {
+  INTENT_CLASSIFICATION_PROMPT,
+  MEMORY_EXTRACTION_JSON_PROMPT,
+  SYSTEM_PROMPT,
+  TITLE_GENERATION_PROMPT,
+} from "@/lib/rag/prompts"
+import { getLangfuseClient, getLangfusePromptLabel } from "./client"
+
+const DEFAULT_CACHE_TTL_SECONDS = 60
+const DEFAULT_FETCH_TIMEOUT_MS = 3000
+
+export const LANGFUSE_PROMPTS = {
+  chatSystem: {
+    name: "hair-concierge-chat-system",
+    fallback: SYSTEM_PROMPT,
+  },
+  intentClassifier: {
+    name: "hair-concierge-intent-classifier",
+    fallback: INTENT_CLASSIFICATION_PROMPT,
+  },
+  titleGenerator: {
+    name: "hair-concierge-title-generator",
+    fallback: TITLE_GENERATION_PROMPT,
+  },
+  memoryExtraction: {
+    name: "hair-concierge-memory-extraction",
+    fallback: MEMORY_EXTRACTION_JSON_PROMPT,
+  },
+} as const
+
+type PromptDefinition = (typeof LANGFUSE_PROMPTS)[keyof typeof LANGFUSE_PROMPTS]
+
+export interface ManagedTextPrompt {
+  text: string
+  ref: LangfusePromptReference
+}
+
+export interface ManagedTextPromptTemplate {
+  template: string
+  ref: LangfusePromptReference
+}
+
+export function buildLangfusePromptConfig(
+  ref: LangfusePromptReference,
+): LangfuseOpenAIConfig["langfusePrompt"] | undefined {
+  if (ref.version === null) return undefined
+
+  return {
+    name: ref.name,
+    version: ref.version,
+    isFallback: ref.is_fallback,
+  }
+}
+
+function compileFallbackTextPrompt(
+  template: string,
+  variables: Record<string, string | undefined> = {},
+): string {
+  return template.replace(/\{\{\s*([A-Z0-9_]+)\s*\}\}/g, (_match, variableName: string) => {
+    return variables[variableName] ?? ""
+  })
+}
+
+function buildFallbackReference(name: string, label: string): LangfusePromptReference {
+  return {
+    name,
+    version: null,
+    label,
+    is_fallback: true,
+  }
+}
+
+export async function getManagedTextPrompt(
+  prompt: PromptDefinition,
+  variables: Record<string, string | undefined> = {},
+): Promise<ManagedTextPrompt> {
+  const managedPrompt = await getManagedTextPromptTemplate(prompt)
+
+  return {
+    text: compileFallbackTextPrompt(managedPrompt.template, variables),
+    ref: managedPrompt.ref,
+  }
+}
+
+export async function getManagedTextPromptTemplate(
+  prompt: PromptDefinition,
+): Promise<ManagedTextPromptTemplate> {
+  const label = getLangfusePromptLabel()
+  const langfuse = getLangfuseClient()
+
+  if (!langfuse) {
+    return {
+      template: prompt.fallback,
+      ref: buildFallbackReference(prompt.name, label),
+    }
+  }
+
+  try {
+    const managedPrompt = await langfuse.prompt.get(prompt.name, {
+      type: "text",
+      label,
+      cacheTtlSeconds: DEFAULT_CACHE_TTL_SECONDS,
+      fetchTimeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
+      maxRetries: 1,
+    })
+
+    return {
+      template: managedPrompt.prompt,
+      ref: {
+        name: managedPrompt.promptResponse.name,
+        version: managedPrompt.promptResponse.version,
+        label,
+        is_fallback: managedPrompt.isFallback,
+      },
+    }
+  } catch (error) {
+    console.warn(`Langfuse prompt fetch failed for ${prompt.name}; using fallback.`, error)
+    return {
+      template: prompt.fallback,
+      ref: buildFallbackReference(prompt.name, label),
+    }
+  }
+}

--- a/src/lib/openai/chat.ts
+++ b/src/lib/openai/chat.ts
@@ -1,5 +1,6 @@
-import { getOpenAI } from "@/lib/openai/client"
+import { getObservedOpenAI } from "@/lib/openai/client"
 import type OpenAI from "openai"
+import type { LangfuseConfig as LangfuseOpenAIConfig } from "@langfuse/openai"
 
 export const DEFAULT_CHAT_COMPLETION_MODEL = "gpt-4o"
 export const DEFAULT_CHAT_COMPLETION_TEMPERATURE = 0.7
@@ -8,6 +9,7 @@ export interface StreamChatCompletionParams {
   messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]
   model?: string
   temperature?: number
+  langfuseConfig?: LangfuseOpenAIConfig
 }
 
 /**
@@ -20,8 +22,9 @@ export async function streamChatCompletion({
   messages,
   model = DEFAULT_CHAT_COMPLETION_MODEL,
   temperature = DEFAULT_CHAT_COMPLETION_TEMPERATURE,
+  langfuseConfig,
 }: StreamChatCompletionParams): Promise<ReadableStream<Uint8Array>> {
-  const response = await getOpenAI().chat.completions.create({
+  const response = await getObservedOpenAI(langfuseConfig).chat.completions.create({
     model,
     messages,
     temperature,

--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -1,15 +1,13 @@
-import OpenAI from "openai"
-
-let instance: OpenAI | null = null
-
-export function getOpenAI(): OpenAI {
-  if (!instance) {
-    if (!process.env.OPENAI_API_KEY) {
-      throw new Error(
-        "Missing OPENAI_API_KEY – set it in your .env.local file."
-      )
-    }
-    instance = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
-  }
-  return instance
-}
+export {
+  ensureLangfuseTracing,
+  flushLangfuseClient,
+  getLangfuseClient,
+  getLangfuseEnvironment,
+  getLangfusePromptLabel,
+  getLangfuseRelease,
+  getObservedOpenAI,
+  getRawOpenAI as getOpenAI,
+  isValidLangfuseTraceId,
+  isLangfuseConfigured,
+  resolveLangfuseTraceId,
+} from "@/lib/langfuse/client"

--- a/src/lib/rag/debug-trace.ts
+++ b/src/lib/rag/debug-trace.ts
@@ -9,6 +9,7 @@ import type {
   CitationSource,
   ClassificationResult,
   HairProfile,
+  LangfusePromptReference,
   Product,
   ProductCategory,
   RoutinePlan,
@@ -38,6 +39,10 @@ export interface PipelineTraceDraft {
     category_decision: CategoryDecision | null
     matched_products: ChatMatchedProductTrace[]
   }
+  prompt_refs: {
+    classification: LangfusePromptReference
+    synthesis: LangfusePromptReference
+  }
   prompt: ChatPromptSnapshot
   latencies_ms: ChatTraceLatencyBreakdown
 }
@@ -48,9 +53,7 @@ function toContentPreview(content: string): string {
     : content
 }
 
-export function buildRetrievedChunkTrace(
-  chunks: RetrievedChunk[],
-): ChatRetrievedChunkTrace[] {
+export function buildRetrievedChunkTrace(chunks: RetrievedChunk[]): ChatRetrievedChunkTrace[] {
   return chunks.map((chunk) => ({
     chunk_id: chunk.id,
     source_type: chunk.source_type,
@@ -65,9 +68,7 @@ export function buildRetrievedChunkTrace(
   }))
 }
 
-export function buildMatchedProductTrace(
-  products: Product[],
-): ChatMatchedProductTrace[] {
+export function buildMatchedProductTrace(products: Product[]): ChatMatchedProductTrace[] {
   return products.map((product) => ({
     id: product.id,
     name: product.name,
@@ -98,6 +99,7 @@ export function buildPipelineTraceDraft(params: {
   routine_plan?: RoutinePlan
   category_decision?: CategoryDecision
   matched_products?: Product[]
+  classification_prompt_ref: LangfusePromptReference
   prompt: ChatPromptSnapshot
   latencies_ms: ChatTraceLatencyBreakdown
 }): PipelineTraceDraft {
@@ -121,6 +123,7 @@ export function buildPipelineTraceDraft(params: {
     routine_plan,
     category_decision,
     matched_products,
+    classification_prompt_ref,
     prompt,
     latencies_ms,
   } = params
@@ -155,6 +158,10 @@ export function buildPipelineTraceDraft(params: {
       category_decision: category_decision ?? null,
       matched_products: buildMatchedProductTrace(matched_products ?? []),
     },
+    prompt_refs: {
+      classification: classification_prompt_ref,
+      synthesis: prompt.prompt_ref,
+    },
     prompt,
     latencies_ms,
   }
@@ -173,7 +180,16 @@ export function finalizeChatTurnTrace(
     total_ms?: number
   },
 ): ChatTurnTrace {
-  const { assistant_content, sources, product_count, status, error, completed_at, stream_read_ms, total_ms } = params
+  const {
+    assistant_content,
+    sources,
+    product_count,
+    status,
+    error,
+    completed_at,
+    stream_read_ms,
+    total_ms,
+  } = params
 
   return {
     trace_version: CHAT_TURN_TRACE_VERSION,
@@ -193,6 +209,7 @@ export function finalizeChatTurnTrace(
     memory_context: draft.memory_context,
     retrieval: draft.retrieval,
     decision_context: draft.decision_context,
+    prompt_refs: draft.prompt_refs,
     prompt: draft.prompt,
     response: {
       assistant_content,
@@ -208,9 +225,7 @@ export function finalizeChatTurnTrace(
   }
 }
 
-export function buildRetrievalDebugEventData(
-  draft: PipelineTraceDraft,
-): Record<string, unknown> {
+export function buildRetrievalDebugEventData(draft: PipelineTraceDraft): Record<string, unknown> {
   return {
     request_id: draft.request_id,
     intent: draft.intent,

--- a/src/lib/rag/intent-classifier.ts
+++ b/src/lib/rag/intent-classifier.ts
@@ -103,7 +103,7 @@ export async function classifyIntent(
     })
 
     const response = await getObservedOpenAI({
-      generationName: "intent-classification",
+      generationName: "intent-classification-llm",
       generationMetadata: {
         prompt_label: managedPrompt.ref.label,
       },

--- a/src/lib/rag/intent-classifier.ts
+++ b/src/lib/rag/intent-classifier.ts
@@ -1,6 +1,17 @@
-import { getOpenAI } from "@/lib/openai/client"
-import { INTENT_CLASSIFICATION_PROMPT } from "@/lib/rag/prompts"
-import type { IntentType, ClassificationResult, ProductCategory, RetrievalMode, Message } from "@/lib/types"
+import { getObservedOpenAI } from "@/lib/openai/client"
+import {
+  buildLangfusePromptConfig,
+  getManagedTextPrompt,
+  LANGFUSE_PROMPTS,
+} from "@/lib/langfuse/prompts"
+import type {
+  IntentType,
+  ClassificationResult,
+  ProductCategory,
+  RetrievalMode,
+  Message,
+  LangfusePromptReference,
+} from "@/lib/types"
 
 const VALID_INTENTS: IntentType[] = [
   "product_recommendation",
@@ -22,7 +33,12 @@ const VALID_CATEGORIES: ProductCategory[] = [
 ]
 
 const VALID_COMPLEXITIES = ["simple", "multi_constraint", "multi_hop"] as const
-const VALID_RETRIEVAL_MODES: RetrievalMode[] = ["faq", "hybrid", "hybrid_plus_graph", "product_sql_plus_hybrid"]
+const VALID_RETRIEVAL_MODES: RetrievalMode[] = [
+  "faq",
+  "hybrid",
+  "hybrid_plus_graph",
+  "product_sql_plus_hybrid",
+]
 
 const DEFAULT_CLASSIFICATION: ClassificationResult = {
   intent: "general_chat",
@@ -32,6 +48,13 @@ const DEFAULT_CLASSIFICATION: ClassificationResult = {
   retrieval_mode: "hybrid",
   normalized_filters: {},
   router_confidence: 0.5,
+}
+
+const FALLBACK_PROMPT_REF: LangfusePromptReference = {
+  name: LANGFUSE_PROMPTS.intentClassifier.name,
+  version: null,
+  label: "fallback",
+  is_fallback: true,
 }
 
 /** Max prior messages to include for follow-up context */
@@ -71,20 +94,26 @@ function buildHistoryContext(history: Message[]): string {
 export async function classifyIntent(
   message: string,
   conversationHistory: Message[] = [],
-): Promise<ClassificationResult> {
+): Promise<{ result: ClassificationResult; promptRef: LangfusePromptReference }> {
   try {
     const historyPrefix = buildHistoryContext(conversationHistory)
+    const managedPrompt = await getManagedTextPrompt(LANGFUSE_PROMPTS.intentClassifier, {
+      HISTORY_PREFIX: historyPrefix,
+      MESSAGE: message,
+    })
 
-    const response = await getOpenAI().chat.completions.create({
+    const response = await getObservedOpenAI({
+      generationName: "intent-classification",
+      generationMetadata: {
+        prompt_label: managedPrompt.ref.label,
+      },
+      langfusePrompt: buildLangfusePromptConfig(managedPrompt.ref),
+    }).chat.completions.create({
       model: "gpt-4o",
       messages: [
         {
           role: "system",
-          content: INTENT_CLASSIFICATION_PROMPT,
-        },
-        {
-          role: "user",
-          content: historyPrefix + message,
+          content: managedPrompt.text,
         },
       ],
       response_format: { type: "json_object" },
@@ -106,11 +135,18 @@ export async function classifyIntent(
     }
 
     // Parse filters: extract known slot keys, ignore unknown
-    const rawFilters = (typeof parsed.filters === "object" && parsed.filters !== null)
-      ? parsed.filters as Record<string, unknown>
-      : {}
+    const rawFilters =
+      typeof parsed.filters === "object" && parsed.filters !== null
+        ? (parsed.filters as Record<string, unknown>)
+        : {}
     const normalized_filters: Record<string, string | string[] | null> = {}
-    for (const key of ["problem", "duration", "products_tried", "routine", "special_circumstances"]) {
+    for (const key of [
+      "problem",
+      "duration",
+      "products_tried",
+      "routine",
+      "special_circumstances",
+    ]) {
       const val = rawFilters[key]
       if (typeof val === "string" && val.trim()) {
         normalized_filters[key] = val.trim()
@@ -121,24 +157,30 @@ export async function classifyIntent(
       }
     }
 
-    const needs_clarification = typeof parsed.needs_clarification === "boolean"
-      ? parsed.needs_clarification
-      : false
+    const needs_clarification =
+      typeof parsed.needs_clarification === "boolean" ? parsed.needs_clarification : false
 
     // Retrieval mode suggestion from LLM (router policy may override)
-    const retrieval_mode = VALID_RETRIEVAL_MODES.find((v) => v === parsed.retrieval_mode) ?? "hybrid"
+    const retrieval_mode =
+      VALID_RETRIEVAL_MODES.find((v) => v === parsed.retrieval_mode) ?? "hybrid"
 
     return {
-      intent,
-      product_category: category,
-      complexity,
-      needs_clarification,
-      retrieval_mode,
-      normalized_filters,
-      router_confidence: confidence,
+      result: {
+        intent,
+        product_category: category,
+        complexity,
+        needs_clarification,
+        retrieval_mode,
+        normalized_filters,
+        router_confidence: confidence,
+      },
+      promptRef: managedPrompt.ref,
     }
   } catch (error) {
     console.error("Intent classification failed, defaulting to general_chat:", error)
-    return { ...DEFAULT_CLASSIFICATION }
+    return {
+      result: { ...DEFAULT_CLASSIFICATION },
+      promptRef: FALLBACK_PROMPT_REF,
+    }
   }
 }

--- a/src/lib/rag/memory-extractor.ts
+++ b/src/lib/rag/memory-extractor.ts
@@ -1,5 +1,12 @@
 import { z } from "zod"
-import { getOpenAI } from "@/lib/openai/client"
+import { startObservation } from "@langfuse/tracing"
+import { context as otelContext, trace as otelTrace } from "@opentelemetry/api"
+import { getObservedOpenAI } from "@/lib/openai/client"
+import {
+  buildLangfusePromptConfig,
+  getManagedTextPrompt,
+  LANGFUSE_PROMPTS,
+} from "@/lib/langfuse/prompts"
 import { createAdminClient } from "@/lib/supabase/admin"
 import {
   buildMemoryPromptContext,
@@ -9,6 +16,8 @@ import {
   type ExtractedMemoryCandidate,
 } from "@/lib/rag/user-memory"
 import type { UserMemoryKind } from "@/lib/types"
+
+export { MEMORY_EXTRACTION_JSON_PROMPT } from "@/lib/rag/prompts"
 
 const MIN_USER_MESSAGES = 3
 
@@ -36,21 +45,6 @@ const extractionResponseSchema = z.object({
   memories: z.array(extractedMemorySchema).default([]),
 })
 
-export const MEMORY_EXTRACTION_JSON_PROMPT = `Du bist ein Analyse-Assistent fuer Hair Concierge. Extrahiere dauerhafte, haarspezifische Erinnerungen aus einem Gespraech.
-
-Antworte NUR als JSON:
-{"memories":[{"kind":"preference|routine|product_experience|hair_history|progress|sensitivity|medical_context|other","memory_key":"stabiler_key","content":"deutscher Satz","evidence":"kurzes Nutzerzitat","confidence":0.0,"product_names":["..."],"sentiment":"positive|negative|neutral"}]}
-
-Regeln:
-- Speichere nur Fakten, die der NUTZER explizit sagt oder bestaetigt.
-- Speichere keine Empfehlungen, Erklaerungen oder Annahmen des Assistenten.
-- Speichere nur hair-care-relevante Fakten: Vorlieben, Routine, Produkterfahrungen, Haarhistorie, Fortschritt, Reaktionen, Sensitivitaeten.
-- Medizinisch angrenzende Fakten wie Haarausfall, Kopfhautbeschwerden, Schwangerschaft, Medikamente oder Allergien nur speichern, wenn der Nutzer sie explizit als relevant nennt.
-- Keine Smalltalk-Fakten, keine allgemeinen Lebensdetails ohne Haarpflegebezug.
-- Bei Produkterfahrungen setze product_names und sentiment. Negative sentiment bedeutet: Produkt nicht wieder priorisieren.
-- memory_key muss stabil sein, z.B. "product:olaplex_no_3", "preference:duft", "routine:wash_frequency". Bei neuem Widerspruch denselben memory_key verwenden, damit die neueste Aussage gewinnt.
-- Wenn nichts Neues speicherwuerdig ist: {"memories":[]}.`
-
 export function parseMemoryExtractionResult(content: string): ExtractedMemoryCandidate[] {
   try {
     const parsed = extractionResponseSchema.safeParse(JSON.parse(content))
@@ -73,7 +67,7 @@ export function parseMemoryExtractionResult(content: string): ExtractedMemoryCan
 async function markConversationExtracted(
   conversationId: string,
   messageCount: number,
-  supabase: ReturnType<typeof createAdminClient>
+  supabase: ReturnType<typeof createAdminClient>,
 ) {
   await supabase
     .from("conversations")
@@ -87,7 +81,7 @@ async function markConversationExtracted(
  */
 export async function extractConversationMemory(
   conversationId: string,
-  userId: string
+  userId: string,
 ): Promise<void> {
   try {
     const supabase = createAdminClient()
@@ -118,36 +112,80 @@ export async function extractConversationMemory(
       return
     }
 
-    const existingMemory = buildMemoryPromptContext(
-      await listUserMemoryEntries(userId, supabase)
-    )
-
-    const transcript = messages
-      .map((message) => `${message.role === "user" ? "Nutzer" : "Assistent"}: ${message.content ?? ""}`)
-      .join("\n")
-
-    const prompt = [
-      MEMORY_EXTRACTION_JSON_PROMPT,
-      existingMemory ? `\nBestehende aktive Erinnerungen:\n${existingMemory}` : "",
-      `\nGespraech:\n${transcript}`,
-    ].join("\n")
-
-    const completion = await getOpenAI().chat.completions.create({
-      model: "gpt-4o-mini",
-      messages: [{ role: "user", content: prompt }],
-      max_tokens: 800,
-      temperature: 0.1,
-      response_format: { type: "json_object" },
+    const observation = startObservation("memory-extraction", {
+      input: {
+        conversationId,
+        userId,
+        messageCount: messages.length,
+      },
+      metadata: {
+        feature: "user-memory",
+      },
     })
+    const observationContext = otelTrace.setSpan(otelContext.active(), observation.otelSpan)
 
-    const content = completion.choices[0]?.message?.content
-    const memories = content ? parseMemoryExtractionResult(content) : []
+    try {
+      await otelContext.with(observationContext, async () => {
+        const existingMemory = buildMemoryPromptContext(await listUserMemoryEntries(userId, supabase))
 
-    if (memories.length > 0) {
-      await insertExtractedMemories(userId, conversationId, memories, supabase)
+        const transcript = messages
+          .map(
+            (message) =>
+              `${message.role === "user" ? "Nutzer" : "Assistent"}: ${message.content ?? ""}`,
+          )
+          .join("\n")
+
+        const managedPrompt = await getManagedTextPrompt(LANGFUSE_PROMPTS.memoryExtraction, {
+          EXISTING_MEMORY_SECTION: existingMemory
+            ? `Bestehende aktive Erinnerungen:\n${existingMemory}`
+            : "Keine bestehenden aktiven Erinnerungen.",
+          TRANSCRIPT: transcript,
+        })
+
+        const completion = await getObservedOpenAI({
+          generationName: "memory-extraction-json",
+          generationMetadata: {
+            conversation_id: conversationId,
+            prompt_label: managedPrompt.ref.label,
+          },
+          langfusePrompt: buildLangfusePromptConfig(managedPrompt.ref),
+        }).chat.completions.create({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: managedPrompt.text }],
+          max_tokens: 800,
+          temperature: 0.1,
+          response_format: { type: "json_object" },
+        })
+
+        const content = completion.choices[0]?.message?.content
+        const memories = content ? parseMemoryExtractionResult(content) : []
+
+        if (memories.length > 0) {
+          await insertExtractedMemories(userId, conversationId, memories, supabase)
+        }
+
+        await markConversationExtracted(conversationId, messages.length, supabase)
+        observation.update({
+          output: {
+            skipped: false,
+            memoryCount: memories.length,
+            prompt: managedPrompt.ref,
+          },
+        })
+      })
+    } catch (error) {
+      console.error("Memory extraction failed:", error)
+      observation.update({
+        output: {
+          failed: true,
+        },
+        metadata: {
+          error: error instanceof Error ? error.message : "memory_extraction_failed",
+        },
+      })
+    } finally {
+      observation.end()
     }
-
-    await markConversationExtracted(conversationId, messages.length, supabase)
   } catch (error) {
     console.error("Memory extraction failed:", error)
   }

--- a/src/lib/rag/orchestrator/conversation-orchestrator.ts
+++ b/src/lib/rag/orchestrator/conversation-orchestrator.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
+import { startObservation } from "@langfuse/tracing"
 import { classifyIntent } from "@/lib/rag/intent-classifier"
 import { evaluateRoute } from "@/lib/rag/router"
 import { emitRouterEvent } from "@/lib/rag/retrieval-telemetry"
@@ -36,6 +37,53 @@ async function measureAsync<T>(work: () => Promise<T>): Promise<{ result: T; dur
   }
 }
 
+async function observeAsyncStage<T>(
+  name: string,
+  input: unknown,
+  work: () => Promise<T>,
+  options?: {
+    asType?: "span" | "chain" | "retriever"
+    output?: (result: T) => unknown
+    metadata?: Record<string, unknown>
+  },
+): Promise<T> {
+  const attributes = {
+    input,
+    metadata: options?.metadata,
+  }
+  const observation =
+    options?.asType === "chain"
+      ? startObservation(name, attributes, { asType: "chain" })
+      : options?.asType === "retriever"
+        ? startObservation(name, attributes, { asType: "retriever" })
+        : startObservation(name, attributes)
+
+  try {
+    const result = await work()
+
+    if (options?.output) {
+      observation.update({
+        output: options.output(result),
+      })
+    }
+
+    return result
+  } catch (error) {
+    observation.update({
+      output: {
+        failed: true,
+      },
+      metadata: {
+        ...(options?.metadata ?? {}),
+        error: error instanceof Error ? error.message : "unknown_stage_error",
+      },
+    })
+    throw error
+  } finally {
+    observation.end()
+  }
+}
+
 // ── Main orchestrator ────────────────────────────────────────────────────────
 
 /**
@@ -56,34 +104,84 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
   const supabase = createAdminClient()
 
   // ── Step 1: Load conversation history + hair profile + memory ─────
-  const [
-    { result: conversationData, durationMs: historyLoadMs },
-    { result: hairProfileResult, durationMs: hairProfileLoadMs },
-    { result: memoryContext, durationMs: memoryLoadMs },
-  ] = await Promise.all([
-    measureAsync(async () =>
-      conversationId
-        ? await supabase
-            .from("messages")
-            .select("*")
-            .eq("conversation_id", conversationId)
-            .order("created_at", { ascending: true })
-            .limit(10)
-            .then(({ data }) => data)
-        : null,
-    ),
-    measureAsync(
-      async () => await supabase.from("hair_profiles").select("*").eq("user_id", userId).single(),
-    ),
-    measureAsync(() => loadUserMemoryContext(userId, supabase)),
-  ])
+  const {
+    conversationData,
+    hairProfileResult,
+    memoryContext,
+    historyLoadMs,
+    hairProfileLoadMs,
+    memoryLoadMs,
+  } = await observeAsyncStage(
+    "load-chat-context",
+    {
+      conversationId,
+      userId,
+    },
+    async () => {
+      const [
+        { result: conversationData, durationMs: historyLoadMs },
+        { result: hairProfileResult, durationMs: hairProfileLoadMs },
+        { result: memoryContext, durationMs: memoryLoadMs },
+      ] = await Promise.all([
+        measureAsync(async () =>
+          conversationId
+            ? await supabase
+                .from("messages")
+                .select("*")
+                .eq("conversation_id", conversationId)
+                .order("created_at", { ascending: true })
+                .limit(10)
+                .then(({ data }) => data)
+            : null,
+        ),
+        measureAsync(
+          async () =>
+            await supabase.from("hair_profiles").select("*").eq("user_id", userId).single(),
+        ),
+        measureAsync(() => loadUserMemoryContext(userId, supabase)),
+      ])
+
+      return {
+        conversationData,
+        hairProfileResult,
+        memoryContext,
+        historyLoadMs,
+        hairProfileLoadMs,
+        memoryLoadMs,
+      }
+    },
+    {
+      output: (result) => ({
+        historyCount: (result.conversationData as Message[] | null)?.length ?? 0,
+        hasHairProfile: Boolean(result.hairProfileResult.data),
+        hasMemoryContext: Boolean(result.memoryContext.promptContext),
+      }),
+    },
+  )
   const conversationHistory: Message[] = (conversationData as Message[]) ?? []
   const hairProfile: HairProfile | null = hairProfileResult.data ?? null
 
   // ── Step 1b: Classify intent (with conversation context) ───────────
-  const { result: classification, durationMs: classificationMs } = await measureAsync(() =>
-    classifyIntent(message, conversationHistory),
+  const { result: classificationOutput, durationMs: classificationMs } = await measureAsync(() =>
+    observeAsyncStage(
+      "intent-classification-stage",
+      {
+        message,
+        conversationHistoryCount: conversationHistory.length,
+      },
+      () => classifyIntent(message, conversationHistory),
+      {
+        output: ({ result, promptRef }) => ({
+          intent: result.intent,
+          product_category: result.product_category,
+          needs_clarification: result.needs_clarification,
+          prompt: promptRef,
+        }),
+      },
+    ),
   )
+  const classification = classificationOutput.result
+  const classificationPromptRef = classificationOutput.promptRef
   const { intent, product_category } = classification
   const shouldPlanRoutine = intent === "routine_help" || product_category === "routine"
   let routinePlan: RoutinePlan | undefined
@@ -108,7 +206,23 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
 
   // ── Step 2: Evaluate routing decision ──────────────────────────────
   const routerStart = performance.now()
-  const routerDecision = evaluateRoute(classification, conversationHistory, hairProfile, message)
+  const routerDecision = await observeAsyncStage(
+    "router-decision-stage",
+    {
+      intent,
+      product_category,
+      message,
+    },
+    async () => evaluateRoute(classification, conversationHistory, hairProfile, message),
+    {
+      output: (result) => ({
+        retrieval_mode: result.retrieval_mode,
+        needs_clarification: result.needs_clarification,
+        confidence: result.confidence,
+        slot_completeness: result.slot_completeness,
+      }),
+    },
+  )
   const routerMs = Math.round(performance.now() - routerStart)
 
   emitRouterEvent({
@@ -193,32 +307,66 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
     // Minimal retrieval for context (but no product matching)
     const clarificationRetrievalCount = 3
     const retrievalStart = performance.now()
-    const { chunks: ragChunks, debug: retrievalDebug } = await retrieve(message, {
-      intent,
-      hairProfile,
-      shampooConcern: decisions.shampoo?.matched_concern_code ?? null,
-      count: clarificationRetrievalCount,
-      subqueries: routinePlan ? buildRoutineRetrievalSubqueries(message, routinePlan) : undefined,
-      userId,
-    })
+    const { chunks: ragChunks, debug: retrievalDebug } = await observeAsyncStage(
+      "clarification-retrieval-stage",
+      {
+        intent,
+        retrievalCount: clarificationRetrievalCount,
+      },
+      () =>
+        retrieve(message, {
+          intent,
+          hairProfile,
+          shampooConcern: decisions.shampoo?.matched_concern_code ?? null,
+          count: clarificationRetrievalCount,
+          subqueries: routinePlan
+            ? buildRoutineRetrievalSubqueries(message, routinePlan)
+            : undefined,
+          userId,
+        }),
+      {
+        asType: "retriever",
+        output: ({ chunks, debug }) => ({
+          final_context_count: chunks.length,
+          candidate_count_before_rerank: debug.candidate_count_before_rerank,
+          fallback_used: debug.fallback_used,
+        }),
+      },
+    )
     const retrievalMs = Math.round(performance.now() - retrievalStart)
 
     const sources = buildSources(ragChunks)
 
-    const synthesisResult = await composeResponse({
-      userMessage: message,
-      conversationHistory,
-      hairProfile,
-      ragChunks,
-      intent,
-      productCategory: product_category,
-      shampooDecision: decisions.shampoo,
-      conditionerDecision: decisions.conditioner,
-      leaveInDecision: decisions.leaveIn,
-      oilDecision: decisions.oil,
-      memoryContext: memoryContext.promptContext,
-      clarificationQuestions,
-    })
+    const synthesisResult = await observeAsyncStage(
+      "clarification-synthesis-stage",
+      {
+        intent,
+        product_category,
+        clarificationQuestionCount: clarificationQuestions.length,
+      },
+      () =>
+        composeResponse({
+          userMessage: message,
+          conversationHistory,
+          hairProfile,
+          ragChunks,
+          intent,
+          productCategory: product_category,
+          shampooDecision: decisions.shampoo,
+          conditionerDecision: decisions.conditioner,
+          leaveInDecision: decisions.leaveIn,
+          oilDecision: decisions.oil,
+          memoryContext: memoryContext.promptContext,
+          clarificationQuestions,
+        }),
+      {
+        asType: "chain",
+        output: (result) => ({
+          model: result.debug.prompt.model,
+          prompt_ref: result.debug.prompt.prompt_ref,
+        }),
+      },
+    )
     const categoryDecision = getPrimaryCategoryDecision(decisions)
     const debugTrace = buildPipelineTraceDraft({
       request_id: requestId,
@@ -240,6 +388,7 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
       routine_plan: routinePlan,
       category_decision: categoryDecision,
       matched_products: [],
+      classification_prompt_ref: classificationPromptRef,
       prompt: synthesisResult.debug.prompt,
       latencies_ms: {
         classification_ms: classificationMs,
@@ -286,15 +435,33 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
   const retrievalCount = routerDecision.retrieval_mode === "faq" ? 3 : 5
 
   const retrievalStart = performance.now()
-  const { chunks: ragChunks, debug: retrievalDebug } = await retrieve(message, {
-    intent,
-    hairProfile,
-    metadataFilter,
-    shampooConcern: decisions.shampoo?.matched_concern_code ?? null,
-    count: retrievalCount,
-    subqueries: routinePlan ? buildRoutineRetrievalSubqueries(message, routinePlan) : undefined,
-    userId,
-  })
+  const { chunks: ragChunks, debug: retrievalDebug } = await observeAsyncStage(
+    "chat-retrieval-stage",
+    {
+      intent,
+      product_category,
+      retrievalCount,
+      metadataFilter,
+    },
+    () =>
+      retrieve(message, {
+        intent,
+        hairProfile,
+        metadataFilter,
+        shampooConcern: decisions.shampoo?.matched_concern_code ?? null,
+        count: retrievalCount,
+        subqueries: routinePlan ? buildRoutineRetrievalSubqueries(message, routinePlan) : undefined,
+        userId,
+      }),
+    {
+      asType: "retriever",
+      output: ({ chunks, debug }) => ({
+        final_context_count: chunks.length,
+        candidate_count_before_rerank: debug.candidate_count_before_rerank,
+        fallback_used: debug.fallback_used,
+      }),
+    },
+  )
   const retrievalMs = Math.round(performance.now() - retrievalStart)
 
   // ── Build enriched citation sources from retrieved chunks ──────────
@@ -305,12 +472,25 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
   let maskDecision: MaskDecision | undefined
   const productMatchingStart = performance.now()
   if (shouldPlanRoutine && routinePlan) {
-    const routineResult = await attachProductsToRoutinePlan({
-      plan: routinePlan,
-      hairProfile,
-      memoryContext,
-      supabase,
-    })
+    const routineResult = await observeAsyncStage(
+      "routine-product-selection-stage",
+      {
+        focusCount: routinePlan.primary_focuses.length,
+      },
+      () =>
+        attachProductsToRoutinePlan({
+          plan: routinePlan!,
+          hairProfile,
+          memoryContext,
+          supabase,
+        }),
+      {
+        asType: "chain",
+        output: (result) => ({
+          matched_product_count: result.matchedProducts.length,
+        }),
+      },
+    )
     routinePlan = routineResult.plan
     matchedProducts = routineResult.matchedProducts
   } else if (PRODUCT_INTENTS.includes(intent)) {
@@ -320,14 +500,28 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
       decisions = { ...decisions, mask: maskDecision }
     }
 
-    const selectionResult = await selectProducts({
-      category: product_category,
-      message,
-      hairProfile,
-      decisions,
-      memoryContext,
-      shouldPlanRoutine: false,
-    })
+    const selectionResult = await observeAsyncStage(
+      "product-selection-stage",
+      {
+        product_category,
+        intent,
+      },
+      () =>
+        selectProducts({
+          category: product_category,
+          message,
+          hairProfile,
+          decisions,
+          memoryContext,
+          shouldPlanRoutine: false,
+        }),
+      {
+        asType: "chain",
+        output: (result) => ({
+          matched_product_count: result.products.length,
+        }),
+      },
+    )
     matchedProducts = selectionResult.products
 
     // Merge updated decisions back
@@ -352,22 +546,38 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
   // Note: memory constraints for non-routine are already applied inside selectProducts()
 
   // ── Step 5: Synthesize streaming response ──────────────────────────
-  const synthesisResult = await composeResponse({
-    userMessage: message,
-    conversationHistory,
-    hairProfile,
-    ragChunks,
-    products: matchedProducts,
-    intent,
-    productCategory: product_category,
-    maskDecision: product_category === "mask" ? maskDecision : undefined,
-    shampooDecision: decisions.shampoo,
-    conditionerDecision: decisions.conditioner,
-    leaveInDecision: decisions.leaveIn,
-    oilDecision: decisions.oil,
-    routinePlan,
-    memoryContext: memoryContext.promptContext,
-  })
+  const synthesisResult = await observeAsyncStage(
+    "chat-synthesis-stage",
+    {
+      intent,
+      product_category,
+      matched_product_count: matchedProducts?.length ?? 0,
+    },
+    () =>
+      composeResponse({
+        userMessage: message,
+        conversationHistory,
+        hairProfile,
+        ragChunks,
+        products: matchedProducts,
+        intent,
+        productCategory: product_category,
+        maskDecision: product_category === "mask" ? maskDecision : undefined,
+        shampooDecision: decisions.shampoo,
+        conditionerDecision: decisions.conditioner,
+        leaveInDecision: decisions.leaveIn,
+        oilDecision: decisions.oil,
+        routinePlan,
+        memoryContext: memoryContext.promptContext,
+      }),
+    {
+      asType: "chain",
+      output: (result) => ({
+        model: result.debug.prompt.model,
+        prompt_ref: result.debug.prompt.prompt_ref,
+      }),
+    },
+  )
   const categoryDecision = getPrimaryCategoryDecision(decisions)
   const debugTrace = buildPipelineTraceDraft({
     request_id: requestId,
@@ -388,6 +598,7 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
     routine_plan: routinePlan,
     category_decision: categoryDecision,
     matched_products: matchedProducts ?? [],
+    classification_prompt_ref: classificationPromptRef,
     prompt: synthesisResult.debug.prompt,
     latencies_ms: {
       classification_ms: classificationMs,

--- a/src/lib/rag/orchestrator/conversation-orchestrator.ts
+++ b/src/lib/rag/orchestrator/conversation-orchestrator.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin"
 import { startObservation } from "@langfuse/tracing"
+import { context as otelContext, trace as otelTrace } from "@opentelemetry/api"
 import { classifyIntent } from "@/lib/rag/intent-classifier"
 import { evaluateRoute } from "@/lib/rag/router"
 import { emitRouterEvent } from "@/lib/rag/retrieval-telemetry"
@@ -24,7 +25,14 @@ import { retrieve, buildSources } from "@/lib/rag/retrieval/retrieval-service"
 import { composeResponse } from "@/lib/rag/response/response-composer"
 import { selectProducts } from "@/lib/rag/selection/product-selection-service"
 import type { PipelineParams, PipelineResult, CategoryDecisions } from "@/lib/rag/contracts"
-import type { Message, HairProfile, MaskDecision, RoutinePlan, Product } from "@/lib/types"
+import type {
+  Message,
+  HairProfile,
+  MaskDecision,
+  RoutinePlan,
+  Product,
+  CategoryDecision,
+} from "@/lib/types"
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -59,7 +67,8 @@ async function observeAsyncStage<T>(
         : startObservation(name, attributes)
 
   try {
-    const result = await work()
+    const observationContext = otelTrace.setSpan(otelContext.active(), observation.otelSpan)
+    const result = await otelContext.with(observationContext, work)
 
     if (options?.output) {
       observation.update({
@@ -82,6 +91,46 @@ async function observeAsyncStage<T>(
   } finally {
     observation.end()
   }
+}
+
+function summarizeCategoryDecision(
+  decision: CategoryDecision | undefined,
+): Record<string, unknown> | null {
+  if (!decision) return null
+
+  const summary: Record<string, unknown> = {
+    category: decision.category,
+    eligible: decision.eligible,
+    missing_profile_fields: decision.missing_profile_fields,
+    no_catalog_match: decision.no_catalog_match,
+  }
+
+  if (decision.category === "shampoo") {
+    summary.matched_bucket = decision.matched_bucket
+    summary.matched_concern_code = decision.matched_concern_code
+  }
+
+  if (decision.category === "conditioner") {
+    summary.matched_balance_need = decision.matched_balance_need
+    summary.matched_weight = decision.matched_weight
+    summary.matched_repair_level = decision.matched_repair_level
+  }
+
+  if (decision.category === "leave_in") {
+    summary.need_bucket = decision.need_bucket
+    summary.styling_context = decision.styling_context
+    summary.conditioner_relationship = decision.conditioner_relationship
+    summary.matched_weight = decision.matched_weight
+  }
+
+  if (decision.category === "oil") {
+    summary.matched_subtype = decision.matched_subtype
+    summary.use_mode = decision.use_mode
+    summary.no_recommendation = decision.no_recommendation
+    summary.no_recommendation_reason = decision.no_recommendation_reason
+  }
+
+  return summary
 }
 
 // ── Main orchestrator ────────────────────────────────────────────────────────
@@ -216,10 +265,15 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
     async () => evaluateRoute(classification, conversationHistory, hairProfile, message),
     {
       output: (result) => ({
-        retrieval_mode: result.retrieval_mode,
-        needs_clarification: result.needs_clarification,
+        classifier_retrieval_mode: classification.retrieval_mode,
+        classifier_needs_clarification: classification.needs_clarification,
+        final_retrieval_mode: result.retrieval_mode,
+        final_needs_clarification: result.needs_clarification,
         confidence: result.confidence,
         slot_completeness: result.slot_completeness,
+        clarification_reason: result.clarification_reason ?? null,
+        policy_overrides: result.policy_overrides,
+        category_requirements: summarizeCategoryDecision(getPrimaryCategoryDecision(decisions)),
       }),
     },
   )

--- a/src/lib/rag/prompts.ts
+++ b/src/lib/rag/prompts.ts
@@ -151,7 +151,8 @@ export const INTENT_CLASSIFICATION_PROMPT = `Klassifiziere die Absicht der folge
 Antworte NUR mit validem JSON.
 Beispiel: {"intent": "product_recommendation", "category": "shampoo", "complexity": "multi_constraint", "confidence": 0.85, "filters": {"problem": "fettige Kopfhaut", "duration": null, "products_tried": null, "routine": null, "special_circumstances": null}, "needs_clarification": true}
 
-Klassifiziere die folgende Nutzer-Nachricht:`
+{{HISTORY_PREFIX}}Klassifiziere die folgende Nutzer-Nachricht:
+{{MESSAGE}}`
 
 /**
  * Prompt for generating a short German conversation title from the first message.
@@ -160,7 +161,7 @@ export const TITLE_GENERATION_PROMPT = `Generiere einen kurzen, praegnanten deut
 
 Antworte NUR mit dem Titel, ohne Anfuehrungszeichen oder zusaetzliche Erklaerung.
 
-Nachricht: `
+Nachricht: {{MESSAGE}}`
 
 /**
  * Prompt for extracting durable memory from a conversation.
@@ -187,3 +188,23 @@ Format: Kompakte Stichpunktliste auf Deutsch. Jeder Punkt beginnt mit "- ".
 Maximal 1500 Zeichen. Keine Ueberschriften, keine Nummerierung.
 
 Wenn es nichts Neues zu extrahieren gibt, antworte mit: KEINE_NEUEN_FAKTEN`
+
+export const MEMORY_EXTRACTION_JSON_PROMPT = `Du bist ein Analyse-Assistent fuer Hair Concierge. Extrahiere dauerhafte, haarspezifische Erinnerungen aus einem Gespraech.
+
+Antworte NUR als JSON:
+{"memories":[{"kind":"preference|routine|product_experience|hair_history|progress|sensitivity|medical_context|other","memory_key":"stabiler_key","content":"deutscher Satz","evidence":"kurzes Nutzerzitat","confidence":0.0,"product_names":["..."],"sentiment":"positive|negative|neutral"}]}
+
+Regeln:
+- Speichere nur Fakten, die der NUTZER explizit sagt oder bestaetigt.
+- Speichere keine Empfehlungen, Erklaerungen oder Annahmen des Assistenten.
+- Speichere nur hair-care-relevante Fakten: Vorlieben, Routine, Produkterfahrungen, Haarhistorie, Fortschritt, Reaktionen, Sensitivitaeten.
+- Medizinisch angrenzende Fakten wie Haarausfall, Kopfhautbeschwerden, Schwangerschaft, Medikamente oder Allergien nur speichern, wenn der Nutzer sie explizit als relevant nennt.
+- Keine Smalltalk-Fakten, keine allgemeinen Lebensdetails ohne Haarpflegebezug.
+- Bei Produkterfahrungen setze product_names und sentiment. Negative sentiment bedeutet: Produkt nicht wieder priorisieren.
+- memory_key muss stabil sein, z.B. "product:olaplex_no_3", "preference:duft", "routine:wash_frequency". Bei neuem Widerspruch denselben memory_key verwenden, damit die neueste Aussage gewinnt.
+- Wenn nichts Neues speicherwuerdig ist: {"memories":[]}.
+
+{{EXISTING_MEMORY_SECTION}}
+
+Gespraech:
+{{TRANSCRIPT}}`

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -1161,7 +1161,7 @@ export async function synthesizeResponse(params: SynthesizeParams): Promise<Synt
     model: DEFAULT_CHAT_COMPLETION_MODEL,
     temperature: DEFAULT_CHAT_COMPLETION_TEMPERATURE,
     langfuseConfig: {
-      generationName: "chat-response",
+      generationName: "chat-response-generation",
       generationMetadata: {
         environment: getLangfuseEnvironment(),
         prompt_label: managedPrompt.ref.label,

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -3,6 +3,12 @@ import {
   DEFAULT_CHAT_COMPLETION_TEMPERATURE,
   streamChatCompletion,
 } from "@/lib/openai/chat"
+import {
+  buildLangfusePromptConfig,
+  getManagedTextPromptTemplate,
+  LANGFUSE_PROMPTS,
+} from "@/lib/langfuse/prompts"
+import { getLangfuseEnvironment } from "@/lib/openai/client"
 import { SYSTEM_PROMPT } from "@/lib/rag/prompts"
 import {
   CONDITIONER_REPAIR_LEVEL_LABELS,
@@ -1025,8 +1031,9 @@ export function buildSystemPrompt(
   routinePlan?: RoutinePlan,
   memoryContext?: string | null,
   clarificationQuestions?: string[],
+  basePromptTemplate = SYSTEM_PROMPT,
 ): string {
-  let prompt = SYSTEM_PROMPT
+  let prompt = basePromptTemplate
 
   // Inject category-specific reasoning instructions
   if (productCategory && CATEGORY_REASONING_PROMPTS[productCategory]) {
@@ -1095,6 +1102,7 @@ export async function synthesizeResponse(params: SynthesizeParams): Promise<Synt
   } = params
 
   const promptBuildStart = performance.now()
+  const managedPrompt = await getManagedTextPromptTemplate(LANGFUSE_PROMPTS.chatSystem)
   const systemPrompt = buildSystemPrompt(
     hairProfile,
     ragChunks,
@@ -1108,6 +1116,7 @@ export async function synthesizeResponse(params: SynthesizeParams): Promise<Synt
     routinePlan,
     memoryContext,
     clarificationQuestions,
+    managedPrompt.template,
   )
 
   // Build the messages array for the API call
@@ -1151,6 +1160,15 @@ export async function synthesizeResponse(params: SynthesizeParams): Promise<Synt
     messages,
     model: DEFAULT_CHAT_COMPLETION_MODEL,
     temperature: DEFAULT_CHAT_COMPLETION_TEMPERATURE,
+    langfuseConfig: {
+      generationName: "chat-response",
+      generationMetadata: {
+        environment: getLangfuseEnvironment(),
+        prompt_label: managedPrompt.ref.label,
+        prompt_is_fallback: String(managedPrompt.ref.is_fallback),
+      },
+      langfusePrompt: buildLangfusePromptConfig(managedPrompt.ref),
+    },
   })
   const streamSetupMs = Math.round(performance.now() - streamSetupStart)
 
@@ -1160,6 +1178,7 @@ export async function synthesizeResponse(params: SynthesizeParams): Promise<Synt
       prompt: {
         model: DEFAULT_CHAT_COMPLETION_MODEL,
         temperature: DEFAULT_CHAT_COMPLETION_TEMPERATURE,
+        prompt_ref: managedPrompt.ref,
         system_prompt: systemPrompt,
         messages: promptMessages,
       },

--- a/src/lib/rag/title-generator.ts
+++ b/src/lib/rag/title-generator.ts
@@ -1,6 +1,10 @@
-import { getOpenAI } from "@/lib/openai/client"
+import { getObservedOpenAI } from "@/lib/openai/client"
 import { createAdminClient } from "@/lib/supabase/admin"
-import { TITLE_GENERATION_PROMPT } from "@/lib/rag/prompts"
+import {
+  buildLangfusePromptConfig,
+  getManagedTextPrompt,
+  LANGFUSE_PROMPTS,
+} from "@/lib/langfuse/prompts"
 
 /**
  * Generates a short German title for a conversation using GPT-4o-mini
@@ -8,14 +12,23 @@ import { TITLE_GENERATION_PROMPT } from "@/lib/rag/prompts"
  */
 export async function generateConversationTitle(
   conversationId: string,
-  userMessage: string
+  userMessage: string,
 ): Promise<void> {
   try {
-    const completion = await getOpenAI().chat.completions.create({
+    const managedPrompt = await getManagedTextPrompt(LANGFUSE_PROMPTS.titleGenerator, {
+      MESSAGE: userMessage,
+    })
+
+    const completion = await getObservedOpenAI({
+      generationName: "conversation-title",
+      generationMetadata: {
+        conversation_id: conversationId,
+        prompt_label: managedPrompt.ref.label,
+      },
+      langfusePrompt: buildLangfusePromptConfig(managedPrompt.ref),
+    }).chat.completions.create({
       model: "gpt-4o-mini",
-      messages: [
-        { role: "user", content: TITLE_GENERATION_PROMPT + userMessage },
-      ],
+      messages: [{ role: "user", content: managedPrompt.text }],
       max_tokens: 30,
       temperature: 0.5,
     })
@@ -24,10 +37,7 @@ export async function generateConversationTitle(
     if (!title) return
 
     const supabase = createAdminClient()
-    await supabase
-      .from("conversations")
-      .update({ title })
-      .eq("id", conversationId)
+    await supabase.from("conversations").update({ title }).eq("id", conversationId)
   } catch (error) {
     console.error("Title generation failed:", error)
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -491,9 +491,17 @@ export interface ChatPromptMessageSnapshot {
   content: string
 }
 
+export interface LangfusePromptReference {
+  name: string
+  version: number | null
+  label: string
+  is_fallback: boolean
+}
+
 export interface ChatPromptSnapshot {
   model: string
   temperature: number
+  prompt_ref: LangfusePromptReference
   system_prompt: string
   messages: ChatPromptMessageSnapshot[]
 }
@@ -569,6 +577,10 @@ export interface ChatTurnTrace {
     category_decision: CategoryDecision | null
     matched_products: ChatMatchedProductTrace[]
   }
+  prompt_refs: {
+    classification: LangfusePromptReference
+    synthesis: LangfusePromptReference
+  }
   prompt: ChatPromptSnapshot
   response: {
     assistant_content: string
@@ -585,6 +597,8 @@ export interface ConversationTurnTrace {
   user_id: string
   user_message_id: string | null
   assistant_message_id: string | null
+  langfuse_trace_id: string | null
+  langfuse_trace_url: string | null
   status: "completed" | "failed"
   trace: ChatTurnTrace
   created_at: string
@@ -610,6 +624,10 @@ export interface Message {
   product_recommendations: Product[] | null
   rag_context: MessageRagContext | null
   token_usage: Record<string, number> | null
+  langfuse_trace_id: string | null
+  langfuse_trace_url: string | null
+  user_feedback_score: -1 | 1 | null
+  user_feedback_at: string | null
   created_at: string
 }
 

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -15,10 +15,7 @@ import {
   BRUSH_TYPES,
   NIGHT_PROTECTIONS,
 } from "@/lib/vocabulary"
-import {
-  CONDITIONER_WEIGHTS,
-  CONDITIONER_REPAIR_LEVELS,
-} from "@/lib/conditioner/constants"
+import { CONDITIONER_WEIGHTS, CONDITIONER_REPAIR_LEVELS } from "@/lib/conditioner/constants"
 import {
   POST_WASH_ACTIONS,
   ROUTINE_PREFERENCES,
@@ -62,17 +59,18 @@ export const hairProfileFullSchema = z.object({
   additional_notes: z.string().nullable().default(null),
 })
 
-const leaveInSpecsSchema = z.object({
-  format: z.enum(LEAVE_IN_FORMATS),
-  weight: z.enum(LEAVE_IN_WEIGHTS),
-  roles: z.array(z.enum(LEAVE_IN_ROLES)).default([]),
-  provides_heat_protection: z.boolean().default(false),
-  heat_protection_max_c: z.number().int().nullable().default(null),
-  heat_activation_required: z.boolean().default(false),
-  care_benefits: z.array(z.enum(LEAVE_IN_CARE_BENEFITS)).default([]),
-  ingredient_flags: z.array(z.enum(LEAVE_IN_INGREDIENT_FLAGS)).default([]),
-  application_stage: z.array(z.enum(LEAVE_IN_APPLICATION_STAGES)).default(["towel_dry"]),
-})
+const leaveInSpecsSchema = z
+  .object({
+    format: z.enum(LEAVE_IN_FORMATS),
+    weight: z.enum(LEAVE_IN_WEIGHTS),
+    roles: z.array(z.enum(LEAVE_IN_ROLES)).default([]),
+    provides_heat_protection: z.boolean().default(false),
+    heat_protection_max_c: z.number().int().nullable().default(null),
+    heat_activation_required: z.boolean().default(false),
+    care_benefits: z.array(z.enum(LEAVE_IN_CARE_BENEFITS)).default([]),
+    ingredient_flags: z.array(z.enum(LEAVE_IN_INGREDIENT_FLAGS)).default([]),
+    application_stage: z.array(z.enum(LEAVE_IN_APPLICATION_STAGES)).default(["towel_dry"]),
+  })
   .superRefine((value, ctx) => {
     if (value.heat_protection_max_c !== null && !value.provides_heat_protection) {
       ctx.addIssue({
@@ -81,10 +79,7 @@ const leaveInSpecsSchema = z.object({
         message: "heat_protection_max_c requires provides_heat_protection = true",
       })
     }
-    if (
-      value.heat_activation_required &&
-      !value.roles.includes("styling_prep")
-    ) {
+    if (value.heat_activation_required && !value.roles.includes("styling_prep")) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["roles"],
@@ -108,13 +103,13 @@ const conditionerSpecsSchema = z.object({
 })
 
 const nullableTextField = z.preprocess(
-  (value) => value === "" ? null : value,
-  z.string().nullable().optional()
+  (value) => (value === "" ? null : value),
+  z.string().nullable().optional(),
 )
 
 const nullableUrlField = z.preprocess(
-  (value) => value === "" ? null : value,
-  z.string().url().nullable().optional()
+  (value) => (value === "" ? null : value),
+  z.string().url().nullable().optional(),
 )
 
 const nullablePriceField = z.preprocess((value) => {
@@ -127,23 +122,29 @@ export const chatMessageSchema = z.object({
   conversation_id: z.string().uuid().optional(),
 })
 
-export const productSchema = z.object({
-  name: z.string().min(1, "Name ist erforderlich."),
-  brand: nullableTextField.default(null),
-  description: nullableTextField.default(null),
-  category: nullableTextField.default(null),
-  affiliate_link: nullableUrlField.default(null),
-  image_url: nullableUrlField.default(null),
-  price_eur: nullablePriceField.default(null),
-  tags: z.array(z.string()).default([]),
-  suitable_thicknesses: z.array(z.string()).default([]),
-  suitable_concerns: z.array(z.string()).default([]),
-  is_active: z.boolean().default(true),
-  sort_order: z.number().int().default(0),
-  conditioner_specs: conditionerSpecsSchema.nullable().optional(),
-  leave_in_specs: leaveInSpecsSchema.nullable().optional(),
-  mask_specs: maskSpecsSchema.nullable().optional(),
+export const chatFeedbackSchema = z.object({
+  message_id: z.string().uuid(),
+  score: z.union([z.literal(-1), z.literal(1)]),
 })
+
+export const productSchema = z
+  .object({
+    name: z.string().min(1, "Name ist erforderlich."),
+    brand: nullableTextField.default(null),
+    description: nullableTextField.default(null),
+    category: nullableTextField.default(null),
+    affiliate_link: nullableUrlField.default(null),
+    image_url: nullableUrlField.default(null),
+    price_eur: nullablePriceField.default(null),
+    tags: z.array(z.string()).default([]),
+    suitable_thicknesses: z.array(z.string()).default([]),
+    suitable_concerns: z.array(z.string()).default([]),
+    is_active: z.boolean().default(true),
+    sort_order: z.number().int().default(0),
+    conditioner_specs: conditionerSpecsSchema.nullable().optional(),
+    leave_in_specs: leaveInSpecsSchema.nullable().optional(),
+    mask_specs: maskSpecsSchema.nullable().optional(),
+  })
   .superRefine((value, ctx) => {
     if (!isOilCategory(value.category)) return
 
@@ -209,6 +210,7 @@ export const articleSchema = z.object({
 
 export type HairProfileFull = z.infer<typeof hairProfileFullSchema>
 export type ChatMessage = z.infer<typeof chatMessageSchema>
+export type ChatFeedbackInput = z.infer<typeof chatFeedbackSchema>
 export type ProductInput = z.infer<typeof productSchema>
 export type QuoteInput = z.infer<typeof quoteSchema>
 export type ArticleInput = z.infer<typeof articleSchema>

--- a/supabase/migrations/20260413120000_add_langfuse_trace_and_feedback_columns.sql
+++ b/supabase/migrations/20260413120000_add_langfuse_trace_and_feedback_columns.sql
@@ -1,0 +1,17 @@
+alter table public.messages
+    add column if not exists langfuse_trace_id text,
+    add column if not exists langfuse_trace_url text,
+    add column if not exists user_feedback_score smallint check (user_feedback_score in (-1, 1)),
+    add column if not exists user_feedback_at timestamptz;
+
+create index if not exists idx_messages_langfuse_trace_id
+    on public.messages (langfuse_trace_id)
+    where langfuse_trace_id is not null;
+
+alter table public.conversation_turn_traces
+    add column if not exists langfuse_trace_id text,
+    add column if not exists langfuse_trace_url text;
+
+create index if not exists idx_conversation_turn_traces_langfuse_trace_id
+    on public.conversation_turn_traces (langfuse_trace_id)
+    where langfuse_trace_id is not null;

--- a/tests/chat-debug-trace.spec.ts
+++ b/tests/chat-debug-trace.spec.ts
@@ -51,9 +51,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
   }
 }
 
-function createClassification(
-  overrides: Partial<ClassificationResult> = {},
-): ClassificationResult {
+function createClassification(overrides: Partial<ClassificationResult> = {}): ClassificationResult {
   return {
     intent: "routine_help",
     product_category: "routine",
@@ -72,9 +70,7 @@ function createClassification(
   }
 }
 
-function createRouterDecision(
-  overrides: Partial<RouterDecision> = {},
-): RouterDecision {
+function createRouterDecision(overrides: Partial<RouterDecision> = {}): RouterDecision {
   return {
     retrieval_mode: "hybrid",
     needs_clarification: false,
@@ -86,9 +82,7 @@ function createRouterDecision(
   }
 }
 
-function createRetrievedChunk(
-  overrides: Partial<RetrievedChunk> = {},
-): RetrievedChunk {
+function createRetrievedChunk(overrides: Partial<RetrievedChunk> = {}): RetrievedChunk {
   return {
     id: "chunk-1",
     source_type: "book",
@@ -239,6 +233,12 @@ function createPromptSnapshot(): ChatPromptSnapshot {
   return {
     model: "gpt-4o",
     temperature: 0.7,
+    prompt_ref: {
+      name: "hair-concierge-chat-system",
+      version: 3,
+      label: "staging",
+      is_fallback: false,
+    },
     system_prompt: "System prompt snapshot",
     messages: [
       { role: "system", content: "System prompt snapshot" },
@@ -275,6 +275,12 @@ test.describe("Chat debug trace", () => {
       should_plan_routine: true,
       routine_plan: createRoutinePlan(),
       matched_products: [createProduct()],
+      classification_prompt_ref: {
+        name: "hair-concierge-intent-classifier",
+        version: 2,
+        label: "staging",
+        is_fallback: false,
+      },
       prompt: createPromptSnapshot(),
       latencies_ms: {
         classification_ms: 20,
@@ -294,7 +300,7 @@ test.describe("Chat debug trace", () => {
     expect(draft.retrieval.subqueries).toEqual(["OWC", "Frizz in Wellen"])
     expect(draft.retrieval.chunks[0].content_preview).toContain("Wash-Day-Technik")
     expect(draft.decision_context.matched_products[0].top_reasons).toContain(
-      "leicht genug fuer feines Haar"
+      "leicht genug fuer feines Haar",
     )
   })
 
@@ -325,6 +331,12 @@ test.describe("Chat debug trace", () => {
       should_plan_routine: true,
       routine_plan: createRoutinePlan(),
       matched_products: [],
+      classification_prompt_ref: {
+        name: "hair-concierge-intent-classifier",
+        version: 2,
+        label: "staging",
+        is_fallback: false,
+      },
       prompt: createPromptSnapshot(),
       latencies_ms: {
         classification_ms: 12,


### PR DESCRIPTION
## Summary

- Adds Langfuse observability integration for production chat tracing, prompt management, and quality evaluation
- Instruments the full RAG pipeline: intent classification, memory extraction, synthesis, title generation — all traced as Langfuse spans
- Adds chat feedback API endpoint for thumbs up/down user feedback, synced to Langfuse scores
- Includes eval-chat integration with Langfuse datasets and scoring
- Adds admin conversation detail enhancements for trace viewing
- Includes scripts for Langfuse setup: dataset seeding, review queue configuration, prompt syncing
- Adds PII masking layer for Langfuse traces
- Database migration for chat feedback table

## Test plan

- [x] `npm run ci:verify` passes (typecheck + lint + build)
- [ ] Verify Langfuse traces appear in dashboard after chat interactions
- [ ] Verify chat feedback (thumbs up/down) persists and syncs to Langfuse
- [ ] Run `npm run test:chat` to verify eval integration
- [ ] Verify PII masking strips sensitive data from traces
- [ ] Test admin conversation detail page shows trace links

🤖 Generated with [Claude Code](https://claude.com/claude-code)