### PR TITLE
fix(stripe): 400 on create-checkout-session when leadId is null

### DIFF
--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -10,7 +10,9 @@ export const runtime = "nodejs"
 
 const BodySchema = z.object({
   interval: z.enum(["month", "quarter", "year"]),
-  leadId: z.string().uuid().optional(),
+  // Accept null too — the client sends `leadId: null` when there's no ?lead=
+  // in the URL (resubscribe path). `.optional()` alone rejects null.
+  leadId: z.string().uuid().nullable().optional(),
 })
 
 export async function POST(req: NextRequest) {

--- a/src/app/pricing/pricing-cards.tsx
+++ b/src/app/pricing/pricing-cards.tsx
@@ -67,7 +67,10 @@ export function PricingCards({
     const res = await fetch("/api/stripe/create-checkout-session", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ interval: selectedInterval, leadId }),
+      body: JSON.stringify({
+        interval: selectedInterval,
+        ...(leadId ? { leadId } : {}),
+      }),
     })
     if (!res.ok) {
       const msg = "Zahlung konnte nicht gestartet werden. Bitte versuche es erneut."


### PR DESCRIPTION
Clean rebase of PR #46 (which had a merge conflict from branch reuse after PR #44's squash).

## Bug

Client sends \`{interval, leadId: null}\` when /pricing has no ?lead= query (middleware redirect /chat → /pricing?reason=resubscribe). Zod .optional() rejects null → 400 "bad request". Observed in prod for user nickrupprechter+30@gmail.com.

## Fix

Dual:
- Server: \`leadId: z.string().uuid().nullable().optional()\`
- Client: omits the key when null rather than sending null

🤖 Generated with [Claude Code](https://claude.com/claude-code)