### PR TITLE
Stripe subscription: hard paywall + embedded Checkout + Customer Portal

### DIFF
--- a/docs/superpowers/specs/2026-04-19-stripe-subscription-design.md
+++ b/docs/superpowers/specs/2026-04-19-stripe-subscription-design.md
@@ -217,9 +217,11 @@ Extend `src/lib/supabase/middleware.ts`. Gate matrix:
 | `/chat`, `/chat/*`             | **yes**  | **yes**     |
 | `/api/chat`                    | **yes**  | **yes**     |
 | `/profile`                     | yes      | no          |
-| `/api/stripe/portal-session`   | yes      | yes         |
+| `/api/stripe/portal-session`   | yes      | no          |
 
 Unauthenticated hit on a session-required route → redirect `/auth?next=<path>` (existing behaviour preserved). Authenticated but `subscription_status !== 'active'` on a sub-required route → redirect `/pricing?reason=resubscribe`.
+
+Canceled users keep portal access so they can view invoices and resubscribe via plan switch.
 
 Subscription state is read from `profiles` via the existing server-side Supabase client — no extra DB round-trip beyond what middleware already does.
 

--- a/docs/superpowers/specs/2026-04-19-stripe-subscription-design.md
+++ b/docs/superpowers/specs/2026-04-19-stripe-subscription-design.md
@@ -1,0 +1,343 @@
+# Stripe Subscription — Design Spec
+
+**Date:** 2026-04-19
+**Status:** Approved during brainstorming; awaiting user sign-off before `writing-plans`
+**Owner:** Nick
+**Related:** `OVERVIEW.md` (Stripe listed as planned), `plans/business-plans.md` (outdated — superseded by this spec)
+
+---
+
+## 1. Context
+
+Hair Concierge is about to gate its post-quiz experience behind a paid subscription. Today the app runs quiz → result → auth → onboarding → chat for free. After this change, access to onboarding and the AI chat requires an active subscription.
+
+This spec defines the first Stripe integration: a hard paywall immediately after the quiz result, three billing intervals on one premium tier, Stripe-embedded Checkout on our domain, Supabase user creation on payment success, magic-link first login, and the Stripe Customer Portal for cancel/upgrade.
+
+### Why now
+
+- Marbella sprint (Apr 7–20) targets a web launch on 2026-04-20. A working paywall is required for launch.
+- Tom's audience is warm (1.5M followers); conversion from the quiz funnel is the primary revenue mechanism.
+- The existing `subscription_tiers` table and `profiles.subscription_tier_id` FK were scaffolded in `00001_initial_schema.sql` but never wired to a payment processor.
+
+### Non-goals (explicitly out of scope for this spec)
+
+- Free trial (deferred; MVP is paid-from-day-1).
+- Freemium chat gating by message count (hard paywall only; no per-message caps).
+- One-time purchases, affiliate payouts, Tom-branded bundles, or Plan 2/3/4 from `business-plans.md`.
+- Progress photos, seasonal refresh, routine tracker as *entitlements* (those are future features; if built, they are all unlocked by the same `subscription_status='active'`).
+- Referral credits, discount codes, promo flows.
+- Accounts v2 migration (we stick with Customers v1 per Stripe's current default).
+- Email receipts / invoicing PDFs beyond what Stripe sends by default.
+
+---
+
+## 2. User flow (end to end)
+
+1. **Quiz** (existing, unchanged) — 7-question pre-auth flow. Email captured into `leads` table at the current step.
+2. **Result card** (existing) — shareable. Adds a "Jetzt freischalten" CTA linking to `/pricing?lead=<leadId>`.
+3. **Pricing page** `/pricing` — three cards:
+   - **Monatlich** — €14.99 / Monat
+   - **Quartal** — €34.99 / 3 Monate (~€11.66/mo, *22% sparen*)
+   - **Jährlich** — €99.99 / Jahr (~€8.33/mo, *44% sparen*) — highlighted as "Beliebt"
+   - Each card's primary CTA posts to `/api/stripe/create-checkout-session` with `{ priceId, leadId }`.
+4. **Embedded Checkout** `/pricing/checkout` — server component creates a `checkout.Session` with `ui_mode: 'embedded'`, `mode: 'subscription'`, `customer_email` pre-filled from the lead's email and locked. Stripe's `<EmbeddedCheckoutProvider>` mounts the iframe. `consent_collection` includes the § 355 BGB withdrawal waiver via `custom_text`. Stripe handles SCA, VAT, dynamic payment methods.
+5. **Payment success** — Stripe fires `checkout.session.completed` to our webhook (see §5). Browser redirects to `return_url = /welcome?session_id={CHECKOUT_SESSION_ID}`.
+6. **`/welcome`** — server component retrieves session via `stripe.checkout.sessions.retrieve(id)`, gets `customer_details.email`, triggers `supabase.auth.admin.generateLink({ type: 'magiclink', email })`. Renders: "Zahlung erfolgreich – wir haben dir einen Login-Link an <email> gesendet."
+7. **Magic link click** — Supabase signs the user in (user row was already created by the webhook), redirects to `/onboarding`.
+8. **Onboarding → Chat** (existing, unchanged).
+
+**Google OAuth is removed entirely from this build.** The existing Google button and handler in `src/components/auth/auth-form.tsx` are deleted. Auth surface after this change:
+
+- **First sign-in for a new paid subscriber** — magic link via `/welcome` (see step 6 above). User lands directly in `/onboarding`; no password is set at this point.
+- **Returning users** on `/auth` — email + password (existing flow) for users who have a password set, and the existing "Passwort vergessen?" reset-link flow for paid users who came in via magic link and never set one. Resetting effectively gives them a password.
+- **Future** — a "Magic-Link senden" button on `/auth` can be added in a follow-up so paid users can sign in without ever setting a password. Out of scope for this spec.
+
+Rationale: one fewer OAuth provider to test and reason about during the Marbella sprint; eliminates the Stripe-email-vs-Google-email mismatch risk class entirely.
+
+### Failure / edge paths
+
+- **User abandons Checkout** — lead remains in `leads`, no Supabase user created, no subscription. Retargeting email can be added later.
+- **Webhook hasn't fired when `/welcome` loads** — `/welcome` still works (reads session from Stripe directly). Magic-link sign-in requires the Supabase user, which the webhook creates synchronously on the server path. If the user opens the magic link before the webhook completes, `/onboarding` shows a 2-second "Aktivierung läuft…" spinner that polls the profile for `subscription_status='active'`.
+- **User types different email in Stripe than in their Google OAuth** — impossible here: `customer_email` is locked in the session and pre-filled from the lead. If they later try to Google-OAuth with a different address, they create a second (free) Supabase user. This is documented but not blocked in MVP; acceptable risk given magic link is the primary sign-in.
+
+---
+
+## 3. Stripe account setup (Sandbox / Test mode first)
+
+All values are placeholders until captured in env.
+
+- **1 Product:** "Hair Concierge Premium"
+- **3 Prices (recurring, EUR):**
+  - Monthly €14.99 → `STRIPE_PRICE_ID_MONTHLY` (sandbox: `price_1TNwPCK0IN8ErFegM1V54x0Q`)
+  - Quarterly €34.99 → `STRIPE_PRICE_ID_QUARTERLY` (sandbox: `price_1TNwPyK0IN8ErFeggwGPBmgc`)
+  - Annual €99.99 → `STRIPE_PRICE_ID_ANNUAL` (sandbox: `price_1TNwPyK0IN8ErFegLWCrHfPo`)
+- **Payment methods enabled:** Card, Apple Pay, Google Pay, SEPA Direct Debit. Stripe auto-shows by country.
+- **Stripe Tax:** enabled; Germany registered.
+- **Customer Portal:** enabled with cancel-at-period-end, plan switching (all 3 prices), payment-method update, invoice history.
+- **Webhook endpoint:** one Snapshot-payload destination, subscribed to exactly:
+  - `checkout.session.completed`
+  - `customer.subscription.updated`
+  - `customer.subscription.deleted`
+  - `invoice.payment_failed`
+- **Live mode:** empty until launch. Live migration = re-create product/prices in live, swap env vars in Vercel, re-register live webhook endpoint.
+
+### Env vars
+
+```
+STRIPE_SECRET_KEY                       sk_test_... (live: sk_live_...)
+STRIPE_WEBHOOK_SECRET                   whsec_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY      pk_test_... (live: pk_live_...)
+STRIPE_PRICE_ID_MONTHLY                 price_...
+STRIPE_PRICE_ID_QUARTERLY               price_...
+STRIPE_PRICE_ID_ANNUAL                  price_...
+```
+
+Store in `.env.local` (gitignored) for dev and Vercel project envs for preview/prod. Never in code or chat.
+
+---
+
+## 4. Database schema
+
+### New migration: `20260419_add_stripe_subscription_fields.sql`
+
+```sql
+ALTER TABLE profiles
+  ADD COLUMN stripe_customer_id      text UNIQUE,
+  ADD COLUMN stripe_subscription_id  text UNIQUE,
+  ADD COLUMN subscription_status     text,        -- 'active' | 'past_due' | 'canceled' | 'incomplete' | NULL
+  ADD COLUMN subscription_interval   text,        -- 'month' | 'quarter' | 'year'
+  ADD COLUMN current_period_end      timestamptz;
+
+CREATE INDEX idx_profiles_stripe_customer_id ON profiles (stripe_customer_id);
+```
+
+### Existing tables — behaviour
+
+- `subscription_tiers` — kept as-is. Seed row `'Free'` and `'Premium'` stay. Pricing columns (`price_eur_monthly`, `price_eur_yearly`) become informational only; Stripe Prices are the source of truth. A follow-up can update the seed rows to match the new pricing if desired, but it's not functional.
+- `profiles.subscription_tier_id` — flipped to the Premium tier row on activation, back to Free on cancel.
+- `profiles.message_count_this_month` / `message_count_reset_at` — unused under hard paywall. Leave in place; remove in a later cleanup migration.
+- `handle_new_user` trigger — unchanged. Webhook-driven user creation still goes through `auth.admin.createUser`, which inserts into `auth.users`, which fires the trigger, which inserts the `profiles` row. Stripe fields are set in a subsequent `UPDATE` within the same webhook.
+
+### RLS
+
+Stripe columns on `profiles` are read by the owner via existing `profiles_select_own` policy. No new policies needed. Webhook writes use the service-role key (bypasses RLS by design).
+
+---
+
+## 5. Webhook handler
+
+**Location:** `src/app/api/stripe/webhook/route.ts`
+
+### Verification
+
+- Read raw body (Next.js route handler: `await req.text()`).
+- Verify via `stripe.webhooks.constructEvent(body, signature, STRIPE_WEBHOOK_SECRET)`.
+- Return 400 on signature failure. Return 200 as soon as fulfillment completes (or queue it; for MVP we execute synchronously — Stripe's 30s timeout is more than enough).
+
+### `checkout.session.completed`
+
+1. Parse `session.customer_details.email`, `session.customer` (Stripe customer ID), `session.subscription` (Stripe subscription ID).
+2. Retrieve the full subscription: `stripe.subscriptions.retrieve(session.subscription, { expand: ['items.data.price'] })` to get the interval (`month` | `year` | for quarterly, `interval='month'` + `interval_count=3`).
+3. Service-role Supabase client:
+   - Look up `auth.users` by email.
+   - If not found: `supabase.auth.admin.createUser({ email, email_confirm: true })`. The `handle_new_user` trigger auto-creates the `profiles` row.
+4. `UPDATE profiles` where `id = user.id`:
+   - `stripe_customer_id`, `stripe_subscription_id`
+   - `subscription_status = 'active'`
+   - `subscription_interval` = `'month'` | `'quarter'` | `'year'` (derived from `interval` + `interval_count`)
+   - `current_period_end` = `to_timestamp(subscription.current_period_end)`
+   - `subscription_tier_id` = Premium tier UUID
+5. Idempotency: the handler is safe to replay. Upsert semantics, no side effects on duplicate calls.
+
+### `customer.subscription.updated`
+
+- Find profile by `stripe_customer_id`.
+- Update `subscription_status`, `subscription_interval`, `current_period_end`.
+- Handles plan switches (Monthly → Annual etc.) and `cancel_at_period_end` transitions (status remains `active`; client reads `current_period_end` to display "Abo endet am …").
+
+### `customer.subscription.deleted`
+
+- Find profile by `stripe_customer_id`.
+- Set `subscription_status = 'canceled'`, `subscription_tier_id` = Free tier UUID.
+- User's next request hits the middleware gate (§7) and is redirected to `/pricing`.
+
+### `invoice.payment_failed`
+
+- MVP: log only (Sentry breadcrumb). Stripe Smart Retries + default dunning emails handle the rest. Final retry failure fires `customer.subscription.deleted`.
+
+---
+
+## 6. Frontend components
+
+### New
+
+- `src/app/pricing/page.tsx` — three-card layout (Monatlich / Quartal / Jährlich). Annual highlighted. Reads `leadId` from query param and includes it in the POST.
+- `src/app/pricing/checkout/page.tsx` — mounts `<EmbeddedCheckoutProvider>` with `fetchClientSecret` from `/api/stripe/create-checkout-session`.
+- `src/app/welcome/page.tsx` — server component; retrieves session, triggers magic link, shows confirmation UI.
+- `src/app/api/stripe/create-checkout-session/route.ts` — creates the Stripe Checkout Session, returns `client_secret`.
+- `src/app/api/stripe/session/route.ts` — returns session status for `/welcome`.
+- `src/app/api/stripe/portal-session/route.ts` — creates a Customer Portal session, redirects.
+- `src/components/profile/manage-subscription-button.tsx` — "Abo verwalten" button on `/profile`.
+- `src/lib/stripe/client.ts` — shared Stripe SDK init (`new Stripe(secret, { apiVersion })`).
+- `src/lib/stripe/gating.ts` — `isSubscriptionActive(profile) => boolean`.
+
+### Modified
+
+- `src/app/result/[leadId]/page.tsx` — add "Jetzt freischalten" CTA.
+- `src/lib/supabase/middleware.ts` — add subscription gate after session check (see §7).
+- `src/app/profile/page.tsx` — add manage-subscription button, show `current_period_end`, show "Abo endet am …" when cancellation pending.
+- `src/components/auth/auth-form.tsx` — remove Google OAuth button, `handleGoogleLogin`, the `"google"` loading state, and `googleButton` JSX from both login and signup tabs. Result: email + password only (forgot-password flow unchanged).
+- `src/app/auth/actions.ts` / `src/app/api/auth/callback/route.ts` — audit for OAuth-specific branches; delete if any reference only the `provider: 'google'` code path.
+
+### Copy (German, final)
+
+- Pricing page title: "Dein personalisierter Haar-Concierge"
+- Withdrawal waiver (Checkout `custom_text.after_submit`): "Ich stimme zu, dass der Zugriff auf das Abo sofort beginnt und ich damit mein 14-tägiges Widerrufsrecht verliere (§ 356 Abs. 4 BGB)."
+- `/welcome`: "Zahlung erfolgreich – wir haben dir einen Login-Link an {email} gesendet."
+- Re-sub banner: "Dein Abo ist abgelaufen — jetzt wieder freischalten."
+- Cancel-pending banner on `/profile`: "Dein Abo endet am {date}. Du kannst bis dahin weiter nutzen."
+
+---
+
+## 7. Route gating
+
+Extend `src/lib/supabase/middleware.ts`. Gate matrix:
+
+| Route                          | Session? | Active sub? |
+|--------------------------------|:--------:|:-----------:|
+| `/`                            | no       | no          |
+| `/quiz/*`                      | no       | no          |
+| `/result/[leadId]`             | no       | no          |
+| `/pricing`, `/pricing/*`       | no       | no          |
+| `/welcome`                     | no       | no          |
+| `/auth/*`                      | no       | no          |
+| `/api/stripe/webhook`          | no       | no          |
+| `/api/stripe/session`          | no       | no          |
+| `/onboarding`, `/onboarding/*` | **yes**  | **yes**     |
+| `/chat`, `/chat/*`             | **yes**  | **yes**     |
+| `/api/chat`                    | **yes**  | **yes**     |
+| `/profile`                     | yes      | no          |
+| `/api/stripe/portal-session`   | yes      | yes         |
+
+Unauthenticated hit on a session-required route → redirect `/auth?next=<path>` (existing behaviour preserved). Authenticated but `subscription_status !== 'active'` on a sub-required route → redirect `/pricing?reason=resubscribe`.
+
+Subscription state is read from `profiles` via the existing server-side Supabase client — no extra DB round-trip beyond what middleware already does.
+
+---
+
+## 8. Customer Portal & cancellation
+
+- On `/profile`, if `stripe_customer_id` is set: "Abo verwalten" button → server action → `stripe.billingPortal.sessions.create({ customer, return_url })` → redirect.
+- Portal handles: plan switch, cancel-at-period-end, payment method update, invoice history. All state changes flow back via `customer.subscription.updated` / `.deleted` webhooks.
+- Cancel lifecycle:
+  1. User clicks Kündigen in Portal → Stripe sets `cancel_at_period_end=true`.
+  2. Webhook updates profile; UI shows "Abo endet am {date}".
+  3. On period end, Stripe fires `customer.subscription.deleted` → profile flips to canceled + Free tier.
+  4. Next chat/onboarding request hits the middleware gate → redirect to `/pricing?reason=resubscribe`.
+- Resubscribe: same pricing page. Creates a new subscription on the existing Stripe customer (reusing `stripe_customer_id` stored on the profile if the user is signed in).
+
+---
+
+## 9. EU / DACH compliance
+
+- **§ 355 BGB 14-day withdrawal right** — waived by explicit unticked consent checkbox in Checkout via `consent_collection.terms_of_service = 'required'` + `custom_text`. Required because service starts immediately.
+- **VAT** — handled entirely by Stripe Tax. Registration in Germany required before going live.
+- **GDPR** — we do not create a Supabase user for non-payers. The `leads` row (email only, pre-consent marketing) remains for abandonment retargeting. Post-payment, Stripe handles PII per their DPA.
+- **EU Directive 2023/2673 "Click to Cancel"** (effective June 2026) — satisfied by the Customer Portal cancel-at-period-end flow accessible in one click from `/profile`.
+- **Invoicing** — Stripe sends invoice emails automatically on successful payments. No custom invoice generation needed for MVP.
+
+---
+
+## 10. Testing strategy
+
+### Local dev
+
+- `stripe listen --forward-to localhost:3000/api/stripe/webhook` — prints a **dev-only** `whsec_…` that you put in your local `.env.local`. This is *different* from the Dashboard webhook endpoint's signing secret, which goes in Vercel's env for preview/prod only. Do not mix the two.
+- Test cards: `4242 4242 4242 4242` (success), `4000 0025 0000 3155` (3DS), `4000 0000 0000 0002` (decline). Any future expiry, any CVC, any postal code.
+- SEPA test IBAN: `DE89370400440532013000` (success), `AT861904300235473202` (fails).
+
+### Unit tests (Vitest)
+
+Fixtures + tests in `src/app/api/stripe/webhook/__tests__/`:
+- `checkout.session.completed` — new email → creates Supabase user + profile update.
+- `checkout.session.completed` — existing email → only profile update.
+- `customer.subscription.updated` — plan switch M→Q→A reflected in `subscription_interval`.
+- `customer.subscription.updated` — `cancel_at_period_end=true` keeps status active.
+- `customer.subscription.deleted` → profile flips to canceled + Free.
+- `invoice.payment_failed` → logs, no state change.
+
+### Playwright E2E
+
+`tests/stripe-subscription.spec.ts`:
+- Full golden path: quiz → pricing → Embedded Checkout test card → `/welcome` → magic-link intercept via Supabase admin API → `/onboarding` → `/chat` loads.
+- Decline / 3DS / SEPA paths deferred to manual QA for MVP.
+
+### Manual QA matrix (pre-launch)
+
+- Card success, card 3DS, card decline
+- SEPA success
+- Apple Pay (Safari on macOS or iOS)
+- Cancel in Portal → access persists → period end → access revoked
+- Reactivate after cancel → new subscription on same `stripe_customer_id`
+- Plan switch (M→A) → `subscription_interval` updated on profile within seconds
+- Orphan cases: delete Stripe subscription directly in Dashboard → webhook fires → profile canceled
+
+---
+
+## 11. Known risks / open questions
+
+- **Paid users without a password** — a user who signs up via Checkout + magic link has no password set. If they return later on `/auth`, they must use "Passwort vergessen?" to receive a reset link and set one. Acceptable for MVP; a "Magic-Link senden" button on `/auth` would make this frictionless and is a small follow-up.
+- **Live mode cutover** — product/prices/webhook endpoint must be recreated in live mode before 2026-04-20. Add to the launch checklist.
+- **Stripe Customer Portal copy localization** — portal UI is auto-localized by Stripe based on browser locale, but some fields (custom plan names) are taken from the product metadata. Confirm the product name "Hair Concierge Premium" renders acceptably in German; rename to a German-native name if desired.
+- **Dunning email branding** — Stripe's default dunning emails are Stripe-branded. Acceptable for MVP; can be replaced later.
+- **Refund self-service** — not in MVP. Manual via Dashboard. Document process in internal runbook before launch.
+
+---
+
+## 12. Out-of-scope follow-ups (later backlog)
+
+- Promo / discount codes via Stripe Coupons.
+- Retargeting email for abandoned Checkouts (using `leads` table).
+- Progress photos, seasonal refresh, routine tracker as entitlements.
+- "Magic-Link senden" sign-in option on `/auth` (so paid users never need a password).
+- Re-introduction of Google OAuth (only worth it once a post-payment email-reconciliation UX is designed).
+- Invoice PDF customization (company branding).
+- Churn / LTV analytics to PostHog via webhook tap.
+- Tier-based message caps (if we ever introduce a cheaper tier that isn't unlimited).
+
+---
+
+## Appendix A — Price ID mapping (sandbox)
+
+| Interval   | Price ID (sandbox)                         | Amount |
+|------------|--------------------------------------------|--------|
+| monthly    | `price_1TNwPCK0IN8ErFegM1V54x0Q`           | €14.99 |
+| quarterly  | `price_1TNwPyK0IN8ErFeggwGPBmgc`           | €34.99 |
+| annual     | `price_1TNwPyK0IN8ErFegLWCrHfPo`           | €99.99 |
+
+Live mode IDs will be captured in Vercel env at launch; this file does not track them.
+
+---
+
+## Appendix B — Files touched (summary)
+
+**New:**
+- `supabase/migrations/20260419_add_stripe_subscription_fields.sql`
+- `src/lib/stripe/client.ts`
+- `src/lib/stripe/gating.ts`
+- `src/app/api/stripe/webhook/route.ts`
+- `src/app/api/stripe/create-checkout-session/route.ts`
+- `src/app/api/stripe/session/route.ts`
+- `src/app/api/stripe/portal-session/route.ts`
+- `src/app/pricing/page.tsx`
+- `src/app/pricing/checkout/page.tsx`
+- `src/app/welcome/page.tsx`
+- `src/components/profile/manage-subscription-button.tsx`
+- `src/app/api/stripe/webhook/__tests__/webhook.test.ts`
+- `tests/stripe-subscription.spec.ts`
+
+**Modified:**
+- `src/app/result/[leadId]/page.tsx`
+- `src/lib/supabase/middleware.ts`
+- `src/app/profile/page.tsx`
+- `.env.local` / Vercel env (not committed)

--- a/docs/superpowers/specs/2026-04-19-stripe-subscription-design.md
+++ b/docs/superpowers/specs/2026-04-19-stripe-subscription-design.md
@@ -147,7 +147,8 @@ Stripe columns on `profiles` are read by the owner via existing `profiles_select
    - `subscription_interval` = `'month'` | `'quarter'` | `'year'` (derived from `interval` + `interval_count`)
    - `current_period_end` = `to_timestamp(subscription.current_period_end)`
    - `subscription_tier_id` = Premium tier UUID
-5. Idempotency: the handler is safe to replay. Upsert semantics, no side effects on duplicate calls.
+5. Call `linkQuizToProfile(userId, email, session.metadata?.lead_id)` to carry the quiz answers from `leads` into a new `hair_profiles` row. Failures are logged, not thrown — a linking error shouldn't fail fulfillment.
+6. Idempotency: the handler is safe to replay. Upsert semantics, no side effects on duplicate calls.
 
 ### `customer.subscription.updated`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -935,101 +935,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
@@ -1042,363 +947,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -1837,6 +1385,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "license": "MIT"
@@ -1949,22 +1508,6 @@
         "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
       }
     },
-    "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
-      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
@@ -1979,145 +1522,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
-      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
-      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
-      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
-      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
-      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
-      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
-      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.80",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
-      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@next/env": {
@@ -2147,118 +1551,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
-      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
-      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
-      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
-      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
-      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
-      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
-      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -4616,7 +3908,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -4849,32 +4141,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
@@ -4886,292 +4152,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -5310,128 +4290,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
-      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
-      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
-      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
-      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
-      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
-      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.58.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
-      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "FSL-1.1-MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -6579,206 +5437,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.0",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tailwindcss/postcss": {
       "version": "4.1.18",
       "dev": true,
@@ -6789,15 +5447,6 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/connect": {
@@ -6816,6 +5465,28 @@
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -6842,7 +5513,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -6911,7 +5581,6 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.13",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7219,6 +5888,181 @@
         "darwin"
       ]
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -7250,6 +6094,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -7286,6 +6143,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -7705,6 +6604,13 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "dev": true,
@@ -7856,6 +6762,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -8152,7 +7068,6 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -8396,7 +7311,6 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8525,6 +7439,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -8995,7 +7916,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -9006,7 +7926,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9132,7 +8051,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9174,6 +8092,23 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -9588,6 +8523,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -9662,7 +8604,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -9678,7 +8619,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10421,6 +9361,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "dev": true,
@@ -10605,216 +9576,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lightningcss/node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss/node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -10868,6 +9629,20 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -11315,7 +10090,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -12046,6 +10820,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/next": {
       "version": "16.2.3",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
@@ -12584,7 +11365,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -12603,7 +11384,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -13077,6 +11858,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -13311,6 +12102,63 @@
       "version": "0.27.0",
       "license": "MIT"
     },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "license": "ISC",
@@ -13402,424 +12250,6 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/sharp/node_modules/semver": {
@@ -13957,11 +12387,32 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -14377,7 +12828,6 @@
     },
     "node_modules/tapable": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14413,6 +12863,66 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -14851,261 +13361,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/unrs-resolver/node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "funding": [
@@ -15190,6 +13445,20 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -15211,6 +13480,98 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack": {
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "loader-runner": "^4.3.1",
+        "mime-db": "^1.54.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -15605,6 +13966,111 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@langfuse/tracing": "^5.1.0",
         "@opentelemetry/sdk-node": "^0.214.0",
         "@sentry/nextjs": "^10.48.0",
+        "@stripe/react-stripe-js": "^5.6.1",
+        "@stripe/stripe-js": "^8.11.0",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
         "class-variance-authority": "^0.7.1",
@@ -29,6 +31,7 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "stripe": "^18.5.0",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.11"
@@ -1832,17 +1835,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -4624,7 +4616,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -6414,6 +6406,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-5.6.1.tgz",
+      "integrity": "sha512-5xBrjkGmFvKvpMod6VvpOaFaa67eRbmieKeFTePZyOr/sUXzm7A3YY91l330pS0usUst5PxTZDUZHWfOc0v1GA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=8.0.0 <9.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.11.0.tgz",
+      "integrity": "sha512-3fVF4z3efsgwgyj64nFK+6F4/vMw0mUXD2TBbOfftJtKVNx4JNv3CSfe1fY4DCtCk0JFp8/YPNcRkzgV0HJ8cg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.95.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
@@ -6803,28 +6818,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "license": "MIT"
@@ -6849,6 +6842,7 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -6917,6 +6911,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7224,181 +7219,6 @@
         "darwin"
       ]
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/wasm-gen": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/helper-wasm-section": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-opt": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1",
-        "@webassemblyjs/wast-printer": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -7430,19 +7250,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -7479,48 +7286,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -7940,13 +7705,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "dev": true,
@@ -7977,7 +7735,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8099,16 +7856,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -8405,6 +8152,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -8648,6 +8396,7 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8776,13 +8525,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -9253,6 +8995,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -9263,6 +9006,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9388,6 +9132,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -9429,23 +9174,6 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "peer": true
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -9860,13 +9588,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -9941,6 +9662,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -9956,6 +9678,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10698,37 +10421,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "dev": true,
@@ -10785,13 +10477,6 @@
       "version": "3.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -11185,20 +10870,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "license": "MIT",
@@ -11304,7 +10975,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -11645,6 +11315,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -12375,13 +12046,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/next": {
       "version": "16.2.3",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
@@ -12530,7 +12194,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12538,7 +12201,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12922,7 +12584,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -12941,7 +12603,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -13109,7 +12771,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -13185,6 +12846,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
@@ -13231,7 +12907,6 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -13398,16 +13073,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13645,63 +13310,6 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
-    },
-    "node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/schema-utils/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -14244,7 +13852,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14262,7 +13869,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14277,7 +13883,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14294,7 +13899,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14353,32 +13957,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -14664,6 +14247,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
@@ -14774,6 +14377,7 @@
     },
     "node_modules/tapable": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14809,66 +14413,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -15646,20 +15190,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -15681,89 +15211,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/webpack": {
-      "version": "5.106.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
-      "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@langfuse/tracing": "^5.1.0",
     "@opentelemetry/sdk-node": "^0.214.0",
     "@sentry/nextjs": "^10.48.0",
+    "@stripe/react-stripe-js": "^5.6.1",
+    "@stripe/stripe-js": "^8.11.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
     "class-variance-authority": "^0.7.1",
@@ -45,6 +47,7 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "stripe": "^18.5.0",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.11"

--- a/plans/2026-04-19-stripe-subscription.md
+++ b/plans/2026-04-19-stripe-subscription.md
@@ -1,0 +1,1714 @@
+# Stripe Subscription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a hard-paywall subscription behind the quiz: 3 billing intervals (€14.99/mo · €34.99/quarter · €99.99/year), Stripe Embedded Checkout, magic-link post-payment sign-in, Customer Portal for cancel/manage, Google OAuth removed.
+
+**Architecture:** Next.js 16 App Router server routes; Stripe Checkout Sessions API in `ui_mode: 'embedded'` + `mode: 'subscription'`; webhook-driven fulfillment creates Supabase users via admin API and updates `profiles` rows; middleware gates `/chat` and `/onboarding` on `subscription_status === 'active'`; Customer Portal is Stripe-hosted.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript 5, Tailwind 4, Supabase Auth (SSR) + Postgres, Stripe Node SDK (`stripe`) + `@stripe/stripe-js` + `@stripe/react-stripe-js`, Playwright (tests).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-stripe-subscription-design.md`.
+
+---
+
+## File Structure
+
+### Created
+
+| Path | Responsibility |
+|---|---|
+| `supabase/migrations/20260419_add_stripe_subscription_fields.sql` | Add 5 Stripe columns + index to `profiles` |
+| `src/lib/stripe/client.ts` | Server-only Stripe SDK init + shared constants (price-id map) |
+| `src/lib/stripe/gating.ts` | Pure `isSubscriptionActive(profile)` predicate |
+| `src/lib/stripe/webhook-handlers.ts` | Pure per-event handlers; takes injected Supabase + Stripe clients |
+| `src/lib/stripe/intervals.ts` | Pure: `intervalFromPrice(price)` → `'month'` / `'quarter'` / `'year'` |
+| `src/app/api/stripe/webhook/route.ts` | Verify signature, dispatch to handlers |
+| `src/app/api/stripe/create-checkout-session/route.ts` | POST: build Stripe Session, return `client_secret` |
+| `src/app/api/stripe/session/route.ts` | GET: read session status (for `/welcome`) |
+| `src/app/api/stripe/portal-session/route.ts` | POST: create Customer Portal session URL |
+| `src/app/pricing/page.tsx` | Server component; renders 3 plan cards |
+| `src/app/pricing/pricing-cards.tsx` | Client component; price-click → POST create-checkout-session → navigate |
+| `src/app/pricing/checkout/page.tsx` | Server component; pulls `leadId` + `priceId`, creates Session |
+| `src/app/pricing/checkout/embedded-checkout.tsx` | Client component; mounts `<EmbeddedCheckoutProvider>` |
+| `src/app/welcome/page.tsx` | Server component; retrieves session, triggers magic link, renders shell |
+| `src/app/welcome/welcome-client.tsx` | Client; polls `/api/stripe/session` for activation if needed |
+| `src/components/profile/manage-subscription-button.tsx` | Client button → POST to portal-session → redirect |
+| `tests/stripe-gating.spec.ts` | Pure-logic tests for `isSubscriptionActive` |
+| `tests/stripe-intervals.spec.ts` | Pure-logic tests for `intervalFromPrice` |
+| `tests/stripe-webhook-handlers.spec.ts` | Pure-logic tests for each handler with stub Supabase/Stripe clients |
+| `tests/stripe-subscription-e2e.spec.ts` | Full golden-path Playwright test |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `src/app/result/[leadId]/result-client.tsx` | Add "Jetzt freischalten" CTA linking to `/pricing?lead=<leadId>` |
+| `src/lib/supabase/middleware.ts` | Add paywall gate (sub-required route list, redirect to `/pricing?reason=resubscribe`) |
+| `src/app/profile/page.tsx` | Show subscription status, `current_period_end`, Manage button |
+| `src/components/auth/auth-form.tsx` | Remove `handleGoogleLogin`, `googleButton`, `"google"` loading state |
+| `.env.local` (gitignored) | Add 6 Stripe env vars |
+| `package.json` | Add `stripe`, `@stripe/stripe-js`, `@stripe/react-stripe-js` |
+
+---
+
+## Environment Setup (one-time)
+
+Populate `.env.local` with values already captured in conversation:
+
+```bash
+# --- Stripe (sandbox) ---
+STRIPE_SECRET_KEY=sk_test_REDACTED_SEE_ENV_LOCAL
+STRIPE_WEBHOOK_SECRET=whsec_REDACTED_SEE_ENV_LOCAL
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51TNwO1K0IN8ErFegbxAHSq7YBzjzeoZp5NWv3kZZy3C4zOe1gZaTj7BeVDg63pRHwjSdzAZ8SB3XD3oUE84bS8yC00X7g3wpbt
+STRIPE_PRICE_ID_MONTHLY=price_1TNwPCK0IN8ErFegM1V54x0Q
+STRIPE_PRICE_ID_QUARTERLY=price_1TNwPyK0IN8ErFeggwGPBmgc
+STRIPE_PRICE_ID_ANNUAL=price_1TNwPyK0IN8ErFegLWCrHfPo
+```
+
+For local webhook forwarding during dev (separate terminal):
+```bash
+stripe listen --forward-to localhost:3000/api/stripe/webhook
+```
+That command prints its own dev `whsec_...` — **do not** overwrite the Dashboard one in `.env.local`. Local dev uses the CLI's secret while it's running; production uses the Dashboard's secret in Vercel env.
+
+---
+
+## Task 0: Worktree + dependencies
+
+**Files:**
+- Create: `.worktrees/stripe-subscription/` (new git worktree)
+- Modify: `package.json` (root checkout stays clean; worktree gets the change)
+
+- [ ] **Step 1: Create worktree from `origin/main`**
+
+Run:
+```bash
+git fetch origin
+npm run worktree:new -- stripe-subscription
+cd .worktrees/stripe-subscription
+```
+Expected: new directory created, new branch `codex/stripe-subscription`, clean working tree.
+
+- [ ] **Step 2: Copy the spec + plan into the worktree**
+
+Because the spec and plan were written on `main` and are not yet committed, copy them across so the worktree has full context:
+```bash
+cp ../../docs/superpowers/specs/2026-04-19-stripe-subscription-design.md docs/superpowers/specs/
+cp ../../plans/2026-04-19-stripe-subscription.md plans/
+```
+Then `git add` and commit:
+```bash
+git add docs/superpowers/specs/2026-04-19-stripe-subscription-design.md plans/2026-04-19-stripe-subscription.md
+git commit -m "docs: add Stripe subscription spec + plan"
+```
+
+- [ ] **Step 3: Install Stripe dependencies**
+
+```bash
+npm install stripe@^18 @stripe/stripe-js@^7 @stripe/react-stripe-js@^5
+```
+Expected: `package-lock.json` updated, no peer-dep errors.
+
+- [ ] **Step 4: Create `.env.local` with sandbox values**
+
+Paste the block from the **Environment Setup** section above into `.worktrees/stripe-subscription/.env.local`. Verify it is gitignored:
+```bash
+git check-ignore .env.local
+```
+Expected: outputs `.env.local`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add stripe sdk dependencies"
+```
+
+---
+
+## Task 1: Database migration
+
+**Files:**
+- Create: `supabase/migrations/20260419_add_stripe_subscription_fields.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Stripe subscription fields on profiles
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS stripe_customer_id      text UNIQUE,
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id  text UNIQUE,
+  ADD COLUMN IF NOT EXISTS subscription_status     text,
+  ADD COLUMN IF NOT EXISTS subscription_interval   text,
+  ADD COLUMN IF NOT EXISTS current_period_end      timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_stripe_customer_id
+  ON profiles (stripe_customer_id);
+
+COMMENT ON COLUMN profiles.subscription_status IS
+  'active | past_due | canceled | incomplete | NULL';
+COMMENT ON COLUMN profiles.subscription_interval IS
+  'month | quarter | year';
+```
+
+- [ ] **Step 2: Apply locally via Supabase CLI**
+
+```bash
+npx supabase db push --password "$SUPABASE_DB_PASSWORD"
+```
+Expected: migration applied, no error. (Use the linked Supabase project `pqdkhefxsxkyeqelqegq` from CLAUDE.md; ask user for password if needed.)
+
+- [ ] **Step 3: Verify the columns exist**
+
+```bash
+npx supabase db execute --file - <<'SQL'
+SELECT column_name, data_type FROM information_schema.columns
+WHERE table_schema='public' AND table_name='profiles'
+  AND column_name IN ('stripe_customer_id','stripe_subscription_id','subscription_status','subscription_interval','current_period_end');
+SQL
+```
+Expected: all 5 rows returned.
+
+- [ ] **Step 4: Regenerate TypeScript types**
+
+```bash
+npx supabase gen types typescript --project-id pqdkhefxsxkyeqelqegq > src/lib/supabase/database.types.ts
+```
+Expected: `profiles.Row` now includes the 5 new fields.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260419_add_stripe_subscription_fields.sql src/lib/supabase/database.types.ts
+git commit -m "feat(db): add stripe subscription fields to profiles"
+```
+
+---
+
+## Task 2: Stripe client module
+
+**Files:**
+- Create: `src/lib/stripe/client.ts`
+- Create: `src/lib/stripe/intervals.ts`
+- Test: `tests/stripe-intervals.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/stripe-intervals.spec.ts`:
+```ts
+import { expect, test } from "@playwright/test"
+import { intervalFromPrice } from "../src/lib/stripe/intervals"
+
+test("month + interval_count=1 → 'month'", () => {
+  expect(intervalFromPrice({ interval: "month", interval_count: 1 })).toBe("month")
+})
+
+test("month + interval_count=3 → 'quarter'", () => {
+  expect(intervalFromPrice({ interval: "month", interval_count: 3 })).toBe("quarter")
+})
+
+test("year + interval_count=1 → 'year'", () => {
+  expect(intervalFromPrice({ interval: "year", interval_count: 1 })).toBe("year")
+})
+
+test("unknown combo throws", () => {
+  expect(() => intervalFromPrice({ interval: "week", interval_count: 1 })).toThrow()
+})
+```
+
+- [ ] **Step 2: Run test — expect 4 failures (module missing)**
+
+```bash
+npx playwright test tests/stripe-intervals.spec.ts
+```
+Expected: FAIL, "Cannot find module".
+
+- [ ] **Step 3: Implement `intervals.ts`**
+
+`src/lib/stripe/intervals.ts`:
+```ts
+export type BillingInterval = "month" | "quarter" | "year"
+
+export interface PriceRecurrence {
+  interval: string
+  interval_count: number
+}
+
+export function intervalFromPrice(p: PriceRecurrence): BillingInterval {
+  if (p.interval === "month" && p.interval_count === 1) return "month"
+  if (p.interval === "month" && p.interval_count === 3) return "quarter"
+  if (p.interval === "year" && p.interval_count === 1) return "year"
+  throw new Error(`Unsupported price recurrence: ${p.interval} x${p.interval_count}`)
+}
+```
+
+- [ ] **Step 4: Run test — expect 4 passes**
+
+```bash
+npx playwright test tests/stripe-intervals.spec.ts
+```
+Expected: 4 passed.
+
+- [ ] **Step 5: Implement `client.ts`**
+
+`src/lib/stripe/client.ts`:
+```ts
+import Stripe from "stripe"
+import type { BillingInterval } from "./intervals"
+
+let _stripe: Stripe | null = null
+
+export function getStripe(): Stripe {
+  if (_stripe) return _stripe
+  const key = process.env.STRIPE_SECRET_KEY
+  if (!key) throw new Error("STRIPE_SECRET_KEY is not set")
+  _stripe = new Stripe(key, { apiVersion: "2025-09-30.clover" })
+  return _stripe
+}
+
+export const PRICE_IDS: Record<BillingInterval, string> = {
+  month: process.env.STRIPE_PRICE_ID_MONTHLY ?? "",
+  quarter: process.env.STRIPE_PRICE_ID_QUARTERLY ?? "",
+  year: process.env.STRIPE_PRICE_ID_ANNUAL ?? "",
+}
+
+export function priceIdToInterval(priceId: string): BillingInterval | null {
+  const entry = Object.entries(PRICE_IDS).find(([, v]) => v === priceId)
+  return entry ? (entry[0] as BillingInterval) : null
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/stripe/client.ts src/lib/stripe/intervals.ts tests/stripe-intervals.spec.ts
+git commit -m "feat(stripe): client init + interval helpers"
+```
+
+---
+
+## Task 3: Gating predicate
+
+**Files:**
+- Create: `src/lib/stripe/gating.ts`
+- Test: `tests/stripe-gating.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/stripe-gating.spec.ts`:
+```ts
+import { expect, test } from "@playwright/test"
+import { isSubscriptionActive } from "../src/lib/stripe/gating"
+
+test("active status → true", () => {
+  expect(isSubscriptionActive({ subscription_status: "active" })).toBe(true)
+})
+
+test("past_due status → true (grace period)", () => {
+  expect(isSubscriptionActive({ subscription_status: "past_due" })).toBe(true)
+})
+
+test("canceled → false", () => {
+  expect(isSubscriptionActive({ subscription_status: "canceled" })).toBe(false)
+})
+
+test("incomplete → false", () => {
+  expect(isSubscriptionActive({ subscription_status: "incomplete" })).toBe(false)
+})
+
+test("null → false", () => {
+  expect(isSubscriptionActive({ subscription_status: null })).toBe(false)
+})
+
+test("missing profile → false", () => {
+  expect(isSubscriptionActive(null)).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+npx playwright test tests/stripe-gating.spec.ts
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`src/lib/stripe/gating.ts`:
+```ts
+export interface SubscriptionProfile {
+  subscription_status: string | null
+}
+
+export function isSubscriptionActive(
+  profile: SubscriptionProfile | null | undefined,
+): boolean {
+  if (!profile) return false
+  return profile.subscription_status === "active" ||
+         profile.subscription_status === "past_due"
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+npx playwright test tests/stripe-gating.spec.ts
+```
+Expected: 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/stripe/gating.ts tests/stripe-gating.spec.ts
+git commit -m "feat(stripe): isSubscriptionActive gating predicate"
+```
+
+---
+
+## Task 4: Webhook handler — checkout.session.completed (new user)
+
+**Files:**
+- Create: `src/lib/stripe/webhook-handlers.ts`
+- Test: `tests/stripe-webhook-handlers.spec.ts`
+
+Handlers take injected `deps` so tests can stub them.
+
+- [ ] **Step 1: Write the failing test (new user path)**
+
+`tests/stripe-webhook-handlers.spec.ts`:
+```ts
+import { expect, test } from "@playwright/test"
+import { handleCheckoutSessionCompleted } from "../src/lib/stripe/webhook-handlers"
+
+function stubDeps() {
+  const calls: any[] = []
+  const users: Record<string, { id: string; email: string }> = {}
+  const profiles: Record<string, any> = {}
+
+  return {
+    calls,
+    users,
+    profiles,
+    deps: {
+      supabase: {
+        auth: {
+          admin: {
+            async createUser({ email }: { email: string }) {
+              calls.push(["createUser", email])
+              const id = `user-${Object.keys(users).length + 1}`
+              users[email] = { id, email }
+              profiles[id] = { id, email, subscription_status: null }
+              return { data: { user: users[email] }, error: null }
+            },
+          },
+        },
+        from(table: string) {
+          return {
+            select() { return this },
+            eq(col: string, val: string) {
+              calls.push([`select-${table}-${col}`, val])
+              const row = table === "profiles"
+                ? Object.values(profiles).find((p: any) => p[col] === val)
+                : Object.values(users).find((u: any) => u[col] === val)
+              return { maybeSingle: async () => ({ data: row ?? null, error: null }) }
+            },
+            update(patch: any) {
+              return {
+                eq(col: string, val: string) {
+                  calls.push([`update-${table}`, val, patch])
+                  const row = Object.values(profiles).find((p: any) => p[col] === val)
+                  if (row) Object.assign(row, patch)
+                  return Promise.resolve({ error: null })
+                },
+              }
+            },
+          }
+        },
+      } as any,
+      stripe: {
+        subscriptions: {
+          async retrieve(_id: string) {
+            return {
+              id: "sub_1",
+              current_period_end: 1_800_000_000,
+              items: { data: [{ price: { interval: "month", interval_count: 1 } }] },
+            } as any
+          },
+        },
+      } as any,
+      premiumTierId: "tier-premium",
+    },
+  }
+}
+
+test("checkout.session.completed creates a new Supabase user and activates the sub", async () => {
+  const { deps, calls, profiles } = stubDeps()
+  const session = {
+    id: "cs_1",
+    customer: "cus_1",
+    customer_details: { email: "new@example.com" },
+    subscription: "sub_1",
+  } as any
+
+  await handleCheckoutSessionCompleted(session, deps)
+
+  expect(calls.some(([op]) => op === "createUser")).toBe(true)
+  const p = Object.values(profiles)[0] as any
+  expect(p.email).toBe("new@example.com")
+  expect(p.subscription_status).toBe("active")
+  expect(p.subscription_interval).toBe("month")
+  expect(p.stripe_customer_id).toBe("cus_1")
+  expect(p.stripe_subscription_id).toBe("sub_1")
+  expect(p.subscription_tier_id).toBe("tier-premium")
+  expect(p.current_period_end).toBeTruthy()
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL (module missing)**
+
+```bash
+npx playwright test tests/stripe-webhook-handlers.spec.ts
+```
+Expected: FAIL, "Cannot find module".
+
+- [ ] **Step 3: Implement `webhook-handlers.ts` with just `handleCheckoutSessionCompleted`**
+
+`src/lib/stripe/webhook-handlers.ts`:
+```ts
+import type Stripe from "stripe"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { intervalFromPrice } from "./intervals"
+
+export interface HandlerDeps {
+  supabase: SupabaseClient
+  stripe: Stripe
+  premiumTierId: string
+}
+
+export async function handleCheckoutSessionCompleted(
+  session: Stripe.Checkout.Session,
+  deps: HandlerDeps,
+): Promise<void> {
+  const email = session.customer_details?.email
+  if (!email) throw new Error("session has no customer email")
+  if (typeof session.customer !== "string") throw new Error("session.customer missing")
+  if (typeof session.subscription !== "string") throw new Error("session.subscription missing")
+
+  // 1. Ensure a Supabase user exists for this email
+  const { data: existing } = await deps.supabase
+    .from("profiles")
+    .select("id, email")
+    .eq("email", email)
+    .maybeSingle()
+
+  let userId: string
+  if (existing) {
+    userId = existing.id
+  } else {
+    const { data, error } = await deps.supabase.auth.admin.createUser({
+      email,
+      email_confirm: true,
+    })
+    if (error || !data.user) {
+      throw new Error(`createUser failed: ${error?.message ?? "unknown"}`)
+    }
+    userId = data.user.id
+  }
+
+  // 2. Retrieve full subscription to get interval + period end
+  const sub = await deps.stripe.subscriptions.retrieve(session.subscription, {
+    expand: ["items.data.price"],
+  })
+  const price = sub.items.data[0].price
+  const interval = intervalFromPrice({
+    interval: price.recurring?.interval ?? price.interval ?? "",
+    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
+  })
+
+  // 3. Update profile
+  await deps.supabase
+    .from("profiles")
+    .update({
+      stripe_customer_id: session.customer,
+      stripe_subscription_id: sub.id,
+      subscription_status: "active",
+      subscription_interval: interval,
+      current_period_end: new Date(sub.current_period_end * 1000).toISOString(),
+      subscription_tier_id: deps.premiumTierId,
+    })
+    .eq("id", userId)
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+npx playwright test tests/stripe-webhook-handlers.spec.ts
+```
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/stripe/webhook-handlers.ts tests/stripe-webhook-handlers.spec.ts
+git commit -m "feat(stripe): checkout.session.completed handler (new user path)"
+```
+
+---
+
+## Task 5: Webhook handler — existing user + subscription.updated + deleted
+
+**Files:**
+- Modify: `src/lib/stripe/webhook-handlers.ts`
+- Modify: `tests/stripe-webhook-handlers.spec.ts`
+
+- [ ] **Step 1: Add failing test — existing user path**
+
+Append to `tests/stripe-webhook-handlers.spec.ts`:
+```ts
+test("checkout.session.completed on existing email reuses the user", async () => {
+  const { deps, calls, profiles, users } = stubDeps()
+  users["ret@example.com"] = { id: "user-existing", email: "ret@example.com" }
+  profiles["user-existing"] = { id: "user-existing", email: "ret@example.com", subscription_status: null }
+
+  const session = {
+    id: "cs_2",
+    customer: "cus_2",
+    customer_details: { email: "ret@example.com" },
+    subscription: "sub_2",
+  } as any
+  await handleCheckoutSessionCompleted(session, deps)
+
+  expect(calls.some(([op]) => op === "createUser")).toBe(false)
+  expect((profiles["user-existing"] as any).subscription_status).toBe("active")
+})
+```
+
+- [ ] **Step 2: Run — expect pass (existing code already handles this path)**
+
+```bash
+npx playwright test tests/stripe-webhook-handlers.spec.ts -g "existing email"
+```
+Expected: 1 passed.
+
+- [ ] **Step 3: Add failing test — subscription.updated cancel-at-period-end**
+
+Append:
+```ts
+import { handleSubscriptionUpdated } from "../src/lib/stripe/webhook-handlers"
+
+test("subscription.updated keeps status=active when cancel_at_period_end flips", async () => {
+  const { deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    email: "x@y",
+    stripe_customer_id: "cus_X",
+    subscription_status: "active",
+    subscription_interval: "year",
+  }
+  const sub = {
+    id: "sub_X",
+    customer: "cus_X",
+    status: "active",
+    current_period_end: 1_900_000_000,
+    cancel_at_period_end: true,
+    items: { data: [{ price: { interval: "year", interval_count: 1 } }] },
+  } as any
+  await handleSubscriptionUpdated(sub, deps)
+  expect((profiles["u"] as any).subscription_status).toBe("active")
+  expect((profiles["u"] as any).current_period_end).toBeTruthy()
+})
+```
+
+- [ ] **Step 4: Implement `handleSubscriptionUpdated`**
+
+Append to `src/lib/stripe/webhook-handlers.ts`:
+```ts
+export async function handleSubscriptionUpdated(
+  sub: Stripe.Subscription,
+  deps: HandlerDeps,
+): Promise<void> {
+  if (typeof sub.customer !== "string") throw new Error("sub.customer not a string")
+  const price = sub.items.data[0].price
+  const interval = intervalFromPrice({
+    interval: price.recurring?.interval ?? price.interval ?? "",
+    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
+  })
+  await deps.supabase
+    .from("profiles")
+    .update({
+      subscription_status: sub.status,
+      subscription_interval: interval,
+      current_period_end: new Date(sub.current_period_end * 1000).toISOString(),
+    })
+    .eq("stripe_customer_id", sub.customer)
+}
+```
+
+- [ ] **Step 5: Run — expect pass**
+
+```bash
+npx playwright test tests/stripe-webhook-handlers.spec.ts -g "cancel_at_period_end"
+```
+
+- [ ] **Step 6: Add failing test — subscription.deleted**
+
+```ts
+import { handleSubscriptionDeleted } from "../src/lib/stripe/webhook-handlers"
+
+test("subscription.deleted flips profile to canceled + Free tier", async () => {
+  const { deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    stripe_customer_id: "cus_D",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+  }
+  const sub = { id: "sub_D", customer: "cus_D", status: "canceled" } as any
+  await handleSubscriptionDeleted(sub, { ...deps, freeTierId: "tier-free" } as any)
+  expect((profiles["u"] as any).subscription_status).toBe("canceled")
+  expect((profiles["u"] as any).subscription_tier_id).toBe("tier-free")
+})
+```
+
+- [ ] **Step 7: Implement `handleSubscriptionDeleted`**
+
+```ts
+export interface DeleteDeps extends HandlerDeps { freeTierId: string }
+
+export async function handleSubscriptionDeleted(
+  sub: Stripe.Subscription,
+  deps: DeleteDeps,
+): Promise<void> {
+  if (typeof sub.customer !== "string") throw new Error("sub.customer not a string")
+  await deps.supabase
+    .from("profiles")
+    .update({
+      subscription_status: "canceled",
+      subscription_tier_id: deps.freeTierId,
+    })
+    .eq("stripe_customer_id", sub.customer)
+}
+```
+
+- [ ] **Step 8: Implement `handleInvoicePaymentFailed` (log-only)**
+
+```ts
+export async function handleInvoicePaymentFailed(
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  console.warn("[stripe] invoice.payment_failed", {
+    invoiceId: invoice.id,
+    customer: invoice.customer,
+    attempt: invoice.attempt_count,
+  })
+}
+```
+
+- [ ] **Step 9: Run all handler tests — expect all pass**
+
+```bash
+npx playwright test tests/stripe-webhook-handlers.spec.ts
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/lib/stripe/webhook-handlers.ts tests/stripe-webhook-handlers.spec.ts
+git commit -m "feat(stripe): subscription updated/deleted + invoice failure handlers"
+```
+
+---
+
+## Task 6: Webhook route (dispatch + signature verification)
+
+**Files:**
+- Create: `src/app/api/stripe/webhook/route.ts`
+
+Signature verification is tested via live `stripe listen` in manual QA (Task 14). Route is thin.
+
+- [ ] **Step 1: Implement route**
+
+`src/app/api/stripe/webhook/route.ts`:
+```ts
+import { NextResponse, type NextRequest } from "next/server"
+import { getStripe } from "@/lib/stripe/client"
+import { createClient } from "@supabase/supabase-js"
+import {
+  handleCheckoutSessionCompleted,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+  handleInvoicePaymentFailed,
+} from "@/lib/stripe/webhook-handlers"
+
+export const runtime = "nodejs"  // raw body needed; not edge
+
+async function getTierIds(supabase: ReturnType<typeof createClient>) {
+  const { data } = await supabase
+    .from("subscription_tiers")
+    .select("id, slug")
+  const free = data?.find((r) => r.slug === "free")?.id
+  const premium = data?.find((r) => r.slug === "premium")?.id
+  if (!free || !premium) throw new Error("subscription_tiers seed rows missing")
+  return { freeTierId: free, premiumTierId: premium }
+}
+
+export async function POST(req: NextRequest) {
+  const sig = req.headers.get("stripe-signature")
+  const body = await req.text()
+  if (!sig) return new NextResponse("missing signature", { status: 400 })
+
+  const secret = process.env.STRIPE_WEBHOOK_SECRET
+  if (!secret) return new NextResponse("server misconfigured", { status: 500 })
+
+  const stripe = getStripe()
+  let event
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, secret)
+  } catch (err: any) {
+    return new NextResponse(`signature verification failed: ${err.message}`, { status: 400 })
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  )
+  const { freeTierId, premiumTierId } = await getTierIds(supabase)
+  const deps = { supabase, stripe, premiumTierId, freeTierId }
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed":
+        await handleCheckoutSessionCompleted(event.data.object as any, deps)
+        break
+      case "customer.subscription.updated":
+        await handleSubscriptionUpdated(event.data.object as any, deps)
+        break
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(event.data.object as any, deps)
+        break
+      case "invoice.payment_failed":
+        await handleInvoicePaymentFailed(event.data.object as any)
+        break
+      default:
+        console.warn("[stripe] unhandled event type:", event.type)
+    }
+  } catch (err: any) {
+    console.error("[stripe] handler error:", err)
+    return new NextResponse(`handler error: ${err.message}`, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: no errors in the new files.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/stripe/webhook/route.ts
+git commit -m "feat(stripe): webhook route with signature verification + dispatch"
+```
+
+---
+
+## Task 7: Create-checkout-session API
+
+**Files:**
+- Create: `src/app/api/stripe/create-checkout-session/route.ts`
+
+- [ ] **Step 1: Implement**
+
+`src/app/api/stripe/create-checkout-session/route.ts`:
+```ts
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { createClient } from "@supabase/supabase-js"
+import { getStripe, PRICE_IDS } from "@/lib/stripe/client"
+import type { BillingInterval } from "@/lib/stripe/intervals"
+
+export const runtime = "nodejs"
+
+const BodySchema = z.object({
+  interval: z.enum(["month", "quarter", "year"]),
+  leadId: z.string().uuid().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  const parsed = BodySchema.safeParse(await req.json())
+  if (!parsed.success) return NextResponse.json({ error: "bad request" }, { status: 400 })
+  const { interval, leadId } = parsed.data
+
+  const priceId = PRICE_IDS[interval as BillingInterval]
+  if (!priceId) return NextResponse.json({ error: "price not configured" }, { status: 500 })
+
+  // Look up lead email to pre-fill Checkout
+  let customerEmail: string | undefined
+  if (leadId) {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { persistSession: false } },
+    )
+    const { data } = await supabase.from("leads").select("email").eq("id", leadId).maybeSingle()
+    customerEmail = data?.email ?? undefined
+  }
+
+  const origin = req.nextUrl.origin
+  const stripe = getStripe()
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    ui_mode: "embedded",
+    line_items: [{ price: priceId, quantity: 1 }],
+    customer_email: customerEmail,
+    return_url: `${origin}/welcome?session_id={CHECKOUT_SESSION_ID}`,
+    automatic_tax: { enabled: true },
+    consent_collection: { terms_of_service: "required" },
+    custom_text: {
+      terms_of_service_acceptance: {
+        message:
+          "Ich stimme zu, dass der Zugriff auf das Abo sofort beginnt und ich damit mein 14-tägiges Widerrufsrecht verliere (§ 356 Abs. 4 BGB).",
+      },
+    },
+    metadata: leadId ? { lead_id: leadId } : undefined,
+  })
+
+  return NextResponse.json({ client_secret: session.client_secret })
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/stripe/create-checkout-session/route.ts
+git commit -m "feat(stripe): create-checkout-session API route"
+```
+
+---
+
+## Task 8: Session status API
+
+**Files:**
+- Create: `src/app/api/stripe/session/route.ts`
+
+- [ ] **Step 1: Implement**
+
+```ts
+import { NextResponse, type NextRequest } from "next/server"
+import { getStripe } from "@/lib/stripe/client"
+
+export const runtime = "nodejs"
+
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.searchParams.get("id")
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 })
+
+  const stripe = getStripe()
+  const session = await stripe.checkout.sessions.retrieve(id)
+  return NextResponse.json({
+    status: session.status,
+    email: session.customer_details?.email ?? null,
+    customer: typeof session.customer === "string" ? session.customer : null,
+  })
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/app/api/stripe/session/route.ts
+git commit -m "feat(stripe): session status API route"
+```
+
+---
+
+## Task 9: Pricing page (3 plan cards)
+
+**Files:**
+- Create: `src/app/pricing/page.tsx`
+- Create: `src/app/pricing/pricing-cards.tsx`
+
+- [ ] **Step 1: Server page**
+
+`src/app/pricing/page.tsx`:
+```tsx
+import { PricingCards } from "./pricing-cards"
+
+export default async function PricingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ lead?: string; reason?: string }>
+}) {
+  const sp = await searchParams
+  const leadId = sp.lead ?? null
+  const showResubBanner = sp.reason === "resubscribe"
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-12">
+      {showResubBanner && (
+        <div className="mb-6 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:bg-amber-950 dark:text-amber-100">
+          Dein Abo ist abgelaufen — jetzt wieder freischalten.
+        </div>
+      )}
+      <header className="mb-10 text-center">
+        <h1 className="font-header text-4xl">Dein personalisierter Haar-Concierge</h1>
+        <p className="mt-3 text-lg text-muted-foreground">
+          Wähle deinen Plan — jederzeit kündbar.
+        </p>
+      </header>
+      <PricingCards leadId={leadId} />
+    </main>
+  )
+}
+```
+
+- [ ] **Step 2: Client cards**
+
+`src/app/pricing/pricing-cards.tsx`:
+```tsx
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+interface Plan {
+  interval: "month" | "quarter" | "year"
+  name: string
+  price: string
+  perMonth: string
+  badge?: string
+  savings?: string
+}
+
+const PLANS: Plan[] = [
+  { interval: "month", name: "Monatlich", price: "€14,99", perMonth: "/ Monat" },
+  { interval: "quarter", name: "Quartal", price: "€34,99", perMonth: "~€11,66 / Monat", savings: "22% sparen" },
+  { interval: "year", name: "Jährlich", price: "€99,99", perMonth: "~€8,33 / Monat", badge: "Beliebt", savings: "44% sparen" },
+]
+
+export function PricingCards({ leadId }: { leadId: string | null }) {
+  const router = useRouter()
+  const [loading, setLoading] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function choose(interval: Plan["interval"]) {
+    setLoading(interval)
+    setError(null)
+    const params = new URLSearchParams({ interval })
+    if (leadId) params.set("lead", leadId)
+    router.push(`/pricing/checkout?${params.toString()}`)
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {PLANS.map((plan) => (
+        <div
+          key={plan.interval}
+          className={`relative rounded-xl border bg-card p-6 shadow-sm ${
+            plan.badge ? "border-primary ring-2 ring-primary/20" : ""
+          }`}
+        >
+          {plan.badge && (
+            <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground">
+              {plan.badge}
+            </span>
+          )}
+          <h2 className="font-header text-2xl">{plan.name}</h2>
+          <div className="mt-4 space-y-1">
+            <p className="text-3xl font-bold">{plan.price}</p>
+            <p className="text-sm text-muted-foreground">{plan.perMonth}</p>
+            {plan.savings && (
+              <p className="text-sm font-medium text-primary">{plan.savings}</p>
+            )}
+          </div>
+          <button
+            onClick={() => choose(plan.interval)}
+            disabled={loading !== null}
+            className="mt-6 w-full rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {loading === plan.interval ? "Wird geladen…" : "Jetzt starten"}
+          </button>
+        </div>
+      ))}
+      {error && (
+        <p className="col-span-full text-center text-sm text-destructive">{error}</p>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck, lint, commit**
+
+```bash
+npm run typecheck && npm run lint -- --fix
+git add src/app/pricing/
+git commit -m "feat(pricing): three-card pricing page"
+```
+
+---
+
+## Task 10: Embedded checkout page
+
+**Files:**
+- Create: `src/app/pricing/checkout/page.tsx`
+- Create: `src/app/pricing/checkout/embedded-checkout.tsx`
+
+- [ ] **Step 1: Server page**
+
+`src/app/pricing/checkout/page.tsx`:
+```tsx
+import { EmbeddedCheckoutMount } from "./embedded-checkout"
+import { redirect } from "next/navigation"
+
+export default async function CheckoutPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ interval?: string; lead?: string }>
+}) {
+  const sp = await searchParams
+  const interval = sp.interval
+  if (interval !== "month" && interval !== "quarter" && interval !== "year") {
+    redirect("/pricing")
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="font-header mb-6 text-2xl">Zahlungsdetails</h1>
+      <EmbeddedCheckoutMount interval={interval} leadId={sp.lead ?? null} />
+    </main>
+  )
+}
+```
+
+- [ ] **Step 2: Client mount**
+
+`src/app/pricing/checkout/embedded-checkout.tsx`:
+```tsx
+"use client"
+
+import { useCallback } from "react"
+import { loadStripe } from "@stripe/stripe-js"
+import {
+  EmbeddedCheckoutProvider,
+  EmbeddedCheckout,
+} from "@stripe/react-stripe-js"
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!)
+
+export function EmbeddedCheckoutMount({
+  interval,
+  leadId,
+}: {
+  interval: "month" | "quarter" | "year"
+  leadId: string | null
+}) {
+  const fetchClientSecret = useCallback(async () => {
+    const res = await fetch("/api/stripe/create-checkout-session", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ interval, leadId }),
+    })
+    if (!res.ok) throw new Error("failed to create checkout session")
+    const data = await res.json()
+    return data.client_secret as string
+  }, [interval, leadId])
+
+  return (
+    <div id="checkout" className="min-h-[600px]">
+      <EmbeddedCheckoutProvider
+        stripe={stripePromise}
+        options={{ fetchClientSecret }}
+      >
+        <EmbeddedCheckout />
+      </EmbeddedCheckoutProvider>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck, commit**
+
+```bash
+npm run typecheck
+git add src/app/pricing/checkout/
+git commit -m "feat(pricing): embedded stripe checkout page"
+```
+
+---
+
+## Task 11: Welcome page + magic link
+
+**Files:**
+- Create: `src/app/welcome/page.tsx`
+- Create: `src/app/welcome/welcome-client.tsx`
+
+- [ ] **Step 1: Server page**
+
+`src/app/welcome/page.tsx`:
+```tsx
+import { redirect } from "next/navigation"
+import { createClient } from "@supabase/supabase-js"
+import { getStripe } from "@/lib/stripe/client"
+import { WelcomeClient } from "./welcome-client"
+
+export default async function WelcomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>
+}) {
+  const { session_id } = await searchParams
+  if (!session_id) redirect("/")
+
+  const stripe = getStripe()
+  const session = await stripe.checkout.sessions.retrieve(session_id)
+  if (session.status !== "complete") redirect("/pricing")
+
+  const email = session.customer_details?.email
+  if (!email) redirect("/")
+
+  // Send magic link (idempotent; Supabase rate-limits on its own)
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  )
+  const { error } = await supabase.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+    options: { redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/onboarding` },
+  })
+  if (error) console.warn("[welcome] magic link failed:", error.message)
+
+  return <WelcomeClient email={email} />
+}
+```
+
+- [ ] **Step 2: Client component**
+
+`src/app/welcome/welcome-client.tsx`:
+```tsx
+"use client"
+
+import { Mail } from "lucide-react"
+
+export function WelcomeClient({ email }: { email: string }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+          <Mail className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="font-header text-3xl">Zahlung erfolgreich</h1>
+        <p className="text-base text-muted-foreground">
+          Wir haben dir einen Login-Link an{" "}
+          <span className="font-medium text-foreground">{email}</span> gesendet.
+          Bitte öffne deine E-Mails, um fortzufahren.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Keine E-Mail erhalten? Prüfe deinen Spam-Ordner oder warte 1–2 Minuten.
+        </p>
+      </div>
+    </main>
+  )
+}
+```
+
+- [ ] **Step 3: Add `NEXT_PUBLIC_SITE_URL` to `.env.local`**
+
+```bash
+echo 'NEXT_PUBLIC_SITE_URL=http://localhost:3000' >> .env.local
+```
+
+- [ ] **Step 4: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/app/welcome/ .env.local
+git diff --cached -- .env.local  # sanity: should be empty (gitignored)
+git commit -m "feat(welcome): post-payment magic link page"
+```
+
+---
+
+## Task 12: Middleware paywall gate
+
+**Files:**
+- Modify: `src/lib/supabase/middleware.ts`
+
+- [ ] **Step 1: Modify middleware**
+
+Insert AFTER the `hc_returning` cookie block (around line 79, i.e. after `supabaseResponse.cookies.set("hc_returning"...)` closes) and BEFORE the existing `if ((pathname === "/auth" || pathname === "/quiz")...)` block:
+
+```ts
+  // --- Subscription paywall ---------------------------------------------
+  const SUB_REQUIRED_PREFIXES = ["/onboarding", "/chat", "/api/chat"]
+  const PUB_SUB_EXEMPT_PREFIXES = [
+    "/api/stripe/webhook",
+    "/api/stripe/session",
+    "/welcome",
+    "/pricing",
+  ]
+  const needsSub = SUB_REQUIRED_PREFIXES.some((p) => pathname.startsWith(p))
+  const subExempt = PUB_SUB_EXEMPT_PREFIXES.some((p) => pathname.startsWith(p))
+
+  if (needsSub && !subExempt) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("subscription_status")
+      .eq("id", user.id)
+      .single()
+    const active =
+      profile?.subscription_status === "active" ||
+      profile?.subscription_status === "past_due"
+    if (!active) {
+      const url = request.nextUrl.clone()
+      url.pathname = "/pricing"
+      url.searchParams.set("reason", "resubscribe")
+      return NextResponse.redirect(url)
+    }
+  }
+  // --- End subscription paywall ------------------------------------------
+```
+
+Also add `/pricing`, `/welcome`, `/api/stripe` to the `publicRoutes` array:
+
+Replace:
+```ts
+  const publicRoutes = [
+    "/auth",
+    "/api/auth/callback",
+    "/auth/confirm",
+    "/quiz",
+    "/api/quiz",
+    "/result",
+    "/api/og",
+    "/datenschutz",
+    "/impressum",
+  ]
+```
+
+With:
+```ts
+  const publicRoutes = [
+    "/auth",
+    "/api/auth/callback",
+    "/auth/confirm",
+    "/quiz",
+    "/api/quiz",
+    "/result",
+    "/api/og",
+    "/datenschutz",
+    "/impressum",
+    "/pricing",
+    "/welcome",
+    "/api/stripe",
+  ]
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/supabase/middleware.ts
+git commit -m "feat(middleware): gate onboarding/chat on active subscription"
+```
+
+---
+
+## Task 13: Result page CTA
+
+**Files:**
+- Modify: `src/app/result/[leadId]/result-client.tsx`
+
+- [ ] **Step 1: Read file to find current CTA**
+
+```bash
+grep -n "button\|Link\|href\|Anmeld" src/app/result/\[leadId\]/result-client.tsx | head -30
+```
+Use this to find where the current primary CTA is (likely linking to `/auth`).
+
+- [ ] **Step 2: Replace primary CTA**
+
+Change the primary "Weiter" / "Anmelden" button so its `href` becomes:
+```tsx
+href={`/pricing?lead=${leadId}`}
+```
+And update the button label to `"Jetzt freischalten"`. Keep any secondary share buttons unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/result/
+git commit -m "feat(result): CTA links to pricing page"
+```
+
+---
+
+## Task 14: Remove Google OAuth from auth form
+
+**Files:**
+- Modify: `src/components/auth/auth-form.tsx`
+- Modify (audit only): `src/app/auth/actions.ts`
+- Modify (audit only): `src/app/api/auth/callback/route.ts`
+
+- [ ] **Step 1: In `src/components/auth/auth-form.tsx` delete in this order:**
+
+1. The `async function handleGoogleLogin()` declaration (lines ~69–87).
+2. The `const googleButton = (...)` JSX block (around line 185).
+3. Both `{googleButton}` references inside the tab panels.
+4. Change `const [loading, setLoading] = useState<"google" | "email" | null>(null)` to `useState<"email" | null>(null)`.
+5. Remove any "Oder" / divider JSX that only existed to separate Google from email.
+
+- [ ] **Step 2: Audit `src/app/auth/actions.ts`**
+
+```bash
+grep -n "oauth\|google\|provider" src/app/auth/actions.ts || echo "no oauth refs"
+```
+Delete any function or branch that only ran for the OAuth flow. If nothing is OAuth-specific, skip.
+
+- [ ] **Step 3: Audit `src/app/api/auth/callback/route.ts`**
+
+```bash
+grep -n "oauth\|google\|provider\|signInWithOAuth" src/app/api/auth/callback/route.ts || echo "no oauth refs"
+```
+Same process. The callback route is still used for magic-link confirmation — keep that path. Only delete OAuth-specific branches.
+
+- [ ] **Step 4: Run typecheck + lint**
+
+```bash
+npm run typecheck && npm run lint -- --fix
+```
+
+- [ ] **Step 5: Smoke-test auth page manually**
+
+```bash
+npm run dev
+# open http://localhost:3000/auth — verify no Google button, login tab works, signup tab works, Passwort vergessen works
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/auth/ src/app/auth/ src/app/api/auth/
+git commit -m "feat(auth): remove google oauth; email + magic-link only"
+```
+
+---
+
+## Task 15: Customer Portal + Profile page
+
+**Files:**
+- Create: `src/app/api/stripe/portal-session/route.ts`
+- Create: `src/components/profile/manage-subscription-button.tsx`
+- Modify: `src/app/profile/page.tsx`
+
+- [ ] **Step 1: Implement portal-session route**
+
+`src/app/api/stripe/portal-session/route.ts`:
+```ts
+import { NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import { getStripe } from "@/lib/stripe/client"
+
+export const runtime = "nodejs"
+
+export async function POST() {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
+      },
+    },
+  )
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: "unauthenticated" }, { status: 401 })
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("stripe_customer_id")
+    .eq("id", user.id)
+    .single()
+
+  if (!profile?.stripe_customer_id) {
+    return NextResponse.json({ error: "no subscription" }, { status: 404 })
+  }
+
+  const origin = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+  const stripe = getStripe()
+  const session = await stripe.billingPortal.sessions.create({
+    customer: profile.stripe_customer_id,
+    return_url: `${origin}/profile`,
+  })
+  return NextResponse.json({ url: session.url })
+}
+```
+
+- [ ] **Step 2: Button component**
+
+`src/components/profile/manage-subscription-button.tsx`:
+```tsx
+"use client"
+
+import { useState } from "react"
+
+export function ManageSubscriptionButton() {
+  const [loading, setLoading] = useState(false)
+  async function onClick() {
+    setLoading(true)
+    const res = await fetch("/api/stripe/portal-session", { method: "POST" })
+    if (!res.ok) {
+      setLoading(false)
+      alert("Konnte Portal nicht öffnen.")
+      return
+    }
+    const { url } = await res.json()
+    window.location.href = url
+  }
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      className="rounded-lg border bg-card px-5 py-2.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+    >
+      {loading ? "Wird geöffnet…" : "Abo verwalten"}
+    </button>
+  )
+}
+```
+
+- [ ] **Step 3: Modify `src/app/profile/page.tsx`**
+
+Add this block alongside any existing profile content (keep the rest untouched):
+```tsx
+import { ManageSubscriptionButton } from "@/components/profile/manage-subscription-button"
+// ...inside the page component, after fetching the profile row:
+
+{profile.stripe_customer_id && (
+  <section className="rounded-xl border bg-card p-6">
+    <h2 className="font-header text-xl mb-3">Dein Abo</h2>
+    <p className="text-sm text-muted-foreground mb-1">
+      Status: <strong className="text-foreground">{profile.subscription_status}</strong>
+    </p>
+    <p className="text-sm text-muted-foreground mb-4">
+      Nächste Abrechnung / Laufzeitende:{" "}
+      <strong className="text-foreground">
+        {profile.current_period_end
+          ? new Date(profile.current_period_end).toLocaleDateString("de-DE")
+          : "—"}
+      </strong>
+    </p>
+    <ManageSubscriptionButton />
+  </section>
+)}
+```
+
+Make sure the page query selects `stripe_customer_id`, `subscription_status`, `current_period_end`.
+
+- [ ] **Step 4: Typecheck + commit**
+
+```bash
+npm run typecheck
+git add src/app/api/stripe/portal-session/ src/components/profile/ src/app/profile/
+git commit -m "feat(profile): customer portal manage-subscription button"
+```
+
+---
+
+## Task 16: E2E golden-path test
+
+**Files:**
+- Create: `tests/stripe-subscription-e2e.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+`tests/stripe-subscription-e2e.spec.ts`:
+```ts
+import { expect, test } from "@playwright/test"
+
+// Prereqs:
+//   - dev server running on :3000
+//   - `stripe listen --forward-to localhost:3000/api/stripe/webhook` running
+//   - Supabase service role creds in .env.local
+//   - Dashboard webhook can be stale — the CLI one supersedes
+
+const TEST_EMAIL = `e2e-${Date.now()}@hair-concierge-test.local`
+
+test("quiz → pricing → stripe test card → welcome shows magic-link", async ({ page }) => {
+  test.setTimeout(120_000)
+
+  // 1. Start at the quiz
+  await page.goto("/quiz")
+  // (Skip ahead to lead capture — project-specific; advance through questions quickly.)
+  // For this MVP test, we open pricing directly with a fabricated lead.
+
+  // 2. Create a lead row via API so /pricing has a leadId + email to pass to Stripe
+  const leadRes = await page.request.post("/api/quiz/lead", {
+    data: { email: TEST_EMAIL, name: "E2E" },
+  })
+  expect(leadRes.ok()).toBeTruthy()
+  const lead = await leadRes.json()
+  const leadId = lead.id ?? lead.leadId
+  expect(leadId).toBeTruthy()
+
+  // 3. Go to pricing and pick monthly
+  await page.goto(`/pricing?lead=${leadId}`)
+  await page.getByRole("button", { name: /Jetzt starten/i }).first().click()
+
+  // 4. Embedded checkout loads — fill in the card inside the Stripe iframe
+  const frame = page.frameLocator("iframe[name^='__privateStripeFrame']").first()
+  await frame.getByLabel(/Kartennummer|Card number/i).fill("4242 4242 4242 4242")
+  await frame.getByLabel(/MM \/ JJ|MM \/ YY|Ablauf/i).fill("12 / 34")
+  await frame.getByLabel(/CVC|Prüfziffer/i).fill("123")
+  await frame.getByLabel(/PLZ|ZIP/i).fill("10115").catch(() => {})
+  // Accept terms-of-service waiver
+  await frame.getByRole("checkbox").check()
+  await page.getByRole("button", { name: /Abonnieren|Subscribe|Pay/i }).click()
+
+  // 5. Welcome page
+  await page.waitForURL(/\/welcome\?session_id=/, { timeout: 60_000 })
+  await expect(page.getByText("Zahlung erfolgreich")).toBeVisible()
+  await expect(page.getByText(TEST_EMAIL)).toBeVisible()
+})
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+# terminal 1
+npm run dev
+# terminal 2
+stripe listen --forward-to localhost:3000/api/stripe/webhook
+# terminal 3
+npx playwright test tests/stripe-subscription-e2e.spec.ts --headed
+```
+
+- [ ] **Step 3: Commit (even if fragile; iterate later)**
+
+```bash
+git add tests/stripe-subscription-e2e.spec.ts
+git commit -m "test(stripe): e2e golden path for subscription checkout"
+```
+
+---
+
+## Task 17: Final verification + PR
+
+- [ ] **Step 1: Full CI gate**
+
+```bash
+npm run ci:verify
+```
+Expected: typecheck + lint + build all green.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+npx playwright test tests/stripe-intervals.spec.ts tests/stripe-gating.spec.ts tests/stripe-webhook-handlers.spec.ts
+```
+Expected: all green.
+
+- [ ] **Step 3: Codex whole-branch review** (per CLAUDE.md)
+
+```bash
+# from .worktrees/stripe-subscription
+git diff main...HEAD | pbcopy
+# then run the /codex:rescue skill with: "review the staged diff for integration-level issues"
+```
+Address real findings. Skip false positives.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin codex/stripe-subscription
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create \
+  --title "Stripe subscription (€14.99/€34.99/€99.99, hard paywall)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Hard paywall after quiz → /pricing → Embedded Stripe Checkout → magic-link post-payment
+- 3 Prices (monthly / quarterly / annual) on one Premium product
+- Removes Google OAuth (magic-link + email+password only)
+- Customer Portal integration on /profile
+
+See `docs/superpowers/specs/2026-04-19-stripe-subscription-design.md`
+and `plans/2026-04-19-stripe-subscription.md`.
+
+## Test plan
+- [ ] `npm run ci:verify` green
+- [ ] Handler unit tests green
+- [ ] E2E golden-path test green (or manually verified)
+- [ ] Stripe Dashboard webhook endpoint URL updated to preview URL
+- [ ] Test card 4242 ends up on /welcome with magic-link copy
+- [ ] Magic link arrives, click → /onboarding loads, chat works
+- [ ] Cancel via Customer Portal → /chat redirects to /pricing after period end
+EOF
+)"
+```
+
+- [ ] **Step 6: Update Stripe Dashboard webhook URL**
+
+Once Vercel gives you a preview URL, go to Stripe Dashboard → Webhooks → `hair web` destination → edit URL from `https://example.com/webhook` to the Vercel preview URL. Keep it pointed at the preview until production deploy.
+
+- [ ] **Step 7: Confirm SSO / magic-link delivery works on preview**
+
+Open the preview URL, run through the golden path with test card, click the magic link that arrives, confirm you land on `/onboarding`.
+
+---
+
+## Self-Review (Plan vs. Spec)
+
+**Spec section coverage:**
+
+| Spec § | Plan task |
+|---|---|
+| §2 User flow | Tasks 9, 10, 11 (pricing → checkout → welcome) + 12 (middleware redirects) |
+| §3 Stripe setup | Environment Setup block + Dashboard work already done by user |
+| §4 DB schema | Task 1 |
+| §5 Webhook handler | Tasks 4, 5, 6 |
+| §6 Frontend components | Tasks 9, 10, 11, 13, 15 (all new files + result CTA + profile) |
+| §7 Route gating | Task 12 |
+| §8 Customer Portal & cancellation | Task 15 + webhook handlers Task 5 |
+| §9 EU/DACH compliance | § 355 waiver in Task 7 (create-checkout-session); Stripe Tax enabled; magic-link-only handles click-to-cancel indirectly |
+| §10 Testing strategy | Tasks 2, 3, 4, 5 (unit); Task 16 (e2e) |
+| §11 Known risks | Documented; paid-users-without-password is known + fallback is the existing reset-password flow already in the codebase |
+| §12 Out-of-scope | Not implemented by design |
+| Google OAuth removal | Task 14 |
+
+**Placeholder scan:** none found — every step shows code or exact commands.
+
+**Type consistency:** `BillingInterval`, `HandlerDeps`, `DeleteDeps` defined once; stub `Deps` in tests matches runtime shape; Stripe event types use inline `as any` casts at handler entry (acceptable for webhook shape variability).
+
+**Known soft spots:**
+- Task 1 Step 2 assumes `SUPABASE_DB_PASSWORD` is available. If not, swap `npx supabase db push` for applying the migration via the Supabase MCP `apply_migration` tool.
+- Task 16 (E2E) selectors for the Stripe iframe can be fragile — marked as commit-even-if-fragile, manual QA is the backstop.
+- Task 12 inserts middleware code at a specific line range; if unrelated edits have moved the file, re-locate by anchor text rather than line numbers.

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { z } from "zod"
+import { createClient } from "@supabase/supabase-js"
+import { getStripe, PRICE_IDS } from "@/lib/stripe/client"
+import type { BillingInterval } from "@/lib/stripe/intervals"
+
+export const runtime = "nodejs"
+
+const BodySchema = z.object({
+  interval: z.enum(["month", "quarter", "year"]),
+  leadId: z.string().uuid().optional(),
+})
+
+export async function POST(req: NextRequest) {
+  const parsed = BodySchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json({ error: "bad request" }, { status: 400 })
+  }
+  const { interval, leadId } = parsed.data
+
+  const priceId = PRICE_IDS[interval as BillingInterval]
+  if (!priceId) {
+    return NextResponse.json({ error: "price not configured" }, { status: 500 })
+  }
+
+  let customerEmail: string | undefined
+  if (leadId) {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { persistSession: false } },
+    )
+    const { data } = await supabase.from("leads").select("email").eq("id", leadId).maybeSingle()
+    customerEmail = data?.email ?? undefined
+  }
+
+  const origin = req.nextUrl.origin
+  const stripe = getStripe()
+  const session = await stripe.checkout.sessions.create({
+    mode: "subscription",
+    ui_mode: "embedded",
+    line_items: [{ price: priceId, quantity: 1 }],
+    customer_email: customerEmail ?? undefined,
+    return_url: `${origin}/welcome?session_id={CHECKOUT_SESSION_ID}`,
+    automatic_tax: { enabled: true },
+    consent_collection: { terms_of_service: "required" },
+    custom_text: {
+      terms_of_service_acceptance: {
+        message:
+          "Ich stimme zu, dass der Zugriff auf das Abo sofort beginnt und ich damit mein 14-tägiges Widerrufsrecht verliere (§ 356 Abs. 4 BGB).",
+      },
+    },
+    metadata: leadId ? { lead_id: leadId } : undefined,
+  })
+
+  return NextResponse.json({ client_secret: session.client_secret })
+}

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse, type NextRequest } from "next/server"
 import { z } from "zod"
 import { createClient } from "@supabase/supabase-js"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
 import { getStripe, PRICE_IDS } from "@/lib/stripe/client"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 
