### PR TITLE
[codex] Fix intake routing for direct auth signups

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -4,6 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin"
 import { OnboardingFlow } from "@/components/onboarding/onboarding-flow"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import { getOnboardingEditScope, type OnboardingStep } from "@/lib/onboarding/store"
+import { resolveIntakeState } from "@/lib/auth/intake-state"
 
 interface OnboardingPageProps {
   searchParams: Promise<{
@@ -99,17 +100,22 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
     .eq("id", user.id)
     .single()
 
-  // If already completed, redirect to chat
-  if (profileRow?.onboarding_completed && !forcedStep) {
-    redirect(returnTo ?? "/chat")
-  }
-
   // Fetch hair profile for pre-filling
   const { data: hairProfile } = await admin
     .from("hair_profiles")
     .select("*")
     .eq("user_id", user.id)
-    .single()
+    .maybeSingle()
+
+  const intakeState = resolveIntakeState(profileRow, hairProfile)
+
+  if (intakeState === "needs_quiz") {
+    redirect("/quiz")
+  }
+
+  if (intakeState === "ready" && !forcedStep) {
+    redirect(returnTo ?? "/chat")
+  }
 
   // Fetch existing product usage
   const { data: productUsage } = await admin

--- a/src/components/quiz/quiz-results.tsx
+++ b/src/components/quiz/quiz-results.tsx
@@ -27,10 +27,14 @@ export function QuizResults() {
       scalp_condition: answers.scalp_condition,
     })
 
-    if (user && isRetakeMode && leadId) {
+    if (user && leadId) {
       const nextUrl = new URL("/onboarding", window.location.origin)
       nextUrl.searchParams.set("lead", leadId)
-      nextUrl.searchParams.set("returnTo", returnTo?.startsWith("/") ? returnTo : "/profile")
+
+      if (isRetakeMode) {
+        nextUrl.searchParams.set("returnTo", returnTo?.startsWith("/") ? returnTo : "/profile")
+      }
+
       router.push(`${nextUrl.pathname}${nextUrl.search}`)
       return
     }

--- a/src/lib/auth/intake-state.ts
+++ b/src/lib/auth/intake-state.ts
@@ -1,43 +1,21 @@
-export type IntakeState = "needs_quiz" | "needs_onboarding" | "ready"
+import {
+  hasCompletedQuizDiagnostics,
+  type PersistedQuizDiagnosticsProfile,
+} from "@/lib/quiz/completion"
 
-type QuizDiagnosticsProfile = {
-  hair_texture?: string | null
-  thickness?: string | null
-  cuticle_condition?: string | null
-  protein_moisture_balance?: string | null
-  scalp_type?: string | null
-  scalp_condition?: string | null
-  chemical_treatment?: string[] | null
-} | null
+export type IntakeState = "needs_quiz" | "needs_onboarding" | "ready"
 
 type ProfileRow = {
   onboarding_completed?: boolean | null
 } | null
 
-export function hasQuizDiagnostics(profile: QuizDiagnosticsProfile): boolean {
-  if (!profile) {
-    return false
-  }
-
-  const requiredFields = [
-    profile.hair_texture,
-    profile.thickness,
-    profile.cuticle_condition,
-    profile.protein_moisture_balance,
-    profile.scalp_type,
-    profile.scalp_condition,
-  ]
-
-  return (
-    requiredFields.every((value) => typeof value === "string" && value.length > 0) &&
-    Array.isArray(profile.chemical_treatment) &&
-    profile.chemical_treatment.length > 0
-  )
+export function hasQuizDiagnostics(profile: PersistedQuizDiagnosticsProfile): boolean {
+  return hasCompletedQuizDiagnostics(profile)
 }
 
 export function resolveIntakeState(
   profile: ProfileRow,
-  hairProfile: QuizDiagnosticsProfile,
+  hairProfile: PersistedQuizDiagnosticsProfile,
 ): IntakeState {
   if (profile?.onboarding_completed) {
     return "ready"

--- a/src/lib/auth/intake-state.ts
+++ b/src/lib/auth/intake-state.ts
@@ -1,0 +1,82 @@
+export type IntakeState = "needs_quiz" | "needs_onboarding" | "ready"
+
+type QuizDiagnosticsProfile = {
+  hair_texture?: string | null
+  thickness?: string | null
+  cuticle_condition?: string | null
+  protein_moisture_balance?: string | null
+  scalp_type?: string | null
+  scalp_condition?: string | null
+  chemical_treatment?: string[] | null
+} | null
+
+type ProfileRow = {
+  onboarding_completed?: boolean | null
+} | null
+
+export function hasQuizDiagnostics(profile: QuizDiagnosticsProfile): boolean {
+  if (!profile) {
+    return false
+  }
+
+  const requiredFields = [
+    profile.hair_texture,
+    profile.thickness,
+    profile.cuticle_condition,
+    profile.protein_moisture_balance,
+    profile.scalp_type,
+    profile.scalp_condition,
+  ]
+
+  return (
+    requiredFields.every((value) => typeof value === "string" && value.length > 0) &&
+    Array.isArray(profile.chemical_treatment) &&
+    profile.chemical_treatment.length > 0
+  )
+}
+
+export function resolveIntakeState(
+  profile: ProfileRow,
+  hairProfile: QuizDiagnosticsProfile,
+): IntakeState {
+  if (profile?.onboarding_completed) {
+    return "ready"
+  }
+
+  if (hasQuizDiagnostics(hairProfile)) {
+    return "needs_onboarding"
+  }
+
+  return "needs_quiz"
+}
+
+export function getAuthenticatedAppRedirect(
+  pathname: string,
+  intakeState: IntakeState,
+  options?: { isQuizRetake?: boolean },
+): string | null {
+  if (pathname === "/quiz" && options?.isQuizRetake) {
+    return null
+  }
+
+  switch (pathname) {
+    case "/auth":
+      if (intakeState === "needs_quiz") return "/quiz"
+      if (intakeState === "needs_onboarding") return "/onboarding"
+      return "/chat"
+    case "/quiz":
+      if (intakeState === "needs_quiz") return null
+      if (intakeState === "needs_onboarding") return "/onboarding"
+      return "/chat"
+    case "/chat":
+      if (intakeState === "needs_quiz") return "/quiz"
+      if (intakeState === "needs_onboarding") return "/onboarding"
+      return null
+    case "/":
+      if (intakeState === "needs_quiz") return "/quiz"
+      if (intakeState === "needs_onboarding") return "/onboarding"
+      return "/chat"
+    default:
+      return null
+  }
+}

--- a/src/lib/quiz/completion.ts
+++ b/src/lib/quiz/completion.ts
@@ -1,0 +1,40 @@
+type PersistedQuizDiagnosticsProfile = {
+  hair_texture?: string | null
+  thickness?: string | null
+  cuticle_condition?: string | null
+  protein_moisture_balance?: string | null
+  scalp_type?: string | null
+  scalp_condition?: string | null
+  chemical_treatment?: string[] | null
+  concerns?: string[] | null
+} | null
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+function hasCompletedScalpStep(profile: NonNullable<PersistedQuizDiagnosticsProfile>): boolean {
+  return (
+    hasNonEmptyString(profile.scalp_type) &&
+    (profile.scalp_condition === null || hasNonEmptyString(profile.scalp_condition))
+  )
+}
+
+export function hasCompletedQuizDiagnostics(profile: PersistedQuizDiagnosticsProfile): boolean {
+  if (!profile) {
+    return false
+  }
+
+  return (
+    hasNonEmptyString(profile.hair_texture) &&
+    hasNonEmptyString(profile.thickness) &&
+    hasNonEmptyString(profile.cuticle_condition) &&
+    hasNonEmptyString(profile.protein_moisture_balance) &&
+    hasCompletedScalpStep(profile) &&
+    Array.isArray(profile.chemical_treatment) &&
+    profile.chemical_treatment.length > 0 &&
+    Array.isArray(profile.concerns)
+  )
+}
+
+export type { PersistedQuizDiagnosticsProfile }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
+import { getAuthenticatedAppRedirect, resolveIntakeState } from "@/lib/auth/intake-state"
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -33,6 +34,8 @@ export async function updateSession(request: NextRequest) {
 
   const { pathname } = request.nextUrl
   const isQuizRetake = pathname === "/quiz" && request.nextUrl.searchParams.get("mode") === "retake"
+  const needsAuthenticatedAppRouting =
+    pathname === "/auth" || pathname === "/quiz" || pathname === "/chat" || pathname === "/"
 
   // Public routes that don't need auth
   const publicRoutes = [
@@ -78,38 +81,35 @@ export async function updateSession(request: NextRequest) {
     })
   }
 
-  // Redirect authenticated users away from auth page and quiz
-  if ((pathname === "/auth" || pathname === "/quiz") && !isQuizRetake) {
-    // Check if user has completed onboarding
+  if (needsAuthenticatedAppRouting) {
     const { data: profile } = await supabase
       .from("profiles")
       .select("onboarding_completed")
       .eq("id", user.id)
-      .single()
+      .maybeSingle()
 
-    const url = request.nextUrl.clone()
-    if (!profile?.onboarding_completed) {
-      url.pathname = "/onboarding"
-      // Preserve lead ID if present
-      const leadId = request.nextUrl.searchParams.get("lead")
-      if (leadId) url.searchParams.set("lead", leadId)
-    } else {
-      url.pathname = "/chat"
-    }
-    return NextResponse.redirect(url)
-  }
+    const { data: hairProfile } = await supabase
+      .from("hair_profiles")
+      .select(
+        "hair_texture, thickness, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment",
+      )
+      .eq("user_id", user.id)
+      .maybeSingle()
 
-  // Redirect authenticated users who haven't completed onboarding away from chat
-  if (pathname === "/chat" || pathname === "/") {
-    const { data: profile } = await supabase
-      .from("profiles")
-      .select("onboarding_completed")
-      .eq("id", user.id)
-      .single()
+    const intakeState = resolveIntakeState(profile, hairProfile)
+    const redirectPath = getAuthenticatedAppRedirect(pathname, intakeState, { isQuizRetake })
 
-    if (!profile?.onboarding_completed) {
+    if (redirectPath) {
       const url = request.nextUrl.clone()
-      url.pathname = "/onboarding"
+      url.pathname = redirectPath
+      if (redirectPath === "/onboarding") {
+        const leadId = request.nextUrl.searchParams.get("lead")
+        if (leadId) {
+          url.searchParams.set("lead", leadId)
+        }
+      } else {
+        url.searchParams.delete("lead")
+      }
       return NextResponse.redirect(url)
     }
   }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -91,7 +91,7 @@ export async function updateSession(request: NextRequest) {
     const { data: hairProfile } = await supabase
       .from("hair_profiles")
       .select(
-        "hair_texture, thickness, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment",
+        "hair_texture, thickness, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment, concerns",
       )
       .eq("user_id", user.id)
       .maybeSingle()

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -131,6 +131,10 @@ test.describe.serial("Authenticated intake routing", () => {
       .click()
     await page.getByRole("button", { name: "NEIN" }).click()
 
+    await expect(page.getByText(/Welche Haarprobleme/i)).toBeVisible()
+    await page.getByText("Trockenheit").click()
+    await page.getByRole("button", { name: /^Weiter$/i }).click()
+
     await page.getByPlaceholder("Dein Vorname").fill("Playwright Intake")
     await page.getByRole("button", { name: /^Weiter$/i }).click()
 

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -98,4 +98,70 @@ test.describe.serial("Authenticated intake routing", () => {
     expect(visitedPathnames).not.toContain("/onboarding")
     await expect(page.getByRole("button", { name: /Quiz starten/i })).toBeVisible()
   })
+
+  test("signed-in quiz completion skips auth and lands in onboarding", async ({ page }) => {
+    await page.goto("/auth", { waitUntil: "networkidle" })
+    await page.locator('input[type="email"]:visible').fill(email)
+    await page.locator('input[type="password"]:visible').fill(password)
+    await page.getByRole("button", { name: /^Anmelden$/ }).click()
+
+    await page.waitForURL("**/quiz", {
+      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+    })
+
+    await page.getByRole("button", { name: /Quiz starten/i }).click()
+    await page.getByText("Wellig").first().click()
+    await page.getByText("Mittel").first().click()
+    await page.getByText("Leicht uneben").click()
+    await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
+
+    await expect(
+      page.getByText("SIND DEINE HAARE CHEMISCH BEHANDELT?", { exact: false }),
+    ).toBeVisible()
+    await page
+      .locator(".quiz-card")
+      .filter({ has: page.getByText(/Gefärbt\s*\/\s*Getönt/i) })
+      .click()
+    await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+    await page
+      .locator(".quiz-card")
+      .filter({ has: page.getByText(/^Trocken$/) })
+      .click()
+    await page.getByRole("button", { name: "NEIN" }).click()
+
+    await page.getByPlaceholder("Dein Vorname").fill("Playwright Intake")
+    await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+    await page.getByPlaceholder("name@beispiel.de").fill(email)
+    await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+    await page.getByRole("button", { name: /JA, WEITER ZU MEINEM PLAN/i }).click()
+
+    await expect(page.getByRole("button", { name: /ZIELE UND ROUTINE FESTLEGEN/i })).toBeVisible({
+      timeout: 45_000,
+    })
+    await page.getByRole("button", { name: /ZIELE UND ROUTINE FESTLEGEN/i }).click()
+
+    await page.waitForURL(/\/onboarding\?lead=/, {
+      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+    })
+
+    await expect(page.getByRole("button", { name: /LOS GEHT/i })).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(page.getByText("PROFIL SPEICHERN", { exact: false })).toHaveCount(0)
+
+    await expect
+      .poll(
+        async () => {
+          const lead = await fetchLatestLead()
+          return lead?.status ?? null
+        },
+        { timeout: 30_000 },
+      )
+      .toBe("linked")
+  })
 })

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -80,6 +80,7 @@ test.describe.serial("Authenticated intake routing", () => {
     })
 
     await page.goto("/auth", { waitUntil: "networkidle" })
+    const appOrigin = new URL(page.url()).origin
     await page.locator('input[type="email"]:visible').fill(email)
     await page.locator('input[type="password"]:visible').fill(password)
     await page.getByRole("button", { name: /^Anmelden$/ }).click()
@@ -90,7 +91,7 @@ test.describe.serial("Authenticated intake routing", () => {
     })
 
     const visitedPathnames = visitedUrls
-      .filter((url) => url.startsWith("http://localhost:3000/"))
+      .filter((url) => new URL(url).origin === appOrigin)
       .map((url) => new URL(url).pathname)
 
     expect(visitedPathnames.at(-1)).toBe("/quiz")

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test"
+import { createClient } from "@supabase/supabase-js"
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error(
+    "NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for intake routing E2E tests",
+  )
+}
+
+const admin = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+test.describe.serial("Authenticated intake routing", () => {
+  const email = `playwright-intake-${Date.now()}@hairconscierge.test`
+  const password = "Playwright123!"
+  const fullName = "Playwright Intake"
+  let userId: string | null = null
+
+  async function fetchLatestLead() {
+    const { data, error } = await admin
+      .from("leads")
+      .select("id, status, user_id")
+      .eq("email", email)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error) throw error
+    return data
+  }
+
+  test.beforeAll(async () => {
+    const { data, error } = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { full_name: fullName },
+    })
+
+    if (error) throw error
+    userId = data.user?.id ?? null
+
+    if (!userId) {
+      throw new Error("Failed to create intake E2E user")
+    }
+
+    const { error: profileError } = await admin.from("profiles").upsert(
+      {
+        id: userId,
+        email,
+        full_name: fullName,
+      },
+      { onConflict: "id" },
+    )
+
+    if (profileError) throw profileError
+  })
+
+  test.afterAll(async () => {
+    await admin.from("leads").delete().eq("email", email)
+
+    if (!userId) return
+
+    await admin.from("user_product_usage").delete().eq("user_id", userId)
+    await admin.from("hair_profiles").delete().eq("user_id", userId)
+    await admin.from("profiles").delete().eq("id", userId)
+    await admin.auth.admin.deleteUser(userId)
+  })
+
+  test("login routes quizless users to /quiz instead of /onboarding", async ({ page }) => {
+    await page.goto("/auth", { waitUntil: "networkidle" })
+    await page.locator('input[type="email"]:visible').fill(email)
+    await page.locator('input[type="password"]:visible').fill(password)
+    await page.getByRole("button", { name: /^Anmelden$/ }).click()
+
+    await page.waitForURL("**/quiz", {
+      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+    })
+
+    await expect(page.getByRole("button", { name: /Quiz starten/i })).toBeVisible()
+  })
+})

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -72,6 +72,13 @@ test.describe.serial("Authenticated intake routing", () => {
   })
 
   test("login routes quizless users to /quiz instead of /onboarding", async ({ page }) => {
+    const visitedUrls: string[] = []
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame()) {
+        visitedUrls.push(frame.url())
+      }
+    })
+
     await page.goto("/auth", { waitUntil: "networkidle" })
     await page.locator('input[type="email"]:visible').fill(email)
     await page.locator('input[type="password"]:visible').fill(password)
@@ -82,6 +89,12 @@ test.describe.serial("Authenticated intake routing", () => {
       waitUntil: "domcontentloaded",
     })
 
+    const visitedPathnames = visitedUrls
+      .filter((url) => url.startsWith("http://localhost:3000/"))
+      .map((url) => new URL(url).pathname)
+
+    expect(visitedPathnames.at(-1)).toBe("/quiz")
+    expect(visitedPathnames).not.toContain("/onboarding")
     await expect(page.getByRole("button", { name: /Quiz starten/i })).toBeVisible()
   })
 })

