### PR TITLE
feat: refresh quiz results and onboarding progress

### DIFF
--- a/docs/superpowers/plans/2026-04-20-quiz-results-narrative-followup.md
+++ b/docs/superpowers/plans/2026-04-20-quiz-results-narrative-followup.md
@@ -1,0 +1,753 @@
+# Quiz Results Narrative Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the quiz results page feel genuinely personalized by connecting the spectrum cards to quiz-derived severity, tightening the row copy, and adding a concise “what your hair needs now” bridge into the detailed routine.
+
+**Architecture:** Keep `buildQuizResultNarrative()` as the single source of truth for row scopes, slider positions, one main lever, and the CTA lead-in copy. Use lightweight quiz-local scoring helpers inspired by the recommendation engine’s damage/care-needs approach, but do not import the full recommendation runtime because the results page only has quiz answers, not the full normalized onboarding profile.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Zustand, lucide-react, Node `node:test`, Playwright
+
+**Spec:** Thread design agreement from April 20, 2026 (results follow-up: combined Row 1 scoring, real slider positions, single main lever, concise CTA bridge)
+
+---
+
+## File Map
+
+| Task | Creates | Modifies |
+|------|---------|----------|
+| 1: Narrative contract + scoring | — | `src/lib/quiz/result-narrative.ts`, `tests/quiz-result-narrative.test.ts` |
+| 2: Results UI + E2E coverage | — | `src/components/quiz/quiz-results.tsx`, `tests/quiz-onboarding-e2e.spec.ts`, `tests/auth-intake-routing.e2e.spec.ts` |
+| 3: Final verification | — | — |
+
+## Shared Decisions To Preserve
+
+- Remove the extra reveal line `Das ist dein Haarprofil — berechnet aus deinen Antworten.`
+- Keep the page headline `SO KOMMEN WIR DEINEM HAARZIEL NÄHER`
+- Row roles stay fixed:
+  - `Haargefühl`
+  - `Was dich gerade ausbremst`
+  - `Worauf wir hinarbeiten`
+- Add a short scope badge to each row header instead of repeating `in den Längen / in der Kopfhaut` inside both value texts
+- Slider semantics:
+  - `currentPosition` = severity now
+  - bucketed positions only: `18`, `34`, `50`, `66`, `82`
+  - fixed `targetPosition` per row:
+    - `Haargefühl` = `78`
+    - `Was dich gerade ausbremst` = `84`
+    - `Worauf wir hinarbeiten` = `88`
+- Row 1 uses combined scoring (`structural`, `surface`, `scalp`) and then chooses the dominant copy family
+- Row 3 left copy is concise and deficit-led:
+  - `wenig Glanz`
+  - `wenig Ruhe`
+  - `wenig Definition`
+  - `wenig Kontrolle`
+- `Was dein Haar jetzt braucht` shows exactly:
+  - one short reassurance + rationale sentence
+  - one main lever only
+  - one product-category-specific bridge sentence
+- CTA block must explain that the next step is the detailed routine, plan, and products
+
+---
+
+### Task 1: Narrative Contract + Scoring
+
+**Context:** The current narrative builder already picks `primaryConcern`, `primaryGoal`, icons, and tick labels, but it still uses a priority cascade for Row 1, fixed 0/100 marker placement, a now-removed reveal line, and no “needs” or CTA lead-in model. This task locks the new data contract in tests first, then implements it in `result-narrative.ts`.
+
+**Files:**
+- Modify: `src/lib/quiz/result-narrative.ts`
+- Test: `tests/quiz-result-narrative.test.ts`
+
+- [ ] **Step 1: Write failing contract tests for scopes, positions, concise goal copy, and needs**
+
+Add these tests to `tests/quiz-result-narrative.test.ts`:
+
+```typescript
+test("surface-led results expose scope labels, bucketed positions, and concise goal copy", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_bounces",
+    concerns: ["frizz"],
+    goals: ["less_frizz", "shine"],
+  })
+
+  assert.equal(narrative.rows[0]?.label, "Haargefühl")
+  assert.equal(narrative.rows[0]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[0]?.currentPosition, 66)
+  assert.equal(narrative.rows[0]?.targetPosition, 78)
+
+  assert.equal(narrative.rows[1]?.label, "Was dich gerade ausbremst")
+  assert.equal(narrative.rows[1]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[1]?.currentPosition, 66)
+  assert.equal(narrative.rows[1]?.targetPosition, 84)
+
+  assert.equal(narrative.rows[2]?.label, "Worauf wir hinarbeiten")
+  assert.equal(narrative.rows[2]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[2]?.before, "wenig Kontrolle")
+  assert.equal(narrative.rows[2]?.after, "mehr Geschmeidigkeit & Kontrolle")
+  assert.equal(narrative.rows[2]?.currentPosition, 50)
+  assert.equal(narrative.rows[2]?.targetPosition, 88)
+
+  assert.equal(narrative.needs.title, "Was dein Haar jetzt braucht")
+  assert.equal(narrative.needs.mainLeverLabel, "Jetzt zuerst")
+  assert.equal(narrative.needs.mainLeverTitle, "Mehr Schutz für Oberfläche und Längen aufbauen")
+  assert.match(narrative.needs.mainLeverBody, /Conditioner/i)
+  assert.match(narrative.needs.mainLeverBody, /Leave-in/i)
+
+  assert.equal(narrative.cta.lead, "Das ist dein Überblick")
+  assert.match(narrative.cta.subline, /persönlichen Pflegeplan/i)
+})
+
+test("dandruff fallback becomes scalp-scoped and names scalp-specific categories", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    scalp_type: "fettig",
+    has_scalp_issue: true,
+    scalp_condition: "schuppen",
+    concerns: [],
+    goals: ["healthy_scalp"],
+  })
+
+  assert.equal(narrative.primaryConcern, null)
+  assert.equal(narrative.rows[0]?.scope, "KOPFHAUT")
+  assert.equal(narrative.rows[1]?.scope, "KOPFHAUT")
+  assert.equal(narrative.rows[2]?.scope, "KOPFHAUT")
+  assert.equal(narrative.rows[2]?.before, "wenig Ruhe")
+  assert.equal(narrative.rows[2]?.after, "mehr Ruhe & Ausgeglichenheit")
+  assert.equal(narrative.rows[1]?.currentPosition, 66)
+  assert.equal(narrative.rows[2]?.currentPosition, 50)
+  assert.equal(narrative.needs.mainLeverTitle, "Die Kopfhaut gezielter ausgleichen")
+  assert.match(narrative.needs.mainLeverBody, /Anti-Schuppen-Shampoo/i)
+})
+
+test("severe structural signals can mention a bondbuilder in the main lever", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_stays",
+    treatment: ["blondiert"],
+    concerns: ["breakage", "hair_damage"],
+    goals: ["anti_breakage", "healthier_hair"],
+  })
+
+  assert.equal(narrative.rows[0]?.scope, "HAAR")
+  assert.equal(narrative.rows[0]?.currentPosition, 82)
+  assert.equal(narrative.rows[1]?.currentPosition, 82)
+  assert.equal(narrative.rows[2]?.before, "wenig Stabilität")
+  assert.match(narrative.needs.mainLeverBody, /Bondbuilder/i)
+})
+```
+
+- [ ] **Step 2: Run the narrative unit tests to verify they fail**
+
+Run:
+
+```bash
+npx tsx --test tests/quiz-result-narrative.test.ts
+```
+
+Expected:
+- FAIL because `scope`, `currentPosition`, `targetPosition`, and `needs` do not exist yet
+- FAIL because Row 3 still uses the old `mehr ...` left copy
+- FAIL because `cta.lead` is not present and the old `reveal` string still exists in the return shape
+
+- [ ] **Step 3: Extend the narrative types and base constants**
+
+In `src/lib/quiz/result-narrative.ts`, add the new row scope, bucket, positions, and needs-section types near the existing icon/type declarations:
+
+```typescript
+export type QuizResultScope =
+  | "HAAR"
+  | "LÄNGEN"
+  | "SPITZEN"
+  | "KOPFHAUT"
+  | "ANSATZ"
+  | "WELLEN & LOCKEN"
+
+type SeverityBucket = "very_low" | "low" | "medium" | "high" | "very_high"
+
+const BUCKET_TO_POSITION: Record<SeverityBucket, number> = {
+  very_low: 18,
+  low: 34,
+  medium: 50,
+  high: 66,
+  very_high: 82,
+}
+
+const ROW_TARGET_POSITIONS = {
+  hairFeel: 78,
+  friction: 84,
+  outcome: 88,
+} as const
+
+export interface QuizResultNarrativeRow {
+  label: "Haargefühl" | "Was dich gerade ausbremst" | "Worauf wir hinarbeiten"
+  scope: QuizResultScope
+  before: string
+  after: string
+  iconKey: QuizResultIconKey
+  tickBefore: string
+  tickAfter: string
+  currentPosition: number
+  targetPosition: number
+}
+
+interface QuizResultNeedsSection {
+  title: string
+  summary: string
+  mainLeverLabel: string
+  mainLeverTitle: string
+  mainLeverBody: string
+}
+
+export interface QuizResultNarrative {
+  intro: string
+  rows: [QuizResultNarrativeRow, QuizResultNarrativeRow, QuizResultNarrativeRow]
+  needs: QuizResultNeedsSection
+  cta: {
+    lead: string
+    subline: string
+    label: string
+  }
+  primaryConcern: QuizConcern | null
+  primaryGoal: Goal | null
+}
+```
+
+- [ ] **Step 4: Replace the Row 1 priority cascade with combined score helpers**
+
+Still in `src/lib/quiz/result-narrative.ts`, add quiz-local scoring helpers above the row builders. Mirror the engine’s “multiple subscores + level mapping” style, but stay local to quiz answers:
+
+```typescript
+function scoreToBucket(score: number): SeverityBucket {
+  if (score >= 8) return "very_high"
+  if (score >= 6) return "high"
+  if (score >= 4) return "medium"
+  if (score >= 2) return "low"
+  return "very_low"
+}
+
+function buildHairFeelScores(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+) {
+  let structural = 0
+  let surface = 0
+  let scalp = 0
+
+  if (answers.pulltest === "stretches_stays") structural += 3
+  if (answers.pulltest === "snaps") structural += 2
+  if (hasColorTreatment(answers)) structural += 3
+  if (primaryConcern === "breakage" || primaryConcern === "hair_damage") structural += 3
+  if (primaryConcern === "split_ends") structural += 2
+  if (
+    primaryGoal === "anti_breakage" ||
+    primaryGoal === "strengthen" ||
+    primaryGoal === "healthier_hair"
+  ) {
+    structural += 2
+  }
+
+  if (answers.fingertest === "rau") surface += 3
+  if (answers.fingertest === "leicht_uneben") surface += 2
+  if (primaryConcern === "dryness" || primaryConcern === "frizz" || primaryConcern === "tangling") {
+    surface += 2
+  }
+  if (
+    primaryGoal === "moisture" ||
+    primaryGoal === "shine" ||
+    primaryGoal === "less_frizz" ||
+    primaryGoal === "curl_definition"
+  ) {
+    surface += 2
+  }
+
+  if (answers.scalp_condition) scalp += 4
+  if (answers.scalp_type === "fettig" || answers.scalp_type === "trocken") scalp += 3
+  if (primaryGoal === "healthy_scalp") scalp += 2
+
+  return { structural, surface, scalp }
+}
+
+function resolveDominantHairFeelAxis(scores: ReturnType<typeof buildHairFeelScores>) {
+  const entries = [
+    ["scalp", scores.scalp],
+    ["structural", scores.structural],
+    ["surface", scores.surface],
+  ] as const
+
+  return [...entries].sort((left, right) => right[1] - left[1])[0][0]
+}
+```
+
+Use those helpers in `buildHairFeelRow()`. Keep the copy families concise:
+
+```typescript
+function buildHairFeelRow(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): QuizResultNarrativeRow {
+  const scores = buildHairFeelScores(answers, primaryConcern, primaryGoal)
+  const dominantAxis = resolveDominantHairFeelAxis(scores)
+
+  if (dominantAxis === "scalp") {
+    const before =
+      answers.scalp_condition === "gereizt"
+        ? "unruhig & gereizt"
+        : answers.scalp_type === "fettig"
+          ? "schnell fettig & schwer"
+          : "unruhig & unausgeglichen"
+
+    return {
+      label: "Haargefühl",
+      scope: "KOPFHAUT",
+      before,
+      after: "ruhiger & ausgeglichener",
+      iconKey: answers.scalp_condition === "gereizt" ? "heart" : "leaf",
+      tickBefore: "unruhig",
+      tickAfter: "ausgeglichen",
+      currentPosition: BUCKET_TO_POSITION[scoreToBucket(scores.scalp)],
+      targetPosition: ROW_TARGET_POSITIONS.hairFeel,
+    }
+  }
+
+  if (dominantAxis === "structural") {
+    return {
+      label: "Haargefühl",
+      scope: "HAAR",
+      before: "geschwächt & strapaziert",
+      after: "kräftiger & geschützter",
+      iconKey: "shield",
+      tickBefore: "strapaziert",
+      tickAfter: "geschützt",
+      currentPosition: BUCKET_TO_POSITION[scoreToBucket(scores.structural)],
+      targetPosition: ROW_TARGET_POSITIONS.hairFeel,
+    }
+  }
+
+  return {
+    label: "Haargefühl",
+    scope: "LÄNGEN",
+    before: primaryConcern === "dryness" || primaryGoal === "moisture"
+      ? "trocken & spröde"
+      : "stumpf & unruhig",
+    after: primaryConcern === "dryness" || primaryGoal === "moisture"
+      ? "weicher & geschmeidiger"
+      : "ruhiger & glänzender",
+    iconKey: primaryConcern === "dryness" || primaryGoal === "moisture" ? "droplet" : "sparkles",
+    tickBefore: primaryConcern === "dryness" || primaryGoal === "moisture" ? "trocken" : "stumpf",
+    tickAfter: primaryConcern === "dryness" || primaryGoal === "moisture" ? "geschmeidig" : "glänzend",
+    currentPosition: BUCKET_TO_POSITION[scoreToBucket(scores.surface)],
+    targetPosition: ROW_TARGET_POSITIONS.hairFeel,
+  }
+}
+```
+
+- [ ] **Step 5: Rebuild Row 2, Row 3, needs, and CTA data from the new contract**
+
+Still in `src/lib/quiz/result-narrative.ts`, update the row copy maps so Row 3 uses short deficit-led `before` values and row scopes are explicit. Then add one main lever and CTA lead-in copy.
+
+Use this exact goal-row direction:
+
+```typescript
+const GOAL_COPY: Record<Goal, QuizResultRowCopy & { intro: string; scope: QuizResultScope }> = {
+  less_frizz: {
+    intro: "ruhigeres, geschmeidigeres Haar",
+    scope: "LÄNGEN",
+    before: "wenig Kontrolle",
+    after: "mehr Geschmeidigkeit & Kontrolle",
+    iconKey: "sparkles",
+    tickBefore: "unruhig",
+    tickAfter: "kontrolliert",
+  },
+  moisture: {
+    intro: "weichere, besser mit Feuchtigkeit versorgte Längen",
+    scope: "LÄNGEN",
+    before: "wenig Feuchtigkeit",
+    after: "mehr Elastizität & Geschmeidigkeit",
+    iconKey: "droplet",
+    tickBefore: "trocken",
+    tickAfter: "geschmeidig",
+  },
+  anti_breakage: {
+    intro: "widerstandsfähigere, geschützte Längen",
+    scope: "LÄNGEN",
+    before: "wenig Stabilität",
+    after: "mehr Spannkraft & Widerstandskraft",
+    iconKey: "shield-check",
+    tickBefore: "instabil",
+    tickAfter: "stabil",
+  },
+  shine: {
+    intro: "glänzenderes, lebendigeres Haar",
+    scope: "HAAR",
+    before: "wenig Glanz",
+    after: "mehr Leuchtkraft & Lebendigkeit",
+    iconKey: "sparkles",
+    tickBefore: "matt",
+    tickAfter: "lebendig",
+  },
+  healthy_scalp: {
+    intro: "eine ruhigere, ausgeglichenere Kopfhaut",
+    scope: "KOPFHAUT",
+    before: "wenig Ruhe",
+    after: "mehr Ruhe & Ausgeglichenheit",
+    iconKey: "heart",
+    tickBefore: "unruhig",
+    tickAfter: "ruhig",
+  },
+  // keep the remaining goals in the same concise pattern
+}
+```
+
+Then add one main-lever builder:
+
+```typescript
+function buildNeedsSection(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): QuizResultNarrative["needs"] {
+  if (answers.scalp_condition === "schuppen" || answers.scalp_condition === "trockene_schuppen") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      summary:
+        "Die gute Nachricht: Das lässt sich mit der richtigen Pflege gut ausgleichen. Deine Antworten zeigen, dass deine Kopfhaut gerade mehr Balance braucht, damit sie ruhiger wird und Schuppen gezielter reduziert werden können.",
+      mainLeverLabel: "Jetzt zuerst",
+      mainLeverTitle: "Die Kopfhaut gezielter ausgleichen",
+      mainLeverBody:
+        "Das erreichen wir vor allem über ein passendes Anti-Schuppen-Shampoo und, wenn sinnvoll, ein beruhigendes Kopfhautserum.",
+    }
+  }
+
+  if (
+    primaryConcern === "breakage" ||
+    primaryConcern === "hair_damage" ||
+    (hasColorTreatment(answers) && answers.pulltest === "stretches_stays")
+  ) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      summary:
+        "Die gute Nachricht: Das lässt sich mit der richtigen Pflege gut ausgleichen. Deine Antworten zeigen, dass deine Längen gerade mehr Stabilität brauchen, damit sie widerstandsfähiger werden und weniger schnell nachgeben.",
+      mainLeverLabel: "Jetzt zuerst",
+      mainLeverTitle: "Mehr Stabilität in die Längen bringen",
+      mainLeverBody:
+        "Das erreichen wir vor allem über einen Repair-Conditioner, eine stärkende Maske und bei stark belasteten Längen auch einen Bondbuilder.",
+    }
+  }
+
+  if (primaryConcern === "split_ends") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      summary:
+        "Die gute Nachricht: Das lässt sich mit der richtigen Pflege gut ausgleichen. Deine Antworten zeigen, dass deine Spitzen gerade mehr Schutz brauchen, damit dein Haar glatter fällt und wieder mehr Glanz aufbauen kann.",
+      mainLeverLabel: "Jetzt zuerst",
+      mainLeverTitle: "Mehr Schutz für Oberfläche und Spitzen aufbauen",
+      mainLeverBody:
+        "Das erreichen wir vor allem über den richtigen Conditioner, ein passendes Leave-in und bei Bedarf ein leichtes Öl in den Spitzen.",
+    }
+  }
+
+  if (primaryConcern === "frizz") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      summary:
+        "Die gute Nachricht: Das lässt sich mit der richtigen Pflege gut ausgleichen. Deine Antworten zeigen, dass deine Längen gerade mehr Schutz brauchen, damit sie ruhiger fallen und sich besser kontrollieren lassen.",
+      mainLeverLabel: "Jetzt zuerst",
+      mainLeverTitle: "Mehr Schutz für Oberfläche und Längen aufbauen",
+      mainLeverBody:
+        "Das erreichen wir vor allem über den richtigen Conditioner und ein passendes Leave-in, das die Oberfläche glättet und Frizz bremst.",
+    }
+  }
+
+  return {
+    title: "Was dein Haar jetzt braucht",
+    summary:
+      "Die gute Nachricht: Das lässt sich mit der richtigen Pflege gut ausgleichen. Deine Antworten zeigen, dass dein Haar jetzt vor allem passgenaue Pflege braucht, damit es ruhiger, geschmeidiger und stimmiger wird.",
+    mainLeverLabel: "Jetzt zuerst",
+    mainLeverTitle: "Das Pflegegewicht besser auf dein Haar abstimmen",
+    mainLeverBody:
+      "Das erreichen wir vor allem über einen passenden Conditioner und ein Leave-in, das dein Haar unterstützt, ohne es zu beschweren.",
+  }
+}
+```
+
+Finish the builder by removing `reveal` and returning the new CTA lead:
+
+```typescript
+return {
+  intro: buildIntro(answers, primaryConcern, primaryGoal),
+  rows: [buildHairFeelRow(answers, primaryConcern, primaryGoal), frictionRow, goalRow],
+  needs: buildNeedsSection(answers, primaryConcern, primaryGoal),
+  cta: {
+    lead: "Das ist dein Überblick",
+    subline:
+      "Im nächsten Schritt zeigen wir dir deinen persönlichen Pflegeplan mit den passenden Produkten, der richtigen Reihenfolge und wie du sie in deiner Routine anwendest.",
+    label: "MEINE ROUTINE STARTEN",
+  },
+  primaryConcern,
+  primaryGoal,
+}
+```
+
+- [ ] **Step 6: Run the narrative unit tests again**
+
+Run:
+
+```bash
+npx tsx --test tests/quiz-result-narrative.test.ts
+```
+
+Expected:
+- PASS for the new scope/position/needs assertions
+- PASS for the older concern-ranking tests after you update them to the new row contract where needed
+
+- [ ] **Step 7: Commit the narrative model**
+
+```bash
+git add src/lib/quiz/result-narrative.ts tests/quiz-result-narrative.test.ts
+git commit -m "feat(quiz): derive scoped results, slider positions, and main lever copy"
+```
+
+---
+
+### Task 2: Results UI + E2E Coverage
+
+**Context:** Once the builder exposes row scopes, real positions, and the needs/CTA bridge, the results component has to render them clearly. This task also updates the end-to-end assertions to match the new results page contract and to protect against regressions on both the normal and signed-in quiz paths.
+
+**Files:**
+- Modify: `src/components/quiz/quiz-results.tsx`
+- Modify: `tests/quiz-onboarding-e2e.spec.ts`
+- Modify: `tests/auth-intake-routing.e2e.spec.ts`
+
+- [ ] **Step 1: Update the results component to render scope badges and real slider positions**
+
+In `src/components/quiz/quiz-results.tsx`, update `SpectrumCard` so it uses the new row data.
+
+Header change:
+
+```tsx
+<div className="mb-4 flex items-center gap-3">
+  <div className="grid size-10 shrink-0 place-items-center rounded-xl bg-[var(--brand-plum-ice)] text-[var(--brand-plum)]">
+    <Icon className="size-5 stroke-[1.75]" />
+  </div>
+  <span className="type-label text-[11px] font-semibold tracking-[0.22em] text-[var(--brand-plum)]">
+    {row.label}
+  </span>
+  <span className="ml-auto rounded-full bg-[var(--brand-plum-ice)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--brand-plum)] [font-family:var(--font-mono)]">
+    {row.scope}
+  </span>
+</div>
+```
+
+Marker change:
+
+```tsx
+<div
+  className="absolute top-1/2 grid size-[22px] place-items-center rounded-full bg-white"
+  style={{
+    left: `${row.currentPosition}%`,
+    transform: "translate(-50%, -50%)",
+    boxShadow: "0 0 0 2px #E35858, 0 4px 12px -2px rgba(227, 88, 88, 0.5)",
+  }}
+>
+  <div className="size-[14px] rounded-full bg-[#E35858]" />
+</div>
+<div
+  className="absolute top-1/2 grid size-[22px] place-items-center rounded-full bg-white"
+  style={{
+    left: `${row.targetPosition}%`,
+    transform: "translate(-50%, -50%)",
+    boxShadow: "0 0 0 2px #4FAE7A",
+  }}
+>
+  <div className="size-[14px] rounded-full border-2 border-dashed border-[#4FAE7A] bg-transparent" />
+</div>
+```
+
+- [ ] **Step 2: Remove the reveal line and add the needs + CTA bridge block**
+
+Still in `src/components/quiz/quiz-results.tsx`, remove the extra paragraph that renders `narrative.reveal`. Keep the intro paragraph, then insert the new section between the cards and CTA buttons:
+
+```tsx
+<div className="mb-8 flex flex-col gap-[18px] sm:gap-[22px]">
+  {narrative.rows.map((row, index) => (
+    <SpectrumCard key={row.label} row={row} index={index} />
+  ))}
+</div>
+
+<section className="mb-8 rounded-[20px] border border-black/6 bg-white px-5 py-5 shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.04),0_8px_28px_-18px_rgba(var(--brand-plum-rgb),0.22)] sm:px-6">
+  <h2 className="mb-3 type-label text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--brand-plum)]">
+    {narrative.needs.title}
+  </h2>
+  <p className="mb-4 text-[15.5px] leading-[1.65] text-muted-foreground sm:text-base">
+    {narrative.needs.summary}
+  </p>
+  <p className="mb-2 text-[13px] font-semibold uppercase tracking-[0.18em] text-[var(--brand-plum)] [font-family:var(--font-mono)]">
+    {narrative.needs.mainLeverLabel}: {narrative.needs.mainLeverTitle}
+  </p>
+  <p className="text-[15px] leading-[1.6] text-foreground sm:text-[15.5px]">
+    {narrative.needs.mainLeverBody}
+  </p>
+</section>
+
+<div className="mx-auto mt-1 flex w-full max-w-[480px] flex-col gap-3">
+  <p className="text-center text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--brand-plum)] [font-family:var(--font-mono)]">
+    {narrative.cta.lead}
+  </p>
+  <p className="text-center text-[13.5px] leading-[1.5] text-muted-foreground">
+    {narrative.cta.subline}
+  </p>
+  <Button
+    onClick={handleStart}
+    variant="unstyled"
+    className="min-h-14 w-full rounded-[14px] bg-[var(--brand-coral)] px-5 py-3 text-[15px] font-bold uppercase tracking-[0.08em] text-white shadow-[0_10px_28px_-14px_rgba(212,97,106,0.55)] transition-transform duration-150 ease-out hover:-translate-y-0.5 hover:shadow-[0_14px_32px_-12px_rgba(212,97,106,0.6)]"
+  >
+    {narrative.cta.label}
+  </Button>
+```
+
+Keep the share button as-is below the primary CTA.
+
+- [ ] **Step 3: Update the E2E assertions for both result-page entry paths**
+
+In `tests/quiz-onboarding-e2e.spec.ts`, replace the reveal assertion with the new result-page contract:
+
+```typescript
+await page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i }).click()
+await expect(
+  page.getByRole("heading", { name: /So kommen wir deinem Haarziel näher/i }),
+).toBeVisible({ timeout: 15_000 })
+await expect(page.getByText(/Was dein Haar jetzt braucht/i)).toBeVisible()
+await expect(page.getByText(/Das ist dein Überblick/i)).toBeVisible()
+await expect(page.getByText(/berechnet aus deinen Antworten/i)).toHaveCount(0)
+await expect(
+  page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }),
+).toBeVisible()
+```
+
+Apply the same assertion swap in `tests/auth-intake-routing.e2e.spec.ts`:
+
+```typescript
+await page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i }).click()
+await expect(
+  page.getByRole("heading", { name: /So kommen wir deinem Haarziel näher/i }),
+).toBeVisible({ timeout: 15_000 })
+await expect(page.getByText(/Was dein Haar jetzt braucht/i)).toBeVisible()
+await expect(page.getByText(/Das ist dein Überblick/i)).toBeVisible()
+await expect(page.getByText(/berechnet aus deinen Antworten/i)).toHaveCount(0)
+await expect(
+  page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }),
+).toBeVisible()
+```
+
+- [ ] **Step 4: Run focused verification for UI + E2E**
+
+Run:
+
+```bash
+npx tsx --test tests/quiz-result-narrative.test.ts
+npm run typecheck -- --pretty false
+npm exec eslint -- --no-ignore src/components/quiz/quiz-results.tsx src/lib/quiz/result-narrative.ts tests/quiz-result-narrative.test.ts tests/quiz-onboarding-e2e.spec.ts tests/auth-intake-routing.e2e.spec.ts
+PLAYWRIGHT_BASE_URL=http://localhost:3675 npx playwright test tests/quiz-onboarding-e2e.spec.ts --grep "quiz hands off into onboarding" --reporter=line
+PLAYWRIGHT_BASE_URL=http://localhost:3675 npx playwright test tests/auth-intake-routing.e2e.spec.ts --grep "signed-in quiz completion skips auth" --reporter=line
+```
+
+Expected:
+- unit tests PASS
+- typecheck PASS
+- eslint PASS
+- both Playwright flows PASS and reach the updated results page
+
+- [ ] **Step 5: Commit the UI follow-up**
+
+```bash
+git add src/components/quiz/quiz-results.tsx tests/quiz-onboarding-e2e.spec.ts tests/auth-intake-routing.e2e.spec.ts
+git commit -m "feat(quiz): add scoped result cards and action bridge"
+```
+
+---
+
+### Task 3: Final Verification
+
+**Context:** The new result page is copy-heavy and visually specific. Before calling it done, verify the full story in a browser and make sure the page still reads well for both hair-length and scalp-led cases.
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the full local verification stack**
+
+From the worktree root, run:
+
+```bash
+npx tsx --test tests/quiz-result-narrative.test.ts tests/quiz-normalization.test.ts tests/result-card-data.test.ts
+npm run typecheck -- --pretty false
+npm exec eslint -- --no-ignore src/components/quiz/quiz-results.tsx src/lib/quiz/result-narrative.ts tests/quiz-result-narrative.test.ts tests/quiz-onboarding-e2e.spec.ts tests/auth-intake-routing.e2e.spec.ts
+PLAYWRIGHT_BASE_URL=http://localhost:3675 npx playwright test tests/quiz-onboarding-e2e.spec.ts --grep "quiz hands off into onboarding" --reporter=line
+PLAYWRIGHT_BASE_URL=http://localhost:3675 npx playwright test tests/auth-intake-routing.e2e.spec.ts --grep "signed-in quiz completion skips auth" --reporter=line
+```
+
+Expected:
+- all commands PASS
+
+- [ ] **Step 2: Do one browser sanity pass for a hair-length case and one scalp-led case**
+
+Use the local dev server at `http://localhost:3675/quiz` and confirm:
+
+- Hair-length case:
+  - row scopes are distinct (`HAAR`, `LÄNGEN`, `SPITZEN` etc.)
+  - current markers are not all pinned to the far-left edge
+  - `Was dein Haar jetzt braucht` shows only one main lever
+  - CTA lead-in explains that the next step is the detailed plan/products view
+
+- Scalp-led case:
+  - row scopes use `KOPFHAUT`
+  - row 3 is concise (`wenig Ruhe` -> `mehr Ruhe & Ausgeglichenheit`)
+  - the main lever mentions scalp-specific categories (`Anti-Schuppen-Shampoo`, `Kopfhautserum`) when appropriate
+
+- [ ] **Step 3: Commit if the verification task required any tiny fixes**
+
+If no code changed during the sanity pass, skip this step.
+
+If tiny copy or spacing fixes were needed:
+
+```bash
+git add src/components/quiz/quiz-results.tsx src/lib/quiz/result-narrative.ts tests/quiz-result-narrative.test.ts
+git commit -m "fix(quiz): polish results narrative follow-up"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- Real slider logic: covered in Task 1 (bucketed positions + row targets) and Task 2 (UI marker positions)
+- Row 1 combined scoring: covered in Task 1 (`buildHairFeelScores`, dominant-axis selection)
+- Row 3 concise `wenig ...` copy: covered in Task 1 (goal copy remap + unit tests)
+- Scope badge instead of repetitive `in Y` text: covered in Task 2
+- Single main lever only: covered in Task 1 (`needs.mainLever*`) and Task 2 rendering
+- Product-category-specific lever copy including advanced categories: covered in Task 1 unit tests + lever builder
+- CTA lead-in clarifying that the next step is the detailed routine/products view: covered in Task 1/2
+- Remove the extra reveal line: covered in Task 2 E2E assertions
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “similar to above” steps remain
+- All code-changing steps include concrete snippets
+- All verification steps include exact commands and expected outcomes
+
+### Type consistency
+
+- `scope`, `currentPosition`, `targetPosition`, and `needs` are defined once in Task 1 and used consistently in Task 2
+- `cta.lead`, `cta.subline`, and `cta.label` are used consistently across the builder and UI
+- `QuizResultScope` values are explicitly enumerated and reused in row builders/tests
+

--- a/src/app/result/[leadId]/page.tsx
+++ b/src/app/result/[leadId]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { createClient } from "@supabase/supabase-js"
-import { buildCardData } from "@/lib/quiz/result-card-data"
 import type { QuizAnswers } from "@/lib/quiz/types"
 import { ResultPageClient } from "./result-client"
 
@@ -22,7 +21,7 @@ async function getLead(leadId: string) {
 
   const { data } = await supabase
     .from("leads")
-    .select("id, name, quiz_answers, ai_insight, share_quote")
+    .select("id, name, quiz_answers, share_quote")
     .eq("id", leadId)
     .single()
 
@@ -39,32 +38,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const name = lead.name as string
   const quote = (lead.share_quote as string) || "Finde heraus, was deine Haare wirklich brauchen."
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000")
 
   return {
-    title: `${name}s Haar-Diagnose — Hair Concierge`,
+    title: `${name}s Haarprofil — Hair Concierge`,
     description: quote,
     robots: { index: false, follow: false },
     openGraph: {
-      title: `${name}s Haar-Diagnose — Hair Concierge`,
+      title: `${name}s Haarprofil — Hair Concierge`,
       description: quote,
-      images: [
-        {
-          url: `${siteUrl}/api/og/result/${leadId}`,
-          width: 1080,
-          height: 1920,
-          alt: `${name}s Haar-Diagnose`,
-        },
-      ],
       type: "website",
     },
     twitter: {
-      card: "summary_large_image",
-      title: `${name}s Haar-Diagnose — Hair Concierge`,
+      card: "summary",
+      title: `${name}s Haarprofil — Hair Concierge`,
       description: quote,
-      images: [`${siteUrl}/api/og/result/${leadId}`],
     },
   }
 }
@@ -77,15 +64,12 @@ export default async function ResultPage({ params }: Props) {
     notFound()
   }
 
-  const cardData = buildCardData(lead.quiz_answers as QuizAnswers)
-
   return (
     <ResultPageClient
       leadId={lead.id}
       name={lead.name}
-      cardData={cardData}
+      quizAnswers={lead.quiz_answers as QuizAnswers}
       shareQuote={lead.share_quote || null}
-      aiInsight={lead.ai_insight || null}
     />
   )
 }

--- a/src/app/result/[leadId]/result-client.tsx
+++ b/src/app/result/[leadId]/result-client.tsx
@@ -1,215 +1,84 @@
 "use client"
 
-import { useEffect, useCallback, useMemo } from "react"
-import Link from "next/link"
-import type { CardData } from "@/lib/quiz/result-card-data"
-import { Button } from "@/components/ui/button"
-import { Icon } from "@/components/ui/icon"
+import { useEffect } from "react"
+import { buildQuizResultNarrative } from "@/lib/quiz/result-narrative"
+import { buildQuizShareConfig } from "@/lib/quiz/share"
+import type { QuizAnswers } from "@/lib/quiz/types"
 import { posthog } from "@/providers/posthog-provider"
+import { useToast } from "@/providers/toast-provider"
+import { QuizResultsView } from "@/components/quiz/quiz-results-view"
 
 interface ResultPageClientProps {
   leadId: string
   name: string
-  cardData: CardData
+  quizAnswers: QuizAnswers
   shareQuote: string | null
-  aiInsight: string | null
 }
 
-export function ResultPageClient({
-  leadId,
-  name,
-  cardData,
-  shareQuote,
-  aiInsight,
-}: ResultPageClientProps) {
-  const resultUrl = useMemo(
-    () => (typeof window !== "undefined" ? `${window.location.origin}/result/${leadId}` : ""),
-    [leadId],
-  )
-  const canShare = useMemo(() => typeof navigator !== "undefined" && !!navigator.share, [])
+export function ResultPageClient({ leadId, name, quizAnswers, shareQuote }: ResultPageClientProps) {
+  const { toast } = useToast()
+  const narrative = buildQuizResultNarrative(quizAnswers)
 
   useEffect(() => {
     posthog.capture("result_page_viewed", { leadId })
   }, [leadId])
 
-  const handleDownload = useCallback(async () => {
-    posthog.capture("result_shared", { method: "download", leadId })
-    try {
-      const res = await fetch(`/api/og/result/${leadId}`)
-      const blob = await res.blob()
-      const fileName = `haar-diagnose-${name.toLowerCase().replace(/\s+/g, "-")}.png`
+  const handleShare = async () => {
+    const share = buildQuizShareConfig({
+      leadId,
+      name,
+      shareQuote,
+      origin: window.location.origin,
+      isMobile:
+        window.matchMedia("(max-width: 767px)").matches ||
+        /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent),
+      canNativeShare: typeof navigator !== "undefined" && typeof navigator.share === "function",
+    })
 
-      // On mobile: use native share with file (opens share sheet → save to photos / Instagram)
-      if (navigator.share && navigator.canShare) {
-        const file = new File([blob], fileName, { type: "image/png" })
-        if (navigator.canShare({ files: [file] })) {
-          await navigator.share({
-            files: [file],
-            title: `${name}s Haar-Diagnose`,
-          })
-          return
-        }
-      }
+    if (!share) return
 
-      // Desktop fallback: trigger download
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = fileName
-      document.body.appendChild(a)
-      a.click()
-      document.body.removeChild(a)
-      URL.revokeObjectURL(url)
-    } catch {
-      // Last resort: open image in new tab
-      window.open(`/api/og/result/${leadId}`, "_blank")
-    }
-  }, [leadId, name])
-
-  const handleNativeShare = useCallback(async () => {
-    posthog.capture("result_shared", { method: "native", leadId })
-    if (navigator.share) {
+    if (share.mode === "native" && navigator.share) {
+      posthog.capture("result_shared", { method: "native", leadId })
       await navigator
         .share({
-          title: `${name}s Haar-Diagnose — Hair Concierge`,
-          text: shareQuote || "Schau dir meine Haar-Diagnose an!",
-          url: resultUrl,
+          title: share.title,
+          text: share.text,
+          url: share.url,
         })
         .catch(() => {})
+      return
     }
-  }, [leadId, name, shareQuote, resultUrl])
 
-  const whatsappUrl = resultUrl
-    ? `https://wa.me/?text=${encodeURIComponent(`Schau dir meine Haar-Diagnose an: ${resultUrl}`)}`
-    : "#"
+    try {
+      await navigator.clipboard.writeText(share.url)
+      posthog.capture("result_shared", { method: "copy_link", leadId })
+      toast({
+        title: "Link kopiert",
+        description: "Du kannst das Ergebnis jetzt direkt teilen.",
+      })
+    } catch {
+      window.open(share.url, "_blank", "noopener,noreferrer")
+      posthog.capture("result_shared", { method: "open_result", leadId })
+      toast({
+        title: "Ergebnis geöffnet",
+        description: "Teile den Link direkt aus deinem Browser.",
+      })
+    }
+  }
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto max-w-2xl px-4 py-8 sm:px-6 sm:py-12">
-        {/* Brand mark */}
-        <div className="flex items-center gap-2 mb-8">
-          <div className="flex gap-[3px]">
-            <div className="w-[3px] h-5 bg-[var(--brand-plum)] rounded-full" />
-            <div className="w-[3px] h-5 bg-[var(--brand-plum)]/60 rounded-full" />
-            <div className="w-[3px] h-5 bg-[var(--brand-plum)]/30 rounded-full" />
-          </div>
-          <span className="font-header text-sm text-[var(--text-sub)] tracking-widest">
-            HAIR CONCIERGE
-          </span>
-        </div>
-
-        {/* Headline */}
-        <h1 className="font-header text-3xl sm:text-4xl text-foreground mb-2">
-          {name.toUpperCase()}, DEINE HAAR-DIAGNOSE
-        </h1>
-        <p className="text-base text-muted-foreground mb-2">{cardData.summaryLine}</p>
-        <p className="text-sm text-[var(--text-sub)] mb-6">
-          Basierend auf dem Haar-Quiz von Hair Concierge
-        </p>
-
-        {/* Profile cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8 items-start">
-          {cardData.cards.map((card) => (
-            <div
-              key={card.title}
-              className="bg-card border border-border border-l-2 border-l-[var(--brand-plum)] rounded-xl p-4"
-            >
-              <div className="flex items-start gap-3">
-                <Icon
-                  name={card.icon}
-                  size={24}
-                  className="text-[var(--brand-plum)] mt-0.5 shrink-0"
-                />
-                <div className="flex-1 min-w-0">
-                  <p className="text-xs font-semibold text-[var(--brand-plum)] uppercase tracking-wide mb-1">
-                    {card.title}
-                  </p>
-                  <p className="text-sm text-foreground leading-relaxed">{card.description}</p>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Result highlight */}
-        {shareQuote && (
-          <div className="border-2 border-[var(--brand-plum)]/30 rounded-xl p-5 mb-8">
-            <p className="text-xs font-semibold text-[var(--brand-plum)] uppercase tracking-wide mb-2">
-              EINSCHAETZUNG
-            </p>
-            <p className="text-base text-foreground leading-relaxed italic">
-              &ldquo;{shareQuote}&rdquo;
-            </p>
-          </div>
-        )}
-
-        {/* AI Insight */}
-        {aiInsight && (
-          <div className="bg-muted border border-[var(--brand-plum)]/20 rounded-xl p-5 mb-8">
-            <p className="text-xs font-semibold text-[var(--brand-plum)] uppercase tracking-wide mb-2">
-              WAS BISHER WAHRSCHEINLICH SCHIEF LIEF
-            </p>
-            <p className="text-sm text-foreground leading-relaxed">{aiInsight}</p>
-          </div>
-        )}
-
-        {/* Share section */}
-        <div className="border-t border-border pt-8 mb-8">
-          <p className="text-sm text-[var(--text-sub)] mb-4 text-center">Teile deine Diagnose</p>
-          <div className="flex flex-col sm:flex-row gap-3">
-            <Button
-              onClick={handleDownload}
-              variant="unstyled"
-              className="quiz-btn-primary flex-1 h-12 text-sm font-bold tracking-wide rounded-xl"
-            >
-              ALS BILD SPEICHERN
-            </Button>
-
-            {canShare && (
-              <Button
-                onClick={handleNativeShare}
-                variant="outline"
-                className="flex-1 h-12 text-sm font-bold tracking-wide rounded-xl"
-              >
-                TEILEN
-              </Button>
-            )}
-
-            <a
-              href={whatsappUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() =>
-                posthog.capture("result_shared", {
-                  method: "whatsapp",
-                  leadId,
-                })
-              }
-              className="flex-1 h-12 inline-flex items-center justify-center text-sm font-bold tracking-wide rounded-xl border border-border text-foreground hover:bg-muted transition-colors"
-            >
-              WHATSAPP
-            </a>
-          </div>
-          <p className="text-xs text-[var(--text-caption)] text-center mt-3">
-            Speichere das Bild und poste es in deiner Instagram Story!
-          </p>
-        </div>
-
-        {/* CTA for viewers */}
-        <div className="text-center">
-          <p className="text-lg text-muted-foreground mb-4">
-            Was passt zu DEINEM Haar?
-          </p>
-          <Link href="/quiz">
-            <Button
-              variant="unstyled"
-              className="quiz-btn-primary w-full sm:max-w-md h-14 text-base font-bold tracking-wide rounded-xl"
-            >
-              Quiz starten
-            </Button>
-          </Link>
-        </div>
-      </div>
-    </div>
+    <QuizResultsView
+      name={name}
+      narrative={{
+        ...narrative,
+        cta: {
+          lead: "Finde heraus, was dein Haar braucht",
+          label: "QUIZ STARTEN",
+          subline: "Mach das Quiz in 2 Minuten für dein eigenes Ergebnis.",
+        },
+      }}
+      primaryAction={{ label: "QUIZ STARTEN", href: "/quiz" }}
+      secondaryAction={{ label: "ERGEBNIS TEILEN", onClick: handleShare }}
+    />
   )
 }

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -887,7 +887,12 @@ export function OnboardingFlow({
     <div>
       {store.currentStep !== "welcome" && store.currentStep !== "celebration" && (
         <div className="mb-6">
-          <OnboardingProgressBar currentStep={store.currentStep} />
+          <OnboardingProgressBar
+            currentStep={store.currentStep}
+            currentDrilldownIndex={store.currentDrilldownIndex}
+            drilldownCount={store.drilldownCategories().length}
+            selectedHeatTools={store.selectedHeatTools}
+          />
         </div>
       )}
       {renderScreen()}

--- a/src/components/onboarding/onboarding-progress-bar.tsx
+++ b/src/components/onboarding/onboarding-progress-bar.tsx
@@ -1,72 +1,76 @@
 "use client"
 
 import type { OnboardingStep } from "@/lib/onboarding/store"
+import { buildOnboardingProgressState } from "@/lib/onboarding/progress"
 
 const SECTION_LABELS = ["Produkte", "Styling", "Alltag"] as const
 
-const STEP_SECTIONS: Record<OnboardingStep, number> = {
-  // Section 0: Produkte
-  welcome: 0,
-  products_basics: 0,
-  products_extras: 0,
-  product_drilldown: 0,
-  // Section 1: Styling
-  heat_tools: 1,
-  heat_frequency: 1,
-  heat_protection: 1,
-  interstitial: 1,
-  // Section 2: Alltag
-  towel_material: 2,
-  towel_technique: 2,
-  drying_method: 2,
-  brush_type: 2,
-  night_protection: 2,
-  celebration: 2,
-}
-
 interface OnboardingProgressBarProps {
   currentStep: OnboardingStep
+  currentDrilldownIndex: number
+  drilldownCount: number
+  selectedHeatTools: string[]
 }
 
-export function OnboardingProgressBar({ currentStep }: OnboardingProgressBarProps) {
-  const currentSection = STEP_SECTIONS[currentStep]
+export function OnboardingProgressBar({
+  currentStep,
+  currentDrilldownIndex,
+  drilldownCount,
+  selectedHeatTools,
+}: OnboardingProgressBarProps) {
+  const progress = buildOnboardingProgressState({
+    currentStep,
+    currentDrilldownIndex,
+    drilldownCount,
+    selectedHeatTools,
+  })
 
   return (
     <div className="w-full">
-      {/* Bar segments */}
-      <div className="flex gap-1">
-        {SECTION_LABELS.map((_, index) => {
-          const isCompleted = index < currentSection
-          const isCurrent = index === currentSection
+      <div className="relative h-4">
+        <div className="absolute inset-x-0 top-1/2 h-[6px] -translate-y-1/2 rounded-full bg-border">
+          <div
+            className="h-full rounded-full transition-all duration-500 ease-out"
+            style={{
+              width: `${progress.progressPercent}%`,
+              background: "linear-gradient(90deg, var(--brand-plum), var(--brand-plum-dark))",
+            }}
+          />
+        </div>
+
+        {progress.milestones.map((milestone, index) => {
+          const isActive = progress.progressPercent >= milestone.percent
+          const isLast = index === progress.milestones.length - 1
+          const left = isLast ? "100%" : `${milestone.percent}%`
 
           return (
-            <div key={index} className="h-[4px] flex-1 rounded-full overflow-hidden bg-border">
-              {(isCompleted || isCurrent) && (
-                <div
-                  className="h-full rounded-full transition-all duration-500 ease-out"
-                  style={{
-                    width: isCompleted ? "100%" : "60%",
-                    background: "linear-gradient(90deg, var(--brand-plum), var(--brand-plum-dark))",
-                  }}
-                />
-              )}
+            <div
+              key={milestone.label}
+              className="pointer-events-none absolute top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2"
+              style={{ left }}
+            >
+              <div
+                className="size-3.5 rounded-full border-2 bg-background transition-all duration-300"
+                style={{
+                  borderColor: isActive ? "var(--brand-plum)" : "rgba(var(--brand-plum-rgb), 0.18)",
+                  backgroundColor: isActive ? "var(--brand-plum)" : "var(--background)",
+                }}
+              />
             </div>
           )
         })}
       </div>
 
-      {/* Labels */}
-      <div className="flex mt-2">
+      <div className="mt-3 flex justify-between gap-2">
         {SECTION_LABELS.map((label, index) => {
-          const isCompleted = index < currentSection
-          const isCurrent = index === currentSection
+          const isActive = index <= progress.currentSectionIndex
 
           return (
-            <div key={index} className="flex-1 text-center">
+            <div key={label} className="flex-1 text-center">
               <span
                 className="text-[11px] font-medium transition-colors duration-300"
                 style={{
-                  color: isCompleted || isCurrent ? "var(--brand-plum)" : "var(--text-caption)",
+                  color: isActive ? "var(--brand-plum)" : "var(--text-caption)",
                 }}
               >
                 {label}

--- a/src/components/quiz/quiz-analysis.tsx
+++ b/src/components/quiz/quiz-analysis.tsx
@@ -14,10 +14,11 @@ const steps = [
 const STEP_DELAY = 1200
 
 export function QuizAnalysis() {
-  const { lead, answers, leadId, setAiInsight, goNext } = useQuizStore()
+  const { lead, answers, leadId, setAiInsight, setShareQuote, goNext } = useQuizStore()
   const [completedSteps, setCompletedSteps] = useState(0)
   const [apiDone, setApiDone] = useState(false)
   const fetched = useRef(false)
+  const canReveal = completedSteps >= steps.length && apiDone
 
   // Animate checklist items
   useEffect(() => {
@@ -45,18 +46,11 @@ export function QuizAnalysis() {
       .then((r) => r.json())
       .then((data) => {
         if (data.insight) setAiInsight(data.insight)
+        if (data.shareQuote) setShareQuote(data.shareQuote)
         setApiDone(true)
       })
       .catch(() => setApiDone(true))
-  }, [leadId, lead.name, answers, setAiInsight])
-
-  // Auto-transition when both animation and API are done
-  useEffect(() => {
-    if (completedSteps >= steps.length && apiDone) {
-      const t = setTimeout(goNext, 400)
-      return () => clearTimeout(t)
-    }
-  }, [completedSteps, apiDone, goNext])
+  }, [leadId, lead.name, answers, setAiInsight, setShareQuote])
 
   return (
     <div className="flex flex-col items-center justify-center py-16 animate-fade-in-up">
@@ -94,6 +88,16 @@ export function QuizAnalysis() {
           )
         })}
       </div>
+
+      {canReveal ? (
+        <button
+          type="button"
+          onClick={goNext}
+          className="quiz-btn-primary mt-10 min-h-14 w-full max-w-md rounded-xl px-5 py-3 text-base font-bold tracking-wide"
+        >
+          MEIN HAARPROFIL ANSEHEN
+        </button>
+      ) : null}
     </div>
   )
 }

--- a/src/components/quiz/quiz-brand-panel.tsx
+++ b/src/components/quiz/quiz-brand-panel.tsx
@@ -1,20 +1,12 @@
 "use client"
 
 import { useQuizStore } from "@/lib/quiz/store"
+import { getQuizBrandPanelContent } from "@/lib/quiz/brand-panel-content"
 
 export function QuizBrandPanel() {
   const step = useQuizStore((s) => s.step)
   const leadCaptureSubStep = useQuizStore((s) => s.leadCaptureSubStep)
-
-  const QUESTION_NUMBER_MAP: Record<number, number> = {
-    2: 1, // texture
-    3: 2, // thickness
-    4: 3, // surface
-    5: 4, // pull
-    7: 5, // chemical
-    6: 6, // scalp
-  }
-  const questionNumber = QUESTION_NUMBER_MAP[step] ?? null
+  const content = getQuizBrandPanelContent(step, leadCaptureSubStep)
 
   return (
     <div className="relative flex h-full w-full flex-col items-center justify-center px-12">
@@ -42,18 +34,21 @@ export function QuizBrandPanel() {
 
       {/* Content */}
       <div className="relative z-10 max-w-[360px] text-center">
-        {step === 1 && <LandingPanel />}
-        {questionNumber !== null && <QuestionPanel questionNumber={questionNumber} />}
-        {step === 9 && <LeadCapturePanel subStep={leadCaptureSubStep} />}
-        {step === 10 && <AnalysisPanel />}
-        {step === 11 && <ResultsPanel />}
-        {step === 14 && <WelcomePanel />}
+        {content.variant === "landing" ? <LandingPanel description={content.description} /> : null}
+        {content.variant === "journey" ? (
+          <JourneyPanel
+            eyebrow={content.eyebrow}
+            description={content.description}
+            progressCurrent={content.progressCurrent}
+            progressComplete={content.progressComplete}
+          />
+        ) : null}
       </div>
     </div>
   )
 }
 
-function LandingPanel() {
+function LandingPanel({ description }: { description: string }) {
   return (
     <>
       <h1 className="font-header text-6xl leading-[0.95] text-foreground mb-6">
@@ -62,21 +57,29 @@ function LandingPanel() {
         Concierge
       </h1>
       <div className="mx-auto mb-6 h-1 w-16 rounded-full bg-[var(--brand-plum)]" />
-      <p className="text-lg text-muted-foreground leading-relaxed">
-        Dein Haar verdient mehr als Raten.
-        <br />
-        Finde heraus, was es wirklich braucht.
-      </p>
+      <p className="text-lg text-muted-foreground leading-relaxed">{description}</p>
     </>
   )
 }
 
-function QuestionPanel({ questionNumber }: { questionNumber: number }) {
+function JourneyPanel({
+  eyebrow,
+  description,
+  progressCurrent,
+  progressComplete,
+}: {
+  eyebrow: string | null
+  description: string
+  progressCurrent: number | null
+  progressComplete: boolean
+}) {
   return (
     <>
-      <div className="mb-6 font-header text-sm tracking-[0.2em] text-[var(--brand-plum)]">
-        FRAGE {questionNumber} VON 6
-      </div>
+      {eyebrow ? (
+        <div className="mb-5 font-header text-sm tracking-[0.2em] text-[var(--brand-plum)]">
+          {eyebrow}
+        </div>
+      ) : null}
       <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
         Hair
         <br />
@@ -86,79 +89,38 @@ function QuestionPanel({ questionNumber }: { questionNumber: number }) {
         className="mx-auto mb-4 h-1 w-12 rounded-full"
         style={{ background: "rgba(var(--brand-plum-rgb), 0.4)" }}
       />
-      <p className="text-sm text-[var(--text-caption)]">Personalisierte Haarpflege-Beratung</p>
+      <p className="text-base text-[var(--text-caption)] leading-relaxed">{description}</p>
+      {progressCurrent ? (
+        <DesktopJourneyProgress current={progressCurrent} complete={progressComplete} />
+      ) : null}
     </>
   )
 }
 
-function LeadCapturePanel({ subStep }: { subStep: string }) {
+function DesktopJourneyProgress({ current, complete }: { current: number; complete: boolean }) {
   return (
-    <>
-      <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
-        Hair
-        <br />
-        Concierge
-      </h2>
-      <div
-        className="mx-auto mb-6 h-1 w-12 rounded-full"
-        style={{ background: "rgba(var(--brand-plum-rgb), 0.4)" }}
-      />
-      <p className="text-lg text-muted-foreground leading-relaxed">
-        {subStep === "consent" ? "Gleich hast du deinen Plan." : "Dein Profil ist fast fertig."}
-      </p>
-    </>
-  )
-}
+    <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
+      {Array.from({ length: 8 }, (_, index) => {
+        const stepNumber = index + 1
+        const isCurrent = !complete && stepNumber === current
+        const isDone = complete || stepNumber < current
 
-function AnalysisPanel() {
-  return (
-    <>
-      <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
-        Hair
-        <br />
-        Concierge
-      </h2>
-      <div
-        className="mx-auto mb-6 h-1 w-12 rounded-full"
-        style={{ background: "rgba(var(--brand-plum-rgb), 0.4)" }}
-      />
-      <p className="font-header text-2xl tracking-wider text-[var(--brand-plum)] animate-pulse">
-        Analysiere...
-      </p>
-    </>
-  )
-}
-
-function ResultsPanel() {
-  return (
-    <>
-      <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
-        Hair
-        <br />
-        Concierge
-      </h2>
-      <div
-        className="mx-auto mb-6 h-1 w-12 rounded-full"
-        style={{ background: "rgba(var(--brand-plum-rgb), 0.4)" }}
-      />
-      <p className="text-lg text-muted-foreground leading-relaxed">Deine Diagnose</p>
-    </>
-  )
-}
-
-function WelcomePanel() {
-  return (
-    <>
-      <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
-        Hair
-        <br />
-        Concierge
-      </h2>
-      <div
-        className="mx-auto mb-6 h-1 w-12 rounded-full"
-        style={{ background: "rgba(var(--brand-plum-rgb), 0.4)" }}
-      />
-      <p className="text-lg text-muted-foreground leading-relaxed">Dein nächster Schritt</p>
-    </>
+        return (
+          <span
+            key={stepNumber}
+            className={[
+              "flex h-8 min-w-8 items-center justify-center rounded-full border px-2 text-xs font-semibold tracking-[0.14em] tabular-nums transition-colors",
+              isCurrent
+                ? "border-[var(--brand-plum)] bg-[var(--brand-plum)] text-white"
+                : isDone
+                  ? "border-[rgba(var(--brand-plum-rgb),0.16)] bg-[rgba(var(--brand-plum-rgb),0.08)] text-[var(--brand-plum)]"
+                  : "border-[rgba(var(--brand-plum-rgb),0.1)] bg-transparent text-[var(--text-caption)]",
+            ].join(" ")}
+          >
+            {String(stepNumber).padStart(2, "0")}
+          </span>
+        )
+      })}
+    </div>
   )
 }

--- a/src/components/quiz/quiz-results-view.tsx
+++ b/src/components/quiz/quiz-results-view.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+import Link from "next/link"
+import type { LucideIcon } from "lucide-react"
+import {
+  ArrowDown,
+  ArrowUp,
+  Droplets,
+  Heart,
+  Leaf,
+  Link2Off,
+  Palette,
+  Scissors,
+  Shield,
+  ShieldCheck,
+  Sparkles,
+  Waves,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type {
+  QuizResultIconKey,
+  QuizResultNarrative,
+  QuizResultNarrativeRow,
+} from "@/lib/quiz/result-narrative"
+
+const ICONS: Record<QuizResultIconKey, LucideIcon> = {
+  droplet: Droplets,
+  shield: Shield,
+  waves: Waves,
+  "shield-check": ShieldCheck,
+  scissors: Scissors,
+  "link-off": Link2Off,
+  heart: Heart,
+  sparkles: Sparkles,
+  leaf: Leaf,
+  "arrow-up": ArrowUp,
+  "arrow-down": ArrowDown,
+  palette: Palette,
+}
+
+const CARD_DELAYS = [0.1, 0.22, 0.34]
+
+export interface QuizResultsViewAction {
+  label: string
+  href?: string
+  onClick?: () => void
+}
+
+interface QuizResultsViewProps {
+  name: string
+  narrative: QuizResultNarrative
+  primaryAction: QuizResultsViewAction
+  secondaryAction?: QuizResultsViewAction | null
+}
+
+function SpectrumCard({ row, index }: { row: QuizResultNarrativeRow; index: number }) {
+  const Icon = ICONS[row.iconKey] ?? Sparkles
+
+  return (
+    <article
+      className="animate-fade-in-up rounded-[20px] border border-black/6 bg-white px-5 py-5 shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.04),0_8px_28px_-18px_rgba(var(--brand-plum-rgb),0.22)] transition-transform duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.06),0_18px_40px_-22px_rgba(var(--brand-plum-rgb),0.3)] sm:px-6 sm:py-6"
+      style={{ animationDelay: `${CARD_DELAYS[index] ?? 0}s` }}
+    >
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="grid size-10 shrink-0 place-items-center rounded-xl bg-[var(--brand-plum-ice)] text-[var(--brand-plum)]">
+            <Icon className="size-5 stroke-[1.75]" />
+          </div>
+          <span className="type-label text-[11px] font-semibold tracking-[0.22em] text-[var(--brand-plum)]">
+            {row.label}
+          </span>
+        </div>
+
+        <span className="rounded-full border border-[rgba(var(--brand-plum-rgb),0.14)] bg-[rgba(var(--brand-plum-rgb),0.04)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--brand-plum)]">
+          {row.scope}
+        </span>
+      </div>
+
+      <div className="mb-3.5 grid grid-cols-2 gap-3 sm:gap-6">
+        <div className="flex min-h-12 flex-col justify-center">
+          <div className="mb-1.5 inline-flex items-center gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.2em] text-[#E35858] [font-family:var(--font-mono)]">
+            <span className="size-[7px] rounded-full bg-[#E35858]" />
+            Heute
+          </div>
+          <div className="font-header text-[15px] leading-[1.25] text-foreground sm:text-lg">
+            {row.before}
+          </div>
+        </div>
+
+        <div className="flex min-h-12 flex-col justify-center text-right">
+          <div className="mb-1.5 inline-flex items-center justify-end gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.2em] text-[#4FAE7A] [font-family:var(--font-mono)]">
+            Ziel
+            <span className="size-[7px] rounded-full bg-[#4FAE7A]" />
+          </div>
+          <div className="font-header text-[15px] leading-[1.25] text-foreground sm:text-lg">
+            {row.after}
+          </div>
+        </div>
+      </div>
+
+      <div className="px-3.5 pb-1.5 pt-3.5">
+        <div className="relative h-2.5 rounded-full bg-[linear-gradient(90deg,#E35858_0%,#EA8247_28%,#F4B23C_50%,#9EC765_72%,#4FAE7A_100%)] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]">
+          <div
+            className="absolute top-1/2 grid size-[22px] place-items-center rounded-full bg-white"
+            style={{
+              left: `${row.currentPosition}%`,
+              transform: "translate(-50%, -50%)",
+              boxShadow: "0 0 0 2px #E35858, 0 4px 12px -2px rgba(227, 88, 88, 0.5)",
+            }}
+          >
+            <div className="size-[14px] rounded-full bg-[#E35858]" />
+          </div>
+          <div
+            className="absolute top-1/2 grid size-[22px] place-items-center rounded-full bg-white"
+            style={{
+              left: `${row.targetPosition}%`,
+              transform: "translate(-50%, -50%)",
+              boxShadow: "0 0 0 2px #4FAE7A",
+            }}
+          >
+            <div className="size-[14px] rounded-full border-2 border-dashed border-[#4FAE7A] bg-transparent" />
+          </div>
+        </div>
+
+        <div className="mt-2.5 flex justify-between px-0.5 text-[9.5px] uppercase tracking-[0.18em] text-[var(--text-sub)] [font-family:var(--font-mono)] sm:text-[10px]">
+          <span>{row.tickBefore}</span>
+          <span>{row.tickAfter}</span>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function ActionButton({
+  action,
+  variant,
+}: {
+  action: QuizResultsViewAction
+  variant: "primary" | "secondary"
+}) {
+  const className =
+    variant === "primary"
+      ? "min-h-14 w-full rounded-[14px] bg-[var(--brand-coral)] px-5 py-3 text-[15px] font-bold uppercase tracking-[0.08em] text-white shadow-[0_10px_28px_-14px_rgba(212,97,106,0.55)] transition-transform duration-150 ease-out hover:-translate-y-0.5 hover:shadow-[0_14px_32px_-12px_rgba(212,97,106,0.6)]"
+      : "h-[46px] w-full rounded-[14px] bg-[var(--brand-plum-ice)] text-[13px] font-bold uppercase tracking-[0.14em] text-[var(--brand-plum)] transition duration-150 ease-out hover:brightness-[0.98]"
+
+  const button = (
+    <Button onClick={action.onClick} variant="unstyled" className={className}>
+      {action.label}
+    </Button>
+  )
+
+  if (action.href && !action.onClick) {
+    return (
+      <Link href={action.href} className={className}>
+        {action.label}
+      </Link>
+    )
+  }
+
+  return button
+}
+
+export function QuizResultsView({
+  name,
+  narrative,
+  primaryAction,
+  secondaryAction,
+}: QuizResultsViewProps) {
+  const displayName = name.trim().split(/\s+/)[0] ?? ""
+
+  return (
+    <div className="mx-auto flex w-full max-w-[760px] flex-col pb-8 animate-fade-in-up">
+      <div className="mb-6 flex items-center gap-2.5">
+        <div className="flex gap-[3px]">
+          <div className="h-5 w-[3px] rounded-full bg-[var(--brand-plum)]" />
+          <div
+            className="h-5 w-[3px] rounded-full"
+            style={{ background: "rgba(var(--brand-plum-rgb), 0.6)" }}
+          />
+          <div
+            className="h-5 w-[3px] rounded-full"
+            style={{ background: "rgba(var(--brand-plum-rgb), 0.3)" }}
+          />
+        </div>
+        <span className="font-header text-[13px] uppercase tracking-[0.22em] text-muted-foreground">
+          Hair Concierge
+        </span>
+      </div>
+
+      <h1 className="mb-3 font-header">
+        {displayName ? (
+          <span className="mb-1 block text-2xl font-medium italic text-[var(--brand-plum)]">
+            {displayName},
+          </span>
+        ) : null}
+        <span className="block text-[28px] font-medium uppercase leading-[1.18] tracking-[0.01em] text-foreground sm:text-[32px]">
+          SO KOMMEN WIR DEINEM HAARZIEL NÄHER
+        </span>
+      </h1>
+
+      <p className="mb-7 max-w-[56ch] text-base leading-[1.6] text-muted-foreground sm:text-[16.5px]">
+        {narrative.intro}
+      </p>
+
+      <div className="mb-8 flex flex-col gap-[18px] sm:gap-[22px]">
+        {narrative.rows.map((row, index) => (
+          <SpectrumCard key={row.label} row={row} index={index} />
+        ))}
+      </div>
+
+      <section className="mb-7 w-full rounded-[24px] border border-black/6 bg-white px-5 py-5 shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.04),0_8px_28px_-18px_rgba(var(--brand-plum-rgb),0.22)] sm:px-6 sm:py-6">
+        <h2 className="type-label mb-3 text-[11px] font-semibold tracking-[0.22em] text-[var(--brand-plum)]">
+          {narrative.needs.title}
+        </h2>
+        <h3 className="max-w-[34ch] font-header text-[24px] font-medium leading-[1.22] text-foreground sm:text-[28px]">
+          {narrative.needs.mainLeverTitle}
+        </h3>
+        <p className="mt-3 max-w-[48ch] text-[15.5px] leading-[1.65] text-foreground sm:text-[17px]">
+          {narrative.needs.mainLeverWhy}
+        </p>
+        <p className="mt-4 max-w-[50ch] text-[15px] leading-[1.7] text-muted-foreground sm:text-[16px]">
+          {narrative.needs.mainLeverProducts}
+        </p>
+      </section>
+
+      <div className="mx-auto mt-1 flex w-full max-w-[480px] flex-col gap-3">
+        <div className="space-y-2 text-center">
+          <p className="font-header text-[20px] leading-[1.3] text-foreground sm:text-[22px]">
+            {narrative.cta.lead}
+          </p>
+          <p className="text-[14.5px] leading-[1.55] text-muted-foreground sm:text-[15.5px]">
+            {narrative.cta.subline}
+          </p>
+        </div>
+
+        <ActionButton action={primaryAction} variant="primary" />
+
+        {secondaryAction ? <ActionButton action={secondaryAction} variant="secondary" /> : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/quiz-results.tsx
+++ b/src/components/quiz/quiz-results.tsx
@@ -1,21 +1,35 @@
 "use client"
 
 import { useRouter, useSearchParams } from "next/navigation"
+import { buildQuizResultNarrative } from "@/lib/quiz/result-narrative"
+import { buildQuizShareConfig } from "@/lib/quiz/share"
 import { useQuizStore } from "@/lib/quiz/store"
-import { hopeText } from "@/lib/quiz/results-lookup"
-import { QuizProfileCard } from "./quiz-profile-card"
-import { QuizCard } from "./quiz-card"
-import { Button } from "@/components/ui/button"
-import { posthog } from "@/providers/posthog-provider"
-import { buildCardData } from "@/lib/quiz/result-card-data"
 import { useAuth } from "@/providers/auth-provider"
+import { posthog } from "@/providers/posthog-provider"
+import { useToast } from "@/providers/toast-provider"
+import { QuizResultsView } from "./quiz-results-view"
+
+function getSafeReturnToPath(value: string | null): string | null {
+  if (!value) return null
+
+  const trimmed = value.trim()
+
+  if (!trimmed.startsWith("/")) return null
+  if (trimmed.startsWith("//")) return null
+  if (trimmed.includes("\\")) return null
+  if (/\s/.test(trimmed)) return null
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed)) return null
+
+  return trimmed
+}
 
 export function QuizResults() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { user } = useAuth()
-  const { lead, answers, aiInsight, leadId, goNext } = useQuizStore()
-  const cardData = buildCardData(answers)
+  const { toast } = useToast()
+  const { lead, answers, leadId, shareQuote, goNext } = useQuizStore()
+  const narrative = buildQuizResultNarrative(answers)
   const returnTo = searchParams.get("returnTo")
   const isRetakeMode = searchParams.get("mode") === "retake"
 
@@ -32,7 +46,7 @@ export function QuizResults() {
       nextUrl.searchParams.set("lead", leadId)
 
       if (isRetakeMode) {
-        nextUrl.searchParams.set("returnTo", returnTo?.startsWith("/") ? returnTo : "/profile")
+        nextUrl.searchParams.set("returnTo", getSafeReturnToPath(returnTo) ?? "/profile")
       }
 
       router.push(`${nextUrl.pathname}${nextUrl.search}`)
@@ -42,85 +56,55 @@ export function QuizResults() {
     goNext()
   }
 
+  const handleShare = async () => {
+    const share = buildQuizShareConfig({
+      leadId,
+      name: lead.name,
+      shareQuote,
+      origin: window.location.origin,
+      isMobile:
+        window.matchMedia("(max-width: 767px)").matches ||
+        /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent),
+      canNativeShare: typeof navigator !== "undefined" && typeof navigator.share === "function",
+    })
+
+    if (!share) return
+
+    if (share.mode === "native" && navigator.share) {
+      posthog.capture("quiz_result_share_clicked", { leadId, method: "native" })
+      await navigator
+        .share({
+          title: share.title,
+          text: share.text,
+          url: share.url,
+        })
+        .catch(() => {})
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(share.url)
+      posthog.capture("quiz_result_share_clicked", { leadId, method: "copy_link" })
+      toast({
+        title: "Link kopiert",
+        description: "Du kannst dein Ergebnis jetzt direkt teilen.",
+      })
+    } catch {
+      window.open(share.url, "_blank", "noopener,noreferrer")
+      posthog.capture("quiz_result_share_clicked", { leadId, method: "open_result" })
+      toast({
+        title: "Ergebnis geöffnet",
+        description: "Teile den Link direkt aus deinem Browser.",
+      })
+    }
+  }
+
   return (
-    <div className="flex flex-col pb-6 animate-fade-in-up">
-      {/* Inline brand mark (replaces left panel on results page) */}
-      <div className="flex items-center gap-2 mb-6">
-        <div className="flex gap-[3px]">
-          <div className="w-[3px] h-5 bg-[var(--brand-plum)] rounded-full" />
-          <div
-            className="w-[3px] h-5 rounded-full"
-            style={{ background: "rgba(var(--brand-plum-rgb), 0.6)" }}
-          />
-          <div
-            className="w-[3px] h-5 rounded-full"
-            style={{ background: "rgba(var(--brand-plum-rgb), 0.3)" }}
-          />
-        </div>
-        <span className="font-header text-sm text-muted-foreground tracking-widest">
-          HAIR CONCIERGE
-        </span>
-      </div>
-
-      {/* Header */}
-      <h2 className="font-header text-3xl text-foreground mb-1">
-        {lead.name.toUpperCase()}, DEIN HAARPROFIL
-      </h2>
-      <p className="text-base text-muted-foreground mb-5">
-        Dein Profil ist fast fertig — als Nächstes bauen wir deine persönliche Routine auf.
-      </p>
-
-      {/* Profile cards — responsive grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        {cardData.cards.map((card, i) => (
-          <QuizProfileCard
-            key={card.title}
-            icon={card.icon}
-            title={card.title}
-            description={card.description}
-            animationDelay={i * 80}
-          />
-        ))}
-      </div>
-
-      {/* Aha-Moment box — full width */}
-      {aiInsight && (
-        <div className="animate-fade-in-up mb-6" style={{ animationDelay: "500ms" }}>
-          <QuizCard className="border-[var(--brand-plum)]/20">
-            <p className="text-xs font-semibold text-[var(--brand-plum)] uppercase tracking-wide mb-2">
-              WAS BISHER WAHRSCHEINLICH SCHIEF LIEF
-            </p>
-            <p className="text-sm text-foreground leading-relaxed">{aiInsight}</p>
-          </QuizCard>
-        </div>
-      )}
-
-      {/* Hope text */}
-      <p className="text-base text-muted-foreground leading-relaxed mb-6">{hopeText}</p>
-
-      {/* CTA */}
-      <div className="flex flex-col gap-3 sm:max-w-md sm:mx-auto w-full">
-        <Button
-          onClick={handleStart}
-          variant="unstyled"
-          className="quiz-btn-primary w-full h-14 text-base font-bold tracking-wide rounded-xl"
-        >
-          ROUTINE FESTLEGEN
-        </Button>
-
-        {leadId && (
-          <Button
-            onClick={() => {
-              posthog.capture("quiz_result_share_clicked", { leadId })
-              window.open(`/result/${leadId}`, "_blank")
-            }}
-            variant="outline"
-            className="w-full h-12 text-sm font-bold tracking-wide rounded-xl border-border text-foreground hover:bg-muted"
-          >
-            ERGEBNIS TEILEN
-          </Button>
-        )}
-      </div>
-    </div>
+    <QuizResultsView
+      name={lead.name}
+      narrative={narrative}
+      primaryAction={{ label: narrative.cta.label, onClick: handleStart }}
+      secondaryAction={leadId ? { label: "ERGEBNIS TEILEN", onClick: handleShare } : null}
+    />
   )
 }

--- a/src/lib/onboarding/progress.ts
+++ b/src/lib/onboarding/progress.ts
@@ -1,0 +1,134 @@
+import type { OnboardingStep } from "./store"
+
+const PRODUCTS_STEPS: OnboardingStep[] = ["products_basics", "products_extras"]
+const STYLING_STEPS: OnboardingStep[] = [
+  "heat_tools",
+  "heat_frequency",
+  "heat_protection",
+  "interstitial",
+]
+const ROUTINE_STEPS: OnboardingStep[] = [
+  "towel_material",
+  "towel_technique",
+  "drying_method",
+  "brush_type",
+  "night_protection",
+]
+
+const STEP_LABELS: Record<OnboardingStep, string> = {
+  welcome: "Willkommen",
+  products_basics: "Produkte Basics",
+  products_extras: "Produkte Extras",
+  product_drilldown: "Produkt-Details",
+  heat_tools: "Heat-Tools",
+  heat_frequency: "Heat-Frequenz",
+  heat_protection: "Hitzeschutz",
+  interstitial: "Styling-Check",
+  towel_material: "Handtuch-Material",
+  towel_technique: "Handtuch-Technik",
+  drying_method: "Trocknen",
+  brush_type: "Bürste",
+  night_protection: "Nachtschutz",
+  celebration: "Abschluss",
+}
+
+export interface OnboardingProgressInput {
+  currentStep: OnboardingStep
+  currentDrilldownIndex: number
+  drilldownCount: number
+  selectedHeatTools: string[]
+}
+
+export interface OnboardingProgressMilestone {
+  label: "Produkte" | "Styling" | "Alltag"
+  percent: number
+}
+
+export interface OnboardingProgressState {
+  path: string[]
+  currentIndex: number
+  currentSectionIndex: number
+  currentLabel: string
+  totalSteps: number
+  progressPercent: number
+  milestones: [
+    OnboardingProgressMilestone,
+    OnboardingProgressMilestone,
+    OnboardingProgressMilestone,
+  ]
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value)
+}
+
+function buildDrilldownSteps(drilldownCount: number): string[] {
+  const safeCount = Math.max(1, drilldownCount)
+  return Array.from({ length: safeCount }, (_, index) => `product_drilldown_${index + 1}`)
+}
+
+export function buildOnboardingProgressPath({
+  drilldownCount,
+  selectedHeatTools,
+}: Pick<OnboardingProgressInput, "drilldownCount" | "selectedHeatTools">): string[] {
+  const hasHeatTools = selectedHeatTools.length > 0
+
+  return [
+    ...PRODUCTS_STEPS,
+    ...buildDrilldownSteps(drilldownCount),
+    "heat_tools",
+    ...(hasHeatTools ? ["heat_frequency", "heat_protection"] : []),
+    ...STYLING_STEPS.slice(-1),
+    ...ROUTINE_STEPS,
+  ]
+}
+
+function getCurrentPathKey({
+  currentStep,
+  currentDrilldownIndex,
+}: Pick<OnboardingProgressInput, "currentStep" | "currentDrilldownIndex">): string {
+  if (currentStep === "product_drilldown") {
+    return `product_drilldown_${Math.max(0, currentDrilldownIndex) + 1}`
+  }
+
+  return currentStep
+}
+
+function getCurrentLabel(input: OnboardingProgressInput): string {
+  if (input.currentStep === "product_drilldown") {
+    return `Produkt-Details ${Math.max(0, input.currentDrilldownIndex) + 1}`
+  }
+
+  return STEP_LABELS[input.currentStep]
+}
+
+export function buildOnboardingProgressState(
+  input: OnboardingProgressInput,
+): OnboardingProgressState {
+  const path = buildOnboardingProgressPath(input)
+  const currentPathKey = getCurrentPathKey(input)
+  const currentIndex = Math.max(0, path.indexOf(currentPathKey))
+  const totalSteps = path.length
+  const progressPercent = roundPercent(((currentIndex + 1) / totalSteps) * 100)
+
+  const productsCount = PRODUCTS_STEPS.length + Math.max(1, input.drilldownCount)
+  const stylingCount = 1 + (input.selectedHeatTools.length > 0 ? 2 : 0) + 1
+  const productsPercent = roundPercent((productsCount / totalSteps) * 100)
+  const stylingPercent = roundPercent(((productsCount + stylingCount) / totalSteps) * 100)
+  const currentSectionIndex =
+    currentIndex < productsCount ? 0 : currentIndex < productsCount + stylingCount ? 1 : 2
+
+  return {
+    path,
+    currentIndex,
+    currentSectionIndex,
+    currentLabel: getCurrentLabel(input),
+    totalSteps,
+    progressPercent,
+    milestones: [
+      { label: "Produkte", percent: productsPercent },
+      { label: "Styling", percent: stylingPercent },
+      { label: "Alltag", percent: 100 },
+    ],
+  }
+}

--- a/src/lib/quiz/brand-panel-content.ts
+++ b/src/lib/quiz/brand-panel-content.ts
@@ -1,0 +1,88 @@
+import type { LeadCaptureSubStep, QuizStep } from "./types"
+
+export interface QuizBrandPanelContent {
+  eyebrow: string | null
+  description: string
+  progressCurrent: number | null
+  progressComplete: boolean
+  variant: "landing" | "journey"
+}
+
+const QUESTION_PANEL_CONTENT: Partial<
+  Record<QuizStep, { questionNumber: number; description: string }>
+> = {
+  2: { questionNumber: 1, description: "Deine natürliche Basis." },
+  3: { questionNumber: 2, description: "Wie fein dein Haar ist." },
+  4: { questionNumber: 3, description: "Wie sich die Oberfläche anfühlt." },
+  5: { questionNumber: 4, description: "Wie belastbar die Längen sind." },
+  7: { questionNumber: 5, description: "Wie stark dein Haar behandelt ist." },
+  6: { questionNumber: 6, description: "Was an der Kopfhaut mitspielt." },
+  8: { questionNumber: 7, description: "Was dich gerade ausbremst." },
+  12: { questionNumber: 8, description: "Worauf wir hinarbeiten." },
+}
+
+export function getQuizBrandPanelContent(
+  step: QuizStep,
+  leadCaptureSubStep: LeadCaptureSubStep,
+): QuizBrandPanelContent {
+  void leadCaptureSubStep
+
+  if (step === 1) {
+    return {
+      eyebrow: null,
+      description: "Dein Haar verdient mehr als Raten. Finde heraus, was es wirklich braucht.",
+      progressCurrent: null,
+      progressComplete: false,
+      variant: "landing",
+    }
+  }
+
+  const questionContent = QUESTION_PANEL_CONTENT[step]
+  if (questionContent) {
+    return {
+      eyebrow: `FRAGE ${questionContent.questionNumber} VON 8`,
+      description: questionContent.description,
+      progressCurrent: questionContent.questionNumber,
+      progressComplete: false,
+      variant: "journey",
+    }
+  }
+
+  if (step === 9) {
+    return {
+      eyebrow: "FAST GESCHAFFT",
+      description: "Gleich zeigen wir dir dein Profil.",
+      progressCurrent: 8,
+      progressComplete: true,
+      variant: "journey",
+    }
+  }
+
+  if (step === 10) {
+    return {
+      eyebrow: "ANALYSE",
+      description: "Wir setzen alles zusammen.",
+      progressCurrent: 8,
+      progressComplete: true,
+      variant: "journey",
+    }
+  }
+
+  if (step === 14) {
+    return {
+      eyebrow: "WILLKOMMEN",
+      description: "Dein nächster Schritt.",
+      progressCurrent: 8,
+      progressComplete: true,
+      variant: "journey",
+    }
+  }
+
+  return {
+    eyebrow: null,
+    description: "Hair Concierge",
+    progressCurrent: null,
+    progressComplete: false,
+    variant: "journey",
+  }
+}

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -1,0 +1,922 @@
+import type { Goal, HairTexture } from "@/lib/vocabulary"
+import { GOALS } from "@/lib/vocabulary"
+import { getOrderedGoals } from "@/lib/onboarding/goal-flow"
+
+import { QUIZ_CONCERN_VALUES, canonicalizeQuizAnswers } from "./normalization"
+import type { QuizAnswers } from "./types"
+
+type QuizConcern = (typeof QUIZ_CONCERN_VALUES)[number]
+export type QuizResultIconKey =
+  | "droplet"
+  | "shield"
+  | "waves"
+  | "shield-check"
+  | "scissors"
+  | "link-off"
+  | "heart"
+  | "sparkles"
+  | "leaf"
+  | "arrow-up"
+  | "arrow-down"
+  | "palette"
+
+export type QuizResultScope =
+  | "HAAR"
+  | "LÄNGEN"
+  | "SPITZEN"
+  | "KOPFHAUT"
+  | "ANSATZ"
+  | "WELLEN & LOCKEN"
+
+type SeverityBucket = "very_low" | "low" | "medium" | "high" | "very_high"
+
+const BUCKET_TO_POSITION: Record<SeverityBucket, number> = {
+  very_low: 18,
+  low: 34,
+  medium: 50,
+  high: 66,
+  very_high: 82,
+}
+
+const ROW_TARGET_POSITIONS = {
+  hairFeel: 78,
+  friction: 84,
+  outcome: 88,
+} as const
+
+interface QuizResultRowCopy {
+  before: string
+  after: string
+  iconKey: QuizResultIconKey
+  tickBefore: string
+  tickAfter: string
+}
+
+interface QuizResultNeedsSection {
+  title: string
+  mainLeverTitle: string
+  mainLeverWhy: string
+  mainLeverProducts: string
+}
+
+export interface QuizResultNarrativeRow {
+  label: "Haargefühl" | "Was dich gerade ausbremst" | "Worauf wir hinarbeiten"
+  scope: QuizResultScope
+  before: string
+  after: string
+  iconKey: QuizResultIconKey
+  tickBefore: string
+  tickAfter: string
+  currentPosition: number
+  targetPosition: number
+}
+
+export interface QuizResultNarrative {
+  intro: string
+  rows: [QuizResultNarrativeRow, QuizResultNarrativeRow, QuizResultNarrativeRow]
+  needs: QuizResultNeedsSection
+  cta: {
+    lead: string
+    label: string
+    subline: string
+  }
+  primaryConcern: QuizConcern | null
+  primaryGoal: Goal | null
+}
+
+const CONCERN_COPY: Record<QuizConcern, QuizResultRowCopy> = {
+  frizz: {
+    before: "Frizz",
+    after: "ruhigere, glattere Längen",
+    iconKey: "sparkles",
+    tickBefore: "unruhig",
+    tickAfter: "glatt",
+  },
+  dryness: {
+    before: "Trockenheit",
+    after: "weichere, besser mit Feuchtigkeit versorgte Längen",
+    iconKey: "droplet",
+    tickBefore: "trocken",
+    tickAfter: "versorgt",
+  },
+  breakage: {
+    before: "Haarbruch",
+    after: "stabilere, geschütztere Längen",
+    iconKey: "shield-check",
+    tickBefore: "instabil",
+    tickAfter: "geschützt",
+  },
+  split_ends: {
+    before: "Spliss",
+    after: "glattere, gepflegtere Spitzen",
+    iconKey: "scissors",
+    tickBefore: "splissig",
+    tickAfter: "gepflegt",
+  },
+  tangling: {
+    before: "Verknotungen",
+    after: "leichter entwirrbare Längen",
+    iconKey: "link-off",
+    tickBefore: "verhakt",
+    tickAfter: "entwirrbar",
+  },
+  hair_damage: {
+    before: "Haarschäden",
+    after: "kräftiger wirkende, besser geschützte Längen",
+    iconKey: "shield",
+    tickBefore: "angegriffen",
+    tickAfter: "geschützt",
+  },
+}
+
+const GOAL_COPY: Record<Goal, QuizResultRowCopy & { intro: string; scope: QuizResultScope }> = {
+  less_frizz: {
+    intro: "ruhigeres, geschmeidigeres Haar",
+    scope: "LÄNGEN",
+    before: "wenig Kontrolle",
+    after: "mehr Geschmeidigkeit & Kontrolle",
+    iconKey: "sparkles",
+    tickBefore: "unruhig",
+    tickAfter: "kontrolliert",
+  },
+  moisture: {
+    intro: "weichere, besser mit Feuchtigkeit versorgte Längen",
+    scope: "LÄNGEN",
+    before: "wenig Feuchtigkeit",
+    after: "mehr Elastizität & Geschmeidigkeit",
+    iconKey: "droplet",
+    tickBefore: "trocken",
+    tickAfter: "geschmeidig",
+  },
+  anti_breakage: {
+    intro: "widerstandsfähigere, geschützte Längen",
+    scope: "HAAR",
+    before: "wenig Stabilität",
+    after: "mehr Spannkraft & Widerstandskraft",
+    iconKey: "shield-check",
+    tickBefore: "instabil",
+    tickAfter: "stabil",
+  },
+  strengthen: {
+    intro: "kräftigeres, belastbareres Haar",
+    scope: "HAAR",
+    before: "wenig Kraft",
+    after: "mehr Kraft & Belastbarkeit",
+    iconKey: "shield",
+    tickBefore: "schwach",
+    tickAfter: "kräftig",
+  },
+  healthier_hair: {
+    intro: "gesünder wirkendes Haar",
+    scope: "HAAR",
+    before: "wenig Stärke",
+    after: "mehr Stärke & Schutz",
+    iconKey: "shield",
+    tickBefore: "angegriffen",
+    tickAfter: "geschützt",
+  },
+  less_split_ends: {
+    intro: "glattere, gepflegtere Spitzen",
+    scope: "SPITZEN",
+    before: "wenig Schutz",
+    after: "mehr Schutz für die Spitzen",
+    iconKey: "scissors",
+    tickBefore: "splissig",
+    tickAfter: "gepflegt",
+  },
+  shine: {
+    intro: "glänzenderes, lebendigeres Haar",
+    scope: "HAAR",
+    before: "wenig Glanz",
+    after: "mehr Leuchtkraft & Lebendigkeit",
+    iconKey: "sparkles",
+    tickBefore: "matt",
+    tickAfter: "glänzend",
+  },
+  curl_definition: {
+    intro: "definiertere Wellen oder Locken",
+    scope: "WELLEN & LOCKEN",
+    before: "wenig Definition",
+    after: "mehr Form & Bündelung",
+    iconKey: "waves",
+    tickBefore: "weich",
+    tickAfter: "definiert",
+  },
+  healthy_scalp: {
+    intro: "eine ruhigere, ausgeglichenere Kopfhaut",
+    scope: "KOPFHAUT",
+    before: "wenig Ruhe",
+    after: "mehr Ruhe & Ausgeglichenheit",
+    iconKey: "leaf",
+    tickBefore: "unruhig",
+    tickAfter: "beruhigt",
+  },
+  volume: {
+    intro: "fülligeres, leichteres Haar",
+    scope: "HAAR",
+    before: "wenig Fülle",
+    after: "mehr Fülle & Leichtigkeit",
+    iconKey: "arrow-up",
+    tickBefore: "flach",
+    tickAfter: "voluminös",
+  },
+  less_volume: {
+    intro: "ruhigeres, kontrollierteres Haar",
+    scope: "HAAR",
+    before: "wenig Ruhe",
+    after: "mehr Ruhe & Kontrolle",
+    iconKey: "arrow-down",
+    tickBefore: "wild",
+    tickAfter: "ruhig",
+  },
+  color_protection: {
+    intro: "länger lebendige Farbe",
+    scope: "HAAR",
+    before: "wenig Schutz",
+    after: "mehr Farbglanz & Schutz",
+    iconKey: "palette",
+    tickBefore: "verblasst",
+    tickAfter: "lebendig",
+  },
+}
+
+const CONCERN_TO_GOAL_PRIORITY: Record<QuizConcern, Goal[]> = {
+  frizz: ["less_frizz", "moisture", "shine"],
+  dryness: ["moisture", "healthier_hair", "shine"],
+  breakage: ["anti_breakage", "strengthen", "healthier_hair"],
+  split_ends: ["less_split_ends", "healthier_hair", "strengthen"],
+  tangling: ["less_frizz", "moisture", "healthier_hair"],
+  hair_damage: ["healthier_hair", "strengthen", "anti_breakage"],
+}
+
+const BASE_CONCERN_SCORES: Record<QuizConcern, number> = {
+  breakage: 60,
+  dryness: 50,
+  hair_damage: 40,
+  tangling: 30,
+  split_ends: 20,
+  frizz: 10,
+}
+
+function isHairTexture(value: QuizAnswers["structure"]): value is HairTexture {
+  return value === "straight" || value === "wavy" || value === "curly" || value === "coily"
+}
+
+function hasColorTreatment(answers: QuizAnswers): boolean {
+  return (
+    answers.treatment?.includes("gefaerbt") === true ||
+    answers.treatment?.includes("blondiert") === true
+  )
+}
+
+function scoreToBucket(score: number): SeverityBucket {
+  if (score >= 8) return "very_high"
+  if (score >= 5) return "high"
+  if (score >= 3) return "medium"
+  if (score >= 1) return "low"
+  return "very_low"
+}
+
+function scoreConcern(concern: QuizConcern, answers: QuizAnswers): number {
+  let score = BASE_CONCERN_SCORES[concern]
+
+  if (answers.pulltest === "snaps" && (concern === "breakage" || concern === "dryness")) {
+    score += 25
+  }
+
+  if (
+    answers.pulltest === "stretches_stays" &&
+    (concern === "breakage" || concern === "hair_damage")
+  ) {
+    score += 25
+  }
+
+  if (
+    answers.fingertest === "rau" &&
+    (concern === "hair_damage" || concern === "tangling" || concern === "split_ends")
+  ) {
+    score += 15
+  }
+
+  if (answers.fingertest === "rau" && concern === "frizz") {
+    score += 5
+  }
+
+  if (
+    hasColorTreatment(answers) &&
+    (concern === "hair_damage" || concern === "breakage" || concern === "split_ends")
+  ) {
+    score += 15
+  }
+
+  return score
+}
+
+function buildHairFeelScores(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): Record<"structural" | "surface" | "scalp", number> {
+  let structural = 0
+  let surface = 0
+  let scalp = 0
+
+  if (answers.pulltest === "stretches_stays") structural += 3
+  if (answers.pulltest === "snaps") structural += 2
+  if (hasColorTreatment(answers)) structural += 2
+  if (primaryConcern === "breakage" || primaryConcern === "hair_damage") structural += 2
+  if (primaryConcern === "split_ends") structural += 1
+  if (
+    primaryGoal === "anti_breakage" ||
+    primaryGoal === "strengthen" ||
+    primaryGoal === "healthier_hair"
+  ) {
+    structural += 1
+  }
+
+  if (answers.fingertest === "rau") surface += 2
+  if (answers.fingertest === "leicht_uneben") surface += 1
+  if (primaryConcern === "dryness" || primaryConcern === "frizz" || primaryConcern === "tangling") {
+    surface += 2
+  }
+  if (
+    answers.goals?.includes("moisture") === true ||
+    answers.goals?.includes("shine") === true ||
+    answers.goals?.includes("less_frizz") === true ||
+    answers.goals?.includes("curl_definition") === true
+  ) {
+    surface += 1
+  }
+
+  if (answers.scalp_condition) scalp += 4
+  if (answers.scalp_type === "fettig" || answers.scalp_type === "trocken") scalp += 2
+  if (primaryGoal === "healthy_scalp") scalp += 1
+
+  return { structural, surface, scalp }
+}
+
+function resolveDominantHairFeelAxis(scores: ReturnType<typeof buildHairFeelScores>) {
+  const entries = [
+    ["scalp", scores.scalp],
+    ["structural", scores.structural],
+    ["surface", scores.surface],
+  ] as const
+
+  return [...entries].sort((left, right) => right[1] - left[1])[0]?.[0] ?? "surface"
+}
+
+function buildHairFeelRow(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): QuizResultNarrativeRow {
+  const scores = buildHairFeelScores(answers, primaryConcern, primaryGoal)
+  const dominantAxis = resolveDominantHairFeelAxis(scores)
+
+  if (dominantAxis === "scalp") {
+    const isGreasy = answers.scalp_type === "fettig"
+    const isDry = answers.scalp_type === "trocken"
+    const isIrritated = answers.scalp_condition === "gereizt"
+
+    return {
+      label: "Haargefühl",
+      scope: "KOPFHAUT",
+      before: isIrritated ? "unruhig" : isGreasy ? "fettig" : isDry ? "trocken" : "unruhig",
+      after: "ruhiger",
+      iconKey: isIrritated ? "heart" : isGreasy || isDry ? "droplet" : "leaf",
+      tickBefore: isGreasy ? "unausgeglichen" : isDry ? "trocken" : "unruhig",
+      tickAfter: "ausgeglichen",
+      currentPosition: BUCKET_TO_POSITION[scoreToBucket(scores.scalp)],
+      targetPosition: ROW_TARGET_POSITIONS.hairFeel,
+    }
+  }
+
+  if (dominantAxis === "structural") {
+    return {
+      label: "Haargefühl",
+      scope: "HAAR",
+      before: "geschwächt & strapaziert",
+      after: "kräftiger & geschützter",
+      iconKey: "shield",
+      tickBefore: "strapaziert",
+      tickAfter: "geschützt",
+      currentPosition: BUCKET_TO_POSITION[scoreToBucket(scores.structural)],
+      targetPosition: ROW_TARGET_POSITIONS.hairFeel,
+    }
+  }
+
+  const isDefinitionLed =
+    primaryGoal === "curl_definition" &&
+    (answers.structure === "wavy" || answers.structure === "curly" || answers.structure === "coily")
+  const isBoostedSurface =
+    primaryConcern === "frizz" ||
+    primaryConcern === "tangling" ||
+    answers.goals?.includes("less_frizz") === true ||
+    answers.goals?.includes("shine") === true ||
+    isDefinitionLed
+  const surfacePosition =
+    primaryConcern === "dryness" || primaryGoal === "moisture"
+      ? BUCKET_TO_POSITION.low
+      : isBoostedSurface
+        ? BUCKET_TO_POSITION.high
+        : BUCKET_TO_POSITION[scoreToBucket(scores.surface)]
+
+  return {
+    label: "Haargefühl",
+    scope: isDefinitionLed ? "WELLEN & LOCKEN" : "LÄNGEN",
+    before:
+      primaryConcern === "dryness" || primaryGoal === "moisture"
+        ? "trocken & spröde"
+        : primaryConcern === "frizz" || primaryGoal === "less_frizz"
+          ? "stumpf & unruhig"
+          : isDefinitionLed
+            ? "wenig Definition"
+            : "rau & unruhig",
+    after:
+      primaryConcern === "dryness" || primaryGoal === "moisture"
+        ? "weicher & geschmeidiger"
+        : primaryConcern === "frizz" || primaryGoal === "less_frizz"
+          ? "ruhiger & glänzender"
+          : isDefinitionLed
+            ? "mehr Form & Bündelung"
+            : "ruhiger & glänzender",
+    iconKey:
+      primaryConcern === "dryness" || primaryGoal === "moisture"
+        ? "droplet"
+        : isDefinitionLed
+          ? "waves"
+          : "sparkles",
+    tickBefore:
+      primaryConcern === "dryness" || primaryGoal === "moisture"
+        ? "trocken"
+        : primaryConcern === "frizz" || primaryGoal === "less_frizz"
+          ? "unruhig"
+          : isDefinitionLed
+            ? "weich"
+            : "rau",
+    tickAfter:
+      primaryConcern === "dryness" || primaryGoal === "moisture"
+        ? "geschmeidig"
+        : primaryConcern === "frizz" || primaryGoal === "less_frizz"
+          ? "glänzend"
+          : isDefinitionLed
+            ? "definiert"
+            : "glänzend",
+    currentPosition: surfacePosition,
+    targetPosition: ROW_TARGET_POSITIONS.hairFeel,
+  }
+}
+
+function resolvePrimaryConcern(answers: QuizAnswers): QuizConcern | null {
+  const concerns = (answers.concerns ?? []).filter((concern): concern is QuizConcern =>
+    QUIZ_CONCERN_VALUES.includes(concern as QuizConcern),
+  )
+
+  if (concerns.length === 0) {
+    return null
+  }
+
+  return (
+    [...concerns].sort((left, right) => {
+      const scoreDelta = scoreConcern(right, answers) - scoreConcern(left, answers)
+      if (scoreDelta !== 0) {
+        return scoreDelta
+      }
+
+      return QUIZ_CONCERN_VALUES.indexOf(left) - QUIZ_CONCERN_VALUES.indexOf(right)
+    })[0] ?? null
+  )
+}
+
+function getOrderedSelectedGoals(answers: QuizAnswers): Goal[] {
+  const selectedGoals = new Set(
+    (answers.goals ?? []).filter((goal): goal is Goal => GOALS.includes(goal as Goal)),
+  )
+
+  if (selectedGoals.size === 0) {
+    return []
+  }
+
+  if (isHairTexture(answers.structure)) {
+    return getOrderedGoals(answers.structure).filter((goal) => selectedGoals.has(goal))
+  }
+
+  return GOALS.filter((goal) => selectedGoals.has(goal))
+}
+
+function resolvePrimaryGoal(answers: QuizAnswers, primaryConcern: QuizConcern | null): Goal | null {
+  const selectedGoals = getOrderedSelectedGoals(answers)
+
+  if (selectedGoals.length === 0) {
+    return null
+  }
+
+  if (primaryConcern) {
+    for (const goal of CONCERN_TO_GOAL_PRIORITY[primaryConcern]) {
+      if (selectedGoals.includes(goal)) {
+        return goal
+      }
+    }
+  }
+
+  return selectedGoals[0] ?? null
+}
+
+function buildIntro(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): string {
+  const goalOutcome = primaryGoal ? GOAL_COPY[primaryGoal].intro : null
+  const goalLead = (answers.goals?.length ?? 0) > 1 ? "unter anderem " : ""
+
+  if (primaryConcern && goalOutcome) {
+    return `Du hast gesagt, dass dich vor allem ${CONCERN_COPY[primaryConcern].before} stört und dass du dir ${goalLead}${goalOutcome} wünschst.`
+  }
+
+  if (goalOutcome) {
+    return `Du hast gesagt, dass du dir ${goalLead}${goalOutcome} wünschst und wir sehen schon, was dein Haar gerade noch ausbremst.`
+  }
+
+  return "Wir sehen schon, was dein Haar gerade noch ausbremst und in welche Richtung wir dein Haar jetzt weiterentwickeln."
+}
+
+function buildFrictionScore(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): number {
+  const canUseScalpFallback = !primaryConcern
+
+  if (canUseScalpFallback && answers.scalp_condition) {
+    let score = 4
+    if (answers.scalp_type === "fettig" || answers.scalp_type === "trocken") {
+      score += 1
+    }
+    if (primaryGoal === "healthy_scalp") {
+      score += 1
+    }
+    return score
+  }
+
+  if (
+    canUseScalpFallback &&
+    (answers.scalp_type === "fettig" || answers.scalp_type === "trocken")
+  ) {
+    let score = 3
+    if (primaryGoal === "healthy_scalp") {
+      score += 1
+    }
+    return score
+  }
+
+  let score = 0
+
+  if (primaryConcern === "hair_damage" || primaryConcern === "breakage") score += 3
+  if (primaryConcern === "split_ends") score += 2
+  if (primaryConcern === "dryness" || primaryConcern === "frizz" || primaryConcern === "tangling") {
+    score += 2
+  }
+
+  if (answers.pulltest === "stretches_stays") score += 3
+  if (answers.pulltest === "snaps") score += 2
+  if (hasColorTreatment(answers)) score += 2
+  if (answers.fingertest === "rau") score += 2
+
+  if (primaryGoal === "healthy_scalp") score += 1
+  if (
+    primaryGoal === "anti_breakage" ||
+    primaryGoal === "strengthen" ||
+    primaryGoal === "healthier_hair"
+  ) {
+    score += 1
+  }
+  if (
+    primaryGoal === "moisture" ||
+    primaryGoal === "shine" ||
+    primaryGoal === "less_frizz" ||
+    primaryGoal === "curl_definition"
+  ) {
+    score += 1
+  }
+
+  return score
+}
+
+function resolveFrictionScope(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): QuizResultScope {
+  const canUseScalpFallback = !primaryConcern
+
+  if (canUseScalpFallback && answers.scalp_condition) {
+    return "KOPFHAUT"
+  }
+
+  if (
+    canUseScalpFallback &&
+    (answers.scalp_type === "fettig" || answers.scalp_type === "trocken")
+  ) {
+    return "ANSATZ"
+  }
+
+  if (primaryConcern === "split_ends" || primaryGoal === "less_split_ends") {
+    return "SPITZEN"
+  }
+
+  if (primaryConcern === "hair_damage" || primaryConcern === "breakage") {
+    return "HAAR"
+  }
+
+  if (primaryGoal === "curl_definition") {
+    return "WELLEN & LOCKEN"
+  }
+
+  return "LÄNGEN"
+}
+
+function buildFrictionRow(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): QuizResultNarrativeRow {
+  const canUseScalpFallback = !primaryConcern
+  const scope = resolveFrictionScope(answers, primaryConcern, primaryGoal)
+
+  if (canUseScalpFallback && answers.scalp_condition === "gereizt") {
+    return {
+      label: "Was dich gerade ausbremst",
+      scope,
+      before: "gereizt",
+      after: "mehr Ruhe",
+      iconKey: "heart",
+      tickBefore: "gereizt",
+      tickAfter: "beruhigt",
+      currentPosition:
+        BUCKET_TO_POSITION[scoreToBucket(buildFrictionScore(answers, primaryConcern, primaryGoal))],
+      targetPosition: ROW_TARGET_POSITIONS.friction,
+    }
+  }
+
+  if (canUseScalpFallback && answers.scalp_condition === "schuppen") {
+    return {
+      label: "Was dich gerade ausbremst",
+      scope,
+      before: "Schuppen",
+      after: "mehr Ruhe",
+      iconKey: "leaf",
+      tickBefore: "unruhig",
+      tickAfter: "ausgeglichen",
+      currentPosition:
+        BUCKET_TO_POSITION[scoreToBucket(buildFrictionScore(answers, primaryConcern, primaryGoal))],
+      targetPosition: ROW_TARGET_POSITIONS.friction,
+    }
+  }
+
+  if (canUseScalpFallback && answers.scalp_condition === "trockene_schuppen") {
+    return {
+      label: "Was dich gerade ausbremst",
+      scope,
+      before: "trockene Schuppen",
+      after: "mehr Balance",
+      iconKey: "droplet",
+      tickBefore: "trocken",
+      tickAfter: "ausgeglichen",
+      currentPosition:
+        BUCKET_TO_POSITION[scoreToBucket(buildFrictionScore(answers, primaryConcern, primaryGoal))],
+      targetPosition: ROW_TARGET_POSITIONS.friction,
+    }
+  }
+
+  if (canUseScalpFallback && answers.scalp_type === "fettig") {
+    return {
+      label: "Was dich gerade ausbremst",
+      scope,
+      before: "fettig",
+      after: "mehr Balance",
+      iconKey: "droplet",
+      tickBefore: "unausgeglichen",
+      tickAfter: "ausgeglichen",
+      currentPosition:
+        BUCKET_TO_POSITION[scoreToBucket(buildFrictionScore(answers, primaryConcern, primaryGoal))],
+      targetPosition: ROW_TARGET_POSITIONS.friction,
+    }
+  }
+
+  if (canUseScalpFallback && answers.scalp_type === "trocken") {
+    return {
+      label: "Was dich gerade ausbremst",
+      scope,
+      before: "trocken",
+      after: "mehr Balance",
+      iconKey: "droplet",
+      tickBefore: "trocken",
+      tickAfter: "ausgeglichen",
+      currentPosition:
+        BUCKET_TO_POSITION[scoreToBucket(buildFrictionScore(answers, primaryConcern, primaryGoal))],
+      targetPosition: ROW_TARGET_POSITIONS.friction,
+    }
+  }
+
+  const copy = primaryConcern
+    ? CONCERN_COPY[primaryConcern]
+    : {
+        before: "Pflege, die noch nicht richtig zu deinem Haar passt",
+        after: "mehr Ruhe, Glanz & Ausgewogenheit",
+        iconKey: "sparkles" as const,
+        tickBefore: "unstimmig",
+        tickAfter: "passend",
+      }
+
+  return {
+    label: "Was dich gerade ausbremst",
+    scope,
+    before: copy.before,
+    after: copy.after,
+    iconKey: copy.iconKey,
+    tickBefore: copy.tickBefore,
+    tickAfter: copy.tickAfter,
+    currentPosition:
+      BUCKET_TO_POSITION[scoreToBucket(buildFrictionScore(answers, primaryConcern, primaryGoal))],
+    targetPosition: ROW_TARGET_POSITIONS.friction,
+  }
+}
+
+function buildGoalScore(primaryGoal: Goal | null): number {
+  if (!primaryGoal) {
+    return 0
+  }
+
+  switch (primaryGoal) {
+    case "less_frizz":
+    case "anti_breakage":
+    case "strengthen":
+    case "healthy_scalp":
+      return 4
+    case "healthier_hair":
+    case "less_split_ends":
+    case "curl_definition":
+      return 3
+    case "moisture":
+    case "shine":
+    case "volume":
+    case "less_volume":
+    case "color_protection":
+      return 2
+    default:
+      return 0
+  }
+}
+
+function resolveGoalScope(primaryGoal: Goal | null): QuizResultScope {
+  if (!primaryGoal) {
+    return "LÄNGEN"
+  }
+
+  switch (primaryGoal) {
+    case "healthy_scalp":
+      return "KOPFHAUT"
+    case "less_split_ends":
+      return "SPITZEN"
+    case "curl_definition":
+      return "WELLEN & LOCKEN"
+    case "shine":
+    case "color_protection":
+    case "volume":
+    case "less_volume":
+    case "healthier_hair":
+    case "anti_breakage":
+    case "strengthen":
+      return "HAAR"
+    case "less_frizz":
+    case "moisture":
+      return "LÄNGEN"
+    default:
+      return "LÄNGEN"
+  }
+}
+
+function buildOutcomeRow(primaryGoal: Goal | null): QuizResultNarrativeRow {
+  const copy = primaryGoal ? GOAL_COPY[primaryGoal] : GOAL_COPY.moisture
+  const score = buildGoalScore(primaryGoal)
+
+  return {
+    label: "Worauf wir hinarbeiten",
+    scope: resolveGoalScope(primaryGoal),
+    before: copy.before,
+    after: copy.after,
+    iconKey: copy.iconKey,
+    tickBefore: copy.tickBefore,
+    tickAfter: copy.tickAfter,
+    currentPosition: BUCKET_TO_POSITION[scoreToBucket(score)],
+    targetPosition: ROW_TARGET_POSITIONS.outcome,
+  }
+}
+
+function buildNeedsSection(
+  answers: QuizAnswers,
+  primaryConcern: QuizConcern | null,
+  primaryGoal: Goal | null,
+): QuizResultNeedsSection {
+  const hasScalpSignals =
+    answers.scalp_condition === "schuppen" ||
+    answers.scalp_condition === "trockene_schuppen" ||
+    answers.scalp_condition === "gereizt" ||
+    answers.scalp_type === "fettig" ||
+    answers.scalp_type === "trocken" ||
+    primaryGoal === "healthy_scalp"
+
+  if (primaryGoal === "healthy_scalp" || (!primaryConcern && hasScalpSignals)) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Die Kopfhaut gezielter ausgleichen",
+      mainLeverWhy:
+        "Wenn die Kopfhaut aus dem Gleichgewicht ist, bleibt sie leichter gereizt und Schuppen kommen schneller wieder.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem passenden Anti-Schuppen-Shampoo; zusätzlich kann ein beruhigendes Kopfhautserum helfen, die Kopfhaut zwischen den Haarwäschen ruhiger zu halten.",
+    }
+  }
+
+  const needsStructuralRepair =
+    primaryConcern === "breakage" ||
+    primaryConcern === "hair_damage" ||
+    hasColorTreatment(answers) ||
+    answers.pulltest === "stretches_stays"
+
+  if (needsStructuralRepair) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Mehr Stabilität in die Längen bringen",
+      mainLeverWhy:
+        "Wenn die Längen geschwächt sind, geben sie schneller nach und Spliss oder Haarbruch werden leichter weiter begünstigt.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem Bondbuilder; zusätzlich kann eine stärkende Maske helfen, die Längen belastbarer zu halten.",
+    }
+  }
+
+  const needsSurfaceSupport =
+    primaryConcern === "frizz" ||
+    primaryConcern === "dryness" ||
+    primaryConcern === "tangling" ||
+    primaryGoal === "less_frizz" ||
+    primaryGoal === "moisture" ||
+    primaryGoal === "shine" ||
+    primaryGoal === "curl_definition"
+
+  if (needsSurfaceSupport) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Mehr Schutz für Oberfläche und Längen aufbauen",
+      mainLeverWhy:
+        "Wenn die Oberfläche aufraut, fallen die Längen schneller unruhig und lassen sich schwerer kontrollieren.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein Leave-in helfen, die Längen zwischen den Wäschen ruhiger zu halten.",
+    }
+  }
+
+  if (primaryConcern === "split_ends" || primaryGoal === "less_split_ends") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Die Spitzen gezielt schützen",
+      mainLeverWhy:
+        "Wenn die Spitzen ausfransen, fühlen sie sich schneller trocken an und fallen weniger glatt.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem leichten Haaröl; zusätzlich kann ein Leave-in helfen, die Spitzen geschmeidiger und besser geschützt zu halten.",
+    }
+  }
+
+  return {
+    title: "Was dein Haar jetzt braucht",
+    mainLeverTitle: "Die Pflegebasis besser auf dein Haar abstimmen",
+    mainLeverWhy:
+      "Wenn die Pflegebasis besser passt, wirkt dein Haar insgesamt ruhiger und stimmiger.",
+    mainLeverProducts:
+      "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein leichtes Leave-in helfen, die Wirkung in den Längen zu halten.",
+  }
+}
+
+export function buildQuizResultNarrative(rawAnswers: QuizAnswers): QuizResultNarrative {
+  const answers = canonicalizeQuizAnswers(rawAnswers)
+  const primaryConcern = resolvePrimaryConcern(answers)
+  const primaryGoal = resolvePrimaryGoal(answers, primaryConcern)
+
+  const hairFeelRow = buildHairFeelRow(answers, primaryConcern, primaryGoal)
+  const frictionRow = buildFrictionRow(answers, primaryConcern, primaryGoal)
+  const outcomeRow = buildOutcomeRow(primaryGoal)
+
+  return {
+    intro: buildIntro(answers, primaryConcern, primaryGoal),
+    rows: [hairFeelRow, frictionRow, outcomeRow],
+    needs: buildNeedsSection(answers, primaryConcern, primaryGoal),
+    cta: {
+      lead: "Als Nächstes: dein persönlicher Plan",
+      label: "MEINE ROUTINE STARTEN",
+      subline: "Mit passenden Produkten, Reihenfolge und Anwendung.",
+    },
+    primaryConcern,
+    primaryGoal,
+  }
+}
+
+export const buildResultNarrative = buildQuizResultNarrative

--- a/src/lib/quiz/share.ts
+++ b/src/lib/quiz/share.ts
@@ -1,0 +1,33 @@
+export interface QuizShareConfigInput {
+  leadId: string | null
+  name: string
+  shareQuote: string | null
+  origin: string
+  isMobile: boolean
+  canNativeShare: boolean
+}
+
+export interface QuizShareConfig {
+  label: string
+  mode: "native" | "copy"
+  title: string
+  text: string
+  url: string
+}
+
+export function buildQuizShareConfig(input: QuizShareConfigInput): QuizShareConfig | null {
+  if (!input.leadId) {
+    return null
+  }
+
+  const firstName = input.name.trim().split(/\s+/)[0] || "Dein"
+  const url = `${input.origin}/result/${input.leadId}`
+
+  return {
+    label: "ERGEBNIS TEILEN",
+    mode: input.isMobile && input.canNativeShare ? "native" : "copy",
+    title: `${firstName}s Ergebnis bei Hair Concierge`,
+    text: input.shareQuote || `Schau dir ${firstName}s Ergebnis bei Hair Concierge an.`,
+    url,
+  }
+}

--- a/src/lib/quiz/store.ts
+++ b/src/lib/quiz/store.ts
@@ -8,6 +8,7 @@ interface QuizState {
   lead: LeadData
   leadId: string | null
   aiInsight: string | null
+  shareQuote: string | null
   isAnalyzing: boolean
 
   goNext: () => void
@@ -16,6 +17,7 @@ interface QuizState {
   setLeadField: <K extends keyof LeadData>(key: K, value: LeadData[K]) => void
   setLeadId: (id: string) => void
   setAiInsight: (insight: string) => void
+  setShareQuote: (quote: string) => void
   setIsAnalyzing: (v: boolean) => void
   setLeadCaptureSubStep: (sub: LeadCaptureSubStep) => void
   setStep: (step: QuizStep) => void
@@ -41,6 +43,7 @@ const initialState = {
   lead: { name: "", email: "", marketingConsent: false } as LeadData,
   leadId: null as string | null,
   aiInsight: null as string | null,
+  shareQuote: null as string | null,
   isAnalyzing: false,
 }
 
@@ -66,6 +69,7 @@ export const useQuizStore = create<QuizState>((set) => ({
 
   setLeadId: (id) => set({ leadId: id }),
   setAiInsight: (insight) => set({ aiInsight: insight }),
+  setShareQuote: (quote) => set({ shareQuote: quote }),
   setIsAnalyzing: (v) => set({ isAnalyzing: v }),
   setLeadCaptureSubStep: (sub) => set({ leadCaptureSubStep: sub }),
   setStep: (step) => set({ step }),

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -85,7 +85,7 @@ test.describe.serial("Authenticated intake routing", () => {
     await page.locator('input[type="password"]:visible').fill(password)
     await page.getByRole("button", { name: /^Anmelden$/ }).click()
 
-    await page.waitForURL("**/quiz", {
+    await page.waitForURL(/\/quiz(\?.*)?$/, {
       timeout: 30_000,
       waitUntil: "domcontentloaded",
     })
@@ -105,10 +105,11 @@ test.describe.serial("Authenticated intake routing", () => {
     await page.locator('input[type="password"]:visible').fill(password)
     await page.getByRole("button", { name: /^Anmelden$/ }).click()
 
-    await page.waitForURL("**/quiz", {
+    await page.waitForURL(/\/quiz(\?.*)?$/, {
       timeout: 30_000,
       waitUntil: "domcontentloaded",
     })
+    await page.waitForLoadState("networkidle")
 
     await page.getByRole("button", { name: /Quiz starten/i }).click()
     await page.getByText("Wellig").first().click()
@@ -117,7 +118,7 @@ test.describe.serial("Authenticated intake routing", () => {
     await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
 
     await expect(
-      page.getByText("SIND DEINE HAARE CHEMISCH BEHANDELT?", { exact: false }),
+      page.getByRole("heading", { name: /Sind deine Haare chemisch behandelt/i }),
     ).toBeVisible()
     await page
       .locator(".quiz-card")
@@ -129,10 +130,21 @@ test.describe.serial("Authenticated intake routing", () => {
       .locator(".quiz-card")
       .filter({ has: page.getByText(/^Trocken$/) })
       .click()
+    await expect(
+      page.getByRole("heading", {
+        name: /Hast du zusätzlich Beschwerden wie Schuppen, Juckreiz oder Rötungen/i,
+      }),
+    ).toBeVisible()
     await page.getByRole("button", { name: "NEIN" }).click()
 
     await expect(page.getByText(/Welche Haarprobleme/i)).toBeVisible()
     await page.getByText("Trockenheit").click()
+    await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+    await expect(page.getByText("Deine Haarziele", { exact: false })).toBeVisible({
+      timeout: 10_000,
+    })
+    await page.getByRole("button", { name: /Mehr Glanz/i }).click()
     await page.getByRole("button", { name: /^Weiter$/i }).click()
 
     await page.getByPlaceholder("Dein Vorname").fill("Playwright Intake")
@@ -143,15 +155,28 @@ test.describe.serial("Authenticated intake routing", () => {
 
     await page.getByRole("button", { name: /JA, WEITER ZU MEINEM PLAN/i }).click()
 
-    await expect(page.getByRole("button", { name: /ZIELE UND ROUTINE FESTLEGEN/i })).toBeVisible({
+    await expect(page.getByText(/DEIN PROFIL WIRD ERSTELLT/i)).toBeVisible({
       timeout: 45_000,
     })
-    await page.getByRole("button", { name: /ZIELE UND ROUTINE FESTLEGEN/i }).click()
+    await expect(page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i })).toBeVisible({
+      timeout: 45_000,
+    })
+    await page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i }).click()
+    await expect(
+      page.getByRole("heading", { name: /So kommen wir deinem Haarziel näher/i }),
+    ).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole("heading", { name: /Was dein Haar jetzt braucht/i })).toBeVisible()
+    await expect(page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i })).toBeVisible()
+    await page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }).click()
 
-    await page.waitForURL(/\/onboarding\?lead=/, {
+    await page.waitForURL((url) => url.pathname === "/onboarding", {
       timeout: 30_000,
       waitUntil: "domcontentloaded",
     })
+
+    const onboardingUrl = new URL(page.url())
+    expect(onboardingUrl.pathname).toBe("/onboarding")
+    expect(onboardingUrl.searchParams.get("lead")).toBeTruthy()
 
     await expect(page.getByRole("button", { name: /LOS GEHT/i })).toBeVisible({
       timeout: 15_000,

--- a/tests/onboarding-progress.test.ts
+++ b/tests/onboarding-progress.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { buildOnboardingProgressState } from "../src/lib/onboarding/progress"
+
+test("product drilldowns count as individual progress steps", () => {
+  const progress = buildOnboardingProgressState({
+    currentStep: "product_drilldown",
+    currentDrilldownIndex: 2,
+    drilldownCount: 3,
+    selectedHeatTools: ["foehn"],
+  })
+
+  assert.equal(progress.totalSteps, 14)
+  assert.equal(progress.currentIndex, 4)
+  assert.equal(progress.currentSectionIndex, 0)
+  assert.equal(progress.currentLabel, "Produkt-Details 3")
+  assert.equal(progress.progressPercent, 36)
+  assert.equal(progress.milestones[0]?.label, "Produkte")
+  assert.equal(progress.milestones[0]?.percent, 36)
+  assert.equal(progress.milestones[1]?.label, "Styling")
+  assert.equal(progress.milestones[1]?.percent, 64)
+})
+
+test("heat branch disappears from the effective path when no tools are selected", () => {
+  const progress = buildOnboardingProgressState({
+    currentStep: "interstitial",
+    currentDrilldownIndex: 1,
+    drilldownCount: 2,
+    selectedHeatTools: [],
+  })
+
+  assert.equal(progress.totalSteps, 11)
+  assert.equal(progress.currentIndex, 5)
+  assert.equal(progress.currentSectionIndex, 1)
+  assert.equal(progress.currentLabel, "Styling-Check")
+  assert.equal(progress.progressPercent, 55)
+  assert.equal(progress.path.includes("heat_frequency"), false)
+  assert.equal(progress.path.includes("heat_protection"), false)
+  assert.equal(progress.milestones[0]?.percent, 36)
+  assert.equal(progress.milestones[1]?.percent, 55)
+})
+
+test("night protection reaches the end of the visible onboarding path", () => {
+  const progress = buildOnboardingProgressState({
+    currentStep: "night_protection",
+    currentDrilldownIndex: 0,
+    drilldownCount: 1,
+    selectedHeatTools: ["glätteisen"],
+  })
+
+  assert.equal(progress.currentLabel, "Nachtschutz")
+  assert.equal(progress.currentIndex, progress.totalSteps - 1)
+  assert.equal(progress.currentSectionIndex, 2)
+  assert.equal(progress.progressPercent, 100)
+  assert.equal(progress.milestones[2]?.label, "Alltag")
+  assert.equal(progress.milestones[2]?.percent, 100)
+})

--- a/tests/quiz-brand-panel-content.test.ts
+++ b/tests/quiz-brand-panel-content.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { getQuizBrandPanelContent } from "../src/lib/quiz/brand-panel-content"
+
+test("question seven keeps the desktop rail with concise concerns copy", () => {
+  const content = getQuizBrandPanelContent(8, "name")
+
+  assert.equal(content.eyebrow, "FRAGE 7 VON 8")
+  assert.equal(content.description, "Was dich gerade ausbremst.")
+  assert.equal(content.progressCurrent, 7)
+  assert.equal(content.progressComplete, false)
+})
+
+test("goals step becomes question eight in the desktop rail", () => {
+  const content = getQuizBrandPanelContent(12, "name")
+
+  assert.equal(content.eyebrow, "FRAGE 8 VON 8")
+  assert.equal(content.description, "Worauf wir hinarbeiten.")
+  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressComplete, false)
+})
+
+test("lead capture uses a short finalization message with completed progress", () => {
+  const content = getQuizBrandPanelContent(9, "email")
+
+  assert.equal(content.eyebrow, "FAST GESCHAFFT")
+  assert.equal(content.description, "Gleich zeigen wir dir dein Profil.")
+  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressComplete, true)
+})
+
+test("analysis keeps the same desktop rail shell with concise processing copy", () => {
+  const content = getQuizBrandPanelContent(10, "consent")
+
+  assert.equal(content.eyebrow, "ANALYSE")
+  assert.equal(content.description, "Wir setzen alles zusammen.")
+  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressComplete, true)
+})

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -102,10 +102,12 @@ test.describe.serial("Quiz to onboarding E2E", () => {
 
   test("quiz hands off into onboarding and persists linked diagnostics", async ({ page }) => {
     await test.step("Complete the quiz and lead capture", async () => {
-      await page.goto("/quiz", { waitUntil: "domcontentloaded" })
+      await page.goto("/quiz", { waitUntil: "networkidle" })
 
       await page.getByRole("button", { name: /QUIZ STARTEN/i }).click()
-      await expect(page.getByText("HAARTEXTUR", { exact: false })).toBeVisible()
+      await expect(
+        page.getByRole("heading", { name: /Was ist deine natürliche Haartextur/i }),
+      ).toBeVisible()
 
       await page.getByText("Wellig").first().click()
       await expect(page.getByText("2/8")).toBeVisible()
@@ -120,7 +122,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await expect(page.getByText("5/8")).toBeVisible()
 
       await expect(
-        page.getByText("SIND DEINE HAARE CHEMISCH BEHANDELT?", { exact: false }),
+        page.getByRole("heading", { name: /Sind deine Haare chemisch behandelt/i }),
       ).toBeVisible()
 
       const naturCard = page.locator(".quiz-card", { hasText: "Naturhaar" })
@@ -132,28 +134,25 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       })
 
       await naturCard.click()
-      await expect(page.locator(".quiz-card-active", { hasText: "Naturhaar" })).toHaveCount(1)
-
       await coloredCard.click()
-      await expect(page.locator(".quiz-card-active", { hasText: "Naturhaar" })).toHaveCount(0)
-
       await bleachedCard.click()
-      await expect(page.locator(".quiz-card-active", { hasText: "Gefärbt / Getönt" })).toHaveCount(
-        1,
-      )
-      await expect(
-        page.locator(".quiz-card-active", { hasText: "Blondiert / Aufgehellt" }),
-      ).toHaveCount(1)
 
       await page.getByRole("button", { name: /^Weiter$/i }).click()
 
       // Scalp question (6/7)
       await expect(page.getByText("6/8")).toBeVisible()
+      await expect(
+        page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
+      ).toBeVisible()
       await page
         .locator(".quiz-card")
         .filter({ has: page.getByText(/^Trocken$/) })
         .click()
-      await expect(page.getByText("BESCHWERDEN WIE SCHUPPEN", { exact: false })).toBeVisible()
+      await expect(
+        page.getByRole("heading", {
+          name: /Hast du zusätzlich Beschwerden wie Schuppen, Juckreiz oder Rötungen/i,
+        }),
+      ).toBeVisible()
       await page.getByRole("button", { name: "JA" }).click()
       await page.getByText("Trockene Schuppen").click()
 
@@ -182,9 +181,15 @@ test.describe.serial("Quiz to onboarding E2E", () => {
     })
 
     await test.step("Verify the lead is analyzed before auth", async () => {
-      await expect(page.getByRole("button", { name: /ROUTINE FESTLEGEN/i })).toBeVisible({
+      await expect(page.getByText(/DEIN PROFIL WIRD ERSTELLT/i)).toBeVisible({
         timeout: 45_000,
       })
+      await expect(page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i })).toBeVisible({
+        timeout: 45_000,
+      })
+      await expect(
+        page.getByRole("heading", { name: /So kommen wir deinem Haarziel näher/i }),
+      ).toHaveCount(0)
 
       await expect
         .poll(
@@ -196,20 +201,19 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         )
         .toBe("analyzed")
 
-      await expect
-        .poll(
-          async () => {
-            const lead = await fetchLatestLead()
-            return typeof lead?.ai_insight === "string" && lead.ai_insight.length > 0
-          },
-          { timeout: 30_000 },
-        )
-        .toBe(true)
+      await page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i }).click()
+      await expect(
+        page.getByRole("heading", { name: /So kommen wir deinem Haarziel näher/i }),
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(
+        page.getByRole("heading", { name: /Was dein Haar jetzt braucht/i }),
+      ).toBeVisible()
+      await expect(page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i })).toBeVisible()
     })
 
     await test.step("Authenticate via inline auth on quiz-welcome", async () => {
       // Advance from results to welcome (step 14 — inline auth)
-      await page.getByRole("button", { name: /ROUTINE FESTLEGEN/i }).click()
+      await page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }).click()
 
       // Welcome page now shows inline dark auth form
       await expect(page.getByText("PROFIL SPEICHERN", { exact: false })).toBeVisible({
@@ -394,7 +398,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
     })
 
     await test.step("Retake the quiz with different diagnostics", async () => {
-      await page.goto("/quiz", { waitUntil: "domcontentloaded" })
+      await page.goto("/quiz", { waitUntil: "networkidle" })
 
       await page.getByRole("button", { name: /QUIZ STARTEN/i }).click()
       await page.getByText("Glatt").first().click()
@@ -403,7 +407,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.getByText("Reißt sofort").click()
 
       await expect(
-        page.getByText("SIND DEINE HAARE CHEMISCH BEHANDELT?", { exact: false }),
+        page.getByRole("heading", { name: /Sind deine Haare chemisch behandelt/i }),
       ).toBeVisible()
 
       const naturCard = page.locator(".quiz-card", { hasText: "Naturhaar" })
@@ -412,18 +416,13 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       })
 
       await coloredCard.click()
-      await expect(page.locator(".quiz-card-active", { hasText: "Gefärbt / Getönt" })).toHaveCount(
-        1,
-      )
-
       await naturCard.click()
-      await expect(page.locator(".quiz-card-active", { hasText: "Naturhaar" })).toHaveCount(1)
-      await expect(page.locator(".quiz-card-active", { hasText: "Gefärbt / Getönt" })).toHaveCount(
-        0,
-      )
 
       await page.getByRole("button", { name: /^Weiter$/i }).click()
       await expect(page.getByText("6/8")).toBeVisible()
+      await expect(
+        page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
+      ).toBeVisible()
       await page
         .locator(".quiz-card")
         .filter({ has: page.getByText(/^Fettig$/) })
@@ -448,14 +447,25 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.getByRole("button", { name: /^Weiter$/i }).click()
       await page.getByRole("button", { name: /JA, WEITER ZU MEINEM PLAN/i }).click()
 
-      await expect(page.getByRole("button", { name: /ROUTINE FESTLEGEN/i })).toBeVisible({
+      await expect(page.getByText(/DEIN PROFIL WIRD ERSTELLT/i)).toBeVisible({
         timeout: 45_000,
       })
+      await expect(page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i })).toBeVisible({
+        timeout: 45_000,
+      })
+      await page.getByRole("button", { name: /MEIN HAARPROFIL ANSEHEN/i }).click()
+      await expect(
+        page.getByRole("heading", { name: /So kommen wir deinem Haarziel näher/i }),
+      ).toBeVisible({ timeout: 15_000 })
+      await expect(
+        page.getByRole("heading", { name: /Was dein Haar jetzt braucht/i }),
+      ).toBeVisible()
+      await expect(page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i })).toBeVisible()
     })
 
     await test.step("Log back in via inline auth and relink the new lead", async () => {
       // Advance from results into the welcome/auth step
-      await page.getByRole("button", { name: /ROUTINE FESTLEGEN/i }).click()
+      await page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }).click()
 
       await expect(page.getByText("PROFIL SPEICHERN", { exact: false })).toBeVisible({
         timeout: 15_000,

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { buildQuizResultNarrative } from "../src/lib/quiz/result-narrative"
+
+test("surface-led results expose scope labels, bucketed positions, concise goal copy, and a main lever", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_bounces",
+    concerns: ["frizz"],
+    goals: ["less_frizz", "shine"],
+  })
+
+  assert.equal(narrative.rows[0]?.label, "Haargefühl")
+  assert.equal(narrative.rows[0]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[0]?.currentPosition, 66)
+  assert.equal(narrative.rows[0]?.targetPosition, 78)
+
+  assert.equal(narrative.rows[1]?.label, "Was dich gerade ausbremst")
+  assert.equal(narrative.rows[1]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[1]?.currentPosition, 66)
+  assert.equal(narrative.rows[1]?.targetPosition, 84)
+
+  assert.equal(narrative.rows[2]?.label, "Worauf wir hinarbeiten")
+  assert.equal(narrative.rows[2]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[2]?.before, "wenig Kontrolle")
+  assert.equal(narrative.rows[2]?.after, "mehr Geschmeidigkeit & Kontrolle")
+  assert.equal(narrative.rows[2]?.currentPosition, 50)
+  assert.equal(narrative.rows[2]?.targetPosition, 88)
+
+  assert.equal(narrative.needs.title, "Was dein Haar jetzt braucht")
+  assert.equal(narrative.needs.mainLeverTitle, "Mehr Schutz für Oberfläche und Längen aufbauen")
+  assert.match(narrative.needs.mainLeverWhy, /unruhig/i)
+  assert.match(narrative.needs.mainLeverProducts, /Conditioner/i)
+  assert.match(narrative.needs.mainLeverProducts, /zusätzlich/i)
+  assert.match(narrative.needs.mainLeverProducts, /Leave-in/i)
+  assert.ok(!("reveal" in narrative))
+
+  assert.equal(narrative.cta.lead, "Als Nächstes: dein persönlicher Plan")
+  assert.equal(narrative.cta.subline, "Mit passenden Produkten, Reihenfolge und Anwendung.")
+})
+
+test("primary concern ranking prefers hair damage over tangling, split ends, and frizz", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_stays",
+    concerns: ["hair_damage", "split_ends", "frizz"],
+    goals: ["healthier_hair", "less_frizz"],
+  })
+
+  assert.equal(narrative.primaryConcern, "hair_damage")
+  assert.equal(narrative.primaryGoal, "healthier_hair")
+  assert.equal(narrative.rows[1]?.label, "Was dich gerade ausbremst")
+  assert.equal(narrative.rows[1]?.before, "Haarschäden")
+  assert.equal(narrative.rows[1]?.scope, "HAAR")
+  assert.equal(narrative.rows[1]?.iconKey, "shield")
+  assert.equal(narrative.rows[1]?.tickBefore, "angegriffen")
+  assert.equal(narrative.rows[1]?.tickAfter, "geschützt")
+})
+
+test("treatment boost changes the concern ranking against untreated hair", () => {
+  const untreated = buildQuizResultNarrative({
+    structure: "curly",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: ["hair_damage", "dryness"],
+    goals: ["healthy_scalp"],
+  })
+
+  const treated = buildQuizResultNarrative({
+    structure: "curly",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    treatment: ["gefaerbt"],
+    concerns: ["hair_damage", "dryness"],
+    goals: ["healthy_scalp"],
+  })
+
+  assert.equal(untreated.primaryConcern, "dryness")
+  assert.equal(treated.primaryConcern, "hair_damage")
+  assert.equal(untreated.rows[1]?.before, "Trockenheit")
+  assert.equal(treated.rows[1]?.before, "Haarschäden")
+})
+
+test("multi-goal intro acknowledges additional selected goals with unter anderem and mirrors the concern", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "leicht_uneben",
+    pulltest: "stretches_bounces",
+    concerns: ["frizz"],
+    goals: ["shine", "less_frizz"],
+  })
+
+  assert.equal(
+    narrative.intro,
+    "Du hast gesagt, dass dich vor allem Frizz stört und dass du dir unter anderem ruhigeres, geschmeidigeres Haar wünschst.",
+  )
+})
+
+test("no-concern fallback can become scalp-led when scalp is the strongest real friction", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    scalp_type: "fettig",
+    has_scalp_issue: true,
+    scalp_condition: "schuppen",
+    goals: ["healthy_scalp"],
+    concerns: [],
+  })
+
+  assert.equal(narrative.primaryConcern, null)
+  assert.equal(narrative.primaryGoal, "healthy_scalp")
+  assert.equal(
+    narrative.intro,
+    "Du hast gesagt, dass du dir eine ruhigere, ausgeglichenere Kopfhaut wünschst und wir sehen schon, was dein Haar gerade noch ausbremst.",
+  )
+  assert.equal(narrative.rows[1]?.label, "Was dich gerade ausbremst")
+  assert.doesNotMatch(narrative.rows[0]?.before ?? "", /Kopfhaut|Ansatz/i)
+  assert.doesNotMatch(narrative.rows[1]?.before ?? "", /Kopfhaut|Ansatz/i)
+  assert.doesNotMatch(narrative.rows[2]?.before ?? "", /Kopfhaut|Ansatz/i)
+  assert.equal(narrative.rows[0]?.scope, "KOPFHAUT")
+  assert.equal(narrative.rows[1]?.scope, "KOPFHAUT")
+  assert.equal(narrative.rows[2]?.scope, "KOPFHAUT")
+  assert.equal(narrative.rows[0]?.iconKey, "droplet")
+  assert.equal(narrative.rows[0]?.tickBefore, "unausgeglichen")
+  assert.equal(narrative.rows[0]?.tickAfter, "ausgeglichen")
+  assert.equal(narrative.rows[1]?.iconKey, "leaf")
+  assert.equal(narrative.rows[1]?.tickBefore, "unruhig")
+  assert.equal(narrative.rows[1]?.tickAfter, "ausgeglichen")
+  assert.equal(narrative.rows[2]?.iconKey, "leaf")
+  assert.equal(narrative.rows[2]?.tickBefore, "unruhig")
+  assert.equal(narrative.rows[2]?.tickAfter, "beruhigt")
+  assert.match(narrative.needs.mainLeverWhy, /Schuppen/i)
+  assert.match(narrative.needs.mainLeverProducts, /Anti-Schuppen-Shampoo/i)
+  assert.match(narrative.needs.mainLeverProducts, /Kopfhautserum/i)
+})
+
+test("an explicit dryness concern keeps row two and the main lever out of the scalp fallback", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "leicht_uneben",
+    pulltest: "stretches_stays",
+    treatment: ["gefaerbt"],
+    scalp_type: "trocken",
+    concerns: ["dryness"],
+    goals: ["shine"],
+  })
+
+  assert.equal(narrative.primaryConcern, "dryness")
+  assert.equal(narrative.rows[1]?.label, "Was dich gerade ausbremst")
+  assert.equal(narrative.rows[1]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[1]?.before, "Trockenheit")
+  assert.equal(narrative.rows[1]?.after, "weichere, besser mit Feuchtigkeit versorgte Längen")
+  assert.doesNotMatch(narrative.needs.mainLeverTitle, /Kopfhaut/i)
+  assert.doesNotMatch(narrative.needs.mainLeverProducts, /Anti-Schuppen-Shampoo|Kopfhautserum/i)
+})
+
+test("ansatz fallback stays concise without repeating location words", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    scalp_type: "fettig",
+    concerns: [],
+    goals: [],
+  })
+
+  assert.equal(narrative.rows[1]?.scope, "ANSATZ")
+  assert.doesNotMatch(narrative.rows[1]?.before ?? "", /Ansatz/i)
+  assert.doesNotMatch(narrative.rows[1]?.after ?? "", /Ansatz/i)
+})
+
+test("primary goal falls back to the existing ordered selected goals when no direct match is selected", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: ["dryness"],
+    goals: ["healthy_scalp", "shine"],
+  })
+
+  assert.equal(narrative.primaryGoal, "shine")
+  assert.equal(narrative.rows[2]?.scope, "HAAR")
+  assert.equal(narrative.rows[2]?.before, "wenig Glanz")
+  assert.equal(narrative.rows[2]?.after, "mehr Leuchtkraft & Lebendigkeit")
+  assert.equal(narrative.rows[2]?.iconKey, "sparkles")
+  assert.equal(narrative.rows[2]?.tickBefore, "matt")
+  assert.equal(narrative.rows[2]?.tickAfter, "glänzend")
+})
+
+test("severe structural signals can mention bondbuilder support in the main lever", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_stays",
+    treatment: ["blondiert"],
+    concerns: ["breakage", "hair_damage"],
+    goals: ["anti_breakage", "healthier_hair"],
+  })
+
+  assert.equal(narrative.rows[0]?.scope, "HAAR")
+  assert.equal(narrative.rows[0]?.currentPosition, 82)
+  assert.equal(narrative.rows[1]?.currentPosition, 82)
+  assert.equal(narrative.rows[2]?.before, "wenig Stabilität")
+  assert.match(narrative.needs.mainLeverProducts, /Bondbuilder/i)
+  assert.match(narrative.needs.mainLeverProducts, /zusätzlich/i)
+  assert.match(narrative.needs.mainLeverProducts, /Maske/i)
+})
+
+test("surface branch explains the main lever with multiple fitting categories", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_bounces",
+    concerns: ["frizz"],
+    goals: ["less_frizz", "shine"],
+  })
+
+  assert.equal(
+    narrative.needs.mainLeverProducts,
+    "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein Leave-in helfen, die Längen zwischen den Wäschen ruhiger zu halten.",
+  )
+})
+
+test("scalp branch explains the main lever with product-specific follow-through", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    scalp_type: "trocken",
+    has_scalp_issue: true,
+    scalp_condition: "schuppen",
+    goals: ["healthy_scalp"],
+    concerns: [],
+  })
+
+  assert.equal(
+    narrative.needs.mainLeverProducts,
+    "Am meisten erreichen wir hier mit einem passenden Anti-Schuppen-Shampoo; zusätzlich kann ein beruhigendes Kopfhautserum helfen, die Kopfhaut zwischen den Haarwäschen ruhiger zu halten.",
+  )
+})
+
+test("split-ends branch explains the main lever with tip-focused product guidance", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: ["split_ends"],
+    goals: ["less_split_ends"],
+  })
+
+  assert.equal(
+    narrative.needs.mainLeverProducts,
+    "Am meisten erreichen wir hier mit einem leichten Haaröl; zusätzlich kann ein Leave-in helfen, die Spitzen geschmeidiger und besser geschützt zu halten.",
+  )
+})
+
+test("fallback branch still offers a concise but fuller product bridge", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: [],
+    goals: [],
+  })
+
+  assert.equal(
+    narrative.needs.mainLeverProducts,
+    "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein leichtes Leave-in helfen, die Wirkung in den Längen zu halten.",
+  )
+})
+
+test("fixed row labels and CTA copy stay compact", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: ["dryness"],
+    goals: ["moisture"],
+  })
+
+  assert.deepEqual(
+    narrative.rows.map((row) => row.label),
+    ["Haargefühl", "Was dich gerade ausbremst", "Worauf wir hinarbeiten"],
+  )
+  assert.equal(typeof narrative.rows[0]?.before, "string")
+  assert.equal(typeof narrative.rows[0]?.after, "string")
+  assert.equal(narrative.rows[0]?.scope, "LÄNGEN")
+  assert.equal(narrative.rows[0]?.currentPosition, 34)
+  assert.equal(narrative.rows[0]?.targetPosition, 78)
+  assert.equal(narrative.cta.lead, "Als Nächstes: dein persönlicher Plan")
+  assert.equal(narrative.cta.label, "MEINE ROUTINE STARTEN")
+  assert.equal(narrative.cta.subline, "Mit passenden Produkten, Reihenfolge und Anwendung.")
+})