@@ -23,15 +25,55 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "price not configured" }, { status: 500 })
   }
 
+  // Identity resolution: prefer existing Stripe customer > email > 400
+  // Priority: leadId email → authed user's stripe_customer_id → authed user's email → 400
+  let customerId: string | undefined
   let customerEmail: string | undefined
+
   if (leadId) {
-    const supabase = createClient(
+    const adminSupabase = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.SUPABASE_SERVICE_ROLE_KEY!,
       { auth: { persistSession: false } },
     )
-    const { data } = await supabase.from("leads").select("email").eq("id", leadId).maybeSingle()
+    const { data } = await adminSupabase
+      .from("leads")
+      .select("email")
+      .eq("id", leadId)
+      .maybeSingle()
     customerEmail = data?.email ?? undefined
+  } else {
+    // Resubscribe / direct-entry path — lock to the authenticated user's identity
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll: () => cookieStore.getAll(),
+          setAll: () => {},
+        },
+      },
+    )
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (user) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("stripe_customer_id")
+        .eq("id", user.id)
+        .single()
+
+      if (profile?.stripe_customer_id) {
+        customerId = profile.stripe_customer_id
+      } else {
+        customerEmail = user.email
+      }
+    } else {
+      return NextResponse.json({ error: "identity required" }, { status: 400 })
+    }
   }
 
   const origin = req.nextUrl.origin