--- a/tests/auth-intake-state.test.ts
+++ b/tests/auth-intake-state.test.ts
@@ -15,15 +15,21 @@ const completeQuizProfile = {
   scalp_type: "dry",
   scalp_condition: "dry_flakes",
   chemical_treatment: ["colored"],
+  concerns: ["dryness"],
 }
 
 test("hasQuizDiagnostics returns false when hair profile is missing", () => {
   assert.equal(hasQuizDiagnostics(null), false)
 })
 
-test("hasQuizDiagnostics requires every quiz-written field", () => {
-  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, scalp_condition: null }), false)
+test("hasQuizDiagnostics accepts a completed no-issue scalp answer", () => {
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, scalp_condition: null }), true)
+})
+
+test("hasQuizDiagnostics requires every other quiz-written field", () => {
   assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, chemical_treatment: [] }), false)
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, concerns: null }), false)
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, concerns: undefined }), false)
 })
 
 test("resolveIntakeState returns ready when onboarding is already completed", () => {

--- a/tests/auth-intake-state.test.ts
+++ b/tests/auth-intake-state.test.ts
@@ -44,10 +44,16 @@ test("resolveIntakeState returns needs_quiz for quizless users", () => {
 test("getAuthenticatedAppRedirect maps entry routes from intake state", () => {
   assert.equal(getAuthenticatedAppRedirect("/auth", "needs_quiz"), "/quiz")
   assert.equal(getAuthenticatedAppRedirect("/auth", "needs_onboarding"), "/onboarding")
+  assert.equal(getAuthenticatedAppRedirect("/auth", "ready"), "/chat")
   assert.equal(getAuthenticatedAppRedirect("/chat", "needs_quiz"), "/quiz")
+  assert.equal(getAuthenticatedAppRedirect("/chat", "needs_onboarding"), "/onboarding")
+  assert.equal(getAuthenticatedAppRedirect("/chat", "ready"), null)
   assert.equal(getAuthenticatedAppRedirect("/quiz", "needs_quiz"), null)
   assert.equal(getAuthenticatedAppRedirect("/quiz", "needs_onboarding"), "/onboarding")
   assert.equal(getAuthenticatedAppRedirect("/quiz", "ready"), "/chat")
+  assert.equal(getAuthenticatedAppRedirect("/", "needs_quiz"), "/quiz")
+  assert.equal(getAuthenticatedAppRedirect("/", "needs_onboarding"), "/onboarding")
+  assert.equal(getAuthenticatedAppRedirect("/", "ready"), "/chat")
 })
 
 test("getAuthenticatedAppRedirect preserves quiz retake access", () => {

--- a/tests/auth-intake-state.test.ts
+++ b/tests/auth-intake-state.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  getAuthenticatedAppRedirect,
+  hasQuizDiagnostics,
+  resolveIntakeState,
+} from "../src/lib/auth/intake-state"
+
+const completeQuizProfile = {
+  hair_texture: "wavy",
+  thickness: "normal",
+  cuticle_condition: "slightly_rough",
+  protein_moisture_balance: "stretches_stays",
+  scalp_type: "dry",
+  scalp_condition: "dry_flakes",
+  chemical_treatment: ["colored"],
+}
+
+test("hasQuizDiagnostics returns false when hair profile is missing", () => {
+  assert.equal(hasQuizDiagnostics(null), false)
+})
+
+test("hasQuizDiagnostics requires every quiz-written field", () => {
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, scalp_condition: null }), false)
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, chemical_treatment: [] }), false)
+})
+
+test("resolveIntakeState returns ready when onboarding is already completed", () => {
+  assert.equal(resolveIntakeState({ onboarding_completed: true }, null), "ready")
+})
+
+test("resolveIntakeState returns needs_onboarding for quiz-complete users", () => {
+  assert.equal(
+    resolveIntakeState({ onboarding_completed: false }, completeQuizProfile),
+    "needs_onboarding",
+  )
+})
+
+test("resolveIntakeState returns needs_quiz for quizless users", () => {
+  assert.equal(resolveIntakeState({ onboarding_completed: false }, null), "needs_quiz")
+})
+
+test("getAuthenticatedAppRedirect maps entry routes from intake state", () => {
+  assert.equal(getAuthenticatedAppRedirect("/auth", "needs_quiz"), "/quiz")
+  assert.equal(getAuthenticatedAppRedirect("/auth", "needs_onboarding"), "/onboarding")
+  assert.equal(getAuthenticatedAppRedirect("/chat", "needs_quiz"), "/quiz")
+  assert.equal(getAuthenticatedAppRedirect("/quiz", "needs_quiz"), null)
+  assert.equal(getAuthenticatedAppRedirect("/quiz", "needs_onboarding"), "/onboarding")
+  assert.equal(getAuthenticatedAppRedirect("/quiz", "ready"), "/chat")
+})
+
+test("getAuthenticatedAppRedirect preserves quiz retake access", () => {
+  assert.equal(getAuthenticatedAppRedirect("/quiz", "ready", { isQuizRetake: true }), null)
+})


### PR DESCRIPTION
## Why
Direct signup/login entry through `/auth` could create an authenticated user without quiz diagnostics and then route that user into onboarding as if the quiz had already been completed. That bypass left the profile incomplete and broke the intended intake order.

## What changed
- add a shared intake-state helper that classifies authenticated users as `needs_quiz`, `needs_onboarding`, or `ready`
- route authenticated `/auth`, `/quiz`, `/chat`, and `/` requests through that helper in middleware
- guard the onboarding entrypoint so it redirects quizless users back to `/quiz`
- send signed-in users from quiz results straight to `/onboarding?lead=...` so they do not see auth twice
- add unit coverage for intake-state decisions and Playwright regression coverage for the direct-auth bypass

## Behavior after this change
- `onboarding_completed = true` -> `/chat`
- quiz data present, onboarding not complete -> `/onboarding`
- quiz data missing -> `/quiz`

## Verification
- `npx tsx --test tests/auth-intake-state.test.ts`
- `npm run typecheck`
- `npx playwright test tests/auth-intake-routing.e2e.spec.ts`