--- a/tests/quiz-results-view.test.tsx
+++ b/tests/quiz-results-view.test.tsx
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { QuizResultsView } from "../src/components/quiz/quiz-results-view"
+import { buildQuizResultNarrative } from "../src/lib/quiz/result-narrative"
+
+test("shared results view renders the new narrative result experience instead of the legacy diagnosis copy", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "leicht_uneben",
+    pulltest: "stretches_bounces",
+    concerns: ["dryness"],
+    goals: ["shine"],
+  })
+
+  const html = renderToStaticMarkup(
+    <QuizResultsView
+      name="Lea"
+      narrative={narrative}
+      primaryAction={{ label: "QUIZ STARTEN", href: "/quiz" }}
+      secondaryAction={{ label: "ERGEBNIS TEILEN", href: "/result/demo" }}
+    />,
+  )
+
+  assert.match(html, /SO KOMMEN WIR DEINEM HAARZIEL NÄHER/i)
+  assert.match(html, /WAS DEIN HAAR JETZT BRAUCHT/i)
+  assert.match(html, /ERGEBNIS TEILEN/i)
+  assert.doesNotMatch(html, /<a[^>]*>\s*<button/i)
+  assert.doesNotMatch(html, /DEINE HAAR-DIAGNOSE|Teile deine Diagnose|ALS BILD SPEICHERN|WHATSAPP/i)
+})