@@ -40,7 +82,8 @@ export async function POST(req: NextRequest) {
     mode: "subscription",
     ui_mode: "embedded",
     line_items: [{ price: priceId, quantity: 1 }],
-    customer_email: customerEmail ?? undefined,
+    // Pass customer OR customer_email — never both (Stripe rejects that combination)
+    ...(customerId ? { customer: customerId } : { customer_email: customerEmail }),
     return_url: `${origin}/welcome?session_id={CHECKOUT_SESSION_ID}`,
     automatic_tax: { enabled: true },
     consent_collection: { terms_of_service: "required" },

--- a/src/app/api/stripe/portal-session/route.ts
+++ b/src/app/api/stripe/portal-session/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server"
+import { createServerClient } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import { getStripe } from "@/lib/stripe/client"
+
+export const runtime = "nodejs"
+
+export async function POST() {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
+      },
+    },
+  )
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 })
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("stripe_customer_id")
+    .eq("id", user.id)
+    .single()
+
+  if (!profile?.stripe_customer_id) {
+    return NextResponse.json({ error: "no subscription" }, { status: 404 })
+  }
+
+  const origin = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+  const stripe = getStripe()
+  const session = await stripe.billingPortal.sessions.create({
+    customer: profile.stripe_customer_id,
+    return_url: `${origin}/profile`,
+  })
+  return NextResponse.json({ url: session.url })
+}

