### PR TITLE
[codex] Align profile editing with onboarding flow

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,9 +3,63 @@ import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { OnboardingFlow } from "@/components/onboarding/onboarding-flow"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
+import { getOnboardingEditScope, type OnboardingStep } from "@/lib/onboarding/store"
 
 interface OnboardingPageProps {
-  searchParams: Promise<{ lead?: string | string[] }>
+  searchParams: Promise<{
+    lead?: string | string[]
+    step?: string | string[]
+    returnTo?: string | string[]
+    category?: string | string[]
+    editMode?: string | string[]
+  }>
+}
+
+const VALID_ONBOARDING_STEPS = new Set<OnboardingStep>([
+  "welcome",
+  "products_basics",
+  "products_extras",
+  "product_drilldown",
+  "heat_tools",
+  "heat_frequency",
+  "heat_protection",
+  "interstitial",
+  "towel_material",
+  "towel_technique",
+  "drying_method",
+  "brush_type",
+  "night_protection",
+  "goals",
+  "celebration",
+])
+
+function resolveOnboardingStep(value: string | string[] | undefined): OnboardingStep | null {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (!candidate || !VALID_ONBOARDING_STEPS.has(candidate as OnboardingStep)) {
+    return null
+  }
+  return candidate as OnboardingStep
+}
+
+function resolveReturnTo(value: string | string[] | undefined): string | null {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (!candidate || !candidate.startsWith("/")) {
+    return null
+  }
+  return candidate
+}
+
+function resolveDrilldownCategory(value: string | string[] | undefined): string | null {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (!candidate?.trim()) {
+    return null
+  }
+  return candidate.trim()
+}
+
+function resolveSingleStepEdit(value: string | string[] | undefined) {
+  const candidate = Array.isArray(value) ? value[0] : value
+  return candidate === "single-step"
 }
 
 export default async function OnboardingPage({ searchParams }: OnboardingPageProps) {
@@ -15,8 +69,16 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
   const leadId = Array.isArray(resolvedSearchParams.lead)
     ? resolvedSearchParams.lead[0]
     : resolvedSearchParams.lead
+  const forcedStep = resolveOnboardingStep(resolvedSearchParams.step)
+  const returnTo = resolveReturnTo(resolvedSearchParams.returnTo)
+  const initialDrilldownCategory = resolveDrilldownCategory(resolvedSearchParams.category)
+  const singleStepEdit = resolveSingleStepEdit(resolvedSearchParams.editMode)
+  const editScope =
+    returnTo && forcedStep && !singleStepEdit ? getOnboardingEditScope(forcedStep) : null
 
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) {
     redirect("/auth?next=/onboarding")
   }
@@ -38,8 +100,8 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
     .single()
 
   // If already completed, redirect to chat
-  if (profileRow?.onboarding_completed) {
-    redirect("/chat")
+  if (profileRow?.onboarding_completed && !forcedStep) {
+    redirect(returnTo ?? "/chat")
   }
 
   // Fetch hair profile for pre-filling
@@ -58,9 +120,15 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
   return (
     <OnboardingFlow
       userId={user.id}
-      initialStep={(profileRow?.onboarding_step as string) ?? "welcome"}
+      initialStep={forcedStep ?? (profileRow?.onboarding_step as string) ?? "welcome"}
       hairProfile={hairProfile}
       productUsage={productUsage ?? []}
+      returnTo={returnTo}
+      editScope={editScope}
+      singleStepEdit={singleStepEdit}
+      initialDrilldownCategory={
+        forcedStep === "product_drilldown" ? initialDrilldownCategory : null
+      }
     />
   )
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,168 +1,312 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { useRouter } from "next/navigation"
 import { Header } from "@/components/layout/header"
-import { useAuth } from "@/providers/auth-provider"
-import { useToast } from "@/providers/toast-provider"
-import { createClient } from "@/lib/supabase/client"
-import {
-  CONCERN_OPTIONS,
-
-  GOAL_OPTIONS,
-  HEAT_STYLING_OPTIONS,
-  POST_WASH_ACTION_OPTIONS,
-  ROUTINE_PRODUCT_OPTIONS,
-  STYLING_TOOL_OPTIONS,
-  WASH_FREQUENCY_OPTIONS,
-} from "@/lib/types"
-import type { Goal, HairProfile, UserMemoryEntry } from "@/lib/types"
-import {
-  fehler,
-  BRUSH_TYPE_OPTIONS,
-  DRYING_METHOD_OPTIONS,
-  NIGHT_PROTECTION_OPTIONS,
-  TOWEL_MATERIAL_OPTIONS,
-  TOWEL_TECHNIQUE_OPTIONS,
-} from "@/lib/vocabulary"
-import { deriveVolumeFromGoals } from "@/lib/onboarding/goal-flow"
-import {
-  PROFILE_FIELD_CONFIG,
-  PROFILE_JOURNEY_STEPS,
-  PROFILE_SECTION_META,
-  type ProfileFieldConfig,
-  type ProfileFieldValue,
-} from "@/lib/profile/section-config"
-import { cn } from "@/lib/utils"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Skeleton } from "@/components/ui/skeleton"
 import { SegmentedControl } from "@/components/ui/segmented-control"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { PRODUCT_CATEGORY_LABELS, PRODUCT_CATEGORY_ORDER } from "@/lib/onboarding/product-options"
+import type { OnboardingStep } from "@/lib/onboarding/store"
+import {
+  PROFILE_FIELD_CONFIG,
+  PROFILE_SECTION_META,
+  type ProfileEditTarget,
+  type ProfileFieldConfig,
+  type ProfileFieldDisplayMode,
+  type ProfileFieldValue,
+  type ProfileJourneySectionKey,
+} from "@/lib/profile/section-config"
+import { createClient } from "@/lib/supabase/client"
+import type { ChemicalTreatment, HairProfile, UserMemoryEntry } from "@/lib/types"
+import {
+  CHEMICAL_TREATMENT_LABELS,
+  HAIR_TEXTURE_OPTIONS,
+  HAIR_THICKNESS_OPTIONS,
+  SCALP_CONDITION_LABELS,
+  SCALP_TYPE_LABELS,
+} from "@/lib/types"
+import { PRODUCT_FREQUENCY_LABELS, type ProductFrequency, fehler } from "@/lib/vocabulary"
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/providers/auth-provider"
+import { useToast } from "@/providers/toast-provider"
 
 type MemoryApiResponse = {
   settings: { memory_enabled: boolean }
   entries: UserMemoryEntry[]
 }
 