--- a/tests/quiz-share.test.ts
+++ b/tests/quiz-share.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { buildQuizShareConfig } from "../src/lib/quiz/share"
+
+test("mobile uses native share with the public result url", () => {
+  const share = buildQuizShareConfig({
+    leadId: "550e8400-e29b-41d4-a716-446655440000",
+    name: "Lea",
+    shareQuote: "Deine Haare brauchen die richtige Reihenfolge.",
+    origin: "https://hair.example",
+    isMobile: true,
+    canNativeShare: true,
+  })
+
+  assert.equal(share?.label, "ERGEBNIS TEILEN")
+  assert.equal(share?.mode, "native")
+  assert.equal(share?.url, "https://hair.example/result/550e8400-e29b-41d4-a716-446655440000")
+  assert.match(share?.text ?? "", /Deine Haare brauchen die richtige Reihenfolge/i)
+})
+
+test("desktop falls back to copying the public result url", () => {
+  const share = buildQuizShareConfig({
+    leadId: "550e8400-e29b-41d4-a716-446655440000",
+    name: "Lea",
+    shareQuote: null,
+    origin: "https://hair.example",
+    isMobile: false,
+    canNativeShare: true,
+  })
+
+  assert.equal(share?.label, "ERGEBNIS TEILEN")
+  assert.equal(share?.mode, "copy")
+  assert.equal(share?.url, "https://hair.example/result/550e8400-e29b-41d4-a716-446655440000")
+  assert.match(share?.text ?? "", /Leas Ergebnis/i)
+})
+
+test("missing lead id disables the share action", () => {
+  const share = buildQuizShareConfig({
+    leadId: null,
+    name: "Lea",
+    shareQuote: null,
+    origin: "https://hair.example",
+    isMobile: true,
+    canNativeShare: true,
+  })
+
+  assert.equal(share, null)
+})