--- a/src/app/api/stripe/session/route.ts
+++ b/src/app/api/stripe/session/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { getStripe } from "@/lib/stripe/client"
+
+export const runtime = "nodejs"
+
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.searchParams.get("id")
+  if (!id) {
+    return NextResponse.json({ error: "id required" }, { status: 400 })
+  }
+
+  const stripe = getStripe()
+  const session = await stripe.checkout.sessions.retrieve(id)
+  return NextResponse.json({
+    status: session.status,
+    email: session.customer_details?.email ?? null,
+    customer: typeof session.customer === "string" ? session.customer : null,
+  })
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import { getStripe } from "@/lib/stripe/client"
+import {
+  handleCheckoutSessionCompleted,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+  handleInvoicePaymentFailed,
+} from "@/lib/stripe/webhook-handlers"
+import type Stripe from "stripe"
+
+export const runtime = "nodejs" // raw body required; edge runtime buffers differently
+
+async function getTierIds(supabase: SupabaseClient): Promise<{
+  freeTierId: string
+  premiumTierId: string
+}> {
+  const { data, error } = await supabase.from("subscription_tiers").select("id, slug")
+  if (error) throw new Error(`failed to load subscription_tiers: ${error.message}`)
+  const free = data?.find((r: { id: string; slug: string }) => r.slug === "free")?.id
+  const premium = data?.find((r: { id: string; slug: string }) => r.slug === "premium")?.id
+  if (!free || !premium) throw new Error("subscription_tiers seed rows missing")
+  return { freeTierId: free, premiumTierId: premium }
+}
+
+export async function POST(req: NextRequest) {
+  const sig = req.headers.get("stripe-signature")
+  const body = await req.text()
+  if (!sig) return new NextResponse("missing signature", { status: 400 })
+
+  const secret = process.env.STRIPE_WEBHOOK_SECRET
+  if (!secret) return new NextResponse("server misconfigured", { status: 500 })
+
+  const stripe = getStripe()
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, secret)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown"
+    return new NextResponse(`signature verification failed: ${message}`, { status: 400 })
+  }
+
+  const supabase: SupabaseClient = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  )
+  const { freeTierId, premiumTierId } = await getTierIds(supabase)
+  const deps = { supabase, stripe, premiumTierId }
+  const deleteDeps = { ...deps, freeTierId }
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed":
+        await handleCheckoutSessionCompleted(
+          event.data.object as unknown as Stripe.Checkout.Session,
+          deps,
+        )
+        break
+      case "customer.subscription.updated":
+        await handleSubscriptionUpdated(event.data.object as unknown as Stripe.Subscription, deps)
+        break
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(
+          event.data.object as unknown as Stripe.Subscription,
+          deleteDeps,
+        )
+        break
+      case "invoice.payment_failed":
+        await handleInvoicePaymentFailed(event.data.object as unknown as Stripe.Invoice)
+        break
+      default:
+        console.warn("[stripe] unhandled event type:", event.type)
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown"
+    console.error("[stripe] handler error:", err)
+    return new NextResponse(`handler error: ${message}`, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -7,6 +7,7 @@ import {
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
 } from "@/lib/stripe/webhook-handlers"
+import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import type Stripe from "stripe"
 
 export const runtime = "nodejs" // raw body required; edge runtime buffers differently
@@ -46,7 +47,7 @@ export async function POST(req: NextRequest) {
     { auth: { persistSession: false } },
   )
   const { freeTierId, premiumTierId } = await getTierIds(supabase)
-  const deps = { supabase, stripe, premiumTierId }
+  const deps = { supabase, stripe, premiumTierId, linkQuizToProfile }
   const deleteDeps = { ...deps, freeTierId }
 
   try {

--- a/src/app/pricing/checkout/embedded-checkout.tsx
+++ b/src/app/pricing/checkout/embedded-checkout.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useCallback } from "react"
+import { loadStripe } from "@stripe/stripe-js"
+import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js"
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!)
+
+export function EmbeddedCheckoutMount({
+  interval,
+  leadId,
+}: {
+  interval: "month" | "quarter" | "year"
+  leadId: string | null
+}) {
+  const fetchClientSecret = useCallback(async () => {
+    const res = await fetch("/api/stripe/create-checkout-session", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ interval, leadId }),
+    })
+    if (!res.ok) throw new Error("failed to create checkout session")
+    const data = await res.json()
+    return data.client_secret as string
+  }, [interval, leadId])
+
+  return (
+    <div id="checkout" className="min-h-[600px]">
+      <EmbeddedCheckoutProvider stripe={stripePromise} options={{ fetchClientSecret }}>
+        <EmbeddedCheckout />
+      </EmbeddedCheckoutProvider>
+    </div>
+  )
+}

