### PR TITLE
[codex] Personalize chat smart starters

### DIFF
--- a/plans/chat-smart-starters-investigation-notes.md
+++ b/plans/chat-smart-starters-investigation-notes.md
@@ -1,0 +1,171 @@
+# Chat Smart Starters Investigation Notes
+
+> Date: 2026-04-16
+> Scope: Underperforming conditioner starter prompts
+
+## Question
+
+Why did the conditioner-oriented starter prompts perform much worse than the routine, scalp, leave-in, and lengths-comparison prompts in the initial evaluation?
+
+## Important Context
+
+The first prompt matrix was run against the root checkout, which was on local `main` and behind `origin/main` by 2 commits.
+
+Between local `main` and `origin/main`, the chat path changed materially:
+
+- router moved to tri-state `response_mode`
+- prompt / synthesis behavior changed substantially
+- classifier handling changed slightly
+
+This means the original “bad conditioner result” needed to be rechecked on a clean `origin/main`-based worktree before treating it as a product truth.
+
+## Recheck On `origin/main`
+
+Tested prompts:
+
+- `Welcher Conditioner passt gerade am besten zu meinem Haar?`
+- `Welcher Conditioner passt bei Feuchtigkeitsmangel?`
+
+Test profile:
+
+- `hair_texture = wavy`
+- `thickness = fine`
+- `density = medium`
+- `protein_moisture_balance = snaps`
+- `cuticle_condition = rough`
+- `chemical_treatment = bleached`
+- `heat_styling = several_weekly`
+- concerns include dryness, damage, frizz
+
+## Finding 1: Conditioner matching itself is not broken
+
+On the clean `origin/main` base, both conditioner prompts classified as:
+
+- `intent = product_recommendation`
+- `product_category = conditioner`
+
+And both ended up with concrete conditioner products from the matcher.
+
+So the issue is not:
+
+- “conditioner category is broken”
+- “conditioner prompts are misclassified into another category”
+- “conditioner product retrieval is empty”
+
+## Finding 2: The generic conditioner chip is still more fragile because of router slot logic
+
+For:
+
+- `Welcher Conditioner passt gerade am besten zu meinem Haar?`
+
+The classifier produced:
+
+- `product_category = conditioner`
+- all normalized free-text slots = `null`
+
+Router result:
+
+- `response_mode = recommend_and_refine`
+- `policy_overrides = ["category_product_mode", "missing_slots"]`
+- `slot_completeness = 0.1`
+
+Why this happens:
+
+- the conditioner profile is actually complete enough for recommendation
+- but slot completeness still depends mostly on free-text filters like `problem`, `routine`, `products_tried`
+- the router gives conditioner only a small bonus for `protein_moisture_balance`
+- that still leaves the generic conditioner question below the product slot threshold
+
+So the router interprets this as “under-specified” even though the deterministic conditioner profile is already sufficient.
+
+On the later synced-root-main rerun, this prompt still recovered to a usable score and returned strong answers. The fragility remains real, but it is not a reason to exclude conditioner entirely anymore.
+
+## Finding 3: The explicit conditioner chip is no longer weak on current base
+
+For:
+
+- `Welcher Conditioner passt bei Feuchtigkeitsmangel?`
+
+The classifier produced:
+
+- `product_category = conditioner`
+- `normalized_filters.problem = "Feuchtigkeitsmangel"`
+
+Router result:
+
+- `response_mode = answer_direct`
+- `policy_overrides = ["category_product_mode"]`
+
+The assistant returned a direct conditioner recommendation with concrete products.
+
+Implication:
+
+- this prompt was weak in the original matrix because that matrix ran on the stale local root checkout
+- on current `origin/main`, this variant is not the same problem anymore
+
+## Root Cause Summary
+
+There are 2 different issues that were initially collapsed into one:
+
+1. **Stale evaluation branch**
+   - The original bad conditioner results were produced on a local checkout behind `origin/main`.
+   - Router/synthesis behavior has changed since then.
+
+2. **Generic conditioner prompt fragility**
+   - The broad wording `Welcher Conditioner passt gerade am besten zu meinem Haar?` contributes no explicit problem slot.
+   - Router fallback logic still treats it as partially under-specified.
+   - This makes it more fragile than sharper prompts like:
+     - `Welches Shampoo passt zu meinem schnell fettenden Ansatz?`
+     - `Welcher Leave-in passt zu meinem Styling-Alltag?`
+     - `Was hilft bei trockenen Schuppen?`
+
+## Synced Root `main` Rerun
+
+After the root checkout was fast-forwarded to match `origin/main`, the full starter matrix was rerun.
+
+Key ranking changes:
+
+- `Welcher Conditioner passt gerade am besten zu meinem Haar?` moved back into the strong group.
+- `Welcher Conditioner passt bei Feuchtigkeitsmangel?` also stayed usable.
+- `Wie bekomme ich mehr Volumen, ohne zu beschweren?` became the weakest prompt in the matrix.
+
+This changes the product conclusion:
+
+- conditioner is back in play for v1
+- volume is the prompt to treat more cautiously
+
+## Recommendation
+
+For v1 starter chips:
+
+- allow conditioner prompts when the profile already supports them
+- prefer the explicit `Feuchtigkeitsmangel` variant when the balance signal is present
+- keep volume conditional on an explicit volume goal rather than using it as a broad default
+
+For follow-up evaluation:
+
+- watch whether broad conditioner wording still underperforms when `protein_moisture_balance` is missing
+- investigate whether the volume chip can be reframed into a stronger first-turn question
+
+## Candidate Fixes
+
+If we want the broad conditioner starter to become more robust later, likely fixes are:
+
+1. Treat eligible conditioner requests as sufficiently specified even when free-text slots are sparse.
+2. Give conditioner slot completeness credit for:
+   - `thickness`
+   - `protein_moisture_balance`
+   - possibly `density`
+   - category eligibility itself
+3. Narrow conditioner starter copy to explicit need-led variants instead of generic “best conditioner” wording.
+
+## Current Practical Decision
+
+The best v1 call after the synced-main rerun is:
+
+- routine
+- scalp/shampoo
+- care-category prompt chosen between conditioner, leave-in, and mask-vs-leave-in
+- outcome
+
+Conditioner no longer needs to stay out of the default starter set. The more important guardrail now is to avoid surfacing the volume chip unless the profile explicitly points there.