### PR DESCRIPTION
## Why
The quiz payoff, sharing flow, and onboarding progress no longer matched the product direction. Results still mixed old and new surfaces, the onboarding progress bar jumped by section instead of reflecting the real path, and the desktop quiz shell dropped away late in the flow.

## What changed
- rebuilt the quiz analysis/results flow around the new narrative result experience, including the explicit `MEIN HAARPROFIL ANSEHEN` reveal step, the spectrum cards, the `Was dein Haar jetzt braucht` section, and the clearer bridge into the detailed routine
- made sharing first-class by using direct mobile native share / desktop copy-link behavior and moving the public `/result/[leadId]` page onto the same new narrative view instead of the legacy diagnosis screen
- made onboarding progress continuous from the effective onboarding path, aligned the milestone dots on the track, and kept the desktop left rail consistent through questions 7/8, lead capture, and analysis

## Verification
- `npx tsx --test tests/quiz-result-narrative.test.ts tests/quiz-share.test.ts tests/onboarding-progress.test.ts tests/quiz-brand-panel-content.test.ts tests/quiz-results-view.test.tsx`
- `PLAYWRIGHT_BASE_URL=http://localhost:3675 npx playwright test tests/quiz-onboarding-e2e.spec.ts --grep "quiz hands off into onboarding" --reporter=line`
- `npm run typecheck -- --pretty false`
- `npm exec eslint -- --no-ignore src/components/quiz/quiz-results-view.tsx src/components/quiz/quiz-results.tsx 'src/app/result/[leadId]/page.tsx' 'src/app/result/[leadId]/result-client.tsx' src/components/onboarding/onboarding-progress-bar.tsx src/lib/quiz/result-narrative.ts src/lib/quiz/share.ts tests/quiz-results-view.test.tsx`
- Browser checks on local dev flow for quiz results, public `/result/[leadId]`, and desktop share-copy behavior

## Notes
- The public result page stays intentionally unauthenticated so shared links remain viewable without login.
- The old OG image route still exists, but the public result metadata no longer points social previews at that legacy asset.