--- a/src/app/pricing/checkout/page.tsx
+++ b/src/app/pricing/checkout/page.tsx
@@ -1,0 +1,21 @@
+import { EmbeddedCheckoutMount } from "./embedded-checkout"
+import { redirect } from "next/navigation"
+
+export default async function CheckoutPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ interval?: string; lead?: string }>
+}) {
+  const sp = await searchParams
+  const interval = sp.interval
+  if (interval !== "month" && interval !== "quarter" && interval !== "year") {
+    redirect("/pricing")
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="font-header mb-6 text-2xl">Zahlungsdetails</h1>
+      <EmbeddedCheckoutMount interval={interval} leadId={sp.lead ?? null} />
+    </main>
+  )
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,26 @@
+import { PricingCards } from "./pricing-cards"
+
+export default async function PricingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ lead?: string; reason?: string }>
+}) {
+  const sp = await searchParams
+  const leadId = sp.lead ?? null
+  const showResubBanner = sp.reason === "resubscribe"
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-12">
+      {showResubBanner && (
+        <div className="mb-6 rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:bg-amber-950 dark:text-amber-100">
+          Dein Abo ist abgelaufen — jetzt wieder freischalten.
+        </div>
+      )}
+      <header className="mb-10 text-center">
+        <h1 className="font-header text-4xl">Dein personalisierter Haar-Concierge</h1>
+        <p className="mt-3 text-lg text-muted-foreground">Wähle deinen Plan — jederzeit kündbar.</p>
+      </header>
+      <PricingCards leadId={leadId} />
+    </main>
+  )
+}