-type ProfileFormData = {
-  hair_texture: string
-  thickness: string
-  density: string
-  concerns: string[]
-  desired_volume: string
-  wash_frequency: string
-  heat_styling: string
-  styling_tools: string[]
-  towel_material: string
-  towel_technique: string
-  drying_method: string[]
-  brush_type: string
-  night_protection: string[]
-  uses_heat_protection: boolean
-  post_wash_actions: string[]
-  current_routine_products: string[]
-  products_used: string
-  goals: string[]
-  additional_notes: string
+type UserProductUsageRow = {
+  id: string
+  category: string
+  product_name: string | null
+  frequency_range: ProductFrequency | null
 }
 
 type StructuredField = ProfileFieldConfig & { value: ProfileFieldValue }
 
-const EDITABLE_GOAL_OPTIONS = GOAL_OPTIONS
+type JourneyField = {
+  key: string
+  label: string
+  helpText: string
+  displayMode: ProfileFieldDisplayMode
+  value: ProfileFieldValue
+  editTarget: ProfileEditTarget | null
+}
 
-const HEAT_PROTECTION_OPTIONS = [
-  { value: "yes", label: "Ja" },
-  { value: "no", label: "Nein" },
+type ProductDetailRow = {
+  key: string
+  category: string
+  categoryLabel: string
+  productName: string | null
+  frequencyLabel: string | null
+  isComplete: boolean
+}
+
+type QuizDraft = {
+  hair_texture: string
+  thickness: string
+  cuticle_condition: string
+  protein_moisture_balance: string
+  scalp_type: string
+  scalp_condition: string
+  chemical_treatment: ChemicalTreatment[]
+}
+
+type QuizSaveNotice =
+  | { variant: "success"; title: string; description: string }
+  | { variant: "error"; title: string; description: string }
+
+const SECTION_META_BY_KEY = Object.fromEntries(
+  PROFILE_SECTION_META.map((meta) => [meta.key, meta]),
+) as Record<ProfileJourneySectionKey, (typeof PROFILE_SECTION_META)[number]>
+
+const PRODUCT_ORDER_INDEX = new Map(
+  PRODUCT_CATEGORY_ORDER.map((category, index) => [category, index]),
+)
+
+const QUIZ_SURFACE_OPTIONS = [
+  { value: "smooth", label: "Glatt wie Glas" },
+  { value: "slightly_rough", label: "Leicht uneben" },
+  { value: "rough", label: "Rau und huckelig" },
 ]
 
-const ROUTINE_DETAIL_FIELD_KEYS = new Set([
-  "styling_tools",
-  "towel_material",
-  "towel_technique",
-  "drying_method",
-  "brush_type",
-  "night_protection",
-  "post_wash_actions",
-  "current_routine_products",
-  "products_used",
-  "additional_notes",
-])
+const QUIZ_ELASTICITY_OPTIONS = [
+  { value: "stretches_bounces", label: "Dehnt sich und geht zurück" },
+  { value: "stretches_stays", label: "Dehnt sich, bleibt ausgeleiert" },
+  { value: "snaps", label: "Reißt sofort" },
+]
 
-function createFormData(profile: HairProfile | null): ProfileFormData {
-  const storedGoals = profile?.goals ?? []
+const QUIZ_SCALP_TYPE_OPTIONS = [
+  { value: "oily", label: SCALP_TYPE_LABELS.oily },
+  { value: "balanced", label: SCALP_TYPE_LABELS.balanced },
+  { value: "dry", label: SCALP_TYPE_LABELS.dry },
+]
 
+const QUIZ_SCALP_CONDITION_OPTIONS = [
+  { value: "none", label: SCALP_CONDITION_LABELS.none },
+  { value: "dandruff", label: SCALP_CONDITION_LABELS.dandruff },
+  { value: "dry_flakes", label: SCALP_CONDITION_LABELS.dry_flakes },
+  { value: "irritated", label: SCALP_CONDITION_LABELS.irritated },
+]
+
+const QUIZ_CHEMICAL_TREATMENT_OPTIONS: Array<{ value: ChemicalTreatment; label: string }> = [
+  { value: "natural", label: CHEMICAL_TREATMENT_LABELS.natural },
+  { value: "colored", label: CHEMICAL_TREATMENT_LABELS.colored },
+  { value: "bleached", label: CHEMICAL_TREATMENT_LABELS.bleached },
+]
+
+function buildOnboardingHref(
+  step: OnboardingStep,
+  options?: { category?: string | null; singleStep?: boolean },
+) {
+  const params = new URLSearchParams({
+    step,
+    returnTo: "/profile",
+  })
+
+  if (options?.category) {
+    params.set("category", options.category)
+  }
+
+  if (options?.singleStep) {
+    params.set("editMode", "single-step")
+  }
+
+  return `/onboarding?${params.toString()}`
+}
+
+function getFieldActionLabel(target: ProfileEditTarget | null) {
+  if (!target) return undefined
+  return "Bearbeiten"
+}
+
+function createQuizDraft(profile: HairProfile | null): QuizDraft {
   return {
-    hair_texture: profile?.hair_texture || "",
-    thickness: profile?.thickness || "",
-    density: profile?.density || "",
-    concerns: profile?.concerns || [],
-    desired_volume: profile?.desired_volume || "",
-    wash_frequency: profile?.wash_frequency || "",
-    heat_styling: profile?.heat_styling || "",
-    styling_tools: profile?.styling_tools || [],
-    towel_material: profile?.towel_material || "",
-    towel_technique: profile?.towel_technique || "",
-    drying_method: profile?.drying_method || [],
-    brush_type: profile?.brush_type || "",
-    night_protection: profile?.night_protection || [],
-    uses_heat_protection: profile?.uses_heat_protection ?? false,
-    post_wash_actions: profile?.post_wash_actions || [],
-    current_routine_products: profile?.current_routine_products || [],
-    products_used: profile?.products_used || "",
-    goals: storedGoals,
-    additional_notes: profile?.additional_notes || "",
+    hair_texture: profile?.hair_texture ?? "",
+    thickness: profile?.thickness ?? "",
+    cuticle_condition: profile?.cuticle_condition ?? "",
+    protein_moisture_balance: profile?.protein_moisture_balance ?? "",
+    scalp_type: profile?.scalp_type ?? "",
+    scalp_condition: profile?.scalp_condition ?? "",
+    chemical_treatment: profile?.chemical_treatment ?? [],
   }
 }
 
-function toggleArrayItem(items: string[], item: string) {
-  return items.includes(item) ? items.filter((entry) => entry !== item) : [...items, item]
+function createLocalHairProfile(
+  currentProfile: HairProfile | null,
+  userId: string,
+  fields: Partial<HairProfile>,
+): HairProfile {
+  const now = fields.updated_at ?? new Date().toISOString()
+
+  return {
+    id: currentProfile?.id ?? `local-${userId}`,
+    user_id: userId,
+    hair_texture: currentProfile?.hair_texture ?? null,
+    thickness: currentProfile?.thickness ?? null,
+    density: currentProfile?.density ?? null,
+    concerns: currentProfile?.concerns ?? [],
+    products_used: currentProfile?.products_used ?? null,
+    wash_frequency: currentProfile?.wash_frequency ?? null,
+    heat_styling: currentProfile?.heat_styling ?? null,
+    styling_tools: currentProfile?.styling_tools ?? [],
+    goals: currentProfile?.goals ?? [],
+    cuticle_condition: currentProfile?.cuticle_condition ?? null,
+    protein_moisture_balance: currentProfile?.protein_moisture_balance ?? null,
+    scalp_type: currentProfile?.scalp_type ?? null,
+    scalp_condition: currentProfile?.scalp_condition ?? null,
+    chemical_treatment: currentProfile?.chemical_treatment ?? [],
+    desired_volume: currentProfile?.desired_volume ?? null,
+    post_wash_actions: currentProfile?.post_wash_actions ?? [],
+    routine_preference: currentProfile?.routine_preference ?? null,
+    current_routine_products: currentProfile?.current_routine_products ?? [],
+    mechanical_stress_factors: currentProfile?.mechanical_stress_factors ?? [],
+    towel_material: currentProfile?.towel_material ?? null,
+    towel_technique: currentProfile?.towel_technique ?? null,
+    drying_method: currentProfile?.drying_method ?? [],
+    brush_type: currentProfile?.brush_type ?? null,
+    night_protection: currentProfile?.night_protection ?? [],
+    uses_heat_protection: currentProfile?.uses_heat_protection ?? false,
+    additional_notes: currentProfile?.additional_notes ?? null,
+    conversation_memory: currentProfile?.conversation_memory ?? null,
+    created_at: currentProfile?.created_at ?? now,
+    updated_at: now,
+    ...fields,
+  }
 }
 
-function SourceBadge({ label }: { label: StructuredField["sourceLabel"] }) {
+function toggleChemicalTreatment(
+  currentValues: ChemicalTreatment[],
+  treatment: ChemicalTreatment,
+): ChemicalTreatment[] {
+  if (treatment === "natural") {
+    return currentValues.includes("natural") ? [] : ["natural"]
+  }
+
+  const withoutNatural = currentValues.filter((value) => value !== "natural")
+
+  if (withoutNatural.includes(treatment)) {
+    return withoutNatural.filter((value) => value !== treatment)
+  }
+
+  return [...withoutNatural, treatment]
+}
+
+function createProductRows(rows: UserProductUsageRow[]): ProductDetailRow[] {
+  return [...rows]
+    .sort((left, right) => {
+      const leftIndex = PRODUCT_ORDER_INDEX.get(left.category) ?? Number.MAX_SAFE_INTEGER
+      const rightIndex = PRODUCT_ORDER_INDEX.get(right.category) ?? Number.MAX_SAFE_INTEGER
+      return leftIndex - rightIndex
+    })
+    .map((row) => {
+      const productName = row.product_name?.trim() || null
+      const frequencyLabel = row.frequency_range
+        ? PRODUCT_FREQUENCY_LABELS[row.frequency_range]
+        : null
+
+      return {
+        key: row.id,
+        category: row.category,
+        categoryLabel: PRODUCT_CATEGORY_LABELS[row.category] ?? row.category,
+        productName,
+        frequencyLabel,
+        isComplete: Boolean(productName && frequencyLabel),
+      }
+    })
+}
+
+function getCompletionLabel(filled: number, total: number) {
+  if (total === 0 || filled === 0) return "Offen"
+  return `${filled}/${total} vollständig`
+}
+
+function getProductCompletionLabel(rows: ProductDetailRow[], onboardingCompleted: boolean) {
+  if (rows.length === 0) {
+    return onboardingCompleted ? "Noch leer" : "Offen"
+  }
+
+  const completeCount = rows.filter((row) => row.isComplete).length
+  return `${completeCount}/${rows.length} vollständig`
+}
+
+function getOpenItemsTitle(count: number, singular: string, plural: string) {
+  const label = count === 1 ? singular : plural
+  return `Noch ${count} ${label} offen`
+}
+
+function SectionStatusBadge({ label }: { label: string }) {
   return (
     <Badge
       variant="outline"
-      className="border-primary/15 bg-muted/60 px-2 py-1 text-[10px] font-medium tracking-[0.12em] text-muted-foreground uppercase"
+      className="border-primary/15 bg-primary/[0.05] px-3 py-1 text-xs font-medium text-primary"
     >
       {label}
     </Badge>
   )
 }
 
-function JourneyStepCard({
-  label,
+function SectionHeader({
+  title,
+  description,
   status,
-  summary,
-  active,
+  action,
 }: {
-  label: string
+  title: string
+  description: string
   status: string
-  summary: string
-  active: boolean
+  action?: ReactNode
 }) {
   return (
-    <div
-      className={cn(
-        "rounded-xl border p-4 transition-colors",
-        active ? "border-primary/20 bg-primary/[0.06]" : "border-border bg-card/70",
-      )}
-    >
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <p className="text-sm font-semibold text-[var(--text-heading)]">{label}</p>
-        <span
-          className={cn(
-            "inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold",
-            active ? "bg-primary/12 text-primary" : "bg-muted text-muted-foreground",
-          )}
-        >
-          {status}
-        </span>
+    <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+      <div>
+        <div className="flex flex-wrap items-center gap-3">
+          <CardTitle className="text-xl text-[var(--text-heading)]">{title}</CardTitle>
+          <SectionStatusBadge label={status} />
+        </div>
+        <CardDescription className="mt-2 max-w-2xl text-sm">{description}</CardDescription>
       </div>
-      <p className="text-sm text-muted-foreground">{summary}</p>
+      {action}
+    </div>
+  )
+}
+
+function SectionGridSkeleton({ count, className }: { count: number; className?: string }) {
+  return (
+    <div className={cn("grid gap-4", className)}>
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={index} className="rounded-xl border border-border/70 bg-card/70 p-4">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="mt-2 h-3 w-48" />
+          <Skeleton className="mt-5 h-8 w-full" />
+        </div>
+      ))}
     </div>
   )
 }
@@ -172,11 +316,13 @@ function ProfileFieldCard({
   children,
   onClick,
   actionLabel,
+  className,
 }: {
-  field: StructuredField
-  children?: React.ReactNode
+  field: JourneyField
+  children?: ReactNode
   onClick?: () => void
   actionLabel?: string
+  className?: string
 }) {
   const interactive = Boolean(onClick)
 
@@ -200,14 +346,12 @@ function ProfileFieldCard({
         interactive
           ? "cursor-pointer hover:border-primary/30 hover:bg-primary/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           : "",
+        className,
       )}
     >
-      <div className="mb-3 flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-[var(--text-heading)]">{field.label}</p>
-          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{field.helpText}</p>
-        </div>
-        <SourceBadge label={field.sourceLabel} />
+      <div className="mb-3 min-w-0">
+        <p className="text-sm font-semibold text-[var(--text-heading)]">{field.label}</p>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{field.helpText}</p>
       </div>
 
       {children ?? <ProfileFieldValue value={field.value} displayMode={field.displayMode} />}
@@ -227,7 +371,7 @@ function ProfileFieldValue({
   displayMode,
 }: {
   value: ProfileFieldValue
-  displayMode: StructuredField["displayMode"]
+  displayMode: ProfileFieldDisplayMode
 }) {
   if (value == null) {
     return <p className="text-sm text-muted-foreground">Noch offen</p>
@@ -261,7 +405,7 @@ function InlinePromptCard({
 }: {
   title: string
   text: string
-  action?: React.ReactNode
+  action?: ReactNode
 }) {
   return (
     <div className="rounded-xl border border-dashed border-border bg-muted/40 p-4">
@@ -272,18 +416,43 @@ function InlinePromptCard({
   )
 }
 
+function QuizEditorField({
+  title,
+  text,
+  children,
+  className,
+}: {
+  title: string
+  text: string
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn("rounded-xl border border-border/80 bg-card/80 p-4", className)}>
+      <p className="text-sm font-semibold text-[var(--text-heading)]">{title}</p>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{text}</p>
+      <div className="mt-4">{children}</div>
+    </div>
+  )
+}
+
 export default function ProfilePage() {
   const router = useRouter()
-  const { user, profile, loading: authLoading, signOut } = useAuth()
+  const { user, profile, loading: authLoading } = useAuth()
   const { toast } = useToast()
-  const supabase = createClient()
+  const supabase = useMemo(() => createClient(), [])
+  const userId = user?.id ?? null
 
   const [hairProfile, setHairProfile] = useState<HairProfile | null>(null)
-  const [formData, setFormData] = useState<ProfileFormData>(() => createFormData(null))
-  const [editing, setEditing] = useState(false)
-  const [routineDetailsOpen, setRoutineDetailsOpen] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [saving, setSaving] = useState(false)
+  const [profileLoading, setProfileLoading] = useState(true)
+  const [productUsage, setProductUsage] = useState<UserProductUsageRow[]>([])
+  const [productsLoading, setProductsLoading] = useState(true)
+  const [quizEditing, setQuizEditing] = useState(false)
+  const [quizSaving, setQuizSaving] = useState(false)
+  const [quizDraft, setQuizDraft] = useState<QuizDraft>(() => createQuizDraft(null))
+  const [quizNotice, setQuizNotice] = useState<QuizSaveNotice | null>(null)
+  const [pendingQuizFocusKey, setPendingQuizFocusKey] = useState<string | null>(null)
+  const quizFieldRefs = useRef<Record<string, HTMLDivElement | null>>({})
 
   const [memoryEntries, setMemoryEntries] = useState<UserMemoryEntry[]>([])
   const [memoryEnabled, setMemoryEnabled] = useState(true)
@@ -293,38 +462,131 @@ export default function ProfilePage() {
   const [memoryDraft, setMemoryDraft] = useState("")
 
   useEffect(() => {
-    async function loadProfile() {
-      if (!user) {
-        setLoading(false)
+    let active = true
+
+    async function loadHairProfile() {
+      if (!userId) {
+        if (active) {
+          setHairProfile(null)
+          setProfileLoading(false)
+        }
         return
       }
 
-      setLoading(true)
+      setProfileLoading(true)
 
       try {
-        const { data } = await supabase
+        const { data, error } = await supabase
           .from("hair_profiles")
           .select("*")
-          .eq("user_id", user.id)
+          .eq("user_id", userId)
           .maybeSingle()
 
+        if (error) throw error
+        if (!active) return
+
         setHairProfile(data ?? null)
-        setFormData(createFormData(data ?? null))
       } catch (error) {
-        console.error("Error loading profile:", error)
+        console.error("Error loading hair profile:", error)
+        if (active) {
+          setHairProfile(null)
+        }
       } finally {
-        setLoading(false)
+        if (active) {
+          setProfileLoading(false)
+        }
       }
     }
 
-    loadProfile()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id])
+    loadHairProfile()
+
+    return () => {
+      active = false
+    }
+  }, [supabase, userId])
 
   useEffect(() => {
+    let active = true
+
+    async function loadProductUsage() {
+      if (!userId) {
+        if (active) {
+          setProductUsage([])
+          setProductsLoading(false)
+        }
+        return
+      }
+
+      setProductsLoading(true)
+
+      try {
+        const { data, error } = await supabase
+          .from("user_product_usage")
+          .select("id, category, product_name, frequency_range")
+          .eq("user_id", userId)
+
+        if (error) throw error
+        if (!active) return
+
+        setProductUsage((data as UserProductUsageRow[] | null) ?? [])
+      } catch (error) {
+        console.error("Error loading product usage:", error)
+        if (active) {
+          setProductUsage([])
+        }
+      } finally {
+        if (active) {
+          setProductsLoading(false)
+        }
+      }
+    }
+
+    loadProductUsage()
+
+    return () => {
+      active = false
+    }
+  }, [supabase, userId])
+
+  useEffect(() => {
+    if (!quizEditing) {
+      setQuizDraft(createQuizDraft(hairProfile))
+    }
+  }, [hairProfile, quizEditing])
+
+  useEffect(() => {
+    if (quizNotice?.variant !== "success") return
+
+    const timeoutId = window.setTimeout(() => {
+      setQuizNotice((current) => (current?.variant === "success" ? null : current))
+    }, 4000)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [quizNotice])
+
+  useEffect(() => {
+    if (!quizEditing || !pendingQuizFocusKey) return
+
+    const target = quizFieldRefs.current[pendingQuizFocusKey]
+    if (!target) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      target.scrollIntoView({ behavior: "smooth", block: "center" })
+      setPendingQuizFocusKey(null)
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [pendingQuizFocusKey, quizEditing])
+
+  useEffect(() => {
+    let active = true
+
     async function loadMemory() {
-      if (!user) {
-        setMemoryLoading(false)
+      if (!userId) {
+        if (active) {
+          setMemoryEntries([])
+          setMemoryLoading(false)
+        }
         return
       }
 
@@ -335,17 +597,25 @@ export default function ProfilePage() {
         if (!response.ok) throw new Error("Memory konnte nicht geladen werden")
 
         const data = (await response.json()) as MemoryApiResponse
+        if (!active) return
+
         setMemoryEnabled(data.settings.memory_enabled)
         setMemoryEntries(data.entries ?? [])
       } catch (error) {
         console.error("Error loading memory:", error)
       } finally {
-        setMemoryLoading(false)
+        if (active) {
+          setMemoryLoading(false)
+        }
       }
     }
 
     loadMemory()
-  }, [user])
+
+    return () => {
+      active = false
+    }
+  }, [userId])
 
   const structuredFields = useMemo<StructuredField[]>(
     () =>
@@ -356,108 +626,111 @@ export default function ProfilePage() {
     [hairProfile],
   )
 
-  const fieldsBySection = useMemo(() => {
-    return {
-      baseline: structuredFields.filter((field) => field.sectionKey === "baseline"),
-      goals: structuredFields.filter((field) => field.sectionKey === "goals"),
-      routine: structuredFields.filter((field) => field.sectionKey === "routine"),
-    }
-  }, [structuredFields])
+  const quizFields = structuredFields.filter((field) => field.sectionKey === "quiz")
+  const stylingFields = structuredFields.filter((field) => field.sectionKey === "styling")
+  const routineFields = structuredFields.filter((field) => field.sectionKey === "routine")
+  const goalsFields = structuredFields.filter((field) => field.sectionKey === "goals")
+  const goalsField = goalsFields[0] ?? null
+  const productRows = useMemo(() => createProductRows(productUsage), [productUsage])
 
-  const baselineFields = fieldsBySection.baseline
-  const goalFields = fieldsBySection.goals
-  const routineFields = fieldsBySection.routine
-  const routineSimpleFields = routineFields.filter((field) => field.editMode === "inline")
-  const routineDetailFields = routineFields.filter((field) =>
-    ROUTINE_DETAIL_FIELD_KEYS.has(field.key),
-  )
-
-  const baselineFilled = baselineFields.filter((field) => field.value !== null)
-  const goalFilled = goalFields.filter((field) => field.value !== null)
+  const quizFilled = quizFields.filter((field) => field.value !== null)
+  const quizMissing = quizFields.filter((field) => field.value === null)
+  const stylingFilled = stylingFields.filter((field) => field.value !== null)
+  const stylingMissing = stylingFields.filter((field) => field.value === null)
   const routineFilled = routineFields.filter((field) => field.value !== null)
-
-  const baselineMissing = baselineFields.filter((field) => field.value === null)
-  const goalMissing = goalFields.filter((field) => field.value === null)
   const routineMissing = routineFields.filter((field) => field.value === null)
+  const goalsFilled = goalsFields.filter((field) => field.value !== null)
+  const selectedProductCategories = productRows.map((row) => row.categoryLabel)
+  const incompleteProductRows = productRows.filter((row) => !row.isComplete)
 
-  const baselineSparse = baselineFilled.length < 3
-  const overallStepCount = PROFILE_JOURNEY_STEPS.length
-  const activeStepCount = [
-    baselineFilled.length > 0,
-    goalFilled.length > 0,
-    routineFilled.length > 0,
-    memoryEnabled,
-  ].filter(Boolean).length
-  const overallPercent = (activeStepCount / overallStepCount) * 100
-
-  const readinessCopy =
-    activeStepCount >= 3
-      ? "Dein Profil ist schon belastbar genug für deutlich präzisere Empfehlungen."
-      : activeStepCount === 2
-        ? "Die Basis steht. Mit noch etwas mehr Kontext werden Empfehlungen spürbar schärfer."
-        : "Mit ein paar gezielten Angaben kann Hair Concierge deutlich kohärenter beraten."
-
-  async function handleSave() {
-    if (!user) return
-
-    setSaving(true)
-
-    try {
-      const goals = formData.goals as Goal[]
-      const derivedVolume = deriveVolumeFromGoals(goals)
-
-      const payload = {
-        user_id: user.id,
-        hair_texture: formData.hair_texture || null,
-        thickness: formData.thickness || null,
-        density: formData.density || null,
-        concerns: formData.concerns,
-        desired_volume: derivedVolume,
-        wash_frequency: formData.wash_frequency || null,
-        heat_styling: formData.heat_styling || null,
-        styling_tools: formData.styling_tools,
-        towel_material: formData.towel_material || null,
-        towel_technique: formData.towel_technique || null,
-        drying_method: formData.drying_method,
-        brush_type: formData.brush_type || null,
-        night_protection: formData.night_protection,
-        uses_heat_protection: formData.uses_heat_protection,
-        post_wash_actions: formData.post_wash_actions,
-        current_routine_products: formData.current_routine_products,
-        products_used: formData.products_used || null,
-        goals,
-        additional_notes: formData.additional_notes || null,
-        updated_at: new Date().toISOString(),
-      }
-
-      const { data, error } = await supabase
-        .from("hair_profiles")
-        .upsert(payload, { onConflict: "user_id" })
-        .select()
-        .single()
-
-      if (error) {
-        toast({ title: fehler("Speichern"), variant: "destructive" })
-        return
-      }
-
-      setHairProfile(data)
-      setFormData(createFormData(data))
-      setEditing(false)
-      setRoutineDetailsOpen(false)
-      toast({ title: "Profil gespeichert!" })
-    } catch (error) {
-      console.error("Error saving profile:", error)
-      toast({ title: fehler("Speichern"), variant: "destructive" })
-    } finally {
-      setSaving(false)
+  function startQuizEditing(fieldKey?: string) {
+    setQuizNotice(null)
+    if (fieldKey) {
+      setPendingQuizFocusKey(fieldKey)
     }
+    setQuizEditing(true)
   }
 
-  function handleCancelEditing() {
-    setFormData(createFormData(hairProfile))
-    setEditing(false)
-    setRoutineDetailsOpen(false)
+  function openTarget(target: ProfileEditTarget | null, fieldKey?: string) {
+    if (!target) return
+
+    if (target.kind === "quiz") {
+      startQuizEditing(fieldKey)
+      return
+    }
+
+    router.push(buildOnboardingHref(target.step, { singleStep: true }))
+  }
+
+  function resetQuizEditing() {
+    setQuizDraft(createQuizDraft(hairProfile))
+    setQuizEditing(false)
+    setPendingQuizFocusKey(null)
+  }
+
+  async function handleSaveQuiz() {
+    if (!userId) return
+
+    setQuizSaving(true)
+    setQuizNotice(null)
+
+    const quizPayload: Pick<
+      HairProfile,
+      | "hair_texture"
+      | "thickness"
+      | "cuticle_condition"
+      | "protein_moisture_balance"
+      | "scalp_type"
+      | "scalp_condition"
+      | "chemical_treatment"
+    > & { updated_at: string } = {
+      hair_texture: (quizDraft.hair_texture || null) as HairProfile["hair_texture"],
+      thickness: (quizDraft.thickness || null) as HairProfile["thickness"],
+      cuticle_condition: (quizDraft.cuticle_condition || null) as HairProfile["cuticle_condition"],
+      protein_moisture_balance: (quizDraft.protein_moisture_balance ||
+        null) as HairProfile["protein_moisture_balance"],
+      scalp_type: (quizDraft.scalp_type || null) as HairProfile["scalp_type"],
+      scalp_condition: (quizDraft.scalp_condition || null) as HairProfile["scalp_condition"],
+      chemical_treatment: quizDraft.chemical_treatment,
+      updated_at: new Date().toISOString(),
+    }
+
+    try {
+      const { error } = await supabase.from("hair_profiles").upsert(
+        {
+          user_id: userId,
+          ...quizPayload,
+        },
+        { onConflict: "user_id" },
+      )
+
+      if (error) throw error
+
+      const nextProfile = createLocalHairProfile(hairProfile, userId, quizPayload)
+      setHairProfile(nextProfile)
+      setQuizDraft(createQuizDraft(nextProfile))
+      setQuizEditing(false)
+      setQuizNotice({
+        variant: "success",
+        title: "Haar-Check gespeichert",
+        description:
+          "Deine Antworten sind direkt aktualisiert und fließen ab jetzt in dein Profil ein.",
+      })
+      toast({
+        title: "Haar-Check gespeichert",
+        description: "Dein Profil wurde aktualisiert.",
+      })
+    } catch (error) {
+      console.error("Error saving quiz data:", error)
+      setQuizNotice({
+        variant: "error",
+        title: "Speichern fehlgeschlagen",
+        description: "Bitte versuche es noch einmal. Deine bisherigen Angaben bleiben erhalten.",
+      })
+      toast({ title: fehler("Speichern"), variant: "destructive" })
+    } finally {
+      setQuizSaving(false)
+    }
   }
 
   async function handleMemoryToggle(checked: boolean) {
@@ -539,442 +812,6 @@ export default function ProfilePage() {
     }
   }
 
-  function openFieldFlow(field: StructuredField) {
-    setEditing(true)
-    setRoutineDetailsOpen(
-      field.sectionKey === "routine" && ROUTINE_DETAIL_FIELD_KEYS.has(field.key),
-    )
-  }
-
-  function getFieldActionLabel(field: StructuredField) {
-    if (field.sectionKey === "baseline") {
-      return "Zur Aktualisierung öffnen"
-    }
-
-    if (field.sectionKey === "routine" && ROUTINE_DETAIL_FIELD_KEYS.has(field.key)) {
-      return "Routine-Details öffnen"
-    }
-
-    return "Zum Bearbeiten öffnen"
-  }
-
-  function renderInlineEditor(field: StructuredField) {
-    switch (field.key) {
-      case "concerns":
-        return (
-          <div className="flex flex-wrap gap-2">
-            {CONCERN_OPTIONS.map((option) => {
-              const active = formData.concerns.includes(option.value)
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  onClick={() =>
-                    setFormData((current) => ({
-                      ...current,
-                      concerns: toggleArrayItem(current.concerns, option.value),
-                    }))
-                  }
-                  className={cn(
-                    "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                    active
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-border hover:bg-muted",
-                  )}
-                >
-                  {option.label}
-                </button>
-              )
-            })}
-          </div>
-        )
-      case "goals":
-        return (
-          <div className="flex flex-wrap gap-2">
-            {EDITABLE_GOAL_OPTIONS.map((option) => {
-              const active = formData.goals.includes(option.value)
-              const atMax = !active && formData.goals.length >= 5
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  disabled={atMax}
-                  onClick={() =>
-                    setFormData((current) => {
-                      if (current.goals.includes(option.value)) {
-                        return { ...current, goals: current.goals.filter((g) => g !== option.value) }
-                      }
-                      if (current.goals.length >= 5) return current
-                      let next = [...current.goals]
-                      if (option.value === "volume") next = next.filter((g) => g !== "less_volume")
-                      if (option.value === "less_volume") next = next.filter((g) => g !== "volume")
-                      next.push(option.value)
-                      return { ...current, goals: next }
-                    })
-                  }
-                  className={cn(
-                    "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                    active
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-border hover:bg-muted",
-                    atMax && "opacity-40 cursor-not-allowed",
-                  )}
-                >
-                  {option.label}
-                </button>
-              )
-            })}
-          </div>
-        )
-      case "wash_frequency":
-        return (
-          <SegmentedControl
-            options={WASH_FREQUENCY_OPTIONS}
-            value={formData.wash_frequency}
-            onChange={(value) => setFormData((current) => ({ ...current, wash_frequency: value }))}
-          />
-        )
-      case "heat_styling":
-        return (
-          <SegmentedControl
-            options={HEAT_STYLING_OPTIONS}
-            value={formData.heat_styling}
-            onChange={(value) => setFormData((current) => ({ ...current, heat_styling: value }))}
-          />
-        )
-      case "uses_heat_protection":
-        return (
-          <SegmentedControl
-            options={HEAT_PROTECTION_OPTIONS}
-            value={formData.uses_heat_protection ? "yes" : "no"}
-            onChange={(value) =>
-              setFormData((current) => ({
-                ...current,
-                uses_heat_protection: value === "yes",
-              }))
-            }
-          />
-        )
-      default:
-        return <ProfileFieldValue value={field.value} displayMode={field.displayMode} />
-    }
-  }
-
-  function renderRoutineDetailsEditor() {
-    return (
-      <div className="rounded-2xl border border-primary/15 bg-muted/40 p-5">
-        <div className="mb-5">
-          <p className="text-sm font-semibold text-[var(--text-heading)]">
-            Routine-Details im Fokus
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Hier ergänzt du die tieferen Alltags-Signale, die nicht bei jedem Profil sofort nötig
-            sind.
-          </p>
-        </div>
-
-        <div className="space-y-6">
-          <div className="space-y-4">
-            <div>
-              <p className="mb-2 text-sm font-semibold text-[var(--text-heading)]">
-                Styling &amp; Schutz
-              </p>
-              <p className="mb-3 text-xs text-muted-foreground">
-                Welche Tools du nutzt und wie du dein Haar tagsüber oder nachts schützt.
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <div>
-                <p className="mb-2 text-sm font-medium">Styling-Tools</p>
-                <div className="flex flex-wrap gap-2">
-                  {STYLING_TOOL_OPTIONS.map((option) => {
-                    const active = formData.styling_tools.includes(option.value)
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({
-                            ...current,
-                            styling_tools: toggleArrayItem(current.styling_tools, option.value),
-                          }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Bürste</p>
-                <div className="flex flex-wrap gap-2">
-                  {BRUSH_TYPE_OPTIONS.map((option) => {
-                    const active = formData.brush_type === option.value
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({ ...current, brush_type: option.value }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Nachtschutz</p>
-                <div className="flex flex-wrap gap-2">
-                  {NIGHT_PROTECTION_OPTIONS.map((option) => {
-                    const active = formData.night_protection.includes(option.value)
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({
-                            ...current,
-                            night_protection: toggleArrayItem(
-                              current.night_protection,
-                              option.value,
-                            ),
-                          }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div>
-              <p className="mb-2 text-sm font-semibold text-[var(--text-heading)]">Trocknen</p>
-              <p className="mb-3 text-xs text-muted-foreground">
-                Material, Technik und Nach-dem-Waschen-Muster liefern oft die fehlenden Frizz- und
-                Schutzsignale.
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <div>
-                <p className="mb-2 text-sm font-medium">Handtuch</p>
-                <div className="flex flex-wrap gap-2">
-                  {TOWEL_MATERIAL_OPTIONS.map((option) => {
-                    const active = formData.towel_material === option.value
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({ ...current, towel_material: option.value }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Trocknungstechnik</p>
-                <div className="flex flex-wrap gap-2">
-                  {TOWEL_TECHNIQUE_OPTIONS.map((option) => {
-                    const active = formData.towel_technique === option.value
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({ ...current, towel_technique: option.value }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Trocknungsmethode</p>
-                <div className="flex flex-wrap gap-2">
-                  {DRYING_METHOD_OPTIONS.map((option) => {
-                    const active = formData.drying_method.includes(option.value)
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({
-                            ...current,
-                            drying_method: toggleArrayItem(current.drying_method, option.value),
-                          }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Nach dem Waschen</p>
-                <div className="flex flex-wrap gap-2">
-                  {POST_WASH_ACTION_OPTIONS.map((option) => {
-                    const active = formData.post_wash_actions.includes(option.value)
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({
-                            ...current,
-                            post_wash_actions: toggleArrayItem(
-                              current.post_wash_actions,
-                              option.value,
-                            ),
-                          }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div>
-              <p className="mb-2 text-sm font-semibold text-[var(--text-heading)]">
-                Produkte &amp; Notizen
-              </p>
-              <p className="mb-3 text-xs text-muted-foreground">
-                Was bereits genutzt wird und welche Freitext-Hinweise wichtig bleiben sollen.
-              </p>
-            </div>
-
-            <div className="space-y-3">
-              <div>
-                <p className="mb-2 text-sm font-medium">Produkte in Routine</p>
-                <div className="flex flex-wrap gap-2">
-                  {ROUTINE_PRODUCT_OPTIONS.map((option) => {
-                    const active = formData.current_routine_products.includes(option.value)
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((current) => ({
-                            ...current,
-                            current_routine_products: toggleArrayItem(
-                              current.current_routine_products,
-                              option.value,
-                            ),
-                          }))
-                        }
-                        className={cn(
-                          "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
-                          active
-                            ? "border-primary bg-primary/10 text-primary"
-                            : "border-border hover:bg-card",
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Verwendete Produkte</p>
-                <Textarea
-                  value={formData.products_used}
-                  onChange={(event) =>
-                    setFormData((current) => ({ ...current, products_used: event.target.value }))
-                  }
-                  rows={3}
-                  placeholder="z. B. Olaplex No. 3, Moroccanoil, Balea ..."
-                />
-              </div>
-
-              <div>
-                <p className="mb-2 text-sm font-medium">Zusätzliche Hinweise</p>
-                <Textarea
-                  value={formData.additional_notes}
-                  onChange={(event) =>
-                    setFormData((current) => ({
-                      ...current,
-                      additional_notes: event.target.value,
-                    }))
-                  }
-                  rows={3}
-                  placeholder="Gibt es noch etwas, das Hair Concierge im Alltag berücksichtigen soll?"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
   if (authLoading) {
     return (
       <>
@@ -990,392 +827,737 @@ export default function ProfilePage() {
     <>
       <Header />
       <main className="mx-auto max-w-5xl px-4 py-8">
-        {editing ? (
-          <div className="sticky top-16 z-30 mb-6">
-            <div className="rounded-2xl border border-primary/20 bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80">
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <p className="text-sm font-semibold text-[var(--text-heading)]">
-                    Du bearbeitest dein Profil
-                  </p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Änderungen werden erst übernommen, wenn du speicherst.
-                  </p>
-                </div>
-
-                <div className="flex flex-wrap gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="w-auto"
-                    onClick={handleCancelEditing}
-                  >
-                    Abbrechen
-                  </Button>
-                  <Button type="button" className="w-auto" onClick={handleSave} disabled={saving}>
-                    {saving ? "Speichere..." : "Speichern"}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : null}
-
-        <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div>
-            <p className="type-overline text-primary">Profilübersicht</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--text-heading)]">
-              Mein Profil
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-              Hier siehst du denselben roten Faden wie im Quiz und Onboarding: Ausgangslage, Ziele,
-              Alltag und das, was Hair Concierge mit der Zeit dazulernt.
-            </p>
-          </div>
-
-          {!editing && !loading ? (
-            <Button type="button" onClick={() => setEditing(true)} className="w-auto">
-              Bearbeiten
-            </Button>
-          ) : null}
+        <div className="mb-8">
+          <p className="type-overline text-primary">Profilübersicht</p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--text-heading)]">
+            Mein Profil
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+            Je vollständiger dein Profil ist, desto besser werden Empfehlungen. Jeder Abschnitt
+            zeigt dir direkt, wie viel schon da ist und was noch ergänzt werden kann.
+          </p>
         </div>
-
-        {loading ? (
-          <>
-            <Card className="mb-6 border-primary/10">
-              <CardHeader className="pb-4">
-                <Skeleton className="h-6 w-48" />
-                <Skeleton className="mt-2 h-4 w-80" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="mb-4 h-2 w-full rounded-full" />
-                <div className="grid gap-3 md:grid-cols-4">
-                  {Array.from({ length: 4 }).map((_, i) => (
-                    <Skeleton key={i} className="h-20 rounded-xl" />
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-            <div className="space-y-6">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Card key={i}>
-                  <CardHeader className="pb-4">
-                    <Skeleton className="h-6 w-40" />
-                    <Skeleton className="mt-2 h-4 w-64" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid gap-4 md:grid-cols-2">
-                      {Array.from({ length: 4 }).map((_, j) => (
-                        <Skeleton key={j} className="h-16 rounded-xl" />
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </>
-        ) : (
-          <>
-            <Card className="mb-6 border-primary/10">
-              <CardHeader className="pb-4">
-                <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-                  <div>
-                    <CardTitle className="text-xl text-[var(--text-heading)]">
-                      So baut sich dein Profil auf
-                    </CardTitle>
-                    <CardDescription className="mt-2 max-w-2xl text-sm">
-                      {readinessCopy}
-                    </CardDescription>
-                  </div>
-                  <Badge className="w-fit px-3 py-1 text-xs">
-                    {activeStepCount} von {overallStepCount} Bausteinen aktiv
-                  </Badge>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="mb-4 h-2 overflow-hidden rounded-full bg-muted">
-                  <div
-                    className="h-full rounded-full bg-primary transition-all"
-                    style={{ width: `${overallPercent}%` }}
-                  />
-                </div>
-
-                <div className="grid gap-3 md:grid-cols-4">
-                  <JourneyStepCard
-                    label="Haar-Check"
-                    status={baselineFilled.length === 0 ? "Offen" : "Aktiv"}
-                    summary={
-                      baselineFilled.length === 0
-                        ? "Noch keine Basisdaten vorhanden."
-                        : `${baselineFilled.length}/${baselineFields.length} Signale vorhanden`
-                    }
-                    active={baselineFilled.length > 0}
-                  />
-                  <JourneyStepCard
-                    label="Ziele"
-                    status={goalFilled.length === 0 ? "Offen" : "Aktiv"}
-                    summary={
-                      goalFilled.length === 0
-                        ? "Noch keine Prioritäten gesetzt."
-                        : `${goalFilled.length}/${goalFields.length} Signale vorhanden`
-                    }
-                    active={goalFilled.length > 0}
-                  />
-                  <JourneyStepCard
-                    label="Alltag"
-                    status={routineFilled.length === 0 ? "Offen" : "Aktiv"}
-                    summary={
-                      routineFilled.length === 0
-                        ? "Noch keine Routinedaten vorhanden."
-                        : `${routineFilled.length}/${routineFields.length} Signale vorhanden`
-                    }
-                    active={routineFilled.length > 0}
-                  />
-                  <JourneyStepCard
-                    label="Merkt sich"
-                    status={memoryEnabled ? "Aktiv" : "Pausiert"}
-                    summary={
-                      memoryEnabled
-                        ? memoryEntries.length > 0
-                          ? `${memoryEntries.length} gespeicherte Erinnerungen`
-                          : "Bereit, neue Chat-Erinnerungen zu speichern"
-                        : "Chat-Erinnerungen sind aktuell ausgeschaltet"
-                    }
-                    active={memoryEnabled}
-                  />
-                </div>
-              </CardContent>
-            </Card>
-
-            <div className="space-y-6">
-              <Card>
-                <CardHeader className="pb-4">
-                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                    <div>
-                      <CardTitle className="text-xl text-[var(--text-heading)]">
-                        {PROFILE_SECTION_META[0].title}
-                      </CardTitle>
-                      <CardDescription className="mt-2 text-sm">
-                        {PROFILE_SECTION_META[0].description}
-                      </CardDescription>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="w-auto"
-                      onClick={() => router.push("/quiz")}
-                    >
-                      Haar-Check aktualisieren
-                    </Button>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {baselineFilled.length > 0 ? (
-                    <div className="grid gap-4 md:grid-cols-2">
-                      {baselineFilled.map((field) => (
-                        <ProfileFieldCard
-                          key={field.key}
-                          field={field}
-                          onClick={!editing ? () => openFieldFlow(field) : undefined}
-                          actionLabel={!editing ? getFieldActionLabel(field) : undefined}
-                        />
-                      ))}
-                    </div>
-                  ) : null}
-
-                  {(baselineSparse || editing) && (
-                    <InlinePromptCard
-                      title="Ausgangslage wird über den Haar-Check gepflegt"
-                      text={
-                        baselineSparse
-                          ? "Damit Diagnose- und Strukturdaten konsistent bleiben, startest du diese Basis nicht direkt hier, sondern über den Haar-Check."
-                          : "Diese Felder bleiben absichtlich read-only im Profil. Für Änderungen führst du den Haar-Check erneut durch."
-                      }
-                      action={
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="w-auto"
-                          onClick={() => router.push("/quiz")}
-                        >
-                          Haar-Check starten
-                        </Button>
-                      }
-                    />
-                  )}
-
-                  {!editing && baselineMissing.length > 0 && !baselineSparse ? (
-                    <InlinePromptCard
-                      title="Ein Teil der Basis fehlt noch"
-                      text={`Noch offen: ${baselineMissing.map((field) => field.label).join(", ")}`}
-                      action={
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="w-auto"
-                          onClick={() => router.push("/quiz")}
-                        >
-                          Basis ergänzen
-                        </Button>
-                      }
-                    />
-                  ) : null}
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="pb-4">
-                  <CardTitle className="text-xl text-[var(--text-heading)]">
-                    {PROFILE_SECTION_META[1].title}
-                  </CardTitle>
-                  <CardDescription className="mt-2 text-sm">
-                    {PROFILE_SECTION_META[1].description}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {editing ? (
-                    <div className="grid gap-4 xl:grid-cols-3">
-                      {goalFields.map((field) => (
-                        <ProfileFieldCard key={field.key} field={field}>
-                          {renderInlineEditor(field)}
-                        </ProfileFieldCard>
-                      ))}
-                    </div>
-                  ) : goalFilled.length > 0 ? (
-                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                      {goalFilled.map((field) => (
-                        <ProfileFieldCard
-                          key={field.key}
-                          field={field}
-                          onClick={() => openFieldFlow(field)}
-                          actionLabel={getFieldActionLabel(field)}
-                        />
-                      ))}
-                    </div>
-                  ) : (
-                    <InlinePromptCard
-                      title="Noch keine Ziele gesetzt"
-                      text="Wähle mindestens dein gewünschtes Volumen oder ein relevantes Ziel, damit der erste Plan klarer priorisieren kann."
-                    />
-                  )}
-
-                  {!editing && goalMissing.length > 0 ? (
-                    <InlinePromptCard
-                      title="Ziele schärfen"
-                      text={`Noch offen: ${goalMissing.map((field) => field.label).join(", ")}`}
-                      action={
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="w-auto"
-                          onClick={() => setEditing(true)}
-                        >
-                          Ziele bearbeiten
-                        </Button>
-                      }
-                    />
-                  ) : null}
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="pb-4">
-                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                    <div>
-                      <CardTitle className="text-xl text-[var(--text-heading)]">
-                        {PROFILE_SECTION_META[2].title}
-                      </CardTitle>
-                      <CardDescription className="mt-2 text-sm">
-                        {PROFILE_SECTION_META[2].description}
-                      </CardDescription>
-                    </div>
-                    {editing ? (
-                      <Button
-                        type="button"
-                        variant={routineDetailsOpen ? "default" : "outline"}
-                        className="w-auto"
-                        onClick={() => setRoutineDetailsOpen((current) => !current)}
-                      >
-                        {routineDetailsOpen
-                          ? "Routine-Details ausblenden"
-                          : "Routine-Details bearbeiten"}
-                      </Button>
-                    ) : null}
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {editing ? (
-                    <div className="grid gap-4 xl:grid-cols-3">
-                      {routineSimpleFields.map((field) => (
-                        <ProfileFieldCard key={field.key} field={field}>
-                          {renderInlineEditor(field)}
-                        </ProfileFieldCard>
-                      ))}
-                    </div>
-                  ) : null}
-
-                  {routineFilled.length > 0 ? (
-                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                      {(editing
-                        ? routineDetailFields.filter((field) => field.value !== null)
-                        : routineFilled
-                      ).map((field) => (
-                        <ProfileFieldCard
-                          key={field.key}
-                          field={field}
-                          onClick={!editing ? () => openFieldFlow(field) : undefined}
-                          actionLabel={!editing ? getFieldActionLabel(field) : undefined}
-                        />
-                      ))}
-                    </div>
-                  ) : null}
-
-                  {editing && routineDetailsOpen ? renderRoutineDetailsEditor() : null}
-
-                  {!editing && routineFilled.length === 0 ? (
-                    <InlinePromptCard
-                      title="Alltags-Signale fehlen noch"
-                      text="Waschhäufigkeit, Hitzemuster und Routinedetails machen Empfehlungen deutlich realistischer."
-                    />
-                  ) : null}
-
-                  {!editing && routineMissing.length > 0 ? (
-                    <InlinePromptCard
-                      title="Alltag weiter schärfen"
-                      text={`Noch offen: ${routineMissing
-                        .map((field) => field.label)
-                        .slice(0, 6)
-                        .join(
-                          ", ",
-                        )}${routineMissing.length > 6 ? ` und ${routineMissing.length - 6} weitere` : ""}`}
-                      action={
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="w-auto"
-                          onClick={() => setEditing(true)}
-                        >
-                          Alltag bearbeiten
-                        </Button>
-                      }
-                    />
-                  ) : null}
-                </CardContent>
-              </Card>
-            </div>
-          </>
-        )}
 
         <div className="space-y-6">
           <Card>
             <CardHeader className="pb-4">
-              <div className="flex items-start justify-between gap-4">
+              <SectionHeader
+                title={SECTION_META_BY_KEY.quiz.title}
+                description="Deine Antworten aus dem Haar-Check. Du kannst sie hier direkt pflegen, ohne den Flow noch einmal neu zu starten."
+                status={
+                  profileLoading
+                    ? "Wird geladen"
+                    : getCompletionLabel(quizFilled.length, quizFields.length)
+                }
+                action={
+                  !quizEditing ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => startQuizEditing()}
+                    >
+                      Haar-Check bearbeiten
+                    </Button>
+                  ) : undefined
+                }
+              />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {quizNotice ? (
+                <div
+                  className={cn(
+                    "rounded-xl border px-4 py-3",
+                    quizNotice.variant === "success"
+                      ? "border-primary/20 bg-primary/[0.05]"
+                      : "border-destructive/20 bg-destructive/5",
+                  )}
+                >
+                  <p className="text-sm font-semibold text-[var(--text-heading)]">
+                    {quizNotice.title}
+                  </p>
+                  <p className="mt-1 text-sm text-muted-foreground">{quizNotice.description}</p>
+                </div>
+              ) : null}
+
+              {profileLoading ? (
+                <SectionGridSkeleton count={6} className="md:grid-cols-2 xl:grid-cols-3" />
+              ) : quizEditing ? (
+                <div className="rounded-2xl border border-primary/15 bg-muted/35 p-5">
+                  <div className="mb-5">
+                    <p className="text-sm font-semibold text-[var(--text-heading)]">
+                      Haar-Check direkt im Profil aktualisieren
+                    </p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      So musst du nicht noch einmal durch Login- oder Marketing-Schritte. Passe nur
+                      die Antworten an, die sich ändern sollen.
+                    </p>
+                  </div>
+
+                  <div className="grid gap-4 xl:grid-cols-2">
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.hair_texture = node
+                      }}
+                    >
+                      <QuizEditorField
+                        title="Haartextur"
+                        text="Wie dein Haar natürlich fällt, wenn es nass ist."
+                      >
+                        <SegmentedControl
+                          options={HAIR_TEXTURE_OPTIONS}
+                          value={quizDraft.hair_texture}
+                          onChange={(value) =>
+                            setQuizDraft((current) => ({ ...current, hair_texture: value }))
+                          }
+                        />
+                      </QuizEditorField>
+                    </div>
+
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.thickness = node
+                      }}
+                    >
+                      <QuizEditorField
+                        title="Haar-Dicke"
+                        text="Wie dick ein einzelnes Haar im Vergleich zu einem Nähfaden ist."
+                      >
+                        <SegmentedControl
+                          options={HAIR_THICKNESS_OPTIONS}
+                          value={quizDraft.thickness}
+                          onChange={(value) =>
+                            setQuizDraft((current) => ({ ...current, thickness: value }))
+                          }
+                        />
+                      </QuizEditorField>
+                    </div>
+
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.cuticle_condition = node
+                      }}
+                    >
+                      <QuizEditorField
+                        title="Oberfläche"
+                        text="Wie sich dein Haar im Finger-Test anfühlt."
+                      >
+                        <SegmentedControl
+                          options={QUIZ_SURFACE_OPTIONS}
+                          value={quizDraft.cuticle_condition}
+                          onChange={(value) =>
+                            setQuizDraft((current) => ({ ...current, cuticle_condition: value }))
+                          }
+                        />
+                      </QuizEditorField>
+                    </div>
+
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.protein_moisture_balance = node
+                      }}
+                    >
+                      <QuizEditorField
+                        title="Elastizität"
+                        text="Wie dein Haar im Zug-Test reagiert."
+                      >
+                        <SegmentedControl
+                          options={QUIZ_ELASTICITY_OPTIONS}
+                          value={quizDraft.protein_moisture_balance}
+                          onChange={(value) =>
+                            setQuizDraft((current) => ({
+                              ...current,
+                              protein_moisture_balance: value,
+                            }))
+                          }
+                        />
+                      </QuizEditorField>
+                    </div>
+
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.scalp_type = node
+                      }}
+                    >
+                      <QuizEditorField
+                        title="Kopfhauttyp"
+                        text="Wie sich deine Kopfhaut zwischen den Haarwäschen verhält."
+                      >
+                        <SegmentedControl
+                          options={QUIZ_SCALP_TYPE_OPTIONS}
+                          value={quizDraft.scalp_type}
+                          onChange={(value) =>
+                            setQuizDraft((current) => ({ ...current, scalp_type: value }))
+                          }
+                        />
+                      </QuizEditorField>
+                    </div>
+
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.scalp_condition = node
+                      }}
+                    >
+                      <QuizEditorField
+                        title="Kopfhaut-Beschwerden"
+                        text="Ob aktuell Schuppen oder Reizungen dabei sind."
+                      >
+                        <SegmentedControl
+                          options={QUIZ_SCALP_CONDITION_OPTIONS}
+                          value={quizDraft.scalp_condition}
+                          onChange={(value) =>
+                            setQuizDraft((current) => ({ ...current, scalp_condition: value }))
+                          }
+                        />
+                      </QuizEditorField>
+                    </div>
+
+                    <div
+                      ref={(node) => {
+                        quizFieldRefs.current.chemical_treatment = node
+                      }}
+                      className="xl:col-span-2"
+                    >
+                      <QuizEditorField
+                        title="Chemische Behandlungen"
+                        text="Was dein Haar in der Vergangenheit chemisch mitgemacht hat."
+                      >
+                        <div className="flex flex-wrap gap-2">
+                          {QUIZ_CHEMICAL_TREATMENT_OPTIONS.map((option) => {
+                            const active = quizDraft.chemical_treatment.includes(option.value)
+
+                            return (
+                              <button
+                                key={option.value}
+                                type="button"
+                                onClick={() =>
+                                  setQuizDraft((current) => ({
+                                    ...current,
+                                    chemical_treatment: toggleChemicalTreatment(
+                                      current.chemical_treatment,
+                                      option.value,
+                                    ),
+                                  }))
+                                }
+                                className={cn(
+                                  "min-h-[40px] rounded-full border px-3 py-2 text-sm transition-colors",
+                                  active
+                                    ? "border-primary bg-primary/10 text-primary"
+                                    : "border-border hover:bg-muted",
+                                )}
+                              >
+                                {option.label}
+                              </button>
+                            )
+                          })}
+                        </div>
+                      </QuizEditorField>
+                    </div>
+                  </div>
+
+                  <div className="mt-6 flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      className="w-auto"
+                      onClick={handleSaveQuiz}
+                      disabled={quizSaving}
+                    >
+                      {quizSaving ? "Speichern..." : "Haar-Check speichern"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={resetQuizEditing}
+                      disabled={quizSaving}
+                    >
+                      Abbrechen
+                    </Button>
+                  </div>
+                </div>
+              ) : quizFilled.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {quizFilled.map((field) => (
+                    <ProfileFieldCard
+                      key={field.key}
+                      field={field}
+                      onClick={() => openTarget(field.editTarget, field.key)}
+                      actionLabel={getFieldActionLabel(field.editTarget)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <InlinePromptCard
+                  title="Noch keine Quiz-Antworten sichtbar"
+                  text="Sobald du hier Angaben hinterlegst, erscheint der Haar-Check in derselben Reihenfolge wie in der Quiz-Logik."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => startQuizEditing()}
+                    >
+                      Haar-Check jetzt ausfüllen
+                    </Button>
+                  }
+                />
+              )}
+
+              {!profileLoading &&
+              !quizEditing &&
+              quizFilled.length > 0 &&
+              quizMissing.length > 0 ? (
+                <InlinePromptCard
+                  title={getOpenItemsTitle(quizMissing.length, "Angabe", "Angaben")}
+                  text="Du kannst die fehlenden Antworten direkt hier ergänzen."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => startQuizEditing()}
+                    >
+                      Fehlende Antworten ergänzen
+                    </Button>
+                  }
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-4">
+              <SectionHeader
+                title={SECTION_META_BY_KEY.products.title}
+                description="Welche Produktkategorien du aktuell nutzt und welche Produktdetails im Onboarding festgehalten wurden."
+                status={
+                  productsLoading
+                    ? "Wird geladen"
+                    : getProductCompletionLabel(productRows, Boolean(profile?.onboarding_completed))
+                }
+                action={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-auto"
+                    onClick={() => router.push(buildOnboardingHref("products_basics"))}
+                  >
+                    Produkte bearbeiten
+                  </Button>
+                }
+              />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {productsLoading ? (
+                <div className="space-y-4">
+                  <div className="rounded-xl border border-border/80 bg-card/80 p-4">
+                    <Skeleton className="h-4 w-36" />
+                    <Skeleton className="mt-2 h-3 w-56" />
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {Array.from({ length: 4 }).map((_, index) => (
+                        <Skeleton key={index} className="h-8 w-24 rounded-full" />
+                      ))}
+                    </div>
+                  </div>
+                  <SectionGridSkeleton count={3} className="md:grid-cols-3" />
+                </div>
+              ) : productRows.length > 0 ? (
+                <div className="space-y-4">
+                  <div className="rounded-xl border border-border/80 bg-card/80 p-4 shadow-sm">
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-[var(--text-heading)]">
+                        Ausgewählte Kategorien
+                      </p>
+                      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                        Damit ist auf einen Blick sichtbar, welche Produkttypen du überhaupt im
+                        Alltag nutzt.
+                      </p>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {selectedProductCategories.map((category) => (
+                        <Badge
+                          key={category}
+                          variant="outline"
+                          className="border-primary/20 bg-primary/[0.04] px-3 py-1 text-xs text-foreground"
+                        >
+                          {category}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="hidden overflow-hidden rounded-xl border border-border/80 md:block">
+                    <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,0.9fr)] gap-4 bg-muted/35 px-4 py-3 text-xs font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+                      <span>Kategorie</span>
+                      <span>Produkt</span>
+                      <span>Häufigkeit</span>
+                    </div>
+
+                    {productRows.map((row) => (
+                      <button
+                        key={row.key}
+                        type="button"
+                        onClick={() =>
+                          router.push(
+                            buildOnboardingHref("product_drilldown", {
+                              category: row.category,
+                              singleStep: true,
+                            }),
+                          )
+                        }
+                        className="grid w-full grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_minmax(0,0.9fr)] gap-4 border-t border-border/70 px-4 py-4 text-left transition-colors hover:bg-primary/[0.04]"
+                      >
+                        <div>
+                          <p className="text-sm font-semibold text-[var(--text-heading)]">
+                            {row.categoryLabel}
+                          </p>
+                          {!row.isComplete ? (
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Details fehlen noch
+                            </p>
+                          ) : null}
+                        </div>
+                        <p
+                          className={cn(
+                            "text-sm",
+                            row.productName ? "text-foreground" : "text-muted-foreground",
+                          )}
+                        >
+                          {row.productName ?? "Noch offen"}
+                        </p>
+                        <p
+                          className={cn(
+                            "text-sm",
+                            row.frequencyLabel ? "text-foreground" : "text-muted-foreground",
+                          )}
+                        >
+                          {row.frequencyLabel ?? "Noch offen"}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+
+                  <div className="grid gap-3 md:hidden">
+                    {productRows.map((row) => (
+                      <button
+                        key={row.key}
+                        type="button"
+                        onClick={() =>
+                          router.push(
+                            buildOnboardingHref("product_drilldown", {
+                              category: row.category,
+                              singleStep: true,
+                            }),
+                          )
+                        }
+                        className="rounded-xl border border-border/80 bg-card/80 p-4 text-left shadow-sm transition-colors hover:bg-primary/[0.04]"
+                      >
+                        <p className="text-sm font-semibold text-[var(--text-heading)]">
+                          {row.categoryLabel}
+                        </p>
+                        <div className="mt-3 space-y-2 text-sm">
+                          <p>
+                            <span className="text-muted-foreground">Produkt:</span>{" "}
+                            <span
+                              className={
+                                row.productName ? "text-foreground" : "text-muted-foreground"
+                              }
+                            >
+                              {row.productName ?? "Noch offen"}
+                            </span>
+                          </p>
+                          <p>
+                            <span className="text-muted-foreground">Häufigkeit:</span>{" "}
+                            <span
+                              className={
+                                row.frequencyLabel ? "text-foreground" : "text-muted-foreground"
+                              }
+                            >
+                              {row.frequencyLabel ?? "Noch offen"}
+                            </span>
+                          </p>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <InlinePromptCard
+                  title={
+                    profile?.onboarding_completed
+                      ? "Noch keine Produkte ausgewählt"
+                      : "Noch keine Produktangaben vorhanden"
+                  }
+                  text={
+                    profile?.onboarding_completed
+                      ? "Im aktuellen Onboarding-Stand wurden noch keine Produktkategorien gespeichert."
+                      : "Sobald du den Produktteil im Onboarding durchläufst, erscheint hier eine klare Übersicht nach Kategorie, Produkt und Häufigkeit."
+                  }
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => router.push(buildOnboardingHref("products_basics"))}
+                    >
+                      Produktteil öffnen
+                    </Button>
+                  }
+                />
+              )}
+
+              {!productsLoading && incompleteProductRows.length > 0 ? (
+                <InlinePromptCard
+                  title={getOpenItemsTitle(
+                    incompleteProductRows.length,
+                    "Produktdetail",
+                    "Produktdetails",
+                  )}
+                  text="Öffne den Produktteil, um die fehlenden Angaben zu ergänzen."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() =>
+                        router.push(
+                          buildOnboardingHref("product_drilldown", {
+                            category: incompleteProductRows[0]?.category ?? null,
+                          }),
+                        )
+                      }
+                    >
+                      Details ergänzen
+                    </Button>
+                  }
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-4">
+              <SectionHeader
+                title={SECTION_META_BY_KEY.styling.title}
+                description={SECTION_META_BY_KEY.styling.description}
+                status={
+                  profileLoading
+                    ? "Wird geladen"
+                    : getCompletionLabel(stylingFilled.length, stylingFields.length)
+                }
+                action={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-auto"
+                    onClick={() => router.push(buildOnboardingHref("heat_tools"))}
+                  >
+                    Styling bearbeiten
+                  </Button>
+                }
+              />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {profileLoading ? (
+                <SectionGridSkeleton count={3} className="md:grid-cols-2 xl:grid-cols-3" />
+              ) : stylingFilled.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {stylingFilled.map((field) => (
+                    <ProfileFieldCard
+                      key={field.key}
+                      field={field}
+                      onClick={() => openTarget(field.editTarget)}
+                      actionLabel={getFieldActionLabel(field.editTarget)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <InlinePromptCard
+                  title="Noch keine Styling-Angaben vorhanden"
+                  text="Hitzetools, Frequenz und Hitzeschutz erscheinen hier, sobald du den Styling-Teil des Onboardings speicherst."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => router.push(buildOnboardingHref("heat_tools"))}
+                    >
+                      Styling öffnen
+                    </Button>
+                  }
+                />
+              )}
+
+              {!profileLoading && stylingFilled.length > 0 && stylingMissing.length > 0 ? (
+                <InlinePromptCard
+                  title={getOpenItemsTitle(stylingMissing.length, "Angabe", "Angaben")}
+                  text="Im Styling-Teil kannst du die fehlenden Angaben ergänzen."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => router.push(buildOnboardingHref("heat_tools"))}
+                    >
+                      Styling ergänzen
+                    </Button>
+                  }
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-4">
+              <SectionHeader
+                title={SECTION_META_BY_KEY.routine.title}
+                description={SECTION_META_BY_KEY.routine.description}
+                status={
+                  profileLoading
+                    ? "Wird geladen"
+                    : getCompletionLabel(routineFilled.length, routineFields.length)
+                }
+                action={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-auto"
+                    onClick={() => router.push(buildOnboardingHref("towel_material"))}
+                  >
+                    Alltag bearbeiten
+                  </Button>
+                }
+              />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {profileLoading ? (
+                <SectionGridSkeleton count={5} className="md:grid-cols-2 xl:grid-cols-3" />
+              ) : routineFilled.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {routineFilled.map((field) => (
+                    <ProfileFieldCard
+                      key={field.key}
+                      field={field}
+                      onClick={() => openTarget(field.editTarget)}
+                      actionLabel={getFieldActionLabel(field.editTarget)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <InlinePromptCard
+                  title="Noch keine Alltagsangaben vorhanden"
+                  text="Trocknen, Bürste und Nachtschutz erscheinen hier, sobald du den Alltagsteil im Onboarding speicherst."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => router.push(buildOnboardingHref("towel_material"))}
+                    >
+                      Alltag öffnen
+                    </Button>
+                  }
+                />
+              )}
+
+              {!profileLoading && routineFilled.length > 0 && routineMissing.length > 0 ? (
+                <InlinePromptCard
+                  title={getOpenItemsTitle(routineMissing.length, "Angabe", "Angaben")}
+                  text="Im Alltag-Teil kannst du die fehlenden Angaben ergänzen."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => router.push(buildOnboardingHref("towel_material"))}
+                    >
+                      Alltag ergänzen
+                    </Button>
+                  }
+                />
+              ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-4">
+              <SectionHeader
+                title={SECTION_META_BY_KEY.goals.title}
+                description={SECTION_META_BY_KEY.goals.description}
+                status={
+                  profileLoading
+                    ? "Wird geladen"
+                    : getCompletionLabel(goalsFilled.length, goalsFields.length)
+                }
+                action={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-auto"
+                    onClick={() => router.push(buildOnboardingHref("goals"))}
+                  >
+                    Ziele bearbeiten
+                  </Button>
+                }
+              />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {profileLoading ? (
+                <div className="rounded-xl border border-border/70 bg-card/70 p-4">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="mt-2 h-3 w-56" />
+                  <div className="mt-5 flex flex-wrap gap-2">
+                    {Array.from({ length: 5 }).map((_, index) => (
+                      <Skeleton key={index} className="h-8 w-28 rounded-full" />
+                    ))}
+                  </div>
+                </div>
+              ) : goalsField?.value ? (
+                <ProfileFieldCard
+                  field={goalsField}
+                  className="max-w-3xl"
+                  onClick={() => openTarget(goalsField.editTarget)}
+                  actionLabel={getFieldActionLabel(goalsField.editTarget)}
+                >
+                  <ProfileFieldValue
+                    value={goalsField.value}
+                    displayMode={goalsField.displayMode}
+                  />
+                </ProfileFieldCard>
+              ) : (
+                <InlinePromptCard
+                  title="Noch keine Ziele gewählt"
+                  text="Hier landen genau die Haarziele aus dem letzten Onboarding-Schritt, sobald du sie speicherst."
+                  action={
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-auto"
+                      onClick={() => router.push(buildOnboardingHref("goals"))}
+                    >
+                      Ziele öffnen
+                    </Button>
+                  }
+                />
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-4">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
                 <div>
-                  <CardTitle className="text-xl text-[var(--text-heading)]">
-                    {PROFILE_SECTION_META[3].title}
-                  </CardTitle>
-                  <CardDescription className="mt-2 text-sm">
-                    {PROFILE_SECTION_META[3].description}
+                  <div className="flex flex-wrap items-center gap-3">
+                    <CardTitle className="text-xl text-[var(--text-heading)]">
+                      {SECTION_META_BY_KEY.memory.title}
+                    </CardTitle>
+                    <SectionStatusBadge
+                      label={memoryLoading ? "Wird geladen" : memoryEnabled ? "Aktiv" : "Pausiert"}
+                    />
+                  </div>
+                  <CardDescription className="mt-2 max-w-2xl text-sm">
+                    {SECTION_META_BY_KEY.memory.description}
                   </CardDescription>
                 </div>
                 <Switch
@@ -1467,7 +1649,8 @@ export default function ProfilePage() {
             <CardHeader className="pb-3">
               <CardTitle className="text-lg text-[var(--text-heading)]">Account</CardTitle>
               <CardDescription className="mt-1 text-sm">
-                Dein Zugang bleibt bewusst sekundär, damit das Profil mit deiner Haarreise startet.
+                Dein Zugang bleibt bewusst sekundär, damit das Profil weiterhin mit deiner Haarreise
+                startet.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -1487,16 +1670,6 @@ export default function ProfilePage() {
               </div>
             </CardContent>
           </Card>
-        </div>
-
-        <div className="mt-8 text-center">
-          <button
-            type="button"
-            onClick={signOut}
-            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Abmelden
-          </button>
         </div>
       </main>
     </>

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -6,20 +6,21 @@ import posthog from "posthog-js"
 import { useToast } from "@/providers/toast-provider"
 import { createClient } from "@/lib/supabase/client"
 import { useOnboardingStore } from "@/lib/onboarding/store"
-import type { OnboardingStep } from "@/lib/onboarding/store"
+import type { OnboardingEditScope, OnboardingStep } from "@/lib/onboarding/store"
 import { OnboardingProgressBar } from "@/components/onboarding/onboarding-progress-bar"
 import { mergeAnsweredFields } from "@/lib/onboarding/answered-fields"
 import {
-  mapShampooFrequency,
-  mapHeatFrequency,
   deriveMechanicalStressFactors,
   derivePostWashActions,
-  mapProductChecklistToRoutineProducts,
   reconcileDiffusor,
 } from "@/lib/onboarding/backward-compat"
-import { deriveVolumeFromGoals } from "@/lib/onboarding/goal-flow"
+import {
+  BASIC_PRODUCT_OPTIONS,
+  EXTRA_PRODUCT_OPTIONS,
+  PRODUCT_CATEGORY_LABELS,
+} from "@/lib/onboarding/product-options"
 import type { ProductFrequency } from "@/lib/vocabulary"
-import type { HairTexture, DesiredVolume } from "@/lib/vocabulary"
+import type { HairTexture, DesiredVolume, HeatStyling } from "@/lib/vocabulary"
 import type { Goal } from "@/lib/vocabulary"
 
 // Import all screens
@@ -54,27 +55,6 @@ import type {
 } from "@/lib/vocabulary/onboarding-care"
 
 import type { IconName } from "@/components/ui/icon"
-
-/* ── Product checklist options ── */
-
-const BASIC_PRODUCT_OPTIONS: { value: string; label: string; icon: IconName }[] = [
-  { value: "shampoo", label: "Shampoo", icon: "product-shampoo" },
-  { value: "conditioner", label: "Conditioner", icon: "product-conditioner" },
-  { value: "leave_in", label: "Leave-in", icon: "product-leave-in" },
-  { value: "oil", label: "\u00D6l", icon: "product-oil" },
-  { value: "mask", label: "Maske", icon: "product-mask" },
-]
-
-const EXTRA_PRODUCT_OPTIONS: { value: string; label: string; icon: IconName }[] = [
-  { value: "peeling", label: "Peeling (Serum/Scrub)", icon: "product-peeling" },
-  { value: "dry_shampoo", label: "Trockenshampoo", icon: "product-dry-shampoo" },
-  { value: "bondbuilder", label: "Bondbuilder", icon: "product-bond-builder" },
-  {
-    value: "deep_cleansing_shampoo",
-    label: "Tiefenreinigungsshampoo",
-    icon: "product-deep-cleansing",
-  },
-]
 
 /* ── Care habit icon maps ── */
 
@@ -116,18 +96,6 @@ const NIGHT_PROTECTION_ICONS: Record<string, IconName> = {
 
 /* ── Label map for drilldown categories ── */
 
-const CATEGORY_LABELS: Record<string, string> = {
-  shampoo: "Shampoo",
-  conditioner: "Conditioner",
-  leave_in: "Leave-in",
-  oil: "Öl",
-  mask: "Maske",
-  peeling: "Peeling",
-  dry_shampoo: "Trockenshampoo",
-  bondbuilder: "Bondbuilder",
-  deep_cleansing_shampoo: "Tiefenreinigungsshampoo",
-}
-
 /* ── Custom subtitle overrides for drilldown screens ── */
 
 const CATEGORY_SUBTITLES: Record<string, string> = {
@@ -141,6 +109,77 @@ interface OnboardingFlowProps {
   initialStep: string
   hairProfile: Record<string, unknown> | null
   productUsage: Array<Record<string, unknown>>
+  returnTo?: string | null
+  editScope?: OnboardingEditScope | null
+  singleStepEdit?: boolean
+  initialDrilldownCategory?: string | null
+}
+
+type OnboardingStateSnapshot = ReturnType<typeof useOnboardingStore.getState>
+
+function shouldReturnAfterScopeStep(
+  completedStep: OnboardingStep,
+  state: OnboardingStateSnapshot,
+  editScope: OnboardingEditScope | null,
+) {
+  switch (editScope) {
+    case "products": {
+      const lastDrilldownIndex = state.drilldownCategories().length - 1
+      return (
+        completedStep === "product_drilldown" && state.currentDrilldownIndex >= lastDrilldownIndex
+      )
+    }
+    case "styling":
+      return (
+        (completedStep === "heat_tools" && state.selectedHeatTools.length === 0) ||
+        completedStep === "heat_protection"
+      )
+    case "routine":
+      return completedStep === "night_protection"
+    case "goals":
+      return completedStep === "goals"
+    default:
+      return false
+  }
+}
+
+function getFinalContinueLabel(
+  currentStep: OnboardingStep,
+  state: OnboardingStateSnapshot,
+  editScope: OnboardingEditScope | null,
+  singleStepEdit: boolean,
+  returnTo: string | null,
+) {
+  if (!returnTo) return "Weiter"
+
+  if (
+    singleStepEdit &&
+    (currentStep === "product_drilldown" ||
+      currentStep === "heat_tools" ||
+      currentStep === "drying_method" ||
+      currentStep === "night_protection" ||
+      currentStep === "goals")
+  ) {
+    return "Speichern und zurück zum Profil"
+  }
+
+  if (currentStep === "goals") {
+    return "Speichern und zurück zum Profil"
+  }
+
+  if (currentStep === "night_protection" && editScope === "routine") {
+    return "Speichern und zurück zum Profil"
+  }
+
+  if (
+    currentStep === "product_drilldown" &&
+    editScope === "products" &&
+    shouldReturnAfterScopeStep(currentStep, state, editScope)
+  ) {
+    return "Speichern und zurück zum Profil"
+  }
+
+  return "Weiter"
 }
 
 /* ── Component ── */
@@ -150,6 +189,10 @@ export function OnboardingFlow({
   initialStep,
   hairProfile,
   productUsage,
+  returnTo = null,
+  editScope = null,
+  singleStepEdit = false,
+  initialDrilldownCategory = null,
 }: OnboardingFlowProps) {
   const router = useRouter()
   const { toast } = useToast()
@@ -184,6 +227,9 @@ export function OnboardingFlow({
     if (hairProfile) {
       if (Array.isArray(hairProfile.styling_tools) && hairProfile.styling_tools.length > 0) {
         store.setSelectedHeatTools(hairProfile.styling_tools as string[])
+      }
+      if (hairProfile.heat_styling) {
+        store.setHeatFrequency(hairProfile.heat_styling as HeatStyling)
       }
       if (hairProfile.towel_material) {
         store.setTowelMaterial(hairProfile.towel_material as TowelMaterial)
@@ -241,6 +287,14 @@ export function OnboardingFlow({
 
       if (basics.length > 0) store.setSelectedBasicProducts(basics)
       if (extras.length > 0) store.setSelectedExtraProducts(extras)
+
+      if (step === "product_drilldown" && initialDrilldownCategory) {
+        const orderedCategories = [...basics, ...extras]
+        const targetIndex = orderedCategories.indexOf(initialDrilldownCategory)
+        if (targetIndex >= 0) {
+          store.setCurrentDrilldownIndex(targetIndex)
+        }
+      }
     }
 
     setHydrated(true)
@@ -269,10 +323,12 @@ export function OnboardingFlow({
       const drilldowns = useOnboardingStore.getState().productDrilldowns
 
       // Get existing rows
-      const { data: existing } = await supabase
+      const { data: existing, error: existingError } = await supabase
         .from("user_product_usage")
         .select("id, category")
         .eq("user_id", userId)
+
+      if (existingError) throw existingError
 
       const existingMap = new Map(
         (existing ?? []).map((r: Record<string, unknown>) => [
@@ -292,9 +348,14 @@ export function OnboardingFlow({
         }
 
         if (existingMap.has(cat)) {
-          await supabase.from("user_product_usage").update(payload).eq("id", existingMap.get(cat))
+          const { error: updateError } = await supabase
+            .from("user_product_usage")
+            .update(payload)
+            .eq("id", existingMap.get(cat))
+          if (updateError) throw updateError
         } else {
-          await supabase.from("user_product_usage").insert(payload)
+          const { error: insertError } = await supabase.from("user_product_usage").insert(payload)
+          if (insertError) throw insertError
         }
       }
 
@@ -304,7 +365,11 @@ export function OnboardingFlow({
         .map((r: Record<string, unknown>) => r.id as string)
 
       if (toDelete.length > 0) {
-        await supabase.from("user_product_usage").delete().in("id", toDelete)
+        const { error: deleteError } = await supabase
+          .from("user_product_usage")
+          .delete()
+          .in("id", toDelete)
+        if (deleteError) throw deleteError
       }
     },
     [userId],
@@ -342,6 +407,9 @@ export function OnboardingFlow({
           case "products_extras": {
             const allProducts = [...state.selectedBasicProducts, ...state.selectedExtraProducts]
             await saveProductUsage(allProducts)
+            await saveHairProfile({
+              current_routine_products: [],
+            })
             break
           }
 
@@ -354,7 +422,7 @@ export function OnboardingFlow({
             if (!drilldown) break
 
             // Update the specific product usage row
-            await supabase
+            const { error: productUsageError } = await supabase
               .from("user_product_usage")
               .update({
                 product_name: drilldown.productName,
@@ -363,10 +431,12 @@ export function OnboardingFlow({
               .eq("user_id", userId)
               .eq("category", currentCat)
 
-            // If shampoo, also update wash_frequency
-            if (currentCat === "shampoo" && drilldown.frequency) {
+            if (productUsageError) throw productUsageError
+
+            // Clear the legacy mirror; shampoo cadence now comes from user_product_usage.
+            if (currentCat === "shampoo") {
               await saveHairProfile({
-                wash_frequency: mapShampooFrequency(drilldown.frequency),
+                wash_frequency: null,
               })
             }
             break
@@ -389,7 +459,7 @@ export function OnboardingFlow({
           case "heat_frequency": {
             if (state.heatFrequency) {
               await saveHairProfile({
-                heat_styling: mapHeatFrequency(state.heatFrequency),
+                heat_styling: state.heatFrequency,
               })
             }
             break
@@ -466,28 +536,52 @@ export function OnboardingFlow({
 
           case "goals": {
             const goals = state.selectedGoals as Goal[]
-            const desiredVolume = deriveVolumeFromGoals(goals)
-            const routineProducts = mapProductChecklistToRoutineProducts(
-              state.allSelectedProducts(),
-            )
             await saveHairProfile({
               goals,
-              desired_volume: desiredVolume,
-              current_routine_products: routineProducts,
+              desired_volume: null,
+              current_routine_products: [],
             })
-            await supabase.from("profiles").update({ onboarding_completed: true }).eq("id", userId)
-            posthog.capture("onboarding_completed", { userId })
+            const { error: onboardingCompletedError } = await supabase
+              .from("profiles")
+              .update({ onboarding_completed: true })
+              .eq("id", userId)
+
+            if (onboardingCompletedError) throw onboardingCompletedError
+
+            if (!returnTo) {
+              posthog.capture("onboarding_completed", { userId })
+            }
+            if (returnTo) {
+              window.location.assign(returnTo)
+              return
+            }
             break
           }
 
           case "celebration": {
-            await supabase
+            const { error: completionPopupError } = await supabase
               .from("profiles")
               .update({ has_seen_completion_popup: true })
               .eq("id", userId)
+
+            if (completionPopupError) throw completionPopupError
+            if (returnTo) {
+              window.location.assign(returnTo)
+              return
+            }
             router.push("/chat")
             return // Don't advance step
           }
+        }
+
+        if (returnTo && singleStepEdit) {
+          window.location.assign(returnTo)
+          return
+        }
+
+        if (returnTo && shouldReturnAfterScopeStep(completedStep, state, editScope)) {
+          window.location.assign(returnTo)
+          return
         }
 
         // Advance the store
@@ -511,7 +605,17 @@ export function OnboardingFlow({
         setSavingStep(null)
       }
     },
-    [userId, router, toast, saveProductUsage, saveHairProfile, saveOnboardingStep],
+    [
+      userId,
+      router,
+      toast,
+      saveProductUsage,
+      saveHairProfile,
+      saveOnboardingStep,
+      returnTo,
+      editScope,
+      singleStepEdit,
+    ],
   )
 
   // ── Toggle helpers ──
@@ -619,6 +723,15 @@ export function OnboardingFlow({
   const currentDrilldown = currentCategory
     ? (store.productDrilldowns[currentCategory] ?? { productName: "", frequency: null })
     : { productName: "", frequency: null }
+  const backTarget = singleStepEdit && returnTo ? returnTo : null
+
+  function handleBack() {
+    if (backTarget) {
+      window.location.assign(backTarget)
+      return
+    }
+    store.goBack()
+  }
 
   // ── Screen rendering ──
 
@@ -636,7 +749,7 @@ export function OnboardingFlow({
             selected={store.selectedBasicProducts}
             onToggle={toggleBasicProduct}
             onContinue={() => handleStepComplete("products_basics")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
             isSaving={savingStep === "products_basics"}
           />
         )
@@ -650,7 +763,7 @@ export function OnboardingFlow({
             selected={store.selectedExtraProducts}
             onToggle={toggleExtraProduct}
             onContinue={() => handleStepComplete("products_extras")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
             noneLabel="Nichts davon"
             onNone={() => {
               store.setSelectedExtraProducts([])
@@ -664,7 +777,7 @@ export function OnboardingFlow({
         return currentCategory ? (
           <ProductDrilldownScreen
             category={currentCategory}
-            categoryLabel={CATEGORY_LABELS[currentCategory] ?? currentCategory}
+            categoryLabel={PRODUCT_CATEGORY_LABELS[currentCategory] ?? currentCategory}
             subtitle={CATEGORY_SUBTITLES[currentCategory]}
             productName={currentDrilldown.productName}
             frequency={currentDrilldown.frequency}
@@ -681,7 +794,14 @@ export function OnboardingFlow({
               })
             }
             onContinue={() => handleStepComplete("product_drilldown")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
+            continueLabel={getFinalContinueLabel(
+              "product_drilldown",
+              store,
+              editScope,
+              singleStepEdit,
+              returnTo,
+            )}
           />
         ) : null
 
@@ -691,12 +811,24 @@ export function OnboardingFlow({
             selected={store.selectedHeatTools}
             onToggle={toggleHeatTool}
             onContinue={() => handleStepComplete("heat_tools")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
             onNone={() => {
               store.setSelectedHeatTools([])
               handleStepComplete("heat_tools")
             }}
             isSaving={savingStep === "heat_tools"}
+            noneLabel={
+              editScope === "styling" || singleStepEdit
+                ? "Keine Hitzetools speichern"
+                : "Nichts davon"
+            }
+            continueLabel={getFinalContinueLabel(
+              "heat_tools",
+              store,
+              editScope,
+              singleStepEdit,
+              returnTo,
+            )}
           />
         )
 
@@ -708,7 +840,7 @@ export function OnboardingFlow({
               store.setHeatFrequency(freq)
               handleStepComplete("heat_frequency")
             }}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
           />
         )
 
@@ -720,7 +852,7 @@ export function OnboardingFlow({
               store.setUsesHeatProtection(val)
               handleStepComplete("heat_protection")
             }}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
           />
         )
 
@@ -728,7 +860,7 @@ export function OnboardingFlow({
         return (
           <InterstitialScreen
             onContinue={() => handleStepComplete("interstitial")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
           />
         )
 
@@ -743,7 +875,7 @@ export function OnboardingFlow({
               store.setTowelMaterial(val as TowelMaterial)
               handleStepComplete("towel_material")
             }}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
           />
         )
 
@@ -758,7 +890,7 @@ export function OnboardingFlow({
               store.setTowelTechnique(val as TowelTechnique)
               handleStepComplete("towel_technique")
             }}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
           />
         )
 
@@ -771,8 +903,15 @@ export function OnboardingFlow({
             selected={store.dryingMethod}
             onToggle={toggleDryingMethod}
             onContinue={() => handleStepComplete("drying_method")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
             isSaving={savingStep === "drying_method"}
+            continueLabel={getFinalContinueLabel(
+              "drying_method",
+              store,
+              editScope,
+              singleStepEdit,
+              returnTo,
+            )}
           />
         )
 
@@ -787,7 +926,7 @@ export function OnboardingFlow({
               store.setBrushType(val as BrushType)
               handleStepComplete("brush_type")
             }}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
           />
         )
 
@@ -800,13 +939,24 @@ export function OnboardingFlow({
             selected={store.nightProtection}
             onToggle={toggleNightProtection}
             onContinue={() => handleStepComplete("night_protection")}
-            onBack={() => store.goBack()}
-            noneLabel="Nichts davon"
+            onBack={handleBack}
+            noneLabel={
+              editScope === "routine" || singleStepEdit
+                ? "Ohne Nachtschutz speichern"
+                : "Nichts davon"
+            }
             onNone={() => {
               store.setNightProtection([])
               handleStepComplete("night_protection")
             }}
             isSaving={savingStep === "night_protection"}
+            continueLabel={getFinalContinueLabel(
+              "night_protection",
+              store,
+              editScope,
+              singleStepEdit,
+              returnTo,
+            )}
           />
         )
 
@@ -817,8 +967,15 @@ export function OnboardingFlow({
             selectedGoals={store.selectedGoals}
             onGoalToggle={toggleGoal}
             onContinue={() => handleStepComplete("goals")}
-            onBack={() => store.goBack()}
+            onBack={handleBack}
             isSaving={savingStep === "goals"}
+            continueLabel={getFinalContinueLabel(
+              "goals",
+              store,
+              editScope,
+              singleStepEdit,
+              returnTo,
+            )}
           />
         )
 

--- a/src/components/onboarding/screens/goals-screen.tsx
+++ b/src/components/onboarding/screens/goals-screen.tsx
@@ -13,6 +13,7 @@ interface GoalsScreenProps {
   onBack: () => void
   isSaving?: boolean
   maxGoals?: number
+  continueLabel?: string
 }
 
 export function GoalsScreen({
@@ -23,6 +24,7 @@ export function GoalsScreen({
   onBack,
   isSaving,
   maxGoals = 5,
+  continueLabel = "Weiter",
 }: GoalsScreenProps) {
   const goals = hairTexture ? getOrderedGoals(hairTexture) : []
 
@@ -106,7 +108,7 @@ export function GoalsScreen({
           disabled={selectedGoals.length < 1 || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {isSaving ? "Speichern..." : "Weiter"}
+          {isSaving ? "Speichern..." : continueLabel}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/heat-frequency-screen.tsx
+++ b/src/components/onboarding/screens/heat-frequency-screen.tsx
@@ -2,12 +2,12 @@
 
 import { useRef, useState } from "react"
 import { ArrowLeft } from "lucide-react"
-import { PRODUCT_FREQUENCY_OPTIONS } from "@/lib/vocabulary"
-import type { ProductFrequency } from "@/lib/vocabulary"
+import { HEAT_STYLING_OPTIONS } from "@/lib/vocabulary"
+import type { HeatStyling } from "@/lib/vocabulary"
 
 interface HeatFrequencyScreenProps {
-  selected: ProductFrequency | null
-  onSelect: (freq: ProductFrequency) => void
+  selected: HeatStyling | null
+  onSelect: (freq: HeatStyling) => void
   onBack: () => void
 }
 
@@ -15,7 +15,7 @@ export function HeatFrequencyScreen({ selected, onSelect, onBack }: HeatFrequenc
   const advancingRef = useRef(false)
   const [localSelected, setLocalSelected] = useState(selected)
 
-  function handleSelect(freq: ProductFrequency) {
+  function handleSelect(freq: HeatStyling) {
     if (advancingRef.current) return
     advancingRef.current = true
     setLocalSelected(freq)
@@ -41,7 +41,7 @@ export function HeatFrequencyScreen({ selected, onSelect, onBack }: HeatFrequenc
 
       <div className="animate-fade-in-up mt-6" style={{ animationDelay: "100ms" }}>
         <div className="flex flex-wrap gap-2">
-          {PRODUCT_FREQUENCY_OPTIONS.map((option) => (
+          {HEAT_STYLING_OPTIONS.map((option) => (
             <button
               key={option.value}
               type="button"

--- a/src/components/onboarding/screens/heat-tools-screen.tsx
+++ b/src/components/onboarding/screens/heat-tools-screen.tsx
@@ -22,6 +22,8 @@ interface HeatToolsScreenProps {
   onBack: () => void
   onNone: () => void
   isSaving?: boolean
+  noneLabel?: string
+  continueLabel?: string
 }
 
 export function HeatToolsScreen({
@@ -31,6 +33,8 @@ export function HeatToolsScreen({
   onBack,
   onNone,
   isSaving,
+  noneLabel = "Nichts davon",
+  continueLabel = "Weiter",
 }: HeatToolsScreenProps) {
   const hasSelection = selected.length > 0
 
@@ -80,7 +84,7 @@ export function HeatToolsScreen({
           disabled={isSaving}
           className="rounded-full border border-border px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground disabled:opacity-40"
         >
-          Nichts davon
+          {noneLabel}
         </button>
       </div>
 
@@ -93,7 +97,7 @@ export function HeatToolsScreen({
           disabled={!hasSelection || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {isSaving ? "Speichern..." : "Weiter"}
+          {isSaving ? "Speichern..." : continueLabel}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/multi-select-screen.tsx
+++ b/src/components/onboarding/screens/multi-select-screen.tsx
@@ -15,6 +15,7 @@ interface MultiSelectScreenProps {
   noneLabel?: string
   onNone?: () => void
   isSaving?: boolean
+  continueLabel?: string
 }
 
 export function MultiSelectScreen({
@@ -28,6 +29,7 @@ export function MultiSelectScreen({
   noneLabel,
   onNone,
   isSaving,
+  continueLabel = "Weiter",
 }: MultiSelectScreenProps) {
   const hasSelection = selected.length > 0
 
@@ -94,7 +96,7 @@ export function MultiSelectScreen({
           disabled={!hasSelection || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {isSaving ? "Speichern..." : "Weiter"}
+          {isSaving ? "Speichern..." : continueLabel}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/product-checklist-screen.tsx
+++ b/src/components/onboarding/screens/product-checklist-screen.tsx
@@ -15,6 +15,7 @@ interface ProductChecklistScreenProps {
   noneLabel?: string
   onNone?: () => void
   isSaving?: boolean
+  continueLabel?: string
 }
 
 export function ProductChecklistScreen({
@@ -28,6 +29,7 @@ export function ProductChecklistScreen({
   noneLabel,
   onNone,
   isSaving,
+  continueLabel = "Weiter",
 }: ProductChecklistScreenProps) {
   const hasSelection = selected.length > 0
 
@@ -92,7 +94,7 @@ export function ProductChecklistScreen({
           disabled={!hasSelection || isSaving}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {isSaving ? "Speichern..." : "Weiter"}
+          {isSaving ? "Speichern..." : continueLabel}
         </button>
       </div>
     </div>

--- a/src/components/onboarding/screens/product-drilldown-screen.tsx
+++ b/src/components/onboarding/screens/product-drilldown-screen.tsx
@@ -14,6 +14,7 @@ interface ProductDrilldownScreenProps {
   onFrequencyChange: (freq: ProductFrequency) => void
   onContinue: () => void
   onBack: () => void
+  continueLabel?: string
 }
 
 export function ProductDrilldownScreen({
@@ -25,6 +26,7 @@ export function ProductDrilldownScreen({
   onFrequencyChange,
   onContinue,
   onBack,
+  continueLabel = "Weiter",
 }: ProductDrilldownScreenProps) {
   return (
     <div>
@@ -85,7 +87,7 @@ export function ProductDrilldownScreen({
           disabled={!frequency}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Weiter
+          {continueLabel}
         </button>
       </div>
     </div>

--- a/src/components/quiz/quiz-results.tsx
+++ b/src/components/quiz/quiz-results.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useRouter, useSearchParams } from "next/navigation"
 import { useQuizStore } from "@/lib/quiz/store"
 import { hopeText } from "@/lib/quiz/results-lookup"
 import { QuizProfileCard } from "./quiz-profile-card"
@@ -7,10 +8,16 @@ import { QuizCard } from "./quiz-card"
 import { Button } from "@/components/ui/button"
 import { posthog } from "@/providers/posthog-provider"
 import { buildCardData } from "@/lib/quiz/result-card-data"
+import { useAuth } from "@/providers/auth-provider"
 
 export function QuizResults() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { user } = useAuth()
   const { lead, answers, aiInsight, leadId, goNext } = useQuizStore()
   const cardData = buildCardData(answers)
+  const returnTo = searchParams.get("returnTo")
+  const isRetakeMode = searchParams.get("mode") === "retake"
 
   const handleStart = () => {
     posthog.capture("quiz_completed", {
@@ -19,6 +26,15 @@ export function QuizResults() {
       scalp_type: answers.scalp_type,
       scalp_condition: answers.scalp_condition,
     })
+
+    if (user && isRetakeMode && leadId) {
+      const nextUrl = new URL("/onboarding", window.location.origin)
+      nextUrl.searchParams.set("lead", leadId)
+      nextUrl.searchParams.set("returnTo", returnTo?.startsWith("/") ? returnTo : "/profile")
+      router.push(`${nextUrl.pathname}${nextUrl.search}`)
+      return
+    }
+
     goNext()
   }
 

--- a/src/lib/hair-profile/derived.ts
+++ b/src/lib/hair-profile/derived.ts
@@ -1,0 +1,111 @@
+import { PRODUCT_CATEGORY_LABELS } from "@/lib/onboarding/product-options"
+import type { HairProfile } from "@/lib/types"
+import {
+  ROUTINE_PRODUCTS,
+  type ProductFrequency,
+  type RoutineProduct,
+  type WashFrequency,
+} from "@/lib/vocabulary"
+
+export type RoutineInventoryLike = {
+  category: string
+  product_name: string | null
+  frequency_range: ProductFrequency | null
+}
+
+const LEGACY_ROUTINE_PRODUCT_SET = new Set<RoutineProduct>(ROUTINE_PRODUCTS)
+
+function mapProductFrequencyToWashFrequency(freq: ProductFrequency): WashFrequency {
+  switch (freq) {
+    case "daily":
+      return "daily"
+    case "5_6x":
+      return "daily"
+    case "3_4x":
+      return "every_2_3_days"
+    case "1_2x":
+      return "once_weekly"
+    case "rarely":
+      return "rarely"
+  }
+}
+
+function normalizeRoutineProductCategory(category: string): RoutineProduct | null {
+  return LEGACY_ROUTINE_PRODUCT_SET.has(category as RoutineProduct)
+    ? (category as RoutineProduct)
+    : null
+}
+
+export function deriveWashFrequencyFromRoutineItems(
+  routineItems: RoutineInventoryLike[],
+  fallback: WashFrequency | null = null,
+): WashFrequency | null {
+  const shampooEntry = routineItems.find(
+    (item) => item.category === "shampoo" && item.frequency_range !== null,
+  )
+
+  return shampooEntry?.frequency_range
+    ? mapProductFrequencyToWashFrequency(shampooEntry.frequency_range)
+    : fallback
+}
+
+export function deriveCurrentRoutineProductsFromRoutineItems(
+  routineItems: RoutineInventoryLike[],
+  fallback: RoutineProduct[] = [],
+): RoutineProduct[] {
+  const categories = Array.from(
+    new Set(
+      routineItems
+        .map((item) => normalizeRoutineProductCategory(item.category))
+        .filter((item): item is RoutineProduct => item !== null),
+    ),
+  )
+
+  return categories.length > 0 ? categories : fallback
+}
+
+export function deriveProductsUsedFromRoutineItems(
+  routineItems: RoutineInventoryLike[],
+  fallback: string | null = null,
+): string | null {
+  if (routineItems.length === 0) return fallback
+
+  const items = routineItems.map((item) => {
+    const categoryLabel = PRODUCT_CATEGORY_LABELS[item.category] ?? item.category
+    const productName = item.product_name?.trim()
+
+    return productName ? `${categoryLabel}: ${productName}` : categoryLabel
+  })
+
+  return items.length > 0 ? items.join(", ") : fallback
+}
+
+export function deriveDesiredVolumeFromGoals(
+  goals: string[] | null | undefined,
+  fallback: HairProfile["desired_volume"],
+): HairProfile["desired_volume"] {
+  if (!goals || goals.length === 0) return fallback
+
+  if (goals.includes("volume")) return "more"
+  if (goals.includes("less_volume")) return "less"
+
+  return null
+}
+
+export function hydrateHairProfileForConsumers(
+  profile: HairProfile | null,
+  routineItems: RoutineInventoryLike[],
+): HairProfile | null {
+  if (!profile) return null
+
+  return {
+    ...profile,
+    wash_frequency: deriveWashFrequencyFromRoutineItems(routineItems, profile.wash_frequency),
+    current_routine_products: deriveCurrentRoutineProductsFromRoutineItems(
+      routineItems,
+      profile.current_routine_products ?? [],
+    ),
+    products_used: deriveProductsUsedFromRoutineItems(routineItems, profile.products_used),
+    desired_volume: deriveDesiredVolumeFromGoals(profile.goals, profile.desired_volume),
+  }
+}

--- a/src/lib/onboarding/product-options.ts
+++ b/src/lib/onboarding/product-options.ts
@@ -1,0 +1,31 @@
+import type { IconName } from "@/components/ui/icon"
+
+export const BASIC_PRODUCT_OPTIONS: { value: string; label: string; icon: IconName }[] = [
+  { value: "shampoo", label: "Shampoo", icon: "product-shampoo" },
+  { value: "conditioner", label: "Conditioner", icon: "product-conditioner" },
+  { value: "leave_in", label: "Leave-in", icon: "product-leave-in" },
+  { value: "oil", label: "Öl", icon: "product-oil" },
+  { value: "mask", label: "Maske", icon: "product-mask" },
+]
+
+export const EXTRA_PRODUCT_OPTIONS: { value: string; label: string; icon: IconName }[] = [
+  { value: "peeling", label: "Peeling (Serum/Scrub)", icon: "product-peeling" },
+  { value: "dry_shampoo", label: "Trockenshampoo", icon: "product-dry-shampoo" },
+  { value: "bondbuilder", label: "Bondbuilder", icon: "product-bond-builder" },
+  {
+    value: "deep_cleansing_shampoo",
+    label: "Tiefenreinigungsshampoo",
+    icon: "product-deep-cleansing",
+  },
+]
+
+export const BASIC_PRODUCT_ORDER = BASIC_PRODUCT_OPTIONS.map((option) => option.value)
+export const EXTRA_PRODUCT_ORDER = EXTRA_PRODUCT_OPTIONS.map((option) => option.value)
+export const PRODUCT_CATEGORY_ORDER = [...BASIC_PRODUCT_ORDER, ...EXTRA_PRODUCT_ORDER]
+
+export const PRODUCT_CATEGORY_LABELS: Record<string, string> = Object.fromEntries(
+  [...BASIC_PRODUCT_OPTIONS, ...EXTRA_PRODUCT_OPTIONS].map((option) => [
+    option.value,
+    option.label,
+  ]),
+)

--- a/src/lib/onboarding/store.ts
+++ b/src/lib/onboarding/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand"
-import type { ProductFrequency } from "@/lib/vocabulary/frequencies"
+import type { HeatStyling, ProductFrequency } from "@/lib/vocabulary/frequencies"
 import type {
   TowelMaterial,
   TowelTechnique,
@@ -28,6 +28,31 @@ export type OnboardingStep =
   | "goals"
   | "celebration"
 
+export type OnboardingEditScope = "products" | "styling" | "routine" | "goals"
+
+export function getOnboardingEditScope(step: OnboardingStep): OnboardingEditScope | null {
+  switch (step) {
+    case "products_basics":
+    case "products_extras":
+    case "product_drilldown":
+      return "products"
+    case "heat_tools":
+    case "heat_frequency":
+    case "heat_protection":
+      return "styling"
+    case "towel_material":
+    case "towel_technique":
+    case "drying_method":
+    case "brush_type":
+    case "night_protection":
+      return "routine"
+    case "goals":
+      return "goals"
+    default:
+      return null
+  }
+}
+
 /* ── Linear step order (branch-free segments) ── */
 
 const LINEAR_BEFORE_HEAT: OnboardingStep[] = [
@@ -38,10 +63,7 @@ const LINEAR_BEFORE_HEAT: OnboardingStep[] = [
   "heat_tools",
 ]
 
-const HEAT_BRANCH: OnboardingStep[] = [
-  "heat_frequency",
-  "heat_protection",
-]
+const HEAT_BRANCH: OnboardingStep[] = ["heat_frequency", "heat_protection"]
 
 const LINEAR_AFTER_HEAT: OnboardingStep[] = [
   "interstitial",
@@ -62,15 +84,12 @@ interface OnboardingState {
   // Product usage
   selectedBasicProducts: string[]
   selectedExtraProducts: string[]
-  productDrilldowns: Record<
-    string,
-    { productName: string; frequency: ProductFrequency | null }
-  >
+  productDrilldowns: Record<string, { productName: string; frequency: ProductFrequency | null }>
   currentDrilldownIndex: number
 
   // Heat styling
   selectedHeatTools: string[]
-  heatFrequency: ProductFrequency | null
+  heatFrequency: HeatStyling | null
   usesHeatProtection: boolean | null
 
   // Care habits
@@ -98,7 +117,7 @@ interface OnboardingState {
   ) => void
   setCurrentDrilldownIndex: (index: number) => void
   setSelectedHeatTools: (tools: string[]) => void
-  setHeatFrequency: (freq: ProductFrequency | null) => void
+  setHeatFrequency: (freq: HeatStyling | null) => void
   setUsesHeatProtection: (val: boolean | null) => void
   setTowelMaterial: (val: TowelMaterial | null) => void
   setTowelTechnique: (val: TowelTechnique | null) => void
@@ -145,7 +164,7 @@ const initialData = {
   currentDrilldownIndex: 0,
 
   selectedHeatTools: [] as string[],
-  heatFrequency: null as ProductFrequency | null,
+  heatFrequency: null as HeatStyling | null,
   usesHeatProtection: null as boolean | null,
 
   towelMaterial: null as TowelMaterial | null,
@@ -248,10 +267,8 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
 
   // ── Setters ──
 
-  setSelectedBasicProducts: (products) =>
-    set({ selectedBasicProducts: products }),
-  setSelectedExtraProducts: (products) =>
-    set({ selectedExtraProducts: products }),
+  setSelectedBasicProducts: (products) => set({ selectedBasicProducts: products }),
+  setSelectedExtraProducts: (products) => set({ selectedExtraProducts: products }),
   setProductDrilldown: (category, data) =>
     set((s) => ({
       productDrilldowns: { ...s.productDrilldowns, [category]: data },
@@ -278,13 +295,7 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
 
 /* ── Build the full linear order including/excluding heat branch ── */
 
-function buildFullOrder(state: {
-  selectedHeatTools: string[]
-}): OnboardingStep[] {
+function buildFullOrder(state: { selectedHeatTools: string[] }): OnboardingStep[] {
   const hasHeat = state.selectedHeatTools.length > 0
-  return [
-    ...LINEAR_BEFORE_HEAT,
-    ...(hasHeat ? HEAT_BRANCH : []),
-    ...LINEAR_AFTER_HEAT,
-  ]
+  return [...LINEAR_BEFORE_HEAT, ...(hasHeat ? HEAT_BRANCH : []), ...LINEAR_AFTER_HEAT]
 }

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -1,22 +1,18 @@
 import {
   CHEMICAL_TREATMENT_LABELS,
-  CONCERN_LABELS,
   CUTICLE_CONDITION_LABELS,
-  DESIRED_VOLUME_LABELS,
   GOAL_LABELS,
-  HAIR_DENSITY_LABELS,
   HAIR_TEXTURE_OPTIONS,
   HAIR_THICKNESS_OPTIONS,
   HEAT_STYLING_OPTIONS,
-  POST_WASH_ACTION_OPTIONS,
   PROTEIN_MOISTURE_LABELS,
-  ROUTINE_PRODUCT_OPTIONS,
   SCALP_CONDITION_LABELS,
   SCALP_TYPE_LABELS,
   STYLING_TOOL_LABELS,
-  WASH_FREQUENCY_OPTIONS,
 } from "@/lib/types"
 import type { HairProfile } from "@/lib/types"
+import { getGoalLabel, getOrderedGoals } from "@/lib/onboarding/goal-flow"
+import type { OnboardingStep } from "@/lib/onboarding/store"
 import {
   BRUSH_TYPE_LABELS,
   DRYING_METHOD_LABELS,
@@ -25,20 +21,27 @@ import {
   TOWEL_TECHNIQUE_LABELS,
 } from "@/lib/vocabulary"
 
-export type ProfileJourneySectionKey = "baseline" | "goals" | "routine" | "memory"
-export type ProfileFieldSourceLabel = "Aus Haar-Check" | "Aus Onboarding" | "Aus Chat"
+export type ProfileJourneySectionKey =
+  | "quiz"
+  | "products"
+  | "styling"
+  | "routine"
+  | "goals"
+  | "memory"
+export type ProfileFieldSourceLabel = "Aus Haar-Check" | "Aus Onboarding"
 export type ProfileFieldDisplayMode = "text" | "badges"
-export type ProfileFieldEditMode = "read_only" | "inline" | "section"
 export type ProfileFieldValue = string | string[] | null
+
+export type ProfileEditTarget = { kind: "quiz" } | { kind: "onboarding"; step: OnboardingStep }
 
 export type ProfileFieldConfig = {
   key: string
   label: string
   helpText: string
-  sectionKey: Exclude<ProfileJourneySectionKey, "memory">
+  sectionKey: Exclude<ProfileJourneySectionKey, "products" | "memory">
   sourceLabel: ProfileFieldSourceLabel
   displayMode: ProfileFieldDisplayMode
-  editMode: ProfileFieldEditMode
+  editTarget: ProfileEditTarget
   getValue: (profile: HairProfile | null) => ProfileFieldValue
 }
 
@@ -58,28 +61,67 @@ function optionLabel(
 
 function optionLabels(
   values: string[] | null | undefined,
-  options: Array<{ value: string; label: string }>,
+  labels: Record<string, string>,
 ): string[] | null {
   if (!values || values.length === 0) return null
-  return values.map((value) => optionLabel(value, options) ?? value)
+  return values.map((value) => labels[value] ?? value)
+}
+
+function orderedGoalLabels(profile: HairProfile | null): string[] | null {
+  if (!profile) return null
+
+  const selectedGoals = new Set(profile.goals ?? [])
+
+  if (profile.desired_volume === "more") {
+    selectedGoals.add("volume")
+  }
+
+  if (profile.desired_volume === "less") {
+    selectedGoals.add("less_volume")
+  }
+
+  if (selectedGoals.size === 0) return null
+
+  const ordered =
+    profile.hair_texture != null
+      ? getOrderedGoals(profile.hair_texture).filter((goal) => selectedGoals.has(goal))
+      : []
+
+  const remainder = Array.from(selectedGoals).filter((goal) => !ordered.includes(goal))
+  const goals = [...ordered, ...remainder]
+
+  return goals.map((goal) =>
+    profile.hair_texture != null
+      ? getGoalLabel(goal, profile.hair_texture)
+      : (GOAL_LABELS[goal] ?? goal),
+  )
 }
 
 export const PROFILE_SECTION_META: ProfileSectionMeta[] = [
   {
-    key: "baseline",
-    title: "Deine Ausgangslage",
-    description:
-      "Was Hair Concierge aus Haar-Check und Profilbasis über Struktur, Diagnose und Behandlungen weiß.",
+    key: "quiz",
+    title: "Haar-Check",
+    description: "Die Antworten aus deinem Haar-Check in derselben Reihenfolge wie im Quiz.",
   },
   {
-    key: "goals",
-    title: "Deine Ziele",
-    description: "Worauf dein Plan ausgerichtet wird und welche Themen dir aktuell wichtig sind.",
+    key: "products",
+    title: "Produkte",
+    description: "Welche Produkte du im Onboarding ausgewählt und genauer beschrieben hast.",
+  },
+  {
+    key: "styling",
+    title: "Styling",
+    description: "Hitzetools, Frequenz und Hitzeschutz aus dem Styling-Teil des Onboardings.",
   },
   {
     key: "routine",
-    title: "Dein Alltag",
-    description: "Wie du dein Haar im Alltag pflegst, trocknest und mit Produkten unterstützt.",
+    title: "Alltag",
+    description: "Trocknen, Bürste und Nachtschutz aus dem Alltagsteil deines Onboardings.",
+  },
+  {
+    key: "goals",
+    title: "Ziele",
+    description: "Deine ausgewählten Haarziele aus dem letzten Onboarding-Schritt.",
   },
   {
     key: "memory",
@@ -90,52 +132,43 @@ export const PROFILE_SECTION_META: ProfileSectionMeta[] = [
 ]
 
 export const PROFILE_JOURNEY_STEPS = [
-  { key: "baseline", label: "Haar-Check" },
-  { key: "goals", label: "Ziele" },
+  { key: "quiz", label: "Haar-Check" },
+  { key: "products", label: "Produkte" },
+  { key: "styling", label: "Styling" },
   { key: "routine", label: "Alltag" },
+  { key: "goals", label: "Ziele" },
   { key: "memory", label: "Merkt sich" },
 ] as const
 
 export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
   {
     key: "hair_texture",
-    label: "Haartyp",
-    helpText: "Grundlage für die Kategorie- und Stylinglogik.",
-    sectionKey: "baseline",
+    label: "Haartextur",
+    helpText: "Dein erster Quiz-Schritt zur natürlichen Haarstruktur.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) => optionLabel(profile?.hair_texture, HAIR_TEXTURE_OPTIONS),
   },
   {
     key: "thickness",
-    label: "Haarstruktur",
-    helpText: "Steuert vor allem Gewicht und Reichhaltigkeit von Empfehlungen.",
-    sectionKey: "baseline",
+    label: "Haar-Dicke",
+    helpText: "Dein zweiter Quiz-Schritt zur Dicke eines einzelnen Haares.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) => optionLabel(profile?.thickness, HAIR_THICKNESS_OPTIONS),
   },
   {
-    key: "density",
-    label: "Haardichte",
-    helpText: "Hilft bei Volumen- und Gewichtsentscheidungen.",
-    sectionKey: "baseline",
-    sourceLabel: "Aus Onboarding",
-    displayMode: "badges",
-    editMode: "read_only",
-    getValue: (profile) =>
-      profile?.density ? (HAIR_DENSITY_LABELS[profile.density] ?? profile.density) : null,
-  },
-  {
     key: "cuticle_condition",
-    label: "Schuppenschicht",
-    helpText: "Zeigt, wie glatt oder aufgeraut die Haaroberfläche ist.",
-    sectionKey: "baseline",
+    label: "Oberfläche",
+    helpText: "Das Ergebnis aus dem Finger-Test im Quiz.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) =>
       profile?.cuticle_condition
         ? (CUTICLE_CONDITION_LABELS[profile.cuticle_condition] ?? profile.cuticle_condition)
@@ -143,12 +176,12 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
   },
   {
     key: "protein_moisture_balance",
-    label: "Protein / Feuchtigkeit",
-    helpText: "Signal für Balance zwischen Stabilität und Hydration.",
-    sectionKey: "baseline",
+    label: "Elastizität",
+    helpText: "Das Ergebnis aus dem Zug-Test im Quiz.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) =>
       profile?.protein_moisture_balance
         ? (PROTEIN_MOISTURE_LABELS[profile.protein_moisture_balance] ??
@@ -158,36 +191,35 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
   {
     key: "scalp_type",
     label: "Kopfhauttyp",
-    helpText: "Bestimmt mit, wie sanft oder regulierend Shampoo ausfallen sollte.",
-    sectionKey: "baseline",
+    helpText: "Deine Angabe aus dem Kopfhaut-Schritt im Quiz.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) =>
       profile?.scalp_type ? (SCALP_TYPE_LABELS[profile.scalp_type] ?? profile.scalp_type) : null,
   },
   {
     key: "scalp_condition",
-    label: "Kopfhautbeschwerden",
-    helpText: "Spezifische Beschwerden werden gesondert berücksichtigt.",
-    sectionKey: "baseline",
+    label: "Kopfhaut-Beschwerden",
+    helpText: "Deine optionalen Beschwerden aus demselben Kopfhaut-Schritt.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) =>
-      profile?.scalp_condition && profile.scalp_condition !== "none"
-        ? (SCALP_CONDITION_LABELS[profile.scalp_condition as keyof typeof SCALP_CONDITION_LABELS] ??
-          profile.scalp_condition)
+      profile?.scalp_condition
+        ? (SCALP_CONDITION_LABELS[profile.scalp_condition] ?? profile.scalp_condition)
         : null,
   },
   {
     key: "chemical_treatment",
-    label: "Behandlungen",
-    helpText: "Zeigt, ob Farbe, Blondierung oder andere chemische Prozesse mitspielen.",
-    sectionKey: "baseline",
+    label: "Chemische Behandlungen",
+    helpText: "Deine Auswahl aus dem letzten Quiz-Schritt.",
+    sectionKey: "quiz",
     sourceLabel: "Aus Haar-Check",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "quiz" },
     getValue: (profile) =>
       profile?.chemical_treatment?.length
         ? profile.chemical_treatment.map(
@@ -196,98 +228,54 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
         : null,
   },
   {
-    key: "concerns",
-    label: "Probleme",
-    helpText: "Themen, die Hair Concierge sichtbar priorisieren soll.",
-    sectionKey: "goals",
-    sourceLabel: "Aus Haar-Check",
-    displayMode: "badges",
-    editMode: "inline",
-    getValue: (profile) =>
-      profile?.concerns?.length
-        ? profile.concerns.map((concern) => CONCERN_LABELS[concern] ?? concern)
-        : null,
-  },
-  {
-    key: "desired_volume",
-    label: "Gewünschtes Volumen",
-    helpText: "Legt fest, ob eher Ruhe, Balance oder mehr Fülle bevorzugt wird.",
-    sectionKey: "goals",
+    key: "styling_tools",
+    label: "Hitzetools",
+    helpText: "Welche Hitzetools du im Styling-Teil ausgewählt hast.",
+    sectionKey: "styling",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "read_only",
+    editTarget: { kind: "onboarding", step: "heat_tools" },
     getValue: (profile) => {
-      const fallback =
-        profile?.desired_volume ?? (profile?.goals?.includes("volume") ? "more" : null)
+      if (profile?.styling_tools?.length) {
+        return optionLabels(profile.styling_tools, STYLING_TOOL_LABELS)
+      }
 
-      return fallback ? (DESIRED_VOLUME_LABELS[fallback] ?? fallback) : null
+      if (profile?.heat_styling === "never") {
+        return "Keine Hitzetools"
+      }
+
+      return null
     },
-  },
-  {
-    key: "goals",
-    label: "Weitere Ziele",
-    helpText: "Zusätzliche Ziele für den ersten Plan und spätere Empfehlungen.",
-    sectionKey: "goals",
-    sourceLabel: "Aus Onboarding",
-    displayMode: "badges",
-    editMode: "inline",
-    getValue: (profile) => {
-      const goals = profile?.goals ?? []
-      return goals.length ? goals.map((goal) => GOAL_LABELS[goal] ?? goal) : null
-    },
-  },
-  {
-    key: "wash_frequency",
-    label: "Wasch-Häufigkeit",
-    helpText: "Ein wichtiger Taktgeber für Routine- und Shampoo-Empfehlungen.",
-    sectionKey: "routine",
-    sourceLabel: "Aus Onboarding",
-    displayMode: "badges",
-    editMode: "inline",
-    getValue: (profile) => optionLabel(profile?.wash_frequency, WASH_FREQUENCY_OPTIONS),
   },
   {
     key: "heat_styling",
-    label: "Hitze-Styling",
-    helpText: "Zeigt, wie stark Hitze den Pflegebedarf beeinflusst.",
-    sectionKey: "routine",
+    label: "Styling-Frequenz",
+    helpText: "Wie oft du Hitze einsetzt, wenn du Tools nutzt.",
+    sectionKey: "styling",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "inline",
+    editTarget: { kind: "onboarding", step: "heat_frequency" },
     getValue: (profile) => optionLabel(profile?.heat_styling, HEAT_STYLING_OPTIONS),
   },
   {
     key: "uses_heat_protection",
     label: "Hitzeschutz",
-    helpText: "Wichtig für die Bewertung von Belastung und Schutzlücken.",
-    sectionKey: "routine",
+    helpText: "Deine Antwort aus dem Hitzeschutz-Schritt.",
+    sectionKey: "styling",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "inline",
+    editTarget: { kind: "onboarding", step: "heat_protection" },
     getValue: (profile) =>
       profile?.uses_heat_protection != null ? (profile.uses_heat_protection ? "Ja" : "Nein") : null,
   },
   {
-    key: "styling_tools",
-    label: "Styling-Tools",
-    helpText: "Welche Tools regelmäßig genutzt werden, beeinflusst Styling- und Schutz-Tipps.",
-    sectionKey: "routine",
-    sourceLabel: "Aus Onboarding",
-    displayMode: "badges",
-    editMode: "section",
-    getValue: (profile) =>
-      profile?.styling_tools?.length
-        ? profile.styling_tools.map((tool) => STYLING_TOOL_LABELS[tool] ?? tool)
-        : null,
-  },
-  {
     key: "towel_material",
-    label: "Handtuch",
-    helpText: "Das Material kann Frizz und mechanische Reibung beeinflussen.",
+    label: "Handtuch-Material",
+    helpText: "Womit du dein Haar im Alltag trocknest.",
     sectionKey: "routine",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "section",
+    editTarget: { kind: "onboarding", step: "towel_material" },
     getValue: (profile) =>
       profile?.towel_material
         ? (TOWEL_MATERIAL_LABELS[profile.towel_material] ?? profile.towel_material)
@@ -296,11 +284,11 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
   {
     key: "towel_technique",
     label: "Trocknungstechnik",
-    helpText: "Wie du trocknest, beeinflusst Frizz, Spannkraft und Schutz.",
+    helpText: "Wie du dein Haar direkt nach dem Waschen trocknest.",
     sectionKey: "routine",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "section",
+    editTarget: { kind: "onboarding", step: "towel_technique" },
     getValue: (profile) =>
       profile?.towel_technique
         ? (TOWEL_TECHNIQUE_LABELS[profile.towel_technique] ?? profile.towel_technique)
@@ -309,80 +297,52 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
   {
     key: "drying_method",
     label: "Trocknungsmethode",
-    helpText: "Zeigt, ob Lufttrocknen, Föhnen oder beides dominieren.",
+    helpText: "Ob du Lufttrocknen, Föhnen oder beides gewählt hast.",
     sectionKey: "routine",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "section",
-    getValue: (profile) =>
-      profile?.drying_method?.length
-        ? profile.drying_method.map((method) => DRYING_METHOD_LABELS[method] ?? method)
-        : null,
+    editTarget: { kind: "onboarding", step: "drying_method" },
+    getValue: (profile) => optionLabels(profile?.drying_method, DRYING_METHOD_LABELS),
   },
   {
     key: "brush_type",
     label: "Bürste",
-    helpText: "Die Bürstenwahl beeinflusst Spannung, Glätte und mechanische Belastung.",
+    helpText: "Deine Bürsten-Auswahl aus dem Alltagsteil.",
     sectionKey: "routine",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "section",
+    editTarget: { kind: "onboarding", step: "brush_type" },
     getValue: (profile) =>
       profile?.brush_type ? (BRUSH_TYPE_LABELS[profile.brush_type] ?? profile.brush_type) : null,
   },
   {
     key: "night_protection",
     label: "Nachtschutz",
-    helpText: "Wie du dein Haar nachts schützt, beeinflusst Reibung und Formhaltbarkeit.",
+    helpText: "Wie du dein Haar nachts schützt.",
     sectionKey: "routine",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "section",
-    getValue: (profile) =>
-      profile?.night_protection?.length
-        ? profile.night_protection.map(
-            (protection) => NIGHT_PROTECTION_LABELS[protection] ?? protection,
-          )
-        : null,
+    editTarget: { kind: "onboarding", step: "night_protection" },
+    getValue: (profile) => {
+      if (profile?.night_protection?.length) {
+        return optionLabels(profile.night_protection, NIGHT_PROTECTION_LABELS)
+      }
+
+      if ((profile?.goals?.length ?? 0) > 0 || profile?.desired_volume != null) {
+        return "Nichts davon"
+      }
+
+      return null
+    },
   },
   {
-    key: "post_wash_actions",
-    label: "Nach dem Waschen",
-    helpText: "Hilft bei Leave-in-, Schutz- und Styling-Empfehlungen.",
-    sectionKey: "routine",
+    key: "goals",
+    label: "Deine Haarziele",
+    helpText: "Genau die Ziele, die du im letzten Onboarding-Schritt ausgewählt hast.",
+    sectionKey: "goals",
     sourceLabel: "Aus Onboarding",
     displayMode: "badges",
-    editMode: "section",
-    getValue: (profile) => optionLabels(profile?.post_wash_actions, POST_WASH_ACTION_OPTIONS),
-  },
-  {
-    key: "current_routine_products",
-    label: "Produkte in Routine",
-    helpText: "Verhindert doppelte Vorschläge und zeigt, was schon im Alltag verankert ist.",
-    sectionKey: "routine",
-    sourceLabel: "Aus Onboarding",
-    displayMode: "badges",
-    editMode: "section",
-    getValue: (profile) => optionLabels(profile?.current_routine_products, ROUTINE_PRODUCT_OPTIONS),
-  },
-  {
-    key: "products_used",
-    label: "Verwendete Produkte",
-    helpText: "Freie Produkthinweise aus deinem Profil oder aus Gesprächen.",
-    sectionKey: "routine",
-    sourceLabel: "Aus Chat",
-    displayMode: "text",
-    editMode: "section",
-    getValue: (profile) => profile?.products_used || null,
-  },
-  {
-    key: "additional_notes",
-    label: "Zusätzliche Hinweise",
-    helpText: "Freitext für Dinge, die in den Standardfeldern keinen guten Platz haben.",
-    sectionKey: "routine",
-    sourceLabel: "Aus Chat",
-    displayMode: "text",
-    editMode: "section",
-    getValue: (profile) => profile?.additional_notes || null,
+    editTarget: { kind: "onboarding", step: "goals" },
+    getValue: (profile) => orderedGoalLabels(profile),
   },
 ]

--- a/src/lib/rag/orchestrator/conversation-orchestrator.ts
+++ b/src/lib/rag/orchestrator/conversation-orchestrator.ts
@@ -14,6 +14,7 @@ import {
   deriveRoutineContext,
 } from "@/lib/routines/planner"
 import { attachProductsToRoutinePlan } from "@/lib/routines/product-attachments"
+import { hydrateHairProfileForConsumers } from "@/lib/hair-profile/derived"
 import { loadUserMemoryContext } from "@/lib/rag/user-memory"
 import {
   buildEngineClarificationQuestions,
@@ -172,7 +173,10 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
     },
   )
   const conversationHistory: Message[] = (conversationData as Message[]) ?? []
-  const hairProfile: HairProfile | null = hairProfileResult.data ?? null
+  const hairProfile: HairProfile | null = hydrateHairProfileForConsumers(
+    (hairProfileResult.data as HairProfile | null) ?? null,
+    routineItems,
+  )
 
   // ── Step 1b: Classify intent (with conversation context) ───────────
   const { result: classificationOutput, durationMs: classificationMs } = await measureAsync(() =>
@@ -234,7 +238,8 @@ export async function orchestrateTurn(params: PipelineParams): Promise<PipelineR
       product_category,
       message,
     },
-    async () => evaluateRoute(classification, conversationHistory, hairProfile, message),
+    async () =>
+      evaluateRoute(classification, conversationHistory, hairProfile, routineItems, message),
     {
       output: (result) => ({
         classifier_retrieval_mode: classification.retrieval_mode,

--- a/src/lib/rag/router.ts
+++ b/src/lib/rag/router.ts
@@ -13,6 +13,7 @@ import {
   getOilMissingProfileFields,
   getShampooMissingProfileFields,
   getShampooProfileCompleteness,
+  type PersistenceRoutineItemRow,
   type RecommendationEngineRuntime,
 } from "@/lib/recommendation-engine"
 import { deriveRoutineContext } from "@/lib/routines/planner"
@@ -130,6 +131,7 @@ export function evaluateRoute(
   classification: ClassificationResult,
   conversationHistory: Message[],
   hairProfile: HairProfile | null,
+  routineItems: PersistenceRoutineItemRow[],
   userMessage = "",
 ): RouterDecision {
   try {
@@ -138,7 +140,7 @@ export function evaluateRoute(
     const shouldPlanRoutine = intent === "routine_help" || product_category === "routine"
     const runtime = buildRecommendationEngineRuntimeForChat({
       hairProfile,
-      routineItems: [],
+      routineItems,
       productCategory: product_category,
       shouldPlanRoutine,
       message: userMessage,

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -152,7 +152,7 @@ function formatUserProfile(
   if (profile.goals.length > 0) {
     parts.push(`Ziele: ${profile.goals.map((g) => GOAL_LABELS[g] ?? g).join(", ")}`)
   }
-  if (profile.desired_volume) {
+  if ((profile.goals?.length ?? 0) === 0 && profile.desired_volume) {
     parts.push(
       `Gewuenschtes Volumen: ${DESIRED_VOLUME_LABELS[profile.desired_volume] ?? profile.desired_volume}`,
     )
@@ -228,7 +228,7 @@ function formatUserProfile(
   if (profile.uses_heat_protection) {
     parts.push("Verwendet Hitzeschutz: Ja")
   }
-  if (profile.products_used) {
+  if ((profile.current_routine_products ?? []).length === 0 && profile.products_used) {
     parts.push(`Aktuelle Produkte: ${profile.products_used}`)
   }
   if (profile.additional_notes) {

--- a/src/lib/recommendation-engine/adapters/from-persistence.ts
+++ b/src/lib/recommendation-engine/adapters/from-persistence.ts
@@ -1,4 +1,8 @@
 import type { HairProfile } from "@/lib/types"
+import {
+  deriveWashFrequencyFromRoutineItems,
+  type RoutineInventoryLike,
+} from "@/lib/hair-profile/derived"
 import type { ProductFrequency } from "@/lib/vocabulary"
 import type {
   InventoryCategory,
@@ -79,7 +83,10 @@ function emptyRawHairProfileInput(): RawHairProfileInput {
   }
 }
 
-function buildRawHairProfileInput(profile: HairProfile | null): RawHairProfileInput {
+function buildRawHairProfileInput(
+  profile: HairProfile | null,
+  routineItems: RoutineInventoryLike[],
+): RawHairProfileInput {
   if (!profile) {
     return emptyRawHairProfileInput()
   }
@@ -90,7 +97,7 @@ function buildRawHairProfileInput(profile: HairProfile | null): RawHairProfileIn
     density: profile.density,
     concerns: profile.concerns ?? [],
     goals: profile.goals ?? [],
-    wash_frequency: profile.wash_frequency,
+    wash_frequency: deriveWashFrequencyFromRoutineItems(routineItems, profile.wash_frequency),
     heat_styling: profile.heat_styling,
     styling_tools: profile.styling_tools ?? [],
     cuticle_condition: profile.cuticle_condition,
@@ -166,7 +173,7 @@ export function adaptRecommendationInputFromPersistence(
 
   return {
     input: {
-      profile: buildRawHairProfileInput(profile),
+      profile: buildRawHairProfileInput(profile, routineItems),
       routineInventory: [...supportedItems.values()],
     },
     unsupportedRoutineCategories,

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -32,6 +32,7 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser()
 
   const { pathname } = request.nextUrl
+  const isQuizRetake = pathname === "/quiz" && request.nextUrl.searchParams.get("mode") === "retake"
 
   // Public routes that don't need auth
   const publicRoutes = [
@@ -78,7 +79,7 @@ export async function updateSession(request: NextRequest) {
   }
 
   // Redirect authenticated users away from auth page and quiz
-  if (pathname === "/auth" || pathname === "/quiz") {
+  if ((pathname === "/auth" || pathname === "/quiz") && !isQuizRetake) {
     // Check if user has completed onboarding
     const { data: profile } = await supabase
       .from("profiles")

--- a/tests/leave-in-decision.spec.ts
+++ b/tests/leave-in-decision.spec.ts
@@ -213,6 +213,7 @@ test.describe("Leave-in strict decision flow", () => {
         concerns: ["dryness"],
         post_wash_actions: ["air_dry"],
       }),
+      [],
     )
 
     expect(routerDecision.response_mode).not.toBe("clarify_only")

--- a/tests/oil-flow.spec.ts
+++ b/tests/oil-flow.spec.ts
@@ -246,6 +246,7 @@ test.describe("Oil structured recommendation flow", () => {
       },
       [],
       createProfile({ thickness: "fine" }),
+      [],
       "Ich brauche ein leichtes Trockenoel, das nicht beschwert.",
     )
 

--- a/tests/profile-page-smoke.spec.ts
+++ b/tests/profile-page-smoke.spec.ts
@@ -42,7 +42,7 @@ test.describe.serial("Profile page smoke", () => {
         email,
         full_name: fullName,
         onboarding_completed: true,
-        onboarding_step: "complete",
+        onboarding_step: "goals",
       },
       { onConflict: "id" },
     )
@@ -54,28 +54,57 @@ test.describe.serial("Profile page smoke", () => {
         user_id: userId,
         hair_texture: "wavy",
         thickness: "fine",
-        density: "medium",
-        concerns: ["frizz"],
-        desired_volume: "balanced",
-        goals: ["shine"],
-        wash_frequency: "every_day",
-        heat_styling: "never",
-        uses_heat_protection: false,
-        current_routine_products: ["shampoo"],
+        wash_frequency: "once_weekly",
+        heat_styling: "once_weekly",
+        styling_tools: ["flat_iron"],
+        uses_heat_protection: true,
         cuticle_condition: "smooth",
-        protein_moisture_balance: "balanced",
+        protein_moisture_balance: "stretches_bounces",
         scalp_type: "oily",
+        scalp_condition: "none",
         chemical_treatment: ["bleached"],
+        towel_material: "frottee",
+        towel_technique: "tupfen",
+        drying_method: ["air_dry"],
+        brush_type: "wide_tooth_comb",
+        night_protection: [],
+        goals: ["shine", "volume"],
+        desired_volume: "more",
+        current_routine_products: ["conditioner"],
       },
       { onConflict: "user_id" },
     )
 
     if (hairProfileError) throw hairProfileError
+
+    const { error: productUsageError } = await admin.from("user_product_usage").insert([
+      {
+        user_id: userId,
+        category: "shampoo",
+        product_name: "Daily Shampoo",
+        frequency_range: "1_2x",
+      },
+      {
+        user_id: userId,
+        category: "conditioner",
+        product_name: "Curl Conditioner",
+        frequency_range: "1_2x",
+      },
+      {
+        user_id: userId,
+        category: "dry_shampoo",
+        product_name: "Dry Refresh",
+        frequency_range: "rarely",
+      },
+    ])
+
+    if (productUsageError) throw productUsageError
   })
 
   test.afterAll(async () => {
     if (!userId) return
 
+    await admin.from("user_product_usage").delete().eq("user_id", userId)
     await admin.from("hair_profiles").delete().eq("user_id", userId)
     await admin.from("profiles").delete().eq("id", userId)
     await admin.from("user_memory_entries").delete().eq("user_id", userId)
@@ -83,7 +112,9 @@ test.describe.serial("Profile page smoke", () => {
     await admin.auth.admin.deleteUser(userId)
   })
 
-  test("journey sections render and profile editing stays scoped", async ({ page }) => {
+  test("journey sections mirror the live flow and edit routes land on the right step", async ({
+    page,
+  }) => {
     await page.goto(`${baseUrl}/auth`, { waitUntil: "domcontentloaded" })
     await expect(page.getByText("Hair Concierge").first()).toBeVisible({ timeout: 15000 })
 
@@ -95,60 +126,144 @@ test.describe.serial("Profile page smoke", () => {
     await page.goto(`${baseUrl}/profile`, { waitUntil: "domcontentloaded" })
     await expect(page.getByRole("heading", { name: "Mein Profil" })).toBeVisible()
 
-    const mainText = await page.locator("main").innerText()
-    expect(mainText.indexOf("Deine Ausgangslage")).toBeLessThan(mainText.indexOf("Deine Ziele"))
-    expect(mainText.indexOf("Deine Ziele")).toBeLessThan(mainText.indexOf("Dein Alltag"))
-    expect(mainText.indexOf("Dein Alltag")).toBeLessThan(
-      mainText.indexOf("Was Hair Concierge sich merkt"),
-    )
+    const sectionPositions = await Promise.all([
+      page.getByText("Haar-Check", { exact: true }).first().boundingBox(),
+      page.getByText("Produkte", { exact: true }).first().boundingBox(),
+      page.getByText("Styling", { exact: true }).first().boundingBox(),
+      page.getByText("Alltag", { exact: true }).first().boundingBox(),
+      page.getByText("Ziele", { exact: true }).first().boundingBox(),
+      page.getByText("Was Hair Concierge sich merkt", { exact: true }).first().boundingBox(),
+    ])
 
-    await expect(page.getByRole("heading", { name: "Diagnose" })).toHaveCount(0)
+    for (const box of sectionPositions) {
+      expect(box).not.toBeNull()
+    }
+
+    expect(sectionPositions[0]!.y).toBeLessThan(sectionPositions[1]!.y)
+    expect(sectionPositions[1]!.y).toBeLessThan(sectionPositions[2]!.y)
+    expect(sectionPositions[2]!.y).toBeLessThan(sectionPositions[3]!.y)
+    expect(sectionPositions[3]!.y).toBeLessThan(sectionPositions[4]!.y)
+    expect(sectionPositions[4]!.y).toBeLessThan(sectionPositions[5]!.y)
+
+    await expect(page.getByText("So baut sich dein Profil auf")).toHaveCount(0)
+    await expect(page.getByText("Basis-Produkte")).toHaveCount(0)
+    await expect(page.getByText("Weitere Produkte")).toHaveCount(0)
+    await expect(page.getByText("Aus Haar-Check")).toHaveCount(0)
+    await expect(page.getByText("Aus Onboarding")).toHaveCount(0)
+    await expect(page.getByText("7/7 vollständig")).toBeVisible()
 
     const memorySwitch = page.getByRole("switch", { name: "Erinnerungen aktivieren" })
     await expect(memorySwitch).toHaveAttribute("aria-checked", "true")
-    await memorySwitch.click()
-    await expect(memorySwitch).toHaveAttribute("aria-checked", "false")
 
-    const goalsCard = page.locator('[role="button"]').filter({ hasText: "Weitere Ziele" })
-    await goalsCard.first().click()
-    await expect(page.getByRole("button", { name: "Haar-Check aktualisieren" })).toBeVisible()
-    await expect(page.getByText("Du bearbeitest dein Profil")).toBeVisible()
+    const chemicalTreatmentsCard = page
+      .getByRole("button")
+      .filter({ hasText: "Chemische Behandlungen" })
+      .first()
+    await chemicalTreatmentsCard.click()
+    await expect(page).toHaveURL(`${baseUrl}/profile`)
+    await expect(page.getByText("Haar-Check direkt im Profil aktualisieren")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Haar-Check speichern" })).toBeVisible()
+    await page.getByRole("radio", { name: "Keine Beschwerden" }).click()
+    await page.getByRole("button", { name: "Naturhaar" }).click()
+    await page.getByRole("button", { name: "Haar-Check speichern" }).click()
+    await expect(page.getByText("Haar-Check gespeichert").first()).toBeVisible()
+    await expect(page.getByText("Keine Beschwerden")).toBeVisible()
+    await expect(page.getByText("Naturhaar")).toBeVisible()
 
-    await expect(page.getByRole("button", { name: /^Glatt$/ })).toHaveCount(0)
-    await expect(page.getByRole("button", { name: /^Wellig$/ })).toHaveCount(0)
+    await page.getByRole("button", { name: "Ziele bearbeiten" }).click()
+    await page.waitForURL(/\/onboarding\?step=goals&returnTo=%2Fprofile$/, { timeout: 15000 })
+    await expect(page.getByText("Deine Haarziele", { exact: false })).toBeVisible()
+    await page.getByRole("button", { name: "Speichern und zurück zum Profil" }).click()
+    await page.waitForURL(/\/profile$/, { timeout: 30000 })
+    await expect(page.getByRole("heading", { name: "Mein Profil" })).toBeVisible()
 
-    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
-    await expect(page.getByRole("button", { name: "Speichern" })).toBeVisible()
+    const { data: goalsCleanupRow, error: goalsCleanupError } = await admin
+      .from("hair_profiles")
+      .select("desired_volume, current_routine_products")
+      .eq("user_id", userId!)
+      .single()
 
-    await page.getByRole("radio", { name: "Alle 2-3 Tage" }).click()
-    await page.getByRole("button", { name: "Speichern" }).click()
+    if (goalsCleanupError) throw goalsCleanupError
+    expect(goalsCleanupRow?.desired_volume).toBeNull()
+    expect(goalsCleanupRow?.current_routine_products ?? []).toEqual([])
 
-    const washCard = page.locator("div.rounded-xl").filter({ hasText: "Wasch-Häufigkeit" })
+    const shampooDetailRow = page
+      .getByRole("button")
+      .filter({ hasText: "Shampoo" })
+      .filter({ hasText: "Daily Shampoo" })
+    await shampooDetailRow.first().click()
+    await page.waitForURL(
+      /\/onboarding\?step=product_drilldown&returnTo=%2Fprofile&category=shampoo&editMode=single-step$/,
+      { timeout: 15000 },
+    )
+    await expect(page.getByText("Dein Shampoo", { exact: false })).toBeVisible()
+    await page.locator('input[placeholder="z.B. Produktname oder Marke"]').fill("Edited Shampoo")
+    await page.getByRole("button", { name: "5-6x pro Woche" }).click()
+    await page.getByRole("button", { name: "Speichern und zurück zum Profil" }).click()
+    await page.waitForURL(/\/profile$/, { timeout: 30000 })
+    await expect(page.getByText("Edited Shampoo").first()).toBeVisible()
+    await expect(page.getByText("5-6x pro Woche").first()).toBeVisible()
 
-    await expect(goalsCard.first()).toContainText("Mehr Glanz")
-    await expect(washCard.first()).toContainText("Alle 2-3 Tage")
+    const { data: shampooCleanupRow, error: shampooCleanupError } = await admin
+      .from("hair_profiles")
+      .select("wash_frequency")
+      .eq("user_id", userId!)
+      .single()
 
-    const routineProductsCard = page
-      .locator('[role="button"]')
-      .filter({ hasText: "Produkte in Routine" })
-    await routineProductsCard.first().click()
-    await expect(page.getByText("Routine-Details im Fokus")).toBeVisible()
+    if (shampooCleanupError) throw shampooCleanupError
+    expect(shampooCleanupRow?.wash_frequency).toBeNull()
 
-    await page.reload({ waitUntil: "domcontentloaded" })
+    const { data: shampooUsageRow, error: shampooUsageError } = await admin
+      .from("user_product_usage")
+      .select("frequency_range")
+      .eq("user_id", userId!)
+      .eq("category", "shampoo")
+      .single()
 
+    if (shampooUsageError) throw shampooUsageError
+    expect(shampooUsageRow?.frequency_range).toBe("5_6x")
+
+    const towelMaterialCard = page
+      .getByRole("button")
+      .filter({ hasText: "Handtuch-Material" })
+      .filter({ hasText: "Frottee-Handtuch" })
+    await towelMaterialCard.first().click()
+    await page.waitForURL(
+      /\/onboarding\?step=towel_material&returnTo=%2Fprofile&editMode=single-step$/,
+      { timeout: 15000 },
+    )
+    await page.getByRole("button", { name: "Mikrofaser-Handtuch" }).click()
+    await page.waitForURL(/\/profile$/, { timeout: 30000 })
+    await expect(page.getByText("Mikrofaser-Handtuch")).toBeVisible()
+
+    const heatFrequencyCard = page
+      .getByRole("button")
+      .filter({ hasText: "Styling-Frequenz" })
+      .filter({ hasText: "1x pro Woche" })
+    await heatFrequencyCard.first().click()
+    await page.waitForURL(
+      /\/onboarding\?step=heat_frequency&returnTo=%2Fprofile&editMode=single-step$/,
+      { timeout: 15000 },
+    )
+    await page.getByRole("button", { name: "Mehrmals pro Woche" }).click()
+    await page.waitForURL(/\/profile$/, { timeout: 30000 })
+    await expect(
+      page
+        .getByRole("button")
+        .filter({ hasText: "Styling-Frequenz" })
+        .filter({ hasText: "Mehrmals pro Woche" })
+        .first(),
+    ).toBeVisible()
+
+    await page.goto(`${baseUrl}/profile`, { waitUntil: "domcontentloaded" })
     await page.setViewportSize({ width: 390, height: 844 })
     await page.reload({ waitUntil: "domcontentloaded" })
     await expect(page.getByRole("heading", { name: "Mein Profil" })).toBeVisible()
-    await expect(page.getByText("Deine Ausgangslage")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Produkte bearbeiten" })).toBeVisible()
 
     const hasHorizontalOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth > window.innerWidth + 1,
     )
     expect(hasHorizontalOverflow).toBe(false)
-
-    const baselineCard = page.locator('[role="button"]').filter({ hasText: "Haartyp" })
-    await baselineCard.first().click()
-    await expect(page).toHaveURL(/\/profile$/)
-    await expect(page.getByRole("button", { name: "Speichern" })).toBeVisible()
   })
 })

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -695,6 +695,7 @@ test.describe("Routine planner", () => {
         scalp_type: null,
         current_routine_products: [],
       }),
+      [],
       "Welche Routine passt zu mir?",
     )
 
@@ -713,6 +714,7 @@ test.describe("Routine planner", () => {
         current_routine_products: [],
         products_used: null,
       }),
+      [],
       "Welche Routine passt zu mir?",
     )
 
@@ -730,6 +732,7 @@ test.describe("Routine planner", () => {
         wash_frequency: "every_2_3_days",
         current_routine_products: ["shampoo", "conditioner"],
       }),
+      [],
       "Welche Routine passt zu mir?",
     )
 

--- a/tests/shampoo-flow.spec.ts
+++ b/tests/shampoo-flow.spec.ts
@@ -303,6 +303,7 @@ test.describe("Shampoo Flow alignment", () => {
         scalp_type: "oily",
         scalp_condition: "none",
       }),
+      [],
     )
 
     expect(routerDecision.response_mode).not.toBe("clarify_only")
@@ -334,6 +335,7 @@ test.describe("Shampoo Flow alignment", () => {
         scalp_type: null,
         scalp_condition: "dandruff",
       }),
+      [],
     )
 
     expect(routerDecision.response_mode).not.toBe("clarify_only")
@@ -365,6 +367,7 @@ test.describe("Shampoo Flow alignment", () => {
         scalp_type: "oily",
         scalp_condition: null,
       }),
+      [],
     )
 
     expect(routerDecision.response_mode).toBe("clarify_only")


### PR DESCRIPTION
## Was sich geändert hat
- Profilseite entlang der echten Quiz- und Onboarding-Reihenfolge neu strukturiert und Abschnitts- sowie Karten-Editing vereinheitlicht
- Einzelne Karten öffnen jetzt nur noch den passenden Bearbeitungsschritt und springen danach direkt zurück ins Profil
- Produkt- und Quizdaten werden konsistenter angezeigt, inklusive exakter Frequenzlabels und direkter Haar-Check-Bearbeitung im Profil
- Veraltete Spiegel-Felder wie `wash_frequency`, `desired_volume` und `current_routine_products` werden nicht mehr als aktive Source of Truth beschrieben; Consumer leiten diese Werte jetzt aus den strukturierten Daten ab

## Warum
- Die Profilseite war nicht sauber an den aktuellen Quiz-/Onboarding-Flow gekoppelt
- Einige Edit-CTAs führten in zu breite oder falsche Flows zurück
- Mehrere Legacy-Felder konnten von den aktuellen Eingaben abweichen und damit inkonsistente Darstellung oder Downstream-Logik verursachen

## Impact
- Profilbearbeitung ist kürzer, verständlicher und näher an der echten Nutzerreise
- Produktfrequenzen und Haar-Check-Angaben bleiben zwischen Eingabe, Persistenz und Anzeige konsistent
- Recommendation- und RAG-Consumer lesen bevorzugt die aktuellen strukturierten Datenquellen statt veralteter Mirrors

## Root Cause
- Profil-UI, Onboarding-Routing und Persistenz hatten sich unabhängig voneinander weiterentwickelt
- Legacy-Felder wurden weiterhin mitgeschrieben, obwohl neuere strukturierte Tabellen/Felder schon die eigentliche Wahrheit enthielten

## Checks
- `npm run typecheck`
- `npm run build`
- `PLAYWRIGHT_BASE_URL=http://localhost:3209 npx playwright test tests/profile-page-smoke.spec.ts --project=chromium`