--- a/plans/chat-smart-starters-v1-spec.md
+++ b/plans/chat-smart-starters-v1-spec.md
@@ -1,0 +1,275 @@
+# Chat Smart Starters V1 Spec
+
+> Status: Draft for alignment
+> Scope: Empty-state chat starter chips in `/chat`
+
+## Goal
+
+Replace the current semi-random welcome chips with 4 deterministic, profile-aware starter prompts that:
+
+- feel smarter and more up to date
+- use only quiz/profile/onboarding data
+- steer users toward questions the current engine answers well on the first turn
+- keep the surface copy outcome-led and user-friendly
+
+## Inputs
+
+Use only `hair_profiles` fields already collected in quiz/profile/onboarding:
+
+- `hair_texture`
+- `thickness`
+- `density`
+- `scalp_type`
+- `scalp_condition`
+- `protein_moisture_balance`
+- `cuticle_condition`
+- `chemical_treatment`
+- `wash_frequency`
+- `heat_styling`
+- `goals`
+- `desired_volume`
+- `current_routine_products`
+- `post_wash_actions`
+- `routine_preference`
+
+Do not use:
+
+- prior chat memory
+- conversation history
+- inferred medical context
+
+## Product Constraints
+
+- Show exactly 4 chips.
+- German only.
+- Deterministic output for the same profile.
+- No random shuffle in v1.
+- No medically adjacent default chips such as hair loss or growth.
+- No ingredient-first chips.
+
+## Evaluation Summary
+
+The following candidate prompts were tested as true first-turn messages against representative profiles using the local chat route and the existing quality rubric.
+
+Strong performers:
+
+- `Welche Routine passt am besten zu meinem Haarprofil?`
+- `Welches Shampoo passt zu meinem schnell fettenden Ansatz?`
+- `Welches Shampoo passt zu meiner Kopfhaut?`
+- `Welcher Conditioner passt gerade am besten zu meinem Haar?`
+- `Welcher Conditioner passt bei Feuchtigkeitsmangel?`
+- `Welcher Leave-in passt zu meinem Styling-Alltag?`
+- `Was hilft bei trockenen Schuppen?`
+- `Was hilft gegen Frizz bei meinem Haarprofil?`
+- `Brauche ich eher Maske oder Leave-in für meine Längen?`
+
+- `Wie bekomme ich mehr Volumen, ohne zu beschweren?` remained usable, but was the weakest prompt in the synced-main rerun.
+
+Implication:
+
+- Routine and scalp/shampoo remain the safest default lanes.
+- Conditioner is back in play when the profile already supports it.
+- Leave-in and mask-vs-leave-in stay useful for styling and support-category entry points.
+- Volume should only appear when the profile has an explicit volume signal.
+
+## Final V1 Structure
+
+Always render one chip per lane:
+
+1. Routine lane
+2. Scalp/shampoo lane
+3. Care-category lane
+4. Outcome lane
+
+## Lane 1: Routine
+
+Always present.
+
+Primary copy:
+
+- `Welche Routine passt am besten zu meinem Haarprofil?`
+
+Rationale:
+
+- Most reliable broad entry point
+- Strong first-turn usefulness across very different profiles
+- Gives the system room to use multiple profile signals well
+
+## Lane 2: Scalp/Shampoo
+
+Purpose:
+
+- Convert strong scalp signals into a concrete first-turn question
+- Prefer highly answerable scalp-first prompts over generic product copy
+
+Priority order:
+
+1. If `scalp_condition === dry_flakes`
+   - `Was hilft bei trockenen Schuppen?`
+2. Else if `scalp_condition === irritated`
+   - `Was hilft bei gereizter Kopfhaut?`
+3. Else if `scalp_condition === dandruff`
+   - `Was hilft bei Schuppen?`
+4. Else if `scalp_type === oily`
+   - `Welches Shampoo passt zu meinem schnell fettenden Ansatz?`
+5. Else
+   - `Welches Shampoo passt zu meiner Kopfhaut?`
+
+Rules:
+
+- Prefer problem-led wording over generic recommendation wording when there is a sharp scalp signal.
+- Keep the lane scalp-first, not damage-first.
+
+## Lane 3: Care Category
+
+Purpose:
+
+- Surface the strongest support-category question for this profile without relying on randomness
+
+Priority order:
+
+1. If `protein_moisture_balance === snaps`
+   - `Welcher Conditioner passt bei Feuchtigkeitsmangel?`
+2. Else if the profile suggests active styling fit and already includes conditioner in the routine
+   - `Welcher Leave-in passt zu meinem Styling-Alltag?`
+3. Else if `thickness` and `protein_moisture_balance` are both present
+   - `Welcher Conditioner passt gerade am besten zu meinem Haar?`
+4. Else if the profile suggests active styling fit and leave-in support
+   - `Welcher Leave-in passt zu meinem Styling-Alltag?`
+5. Else if the profile suggests damaged or dry lengths
+   - `Brauche ich eher Maske oder Leave-in für meine Längen?`
+6. Fallback
+   - `Welcher Conditioner passt gerade am besten zu meinem Haar?`
+
+Suggested signal set for `Conditioner passt bei Feuchtigkeitsmangel`:
+
+- `protein_moisture_balance === snaps`
+
+Suggested signal set for `Leave-in passt zu meinem Styling-Alltag`:
+
+- `goals` includes `less_frizz` or `curl_definition`
+- or `concerns` include `frizz`
+- or `heat_styling` is not `never`
+- or `post_wash_actions` include styling after washing
+- or `current_routine_products` already includes `conditioner` and the hair is `wavy|curly|coily`
+
+Suggested signal set for `Maske oder Leave-in für meine Längen`:
+
+- `cuticle_condition` is not `smooth`
+- or `protein_moisture_balance === snaps`
+- or `chemical_treatment` includes `colored` or `bleached`
+- or concerns include `dryness`, `hair_damage`, or `frizz`
+
+Rules:
+
+- Favor the sharpest validated category prompt available for the profile.
+- Use conditioner only when the profile already gives enough support to keep the first answer useful.
+
+## Lane 4: Outcome
+
+Purpose:
+
+- Keep one chip user-outcome-led while still staying inside strong engine territory
+
+Priority order:
+
+1. If `goals` or concerns include `less_frizz` or `frizz`
+   - `Was hilft gegen Frizz bei meinem Haarprofil?`
+2. Else if `desired_volume === more` or `goals` includes `volume`
+   - `Wie bekomme ich mehr Volumen, ohne zu beschweren?`
+3. Else
+   - `Was ist der nächste sinnvolle Schritt für mein Haarprofil?`
+
+Rules:
+
+- Keep this lane advisory, not medical.
+- Prefer benefit-first phrasing.
+- Do not show the volume prompt unless the profile explicitly asks for more volume.
+
+## Copy Rules
+
+Every chip should follow:
+
+- concrete benefit or category
+- slight personalization
+- engine-safe framing
+
+Good examples:
+
+- `Welches Shampoo passt zu meinem schnell fettenden Ansatz?`
+- `Welcher Conditioner passt bei Feuchtigkeitsmangel?`
+- `Welcher Leave-in passt zu meinem Styling-Alltag?`
+- `Was hilft gegen Frizz bei meinem Haarprofil?`
+
+Avoid:
+
+- `Kannst du mir ein gutes Shampoo empfehlen?`
+- `Was hilft wirklich ...`
+- `endlich`
+- `perfekt`
+
+## Excluded From V1
+
+Do not surface these as default starter chips:
+
+- hair loss / growth starters
+- ingredient starters
+- volume prompts without an explicit volume signal
+- broad medical/scalp diagnostic starters beyond the tested dry-flakes wording
+
+## Fallback Set
+
+If the profile is sparse, use:
+
+- `Welche Routine passt am besten zu meinem Haar?`
+- `Welches Shampoo passt zu meiner Kopfhaut?`
+- `Welcher Conditioner passt gerade am besten zu meinem Haar?`
+- `Was hilft gegen Frizz?`
+
+## Subtitle Copy
+
+Replace the current generic subtitle with a line that reflects profile-aware guidance.
+
+Preferred v1 copy:
+
+- `Frag mich nach deiner Routine, passenden Produkten oder dem nächsten sinnvollen Schritt für dein Haarprofil.`
+
+## Implementation Outline
+
+1. Refactor `src/lib/suggested-prompts.ts` into lane-based deterministic generation.
+2. Remove random selection and shuffle behavior in v1.
+3. Introduce explicit lane builders:
+   - `buildRoutinePrompt(profile)`
+   - `buildScalpPrompt(profile)`
+   - `buildLengthsPrompt(profile)`
+   - `buildOutcomePrompt(profile)`
+4. Keep existing icon support, but map icons by lane and selected variant.
+5. Update subtitle copy in `src/components/chat/chat-container.tsx`.
+6. Add tests for representative profile combinations and assert exact prompt sets.
+
+## Verification Cases
+
+At minimum verify:
+
+1. Oily scalp + fine hair + volume
+   - includes routine
+   - includes `Welches Shampoo passt zu meinem schnell fettenden Ansatz?`
+   - includes `Wie bekomme ich mehr Volumen, ohne zu beschweren?`
+2. Dry flakes profile
+   - includes `Was hilft bei trockenen Schuppen?`
+3. Curly/frizz profile
+   - includes `Welcher Leave-in passt zu meinem Styling-Alltag?`
+   - includes `Was hilft gegen Frizz bei meinem Haarprofil?`
+4. Dry/damaged/bleached profile
+   - includes `Welcher Conditioner passt bei Feuchtigkeitsmangel?` when `protein_moisture_balance === snaps`
+   - falls back to `Brauche ich eher Maske oder Leave-in für meine Längen?` when conditioner inputs are missing
+5. Sparse profile
+   - falls back to the generic v1 set
+
+## Open Investigation
+
+The synced-main rerun improved confidence in conditioner starters, but a few follow-ups are still worth tracking:
+
+- classifier category choice on broad conditioner-oriented first turns
+- router missing-slot behavior for conditioner prompts without an explicit need phrase
+- whether the volume prompt can be reframed into a stronger first-turn path without losing the clear user benefit

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -262,7 +262,8 @@ export function ChatContainer() {
                 className="animate-fade-in-up mb-8 max-w-md text-center type-body-sm text-muted-foreground"
                 style={{ animationDelay: "250ms" }}
               >
-                Frag mich alles rund ums Thema Haare — von Pflege-Tipps bis Produktempfehlungen!
+                Frag mich nach deiner Routine, passenden Produkten oder dem nächsten sinnvollen
+                Schritt für dein Haarprofil.
               </p>
               <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
                 {suggestedPrompts.map((prompt, index) => (

--- a/src/lib/suggested-prompts.ts
+++ b/src/lib/suggested-prompts.ts
@@ -1,5 +1,4 @@
-import type { HairProfile, HairTexture, Concern, Goal } from "@/lib/types"
-import { HAIR_TEXTURE_ADJECTIVE, HAIR_THICKNESS_ADJECTIVE } from "@/lib/vocabulary"
+import type { HairProfile, HairTexture, Concern, Goal, RoutineProduct } from "@/lib/types"
 import type { IconName } from "@/components/ui/icon"
 
 export interface SuggestedPrompt {
@@ -8,13 +7,14 @@ export interface SuggestedPrompt {
 }
 
 const FALLBACK_PROMPTS: SuggestedPrompt[] = [
-  { text: "Welche Routine empfiehlst du für lockiges Haar?", icon: "hair-curly" },
-  { text: "Was hilft gegen Spliss?", icon: "goal-split-ends" },
-  { text: "Kannst du mir ein gutes Shampoo empfehlen?", icon: "product-shampoo" },
-  { text: "Wie bekomme ich mehr Volumen?", icon: "goal-volume" },
+  { text: "Welche Routine passt am besten zu meinem Haar?", icon: "product-shampoo" },
+  { text: "Welches Shampoo passt zu meiner Kopfhaut?", icon: "product-shampoo" },
+  {
+    text: "Welcher Conditioner passt gerade am besten zu meinem Haar?",
+    icon: "product-conditioner",
+  },
+  { text: "Was hilft gegen Frizz?", icon: "goal-frizz" },
 ]
-
-/* ── Slot 1: Template prompts (one picked based on available profile data) ── */
 
 const TEXTURE_ICON: Record<HairTexture, IconName> = {
   straight: "hair-straight",
@@ -23,217 +23,197 @@ const TEXTURE_ICON: Record<HairTexture, IconName> = {
   coily: "hair-coily",
 }
 
-function getTemplatePrompts(profile: HairProfile): SuggestedPrompt[] {
-  const prompts: SuggestedPrompt[] = []
-  const ht = profile.hair_texture
-  const tx = profile.thickness
-
-  if (ht && tx) {
-    prompts.push({
-      text: `Welche Pflegeroutine passt am besten zu meinem ${HAIR_TEXTURE_ADJECTIVE[ht]}, ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar?`,
-      icon: TEXTURE_ICON[ht],
-    })
-    prompts.push({
-      text: `Was sind die besten Produkte für ${HAIR_TEXTURE_ADJECTIVE[ht]} und ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar?`,
-      icon: TEXTURE_ICON[ht],
-    })
-  }
-  if (ht) {
-    prompts.push({
-      text: `Welche Pflegeroutine empfiehlst du für ${HAIR_TEXTURE_ADJECTIVE[ht]} Haar?`,
-      icon: TEXTURE_ICON[ht],
-    })
-    prompts.push({
-      text: `Wie style ich ${HAIR_TEXTURE_ADJECTIVE[ht]} Haar am besten?`,
-      icon: TEXTURE_ICON[ht],
-    })
-  }
-  if (tx) {
-    prompts.push({
-      text: `Worauf sollte ich bei ${HAIR_THICKNESS_ADJECTIVE[tx]} Haar besonders achten?`,
-      icon: "product-shampoo",
-    })
-  }
-
-  // Always have at least one generic template
-  prompts.push({
-    text: "Welche Pflegeroutine würdest du mir persönlich empfehlen?",
-    icon: "product-shampoo",
-  })
-
-  return prompts
+function hasTexturedHair(profile: HairProfile): boolean {
+  return (
+    profile.hair_texture === "wavy" ||
+    profile.hair_texture === "curly" ||
+    profile.hair_texture === "coily"
+  )
 }
 
-/* ── Slots 2-4: Pool prompts tagged by concern / goal / hair type ── */
-
-interface PoolPrompt {
-  text: string
-  icon?: IconName
-  concerns?: Concern[]
-  goals?: Goal[]
-  hairTextures?: HairTexture[]
+function hasConcern(profile: HairProfile, concern: Concern): boolean {
+  return (profile.concerns ?? []).includes(concern)
 }
 
-const POOL_PROMPTS: PoolPrompt[] = [
-  // Concern-based
-  {
-    text: "Meine Haare sind so trocken — welche Pflege hilft wirklich?",
-    icon: "goal-moisture",
-    concerns: ["dryness"],
-  },
-  {
-    text: "Was kann ich gegen Spliss an den Spitzen tun?",
-    icon: "goal-split-ends",
-    concerns: ["split_ends"],
-  },
-  {
-    text: "Wie werde ich Schuppen endlich los?",
-    icon: "scalp-dry",
-    concerns: ["dandruff"],
-  },
-  {
-    text: "Meine Kopfhaut fettet so schnell nach — was hilft?",
-    icon: "scalp-oily",
-    concerns: ["oily_scalp"],
-  },
-  {
-    text: "Wie kann ich Haarausfall vorbeugen?",
-    icon: "goal-growth",
-    concerns: ["hair_loss"],
-  },
-  {
-    text: "Mein Haar ist durch Färben strapaziert — wie repariere ich es?",
-    icon: "goal-color-protection",
-    concerns: ["hair_damage", "colored"],
-  },
-  { text: "Was hilft wirklich gegen Frizz?", icon: "goal-frizz", concerns: ["frizz"] },
-  {
-    text: "Mein Haar wird immer dünner — welche Produkte stärken es?",
-    icon: "goal-growth",
-    concerns: ["thinning"],
-  },
-  {
-    text: "Wie schütze ich meine Haarfarbe vor dem Verblassen?",
-    icon: "goal-color-protection",
-    concerns: ["colored"],
-  },
+function hasGoal(profile: HairProfile, goal: Goal): boolean {
+  return (profile.goals ?? []).includes(goal)
+}
 
-  // Goal-based
-  {
-    text: "Wie bekomme ich mehr Volumen in meine Haare?",
-    icon: "goal-volume",
-    goals: ["volume"],
-  },
-  { text: "Was kann ich tun, damit mein Haar schneller wächst?", icon: "goal-growth" },
-  {
-    text: "Wie definiere ich meine Locken am besten?",
-    icon: "hair-curly",
-    goals: ["curl_definition"],
-  },
-  { text: "Welche Produkte sorgen für mehr Glanz?", icon: "goal-shine", goals: ["shine"] },
-  {
-    text: "Wie bringe ich mehr Feuchtigkeit in mein Haar?",
-    icon: "goal-moisture",
-    goals: ["moisture"],
-  },
-  {
-    text: "Was hilft für eine gesunde Kopfhaut?",
-    icon: "goal-scalp-health",
-    goals: ["healthy_scalp"],
-  },
-  {
-    text: "Wie bekomme ich meine Haare gesünder?",
-    icon: "goal-repair",
-    goals: ["healthier_hair"],
-  },
-  { text: "Wie reduziere ich Frizz dauerhaft?", icon: "goal-frizz", goals: ["less_frizz"] },
-  {
-    text: "Wie schütze ich meine Farbe am besten?",
-    icon: "goal-color-protection",
-    goals: ["color_protection"],
-  },
-  {
-    text: "Was hilft wirklich gegen Spliss und abgebrochene Spitzen?",
-    icon: "goal-split-ends",
-    goals: ["less_split_ends"],
-  },
+function hasRoutineProduct(profile: HairProfile, product: RoutineProduct): boolean {
+  return (profile.current_routine_products ?? []).includes(product)
+}
 
-  // Hair-texture-based
-  {
-    text: "Wie style ich Locken ohne Hitze?",
-    icon: "hair-curly",
-    hairTextures: ["curly", "coily"],
-  },
-  {
-    text: "Wie pflege ich welliges Haar, ohne es zu beschweren?",
-    icon: "hair-wavy",
-    hairTextures: ["wavy"],
-  },
-  {
-    text: "Welche Leave-in-Produkte eignen sich für glattes Haar?",
-    icon: "hair-straight",
-    hairTextures: ["straight"],
-  },
-  {
-    text: "Welche Schlafschutz-Routine eignet sich für Locken?",
-    icon: "hair-curly",
-    hairTextures: ["curly", "coily"],
-  },
-]
+function hasMeaningfulProfile(profile: HairProfile | null): profile is HairProfile {
+  if (!profile) return false
 
-function shuffle<T>(arr: T[]): T[] {
-  const a = [...arr]
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[a[i], a[j]] = [a[j], a[i]]
+  return Boolean(
+    profile.hair_texture ||
+    profile.thickness ||
+    profile.density ||
+    profile.scalp_type ||
+    (profile.scalp_condition && profile.scalp_condition !== "none") ||
+    profile.protein_moisture_balance ||
+    profile.cuticle_condition ||
+    profile.wash_frequency ||
+    profile.heat_styling ||
+    profile.desired_volume ||
+    profile.routine_preference ||
+    (profile.concerns ?? []).length > 0 ||
+    (profile.goals ?? []).length > 0 ||
+    (profile.chemical_treatment ?? []).length > 0 ||
+    (profile.current_routine_products ?? []).length > 0 ||
+    (profile.post_wash_actions ?? []).length > 0,
+  )
+}
+
+function hasHeatOrStylingSignal(profile: HairProfile): boolean {
+  return Boolean(
+    (profile.heat_styling && profile.heat_styling !== "never") ||
+    (profile.post_wash_actions ?? []).includes("heat_tool_styling") ||
+    (profile.post_wash_actions ?? []).includes("non_heat_styling") ||
+    (profile.styling_tools ?? []).length > 0 ||
+    hasRoutineProduct(profile, "heat_protectant"),
+  )
+}
+
+function hasLeaveInSignals(profile: HairProfile): boolean {
+  return Boolean(
+    hasHeatOrStylingSignal(profile) ||
+    hasRoutineProduct(profile, "leave_in") ||
+    hasGoal(profile, "less_frizz") ||
+    hasGoal(profile, "curl_definition") ||
+    hasConcern(profile, "frizz"),
+  )
+}
+
+function hasDamageSignals(profile: HairProfile): boolean {
+  return Boolean(
+    profile.cuticle_condition === "slightly_rough" ||
+    profile.cuticle_condition === "rough" ||
+    profile.protein_moisture_balance === "snaps" ||
+    hasConcern(profile, "dryness") ||
+    hasConcern(profile, "hair_damage") ||
+    hasConcern(profile, "split_ends") ||
+    hasGoal(profile, "moisture") ||
+    hasGoal(profile, "anti_breakage") ||
+    profile.chemical_treatment.includes("colored") ||
+    profile.chemical_treatment.includes("bleached"),
+  )
+}
+
+function buildRoutinePrompt(profile: HairProfile): SuggestedPrompt {
+  return {
+    text: "Welche Routine passt am besten zu meinem Haarprofil?",
+    icon: profile.hair_texture ? TEXTURE_ICON[profile.hair_texture] : "product-shampoo",
   }
-  return a
 }
 
-function matchesProfile(prompt: PoolPrompt, profile: HairProfile): boolean {
-  const concerns = profile.concerns ?? []
-  const goals = profile.goals ?? []
-  const ht = profile.hair_texture
+function buildScalpPrompt(profile: HairProfile): SuggestedPrompt {
+  if (profile.scalp_condition === "dry_flakes") {
+    return { text: "Was hilft bei trockenen Schuppen?", icon: "scalp-dry-flakes" }
+  }
 
-  if (prompt.concerns?.some((c) => concerns.includes(c))) return true
-  if (prompt.goals?.some((g) => goals.includes(g))) return true
-  if (prompt.hairTextures && ht && prompt.hairTextures.includes(ht)) return true
+  if (profile.scalp_condition === "irritated") {
+    return { text: "Was hilft bei gereizter Kopfhaut?", icon: "scalp-irritated" }
+  }
 
-  return false
-}
+  if (profile.scalp_condition === "dandruff" || hasConcern(profile, "dandruff")) {
+    return { text: "Was hilft bei Schuppen?", icon: "scalp-flaky" }
+  }
 
-/* ── Main export ── */
-
-export function generateSuggestedPrompts(profile: HairProfile | null): SuggestedPrompt[] {
   if (
-    !profile ||
-    (!profile.hair_texture &&
-      !profile.thickness &&
-      (profile.concerns ?? []).length === 0 &&
-      (profile.goals ?? []).length === 0)
+    profile.scalp_type === "oily" ||
+    hasConcern(profile, "oily_scalp") ||
+    profile.wash_frequency === "daily"
   ) {
-    return FALLBACK_PROMPTS
-  }
-
-  // Slot 1: pick one random template prompt
-  const templates = getTemplatePrompts(profile)
-  const template = templates[Math.floor(Math.random() * templates.length)]
-
-  // Slots 2-4: pick 3 from the filtered pool
-  const matched = POOL_PROMPTS.filter((p) => matchesProfile(p, profile))
-  const pool = matched.length >= 3 ? matched : [...matched, ...POOL_PROMPTS]
-  const unique = shuffle(pool).filter((p) => p.text !== template.text)
-
-  // Deduplicate
-  const seen = new Set<string>([template.text])
-  const picked: SuggestedPrompt[] = []
-  for (const p of unique) {
-    if (picked.length >= 3) break
-    if (!seen.has(p.text)) {
-      seen.add(p.text)
-      picked.push({ text: p.text, icon: p.icon })
+    return {
+      text: "Welches Shampoo passt zu meinem schnell fettenden Ansatz?",
+      icon: "scalp-oily",
     }
   }
 
-  return [template, ...picked]
+  return {
+    text: "Welches Shampoo passt zu meiner Kopfhaut?",
+    icon: profile.scalp_type === "dry" ? "scalp-dry" : "product-shampoo",
+  }
+}
+
+function buildCarePrompt(profile: HairProfile): SuggestedPrompt {
+  if (profile.protein_moisture_balance === "snaps") {
+    return {
+      text: "Welcher Conditioner passt bei Feuchtigkeitsmangel?",
+      icon: "goal-moisture",
+    }
+  }
+
+  if (
+    hasRoutineProduct(profile, "conditioner") &&
+    (hasLeaveInSignals(profile) || hasTexturedHair(profile))
+  ) {
+    return {
+      text: "Welcher Leave-in passt zu meinem Styling-Alltag?",
+      icon: "product-leave-in",
+    }
+  }
+
+  if (profile.thickness && profile.protein_moisture_balance) {
+    return {
+      text: "Welcher Conditioner passt gerade am besten zu meinem Haar?",
+      icon: "product-conditioner",
+    }
+  }
+
+  if (hasLeaveInSignals(profile)) {
+    return {
+      text: "Welcher Leave-in passt zu meinem Styling-Alltag?",
+      icon: "product-leave-in",
+    }
+  }
+
+  if (hasDamageSignals(profile)) {
+    return {
+      text: "Brauche ich eher Maske oder Leave-in für meine Längen?",
+      icon: "product-mask",
+    }
+  }
+
+  return {
+    text: "Welcher Conditioner passt gerade am besten zu meinem Haar?",
+    icon: "product-conditioner",
+  }
+}
+
+function buildOutcomePrompt(profile: HairProfile): SuggestedPrompt {
+  if (hasConcern(profile, "frizz") || hasGoal(profile, "less_frizz")) {
+    return { text: "Was hilft gegen Frizz bei meinem Haarprofil?", icon: "goal-frizz" }
+  }
+
+  if (profile.desired_volume === "more" || hasGoal(profile, "volume")) {
+    return {
+      text: "Wie bekomme ich mehr Volumen, ohne zu beschweren?",
+      icon: "goal-volume",
+    }
+  }
+
+  if (hasTexturedHair(profile) && hasDamageSignals(profile)) {
+    return { text: "Was hilft gegen Frizz bei meinem Haarprofil?", icon: "goal-frizz" }
+  }
+
+  return {
+    text: "Was ist der nächste sinnvolle Schritt für mein Haarprofil?",
+    icon: "arrow-right",
+  }
+}
+
+export function generateSuggestedPrompts(profile: HairProfile | null): SuggestedPrompt[] {
+  if (!hasMeaningfulProfile(profile)) {
+    return FALLBACK_PROMPTS
+  }
+
+  return [
+    buildRoutinePrompt(profile),
+    buildScalpPrompt(profile),
+    buildCarePrompt(profile),
+    buildOutcomePrompt(profile),
+  ]
 }

--- a/tests/suggested-prompts.test.ts
+++ b/tests/suggested-prompts.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { generateSuggestedPrompts } from "../src/lib/suggested-prompts"
+import type { HairProfile } from "../src/lib/types"
+
+function makeProfile(overrides: Partial<HairProfile> = {}): HairProfile {
+  return {
+    id: "hp_test",
+    user_id: "user_test",
+    hair_texture: null,
+    thickness: null,
+    density: null,
+    concerns: [],
+    products_used: null,
+    wash_frequency: null,
+    heat_styling: null,
+    styling_tools: [],
+    goals: [],
+    cuticle_condition: null,
+    protein_moisture_balance: null,
+    scalp_type: null,
+    scalp_condition: null,
+    chemical_treatment: [],
+    desired_volume: null,
+    post_wash_actions: [],
+    routine_preference: null,
+    current_routine_products: [],
+    mechanical_stress_factors: [],
+    towel_material: null,
+    towel_technique: null,
+    drying_method: [],
+    brush_type: null,
+    night_protection: [],
+    uses_heat_protection: false,
+    additional_notes: null,
+    conversation_memory: null,
+    created_at: "2026-04-16T00:00:00.000Z",
+    updated_at: "2026-04-16T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+test("returns the generic fallback set when there is no usable profile", () => {
+  assert.deepEqual(
+    generateSuggestedPrompts(null).map((prompt) => prompt.text),
+    [
+      "Welche Routine passt am besten zu meinem Haar?",
+      "Welches Shampoo passt zu meiner Kopfhaut?",
+      "Welcher Conditioner passt gerade am besten zu meinem Haar?",
+      "Was hilft gegen Frizz?",
+    ],
+  )
+})
+
+test("uses the synced-main winners for oily scalp and explicit volume goals", () => {
+  const profile = makeProfile({
+    thickness: "fine",
+    scalp_type: "oily",
+    protein_moisture_balance: "stretches_bounces",
+    desired_volume: "more",
+    goals: ["volume"],
+  })
+
+  assert.deepEqual(
+    generateSuggestedPrompts(profile).map((prompt) => prompt.text),
+    [
+      "Welche Routine passt am besten zu meinem Haarprofil?",
+      "Welches Shampoo passt zu meinem schnell fettenden Ansatz?",
+      "Welcher Conditioner passt gerade am besten zu meinem Haar?",
+      "Wie bekomme ich mehr Volumen, ohne zu beschweren?",
+    ],
+  )
+})
+
+test("keeps an explicit volume chip even when texture and damage would otherwise imply frizz", () => {
+  const profile = makeProfile({
+    hair_texture: "wavy",
+    thickness: "fine",
+    cuticle_condition: "rough",
+    desired_volume: "more",
+    goals: ["volume"],
+  })
+
+  assert.deepEqual(
+    generateSuggestedPrompts(profile).map((prompt) => prompt.text),
+    [
+      "Welche Routine passt am besten zu meinem Haarprofil?",
+      "Welches Shampoo passt zu meiner Kopfhaut?",
+      "Brauche ich eher Maske oder Leave-in für meine Längen?",
+      "Wie bekomme ich mehr Volumen, ohne zu beschweren?",
+    ],
+  )
+})
+
+test("prefers leave-in plus frizz when the profile points to styling support", () => {
+  const profile = makeProfile({
+    hair_texture: "wavy",
+    thickness: "normal",
+    scalp_type: "balanced",
+    heat_styling: "several_weekly",
+    concerns: ["frizz"],
+    goals: ["less_frizz"],
+    current_routine_products: ["conditioner"],
+  })
+
+  assert.deepEqual(
+    generateSuggestedPrompts(profile).map((prompt) => prompt.text),
+    [
+      "Welche Routine passt am besten zu meinem Haarprofil?",
+      "Welches Shampoo passt zu meiner Kopfhaut?",
+      "Welcher Leave-in passt zu meinem Styling-Alltag?",
+      "Was hilft gegen Frizz bei meinem Haarprofil?",
+    ],
+  )
+})
+
+test("reintroduces conditioner for explicit moisture-balance signals", () => {
+  const profile = makeProfile({
+    scalp_condition: "dry_flakes",
+    protein_moisture_balance: "snaps",
+    cuticle_condition: "rough",
+    concerns: ["dryness", "hair_damage"],
+    chemical_treatment: ["bleached"],
+  })
+
+  assert.deepEqual(
+    generateSuggestedPrompts(profile).map((prompt) => prompt.text),
+    [
+      "Welche Routine passt am besten zu meinem Haarprofil?",
+      "Was hilft bei trockenen Schuppen?",
+      "Welcher Conditioner passt bei Feuchtigkeitsmangel?",
+      "Was ist der nächste sinnvolle Schritt für mein Haarprofil?",
+    ],
+  )
+})
+
+test("falls back to mask versus leave-in when damage is present but conditioner inputs are missing", () => {
+  const profile = makeProfile({
+    scalp_type: "dry",
+    cuticle_condition: "rough",
+    concerns: ["dryness", "hair_damage"],
+    chemical_treatment: ["colored"],
+  })
+
+  assert.deepEqual(
+    generateSuggestedPrompts(profile).map((prompt) => prompt.text),
+    [
+      "Welche Routine passt am besten zu meinem Haarprofil?",
+      "Welches Shampoo passt zu meiner Kopfhaut?",
+      "Brauche ich eher Maske oder Leave-in für meine Längen?",
+      "Was ist der nächste sinnvolle Schritt für mein Haarprofil?",
+    ],
+  )
+})


### PR DESCRIPTION
## What changed
- replaced the random chat starter prompt generator with deterministic, profile-aware lanes
- reintroduced conditioner starters when profile signals support them, while keeping volume conditional on explicit volume goals
- updated the empty-state subtitle to match the smarter starter behavior
- added focused tests for fallback, scalp, conditioner, leave-in, mask-vs-leave-in, and explicit-volume edge cases
- documented the validated v1 spec and investigation notes for the prompt rerun

## Why
The previous starter chips were lightly personalized and partly random, so they could surface weaker questions even when the profile already contained stronger recommendation signals. The synced-main prompt rerun showed conditioner was back in play, while volume needed to be more conservative.

## Review note
An independent sub-agent review caught one prioritization issue: textured hair alone was making the leave-in chip win too early. This PR fixes that by requiring a real styling or routine signal before leave-in overrides the mask-vs-leave-in path.

## Validation
- `node --import tsx --test tests/suggested-prompts.test.ts`
- `npm run typecheck`
- commit hooks: `eslint --fix`, `prettier --write`, `tsc --noEmit`