--- a/src/app/pricing/pricing-cards.tsx
+++ b/src/app/pricing/pricing-cards.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+interface Plan {
+  interval: "month" | "quarter" | "year"
+  name: string
+  price: string
+  perMonth: string
+  badge?: string
+  savings?: string
+}
+
+const PLANS: Plan[] = [
+  { interval: "month", name: "Monatlich", price: "€14,99", perMonth: "/ Monat" },
+  {
+    interval: "quarter",
+    name: "Quartal",
+    price: "€34,99",
+    perMonth: "~€11,66 / Monat",
+    savings: "22% sparen",
+  },
+  {
+    interval: "year",
+    name: "Jährlich",
+    price: "€99,99",
+    perMonth: "~€8,33 / Monat",
+    badge: "Beliebt",
+    savings: "44% sparen",
+  },
+]
+
+export function PricingCards({ leadId }: { leadId: string | null }) {
+  const router = useRouter()
+  const [loading, setLoading] = useState<string | null>(null)
+
+  function choose(interval: Plan["interval"]) {
+    setLoading(interval)
+    const params = new URLSearchParams({ interval })
+    if (leadId) params.set("lead", leadId)
+    router.push(`/pricing/checkout?${params.toString()}`)
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {PLANS.map((plan) => (
+        <div
+          key={plan.interval}
+          className={`relative rounded-xl border bg-card p-6 shadow-sm ${
+            plan.badge ? "border-primary ring-2 ring-primary/20" : ""
+          }`}
+        >
+          {plan.badge && (
+            <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs font-medium text-primary-foreground">
+              {plan.badge}
+            </span>
+          )}
+          <h2 className="font-header text-2xl">{plan.name}</h2>
+          <div className="mt-4 space-y-1">
+            <p className="text-3xl font-bold">{plan.price}</p>
+            <p className="text-sm text-muted-foreground">{plan.perMonth}</p>
+            {plan.savings && <p className="text-sm font-medium text-primary">{plan.savings}</p>}
+          </div>
+          <button
+            onClick={() => choose(plan.interval)}
+            disabled={loading !== null}
+            className="mt-6 w-full rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {loading === plan.interval ? "Wird geladen…" : "Jetzt starten"}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -11,6 +11,7 @@ import { SegmentedControl } from "@/components/ui/segmented-control"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { ManageSubscriptionButton } from "@/components/profile/manage-subscription-button"
 import { PRODUCT_CATEGORY_LABELS, PRODUCT_CATEGORY_ORDER } from "@/lib/onboarding/product-options"
 import type { OnboardingStep } from "@/lib/onboarding/store"
 import {
@@ -1763,6 +1764,25 @@ export default function ProfilePage() {
               )}
             </CardContent>
           </Card>
+
+          {profile?.stripe_customer_id && (
+            <section className="rounded-xl border bg-card p-6">
+              <h2 className="mb-3 font-header text-xl">Dein Abo</h2>
+              <p className="mb-1 text-sm text-muted-foreground">
+                Status:{" "}
+                <strong className="text-foreground">{profile.subscription_status ?? "—"}</strong>
+              </p>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Nächste Abrechnung / Laufzeitende:{" "}
+                <strong className="text-foreground">
+                  {profile.current_period_end
+                    ? new Date(profile.current_period_end).toLocaleDateString("de-DE")
+                    : "—"}
+                </strong>
+              </p>
+              <ManageSubscriptionButton />
+            </section>
+          )}
 
           <Card className="bg-muted/35">
             <CardHeader className="pb-3">

--- a/src/app/result/[leadId]/result-client.tsx
+++ b/src/app/result/[leadId]/result-client.tsx
@@ -153,6 +153,16 @@ export function ResultPageClient({
           </div>
         )}
 
+        {/* Primary CTA */}
+        <div className="mb-8">
+          <Link
+            href={`/pricing?lead=${leadId}`}
+            className="inline-flex w-full items-center justify-center rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
+          >
+            Jetzt freischalten
+          </Link>
+        </div>
+
         {/* Share section */}
         <div className="border-t border-border pt-8 mb-8">
           <p className="text-sm text-[var(--text-sub)] mb-4 text-center">Teile deine Diagnose</p>
@@ -197,9 +207,7 @@ export function ResultPageClient({
 
         {/* CTA for viewers */}
         <div className="text-center">
-          <p className="text-lg text-muted-foreground mb-4">
-            Was passt zu DEINEM Haar?
-          </p>
+          <p className="text-lg text-muted-foreground mb-4">Was passt zu DEINEM Haar?</p>
           <Link href="/quiz">
             <Button
               variant="unstyled"

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -26,12 +26,14 @@ export default async function WelcomePage({
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     { auth: { persistSession: false } },
   )
-  const { error } = await supabase.auth.admin.generateLink({
-    type: "magiclink",
+  const { error } = await supabase.auth.signInWithOtp({
     email,
-    options: { redirectTo: `${siteUrl}/onboarding` },
+    options: {
+      emailRedirectTo: `${siteUrl}/onboarding`,
+      shouldCreateUser: false,
+    },
   })
-  if (error) console.warn("[welcome] magic link generation failed:", error.message)
+  if (error) console.warn("[welcome] magic link dispatch failed:", error.message)
 
   return <WelcomeClient email={email} />
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,0 +1,37 @@
+import { redirect } from "next/navigation"
+import { createClient } from "@supabase/supabase-js"
+import { getStripe } from "@/lib/stripe/client"
+import { WelcomeClient } from "./welcome-client"
+
+export const dynamic = "force-dynamic"
+
+export default async function WelcomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>
+}) {
+  const { session_id } = await searchParams
+  if (!session_id) redirect("/")
+
+  const stripe = getStripe()
+  const session = await stripe.checkout.sessions.retrieve(session_id)
+  if (session.status !== "complete") redirect("/pricing")
+
+  const email = session.customer_details?.email
+  if (!email) redirect("/")
+
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  )
+  const { error } = await supabase.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+    options: { redirectTo: `${siteUrl}/onboarding` },
+  })
+  if (error) console.warn("[welcome] magic link generation failed:", error.message)
+
+  return <WelcomeClient email={email} />
+}

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { Mail } from "lucide-react"
+
+export function WelcomeClient({ email }: { email: string }) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+          <Mail className="h-6 w-6 text-primary" />
+        </div>
+        <h1 className="font-header text-3xl">Zahlung erfolgreich</h1>
+        <p className="text-base text-muted-foreground">
+          Wir haben dir einen Login-Link an{" "}
+          <span className="font-medium text-foreground">{email}</span> gesendet. Bitte öffne deine
+          E-Mails, um fortzufahren.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Keine E-Mail erhalten? Prüfe deinen Spam-Ordner oder warte 1–2 Minuten.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -52,7 +52,7 @@ export function AuthForm({
   const supabase = createClient()
   const router = useRouter()
 
-  const [loading, setLoading] = useState<"google" | "email" | null>(null)
+  const [loading, setLoading] = useState<"email" | null>(null)
   const [email, setEmail] = useState(defaultEmail ?? "")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
@@ -65,26 +65,6 @@ export function AuthForm({
   const errorBanner = error ? (
     <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
   ) : null
-
-  async function handleGoogleLogin() {
-    setLoading("google")
-    setError(null)
-    const callbackUrl = new URL("/api/auth/callback", window.location.origin)
-    if (leadId) callbackUrl.searchParams.set("lead", leadId)
-    callbackUrl.searchParams.set("next", next)
-
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        redirectTo: callbackUrl.toString(),
-      },
-    })
-    if (error) {
-      console.error("Auth error:", error)
-      setError("Google-Anmeldung fehlgeschlagen. Bitte versuche es erneut.")
-      setLoading(null)
-    }
-  }
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -181,42 +161,6 @@ export function AuthForm({
       setLoading(null)
     }
   }
-
-  const googleButton = (
-    <button
-      onClick={handleGoogleLogin}
-      disabled={loading !== null}
-      className="inline-flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-100 disabled:opacity-50"
-    >
-      <svg className="h-5 w-5" viewBox="0 0 24 24">
-        <path
-          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-          fill="#4285F4"
-        />
-        <path
-          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-          fill="#34A853"
-        />
-        <path
-          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-          fill="#FBBC05"
-        />
-        <path
-          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-          fill="#EA4335"
-        />
-      </svg>
-      {loading === "google" ? "Wird geladen..." : "Mit Google anmelden"}
-    </button>
-  )
-
-  const divider = (
-    <div className="flex items-center gap-3">
-      <div className="h-px flex-1 bg-border" />
-      <span className="text-xs text-muted-foreground">oder</span>
-      <div className="h-px flex-1 bg-border" />
-    </div>
-  )
 
   // Forgot password sub-view
   if (view === "forgot" && showForgotPassword) {
@@ -324,9 +268,6 @@ export function AuthForm({
               Passwort vergessen?
             </button>
           )}
-
-          {divider}
-          {googleButton}
         </div>
       </TabsContent>
 
@@ -377,9 +318,6 @@ export function AuthForm({
               {loading === "email" ? "Wird geladen..." : "Konto erstellen"}
             </button>
           </form>
-
-          {divider}
-          {googleButton}
         </div>
       </TabsContent>
     </Tabs>

--- a/src/components/profile/manage-subscription-button.tsx
+++ b/src/components/profile/manage-subscription-button.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useState } from "react"
+
+export function ManageSubscriptionButton() {
+  const [loading, setLoading] = useState(false)
+
+  async function onClick() {
+    setLoading(true)
+    const res = await fetch("/api/stripe/portal-session", { method: "POST" })
+    if (!res.ok) {
+      setLoading(false)
+      alert("Konnte Portal nicht öffnen.")
+      return
+    }
+    const { url } = await res.json()
+    window.location.href = url
+  }
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      className="rounded-lg border bg-card px-5 py-2.5 text-sm font-medium hover:bg-accent disabled:opacity-50"
+    >
+      {loading ? "Wird geöffnet…" : "Abo verwalten"}
+    </button>
+  )
+}

--- a/src/lib/stripe/client.ts
+++ b/src/lib/stripe/client.ts
@@ -1,0 +1,23 @@
+import Stripe from "stripe"
+import type { BillingInterval } from "./intervals"
+
+let _stripe: Stripe | null = null
+
+export function getStripe(): Stripe {
+  if (_stripe) return _stripe
+  const key = process.env.STRIPE_SECRET_KEY
+  if (!key) throw new Error("STRIPE_SECRET_KEY is not set")
+  _stripe = new Stripe(key, { apiVersion: "2025-08-27.basil" })
+  return _stripe
+}
+
+export const PRICE_IDS: Record<BillingInterval, string> = {
+  month: process.env.STRIPE_PRICE_ID_MONTHLY ?? "",
+  quarter: process.env.STRIPE_PRICE_ID_QUARTERLY ?? "",
+  year: process.env.STRIPE_PRICE_ID_ANNUAL ?? "",
+}
+
+export function priceIdToInterval(priceId: string): BillingInterval | null {
+  const entry = Object.entries(PRICE_IDS).find(([, v]) => v === priceId)
+  return entry ? (entry[0] as BillingInterval) : null
+}

--- a/src/lib/stripe/gating.ts
+++ b/src/lib/stripe/gating.ts
@@ -1,0 +1,8 @@
+export interface SubscriptionProfile {
+  subscription_status: string | null
+}
+
+export function isSubscriptionActive(profile: SubscriptionProfile | null | undefined): boolean {
+  if (!profile) return false
+  return profile.subscription_status === "active" || profile.subscription_status === "past_due"
+}

--- a/src/lib/stripe/intervals.ts
+++ b/src/lib/stripe/intervals.ts
@@ -1,0 +1,13 @@
+export type BillingInterval = "month" | "quarter" | "year"
+
+export interface PriceRecurrence {
+  interval: string
+  interval_count: number
+}
+
+export function intervalFromPrice(p: PriceRecurrence): BillingInterval {
+  if (p.interval === "month" && p.interval_count === 1) return "month"
+  if (p.interval === "month" && p.interval_count === 3) return "quarter"
+  if (p.interval === "year" && p.interval_count === 1) return "year"
+  throw new Error(`Unsupported price recurrence: ${p.interval} x${p.interval_count}`)
+}

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -1,0 +1,78 @@
+import type Stripe from "stripe"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { intervalFromPrice } from "./intervals"
+
+export interface HandlerDeps {
+  supabase: SupabaseClient
+  stripe: Stripe
+  premiumTierId: string
+}
+
+/** Shape we actually read from the retrieved subscription. */
+interface RetrievedSub {
+  id: string
+  current_period_end: number
+  items: {
+    data: Array<{
+      price: {
+        interval?: string
+        interval_count?: number
+        recurring?: { interval: string; interval_count: number }
+      }
+    }>
+  }
+}
+
+export async function handleCheckoutSessionCompleted(
+  session: Stripe.Checkout.Session,
+  deps: HandlerDeps,
+): Promise<void> {
+  const email = session.customer_details?.email
+  if (!email) throw new Error("session has no customer email")
+  if (typeof session.customer !== "string") throw new Error("session.customer missing")
+  if (typeof session.subscription !== "string") throw new Error("session.subscription missing")
+
+  // 1. Ensure a Supabase user exists for this email
+  const { data: existing } = await deps.supabase
+    .from("profiles")
+    .select("id, email")
+    .eq("email", email)
+    .maybeSingle()
+
+  let userId: string
+  if (existing) {
+    userId = existing.id
+  } else {
+    const { data, error } = await deps.supabase.auth.admin.createUser({
+      email,
+      email_confirm: true,
+    })
+    if (error || !data.user) {
+      throw new Error(`createUser failed: ${error?.message ?? "unknown"}`)
+    }
+    userId = data.user.id
+  }
+
+  // 2. Retrieve full subscription to get interval + period end
+  const sub = (await deps.stripe.subscriptions.retrieve(session.subscription, {
+    expand: ["items.data.price"],
+  })) as unknown as RetrievedSub
+  const price = sub.items.data[0].price
+  const interval = intervalFromPrice({
+    interval: price.recurring?.interval ?? price.interval ?? "",
+    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
+  })
+
+  // 3. Update profile
+  await deps.supabase
+    .from("profiles")
+    .update({
+      stripe_customer_id: session.customer,
+      stripe_subscription_id: sub.id,
+      subscription_status: "active",
+      subscription_interval: interval,
+      current_period_end: new Date(sub.current_period_end * 1000).toISOString(),
+      subscription_tier_id: deps.premiumTierId,
+    })
+    .eq("id", userId)
+}

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -6,6 +6,7 @@ export interface HandlerDeps {
   supabase: SupabaseClient
   stripe: Stripe
   premiumTierId: string
+  linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
 }
 
 /** Shape we actually read from the retrieved subscription. */
@@ -76,6 +77,17 @@ export async function handleCheckoutSessionCompleted(
       subscription_tier_id: deps.premiumTierId,
     })
     .eq("id", userId)
+
+  // 4. Carry quiz answers from leads into hair_profiles (fire-and-forget — a
+  //    linking failure must not fail fulfillment)
+  if (deps.linkQuizToProfile) {
+    const leadId = session.metadata?.lead_id || undefined
+    try {
+      await deps.linkQuizToProfile(userId, email, leadId)
+    } catch (err) {
+      console.error("[stripe] linkQuizToProfile failed:", err)
+    }
+  }
 }
 
 /** Narrow shape we read from a subscription event. */

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -11,9 +11,10 @@ export interface HandlerDeps {
 /** Shape we actually read from the retrieved subscription. */
 interface RetrievedSub {
   id: string
-  current_period_end: number
+  current_period_end?: number
   items: {
     data: Array<{
+      current_period_end?: number
       price: {
         interval?: string
         interval_count?: number
@@ -71,7 +72,7 @@ export async function handleCheckoutSessionCompleted(
       stripe_subscription_id: sub.id,
       subscription_status: "active",
       subscription_interval: interval,
-      current_period_end: new Date(sub.current_period_end * 1000).toISOString(),
+      current_period_end: subPeriodEndIso(sub as unknown as RetrievedSub),
       subscription_tier_id: deps.premiumTierId,
     })
     .eq("id", userId)
@@ -82,9 +83,11 @@ interface UpdatedSub {
   id: string
   customer: string | { id: string } | null
   status: string
-  current_period_end: number
+  current_period_end?: number
+  cancel_at_period_end?: boolean
   items: {
     data: Array<{
+      current_period_end?: number
       price: {
         recurring?: { interval: string; interval_count: number }
         interval?: string
@@ -92,6 +95,21 @@ interface UpdatedSub {
       }
     }>
   }
+}
+
+/**
+ * In Stripe API version 2025-08-27.basil, current_period_end moved from the
+ * Subscription root to each SubscriptionItem. Read item first, fall back to
+ * root for older API versions.
+ */
+function subPeriodEndIso(sub: RetrievedSub | UpdatedSub): string {
+  const itemEnd = sub.items.data[0]?.current_period_end
+  const rootEnd = (sub as { current_period_end?: number }).current_period_end
+  const unix = itemEnd ?? rootEnd
+  if (typeof unix !== "number" || Number.isNaN(unix)) {
+    throw new Error("subscription has no current_period_end on item or root")
+  }
+  return new Date(unix * 1000).toISOString()
 }
 
 export async function handleSubscriptionUpdated(
@@ -110,7 +128,7 @@ export async function handleSubscriptionUpdated(
     .update({
       subscription_status: s.status,
       subscription_interval: interval,
-      current_period_end: new Date(s.current_period_end * 1000).toISOString(),
+      current_period_end: subPeriodEndIso(s),
     })
     .eq("stripe_customer_id", s.customer)
 }

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -76,3 +76,68 @@ export async function handleCheckoutSessionCompleted(
     })
     .eq("id", userId)
 }
+
+/** Narrow shape we read from a subscription event. */
+interface UpdatedSub {
+  id: string
+  customer: string | { id: string } | null
+  status: string
+  current_period_end: number
+  items: {
+    data: Array<{
+      price: {
+        recurring?: { interval: string; interval_count: number }
+        interval?: string
+        interval_count?: number
+      }
+    }>
+  }
+}
+
+export async function handleSubscriptionUpdated(
+  sub: Stripe.Subscription,
+  deps: HandlerDeps,
+): Promise<void> {
+  const s = sub as unknown as UpdatedSub
+  if (typeof s.customer !== "string") throw new Error("sub.customer not a string")
+  const price = s.items.data[0].price
+  const interval = intervalFromPrice({
+    interval: price.recurring?.interval ?? price.interval ?? "",
+    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
+  })
+  await deps.supabase
+    .from("profiles")
+    .update({
+      subscription_status: s.status,
+      subscription_interval: interval,
+      current_period_end: new Date(s.current_period_end * 1000).toISOString(),
+    })
+    .eq("stripe_customer_id", s.customer)
+}
+
+export interface DeleteDeps extends HandlerDeps {
+  freeTierId: string
+}
+
+export async function handleSubscriptionDeleted(
+  sub: Stripe.Subscription,
+  deps: DeleteDeps,
+): Promise<void> {
+  const customer = typeof sub.customer === "string" ? sub.customer : null
+  if (!customer) throw new Error("sub.customer not a string")
+  await deps.supabase
+    .from("profiles")
+    .update({
+      subscription_status: "canceled",
+      subscription_tier_id: deps.freeTierId,
+    })
+    .eq("stripe_customer_id", customer)
+}
+
+export async function handleInvoicePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
+  console.warn("[stripe] invoice.payment_failed", {
+    invoiceId: invoice.id,
+    customer: invoice.customer,
+    attempt: invoice.attempt_count,
+  })
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -48,6 +48,9 @@ export async function updateSession(request: NextRequest) {
     "/api/og",
     "/datenschutz",
     "/impressum",
+    "/pricing",
+    "/welcome",
+    "/api/stripe",
   ]
   const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
 
@@ -80,6 +83,27 @@ export async function updateSession(request: NextRequest) {
       maxAge: 60 * 60 * 24 * 365,
     })
   }
+
+  // --- Subscription paywall ---------------------------------------------
+  const SUB_REQUIRED_PREFIXES = ["/onboarding", "/chat", "/api/chat"]
+  const needsSub = SUB_REQUIRED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+
+  if (needsSub) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("subscription_status")
+      .eq("id", user.id)
+      .single()
+    const active =
+      profile?.subscription_status === "active" || profile?.subscription_status === "past_due"
+    if (!active) {
+      const url = request.nextUrl.clone()
+      url.pathname = "/pricing"
+      url.searchParams.set("reason", "resubscribe")
+      return NextResponse.redirect(url)
+    }
+  }
+  // --- End subscription paywall ------------------------------------------
 
   if (needsAuthenticatedAppRouting) {
     const { data: profile } = await supabase

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,6 +119,11 @@ export interface Profile {
   subscription_tier_id: string | null
   message_count_this_month: number
   message_count_reset_at: string | null
+  stripe_customer_id: string | null
+  stripe_subscription_id: string | null
+  subscription_status: "active" | "past_due" | "canceled" | "incomplete" | null
+  subscription_interval: "month" | "quarter" | "year" | null
+  current_period_end: string | null
   created_at: string
   updated_at: string
 }

--- a/supabase/migrations/20260419_add_stripe_subscription_fields.sql
+++ b/supabase/migrations/20260419_add_stripe_subscription_fields.sql
@@ -1,0 +1,15 @@
+-- Stripe subscription fields on profiles
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS stripe_customer_id      text UNIQUE,
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id  text UNIQUE,
+  ADD COLUMN IF NOT EXISTS subscription_status     text,
+  ADD COLUMN IF NOT EXISTS subscription_interval   text,
+  ADD COLUMN IF NOT EXISTS current_period_end      timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_profiles_stripe_customer_id
+  ON profiles (stripe_customer_id);
+
+COMMENT ON COLUMN profiles.subscription_status IS
+  'active | past_due | canceled | incomplete | NULL';
+COMMENT ON COLUMN profiles.subscription_interval IS
+  'month | quarter | year';

--- a/tests/stripe-gating.spec.ts
+++ b/tests/stripe-gating.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test"
+import { isSubscriptionActive } from "../src/lib/stripe/gating"
+
+test("active status → true", () => {
+  expect(isSubscriptionActive({ subscription_status: "active" })).toBe(true)
+})
+
+test("past_due status → true (grace period)", () => {
+  expect(isSubscriptionActive({ subscription_status: "past_due" })).toBe(true)
+})
+
+test("canceled → false", () => {
+  expect(isSubscriptionActive({ subscription_status: "canceled" })).toBe(false)
+})
+
+test("incomplete → false", () => {
+  expect(isSubscriptionActive({ subscription_status: "incomplete" })).toBe(false)
+})
+
+test("null → false", () => {
+  expect(isSubscriptionActive({ subscription_status: null })).toBe(false)
+})
+
+test("missing profile → false", () => {
+  expect(isSubscriptionActive(null)).toBe(false)
+})

--- a/tests/stripe-intervals.spec.ts
+++ b/tests/stripe-intervals.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test"
+import { intervalFromPrice } from "../src/lib/stripe/intervals"
+
+test("month + interval_count=1 → 'month'", () => {
+  expect(intervalFromPrice({ interval: "month", interval_count: 1 })).toBe("month")
+})
+
+test("month + interval_count=3 → 'quarter'", () => {
+  expect(intervalFromPrice({ interval: "month", interval_count: 3 })).toBe("quarter")
+})
+
+test("year + interval_count=1 → 'year'", () => {
+  expect(intervalFromPrice({ interval: "year", interval_count: 1 })).toBe("year")
+})
+
+test("unknown combo throws", () => {
+  expect(() => intervalFromPrice({ interval: "week", interval_count: 1 })).toThrow()
+})

--- a/tests/stripe-subscription-e2e.spec.ts
+++ b/tests/stripe-subscription-e2e.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test"
+
+// This E2E is intentionally skipped by default.
+// Run manually:
+//   terminal 1: npm run dev
+//   terminal 2: stripe listen --forward-to localhost:3000/api/stripe/webhook
+//   terminal 3: npx playwright test tests/stripe-subscription-e2e.spec.ts --headed
+// Then remove .skip from the describe block below for the run.
+
+const TEST_EMAIL = `e2e-${Date.now()}@hair-concierge-test.local`
+
+test.describe.skip("Stripe subscription golden path (manual)", () => {
+  test("quiz → pricing → stripe test card → welcome shows magic-link", async ({ page }) => {
+    test.setTimeout(120_000)
+
+    // 1. Open the landing / quiz to establish a session
+    await page.goto("/quiz")
+
+    // 2. Seed a lead via the existing API so /pricing has a leadId + email
+    const leadRes = await page.request.post("/api/quiz/lead", {
+      data: { email: TEST_EMAIL, name: "E2E" },
+    })
+    expect(leadRes.ok()).toBeTruthy()
+    const lead = await leadRes.json()
+    const leadId = lead.id ?? lead.leadId
+    expect(leadId).toBeTruthy()
+
+    // 3. Navigate to pricing and choose monthly (first button is Monatlich)
+    await page.goto(`/pricing?lead=${leadId}`)
+    await page
+      .getByRole("button", { name: /Jetzt starten/i })
+      .first()
+      .click()
+
+    // 4. The embedded Stripe iframe loads on /pricing/checkout — fill the card
+    const frame = page.frameLocator("iframe[name^='__privateStripeFrame']").first()
+    await frame.getByLabel(/Kartennummer|Card number/i).fill("4242 4242 4242 4242")
+    await frame.getByLabel(/MM \/ JJ|MM \/ YY|Ablauf|Expiration/i).fill("12 / 34")
+    await frame.getByLabel(/CVC|Prüfziffer/i).fill("123")
+    await frame
+      .getByLabel(/PLZ|ZIP|Postleitzahl/i)
+      .fill("10115")
+      .catch(() => {
+        // PLZ field may not appear depending on Stripe locale
+      })
+    // Accept the § 355 BGB withdrawal-waiver checkbox that Stripe renders
+    await frame.getByRole("checkbox").first().check()
+
+    // 5. Submit
+    await page.getByRole("button", { name: /Abonnieren|Subscribe|Pay|Bezahlen/i }).click()
+
+    // 6. After redirect, welcome page should be visible with the magic-link copy
+    await page.waitForURL(/\/welcome\?session_id=/, { timeout: 60_000 })
+    await expect(page.getByText(/Zahlung erfolgreich/i)).toBeVisible()
+    await expect(page.getByText(TEST_EMAIL)).toBeVisible()
+  })
+})

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -4,6 +4,7 @@ import {
   handleSubscriptionUpdated,
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
+  type HandlerDeps,
 } from "../src/lib/stripe/webhook-handlers"
 
 function stubDeps() {
@@ -11,69 +12,66 @@ function stubDeps() {
   const users: Record<string, { id: string; email: string }> = {}
   const profiles: Record<string, any> = {}
 
-  return {
-    calls,
-    users,
-    profiles,
-    deps: {
-      supabase: {
-        auth: {
-          admin: {
-            async createUser({ email }: { email: string }) {
-              calls.push(["createUser", email])
-              const id = `user-${Object.keys(users).length + 1}`
-              users[email] = { id, email }
-              profiles[id] = { id, email, subscription_status: null }
-              return { data: { user: users[email] }, error: null }
-            },
+  const deps: HandlerDeps = {
+    supabase: {
+      auth: {
+        admin: {
+          async createUser({ email }: { email: string }) {
+            calls.push(["createUser", email])
+            const id = `user-${Object.keys(users).length + 1}`
+            users[email] = { id, email }
+            profiles[id] = { id, email, subscription_status: null }
+            return { data: { user: users[email] }, error: null }
           },
         },
-        from(table: string) {
-          return {
-            select() {
-              return this
-            },
-            eq(col: string, val: string) {
-              calls.push([`select-${table}-${col}`, val])
-              const row =
-                table === "profiles"
-                  ? Object.values(profiles).find((p: any) => p[col] === val)
-                  : Object.values(users).find((u: any) => u[col] === val)
-              return { maybeSingle: async () => ({ data: row ?? null, error: null }) }
-            },
-            update(patch: any) {
-              return {
-                eq(col: string, val: string) {
-                  calls.push([`update-${table}`, val, patch])
-                  const row = Object.values(profiles).find((p: any) => p[col] === val)
-                  if (row) Object.assign(row, patch)
-                  return Promise.resolve({ error: null })
-                },
-              }
-            },
-          }
-        },
-      } as any,
-      stripe: {
-        subscriptions: {
-          async retrieve(_id: string) {
+      },
+      from(table: string) {
+        return {
+          select() {
+            return this
+          },
+          eq(col: string, val: string) {
+            calls.push([`select-${table}-${col}`, val])
+            const row =
+              table === "profiles"
+                ? Object.values(profiles).find((p: any) => p[col] === val)
+                : Object.values(users).find((u: any) => u[col] === val)
+            return { maybeSingle: async () => ({ data: row ?? null, error: null }) }
+          },
+          update(patch: any) {
             return {
-              id: "sub_1",
-              items: {
-                data: [
-                  {
-                    price: { interval: "month", interval_count: 1 },
-                    current_period_end: 1_800_000_000,
-                  },
-                ],
+              eq(col: string, val: string) {
+                calls.push([`update-${table}`, val, patch])
+                const row = Object.values(profiles).find((p: any) => p[col] === val)
+                if (row) Object.assign(row, patch)
+                return Promise.resolve({ error: null })
               },
-            } as any
+            }
           },
+        }
+      },
+    } as any,
+    stripe: {
+      subscriptions: {
+        async retrieve(_id: string) {
+          return {
+            id: "sub_1",
+            items: {
+              data: [
+                {
+                  price: { interval: "month", interval_count: 1 },
+                  current_period_end: 1_800_000_000,
+                },
+              ],
+            },
+          } as any
         },
-      } as any,
-      premiumTierId: "tier-premium",
-    },
+      },
+    } as any,
+    premiumTierId: "tier-premium",
   }
+
+  return { calls, users, profiles, deps }
 }
 
 test("checkout.session.completed creates a new Supabase user and activates the sub", async () => {
@@ -165,6 +163,76 @@ test("invoice.payment_failed logs and returns (no throw)", async () => {
   const invoice = { id: "in_1", customer: "cus_1", attempt_count: 2 } as any
   await handleInvoicePaymentFailed(invoice)
   // no assertion beyond no-throw; log-only for MVP
+})
+
+test("checkout.session.completed with metadata.lead_id calls linkQuizToProfile with that id", async () => {
+  const { deps } = stubDeps()
+  const calls: Array<[string, string | undefined, string | undefined]> = []
+  deps.linkQuizToProfile = async (userId, email, leadId) => {
+    calls.push([userId, email, leadId])
+  }
+
+  const session = {
+    id: "cs_lead",
+    customer: "cus_lead",
+    customer_details: { email: "lead@example.com" },
+    subscription: "sub_lead",
+    metadata: { lead_id: "lead-xyz" },
+  } as any
+
+  await handleCheckoutSessionCompleted(session, deps)
+
+  expect(calls).toHaveLength(1)
+  const [calledUserId, calledEmail, calledLeadId] = calls[0]
+  expect(calledEmail).toBe("lead@example.com")
+  expect(calledLeadId).toBe("lead-xyz")
+  expect(typeof calledUserId).toBe("string")
+  expect(calledUserId.length).toBeGreaterThan(0)
+})
+
+test("checkout.session.completed without metadata calls linkQuizToProfile with undefined leadId", async () => {
+  const { deps } = stubDeps()
+  const calls: Array<[string, string | undefined, string | undefined]> = []
+  deps.linkQuizToProfile = async (userId, email, leadId) => {
+    calls.push([userId, email, leadId])
+  }
+
+  const session = {
+    id: "cs_nolead",
+    customer: "cus_nolead",
+    customer_details: { email: "nolead@example.com" },
+    subscription: "sub_nolead",
+    // no metadata
+  } as any
+
+  await handleCheckoutSessionCompleted(session, deps)
+
+  expect(calls).toHaveLength(1)
+  const [, calledEmail, calledLeadId] = calls[0]
+  expect(calledEmail).toBe("nolead@example.com")
+  expect(calledLeadId).toBeUndefined()
+})
+
+test("checkout.session.completed does not throw when linkQuizToProfile rejects", async () => {
+  const { deps, profiles } = stubDeps()
+  deps.linkQuizToProfile = async () => {
+    throw new Error("lead lookup failed")
+  }
+
+  const session = {
+    id: "cs_err",
+    customer: "cus_err",
+    customer_details: { email: "err@example.com" },
+    subscription: "sub_err",
+    metadata: { lead_id: "lead-err" },
+  } as any
+
+  // Should resolve normally despite linkQuizToProfile throwing
+  await expect(handleCheckoutSessionCompleted(session, deps)).resolves.toBeUndefined()
+
+  // Profile update still happened
+  const p = Object.values(profiles).find((x: any) => x.email === "err@example.com") as any
+  expect(p?.subscription_status).toBe("active")
 })
 
 test("checkout.session.completed falls back to root current_period_end when item has none", async () => {

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test"
+import { handleCheckoutSessionCompleted } from "../src/lib/stripe/webhook-handlers"
+
+function stubDeps() {
+  const calls: any[] = []
+  const users: Record<string, { id: string; email: string }> = {}
+  const profiles: Record<string, any> = {}
+
+  return {
+    calls,
+    users,
+    profiles,
+    deps: {
+      supabase: {
+        auth: {
+          admin: {
+            async createUser({ email }: { email: string }) {
+              calls.push(["createUser", email])
+              const id = `user-${Object.keys(users).length + 1}`
+              users[email] = { id, email }
+              profiles[id] = { id, email, subscription_status: null }
+              return { data: { user: users[email] }, error: null }
+            },
+          },
+        },
+        from(table: string) {
+          return {
+            select() {
+              return this
+            },
+            eq(col: string, val: string) {
+              calls.push([`select-${table}-${col}`, val])
+              const row =
+                table === "profiles"
+                  ? Object.values(profiles).find((p: any) => p[col] === val)
+                  : Object.values(users).find((u: any) => u[col] === val)
+              return { maybeSingle: async () => ({ data: row ?? null, error: null }) }
+            },
+            update(patch: any) {
+              return {
+                eq(col: string, val: string) {
+                  calls.push([`update-${table}`, val, patch])
+                  const row = Object.values(profiles).find((p: any) => p[col] === val)
+                  if (row) Object.assign(row, patch)
+                  return Promise.resolve({ error: null })
+                },
+              }
+            },
+          }
+        },
+      } as any,
+      stripe: {
+        subscriptions: {
+          async retrieve(_id: string) {
+            return {
+              id: "sub_1",
+              current_period_end: 1_800_000_000,
+              items: { data: [{ price: { interval: "month", interval_count: 1 } }] },
+            } as any
+          },
+        },
+      } as any,
+      premiumTierId: "tier-premium",
+    },
+  }
+}
+
+test("checkout.session.completed creates a new Supabase user and activates the sub", async () => {
+  const { deps, calls, profiles } = stubDeps()
+  const session = {
+    id: "cs_1",
+    customer: "cus_1",
+    customer_details: { email: "new@example.com" },
+    subscription: "sub_1",
+  } as any
+
+  await handleCheckoutSessionCompleted(session, deps)
+
+  expect(calls.some(([op]) => op === "createUser")).toBe(true)
+  const p = Object.values(profiles)[0] as any
+  expect(p.email).toBe("new@example.com")
+  expect(p.subscription_status).toBe("active")
+  expect(p.subscription_interval).toBe("month")
+  expect(p.stripe_customer_id).toBe("cus_1")
+  expect(p.stripe_subscription_id).toBe("sub_1")
+  expect(p.subscription_tier_id).toBe("tier-premium")
+  expect(p.current_period_end).toBeTruthy()
+})

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test"
-import { handleCheckoutSessionCompleted } from "../src/lib/stripe/webhook-handlers"
+import {
+  handleCheckoutSessionCompleted,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+  handleInvoicePaymentFailed,
+} from "../src/lib/stripe/webhook-handlers"
 
 function stubDeps() {
   const calls: any[] = []
@@ -85,4 +90,67 @@ test("checkout.session.completed creates a new Supabase user and activates the s
   expect(p.stripe_subscription_id).toBe("sub_1")
   expect(p.subscription_tier_id).toBe("tier-premium")
   expect(p.current_period_end).toBeTruthy()
+})
+
+test("checkout.session.completed on existing email reuses the user", async () => {
+  const { deps, calls, profiles, users } = stubDeps()
+  users["ret@example.com"] = { id: "user-existing", email: "ret@example.com" }
+  profiles["user-existing"] = {
+    id: "user-existing",
+    email: "ret@example.com",
+    subscription_status: null,
+  }
+
+  const session = {
+    id: "cs_2",
+    customer: "cus_2",
+    customer_details: { email: "ret@example.com" },
+    subscription: "sub_2",
+  } as any
+  await handleCheckoutSessionCompleted(session, deps)
+
+  expect(calls.some(([op]) => op === "createUser")).toBe(false)
+  expect((profiles["user-existing"] as any).subscription_status).toBe("active")
+})
+
+test("subscription.updated keeps status=active when cancel_at_period_end flips", async () => {
+  const { deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    email: "x@y",
+    stripe_customer_id: "cus_X",
+    subscription_status: "active",
+    subscription_interval: "year",
+  }
+  const sub = {
+    id: "sub_X",
+    customer: "cus_X",
+    status: "active",
+    current_period_end: 1_900_000_000,
+    cancel_at_period_end: true,
+    items: { data: [{ price: { interval: "year", interval_count: 1 } }] },
+  } as any
+  await handleSubscriptionUpdated(sub, deps)
+  expect((profiles["u"] as any).subscription_status).toBe("active")
+  expect((profiles["u"] as any).current_period_end).toBeTruthy()
+})
+
+test("subscription.deleted flips profile to canceled + Free tier", async () => {
+  const { deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    stripe_customer_id: "cus_D",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+  }
+  const sub = { id: "sub_D", customer: "cus_D", status: "canceled" } as any
+  await handleSubscriptionDeleted(sub, { ...deps, freeTierId: "tier-free" } as any)
+  expect((profiles["u"] as any).subscription_status).toBe("canceled")
+  expect((profiles["u"] as any).subscription_tier_id).toBe("tier-free")
+})
+
+test("invoice.payment_failed logs and returns (no throw)", async () => {
+  const invoice = { id: "in_1", customer: "cus_1", attempt_count: 2 } as any
+  await handleInvoicePaymentFailed(invoice)
+  // no assertion beyond no-throw; log-only for MVP
 })

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -59,8 +59,14 @@ function stubDeps() {
           async retrieve(_id: string) {
             return {
               id: "sub_1",
-              current_period_end: 1_800_000_000,
-              items: { data: [{ price: { interval: "month", interval_count: 1 } }] },
+              items: {
+                data: [
+                  {
+                    price: { interval: "month", interval_count: 1 },
+                    current_period_end: 1_800_000_000,
+                  },
+                ],
+              },
             } as any
           },
         },
@@ -126,9 +132,15 @@ test("subscription.updated keeps status=active when cancel_at_period_end flips",
     id: "sub_X",
     customer: "cus_X",
     status: "active",
-    current_period_end: 1_900_000_000,
     cancel_at_period_end: true,
-    items: { data: [{ price: { interval: "year", interval_count: 1 } }] },
+    items: {
+      data: [
+        {
+          price: { interval: "year", interval_count: 1 },
+          current_period_end: 1_900_000_000,
+        },
+      ],
+    },
   } as any
   await handleSubscriptionUpdated(sub, deps)
   expect((profiles["u"] as any).subscription_status).toBe("active")
@@ -153,4 +165,28 @@ test("invoice.payment_failed logs and returns (no throw)", async () => {
   const invoice = { id: "in_1", customer: "cus_1", attempt_count: 2 } as any
   await handleInvoicePaymentFailed(invoice)
   // no assertion beyond no-throw; log-only for MVP
+})
+
+test("checkout.session.completed falls back to root current_period_end when item has none", async () => {
+  const { deps, profiles } = stubDeps()
+  // override stripe.subscriptions.retrieve for this test
+  deps.stripe.subscriptions = {
+    async retrieve() {
+      return {
+        id: "sub_root",
+        current_period_end: 1_800_000_000,
+        items: { data: [{ price: { interval: "month", interval_count: 1 } }] },
+      } as any
+    },
+  } as any
+  const session = {
+    id: "cs_root",
+    customer: "cus_root",
+    customer_details: { email: "root@example.com" },
+    subscription: "sub_root",
+  } as any
+  await handleCheckoutSessionCompleted(session, deps)
+  const p = Object.values(profiles).find((x: any) => x.email === "root@example.com") as any
+  expect(p.current_period_end).toBeTruthy()
+  expect(p.subscription_status).toBe("active")
 })


### PR DESCRIPTION
## Summary

- Hard paywall behind the quiz: three Stripe prices (€14.99/mo · €34.99/quarter · €99.99/year) on one Premium product.
- Embedded Stripe Checkout on our domain (no redirect), § 355 BGB withdrawal-waiver consent collected, VAT via Stripe Tax.
- Magic-link post-payment sign-in (Supabase `signInWithOtp`). Google OAuth removed.
- Customer Portal wired up on `/profile` for cancel / plan-switch / payment-method updates.
- Webhook-driven fulfillment: `checkout.session.completed` creates the Supabase user, links the quiz lead to a populated `hair_profiles`, flips `subscription_status=active`, tier → Premium. `subscription.updated` and `subscription.deleted` keep the profile in sync; `invoice.payment_failed` logs only (Stripe Smart Retries owns dunning).
- Middleware gate: `/onboarding`, `/chat`, `/api/chat` require `subscription_status in ('active','past_due')`; otherwise redirect to `/pricing?reason=resubscribe`.

Spec: `docs/superpowers/specs/2026-04-19-stripe-subscription-design.md`
Plan: `plans/2026-04-19-stripe-subscription.md`

## What already passed locally

- ✅ `npm run ci:verify` (typecheck + lint + build) green
- ✅ 17 pure-logic Playwright tests (intervals, gating, 9× webhook handlers) green
- ✅ Codex whole-branch review: 3 findings addressed in `9133b3c`
- ✅ Manual E2E with real email: quiz → pricing → 4242 card → webhook → magic link → onboarding (pre-filled from lead) → chat with messages
- ✅ Cancel via Stripe Dashboard → `subscription.deleted` → profile flipped to `canceled` + Free tier
- ⏳ Plan switch (M → Q → A) only exercised via the `handleSubscriptionUpdated` code path; the Portal UI flow is the last thing to try on this PR's Vercel preview

## Test plan (for the Vercel preview)

- [ ] Add Stripe env vars to Vercel preview env: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` (Dashboard value, not CLI), `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRICE_ID_MONTHLY`, `STRIPE_PRICE_ID_QUARTERLY`, `STRIPE_PRICE_ID_ANNUAL`
- [ ] Update Stripe Dashboard webhook endpoint from placeholder to the Vercel preview URL + `/api/stripe/webhook`
- [ ] Fresh purchase on preview URL (test card) → confirm `/welcome` + magic link arrival
- [ ] `/profile` → **Abo verwalten** → Customer Portal opens → switch plan Monthly → Quarterly → verify DB `subscription_interval` = `quarter`
- [ ] Customer Portal cancel → DB transition to `canceled` + Free tier
- [ ] Attempt `/chat` after cancel → redirects to `/pricing?reason=resubscribe`

## Post-merge

- Remove `test.describe.skip` on `tests/stripe-subscription-e2e.spec.ts` if we want it in CI (needs live sandbox)
- Later: add "Magic-Link senden" button on `/auth` so paid users without a password can sign in without going through reset-password

🤖 Generated with [Claude Code](https://claude.com/claude-code)