### PR TITLE
feat(conditioner): structured ingredient_flags (mirror leave-ins)

### DIFF
--- a/scripts/backfill-conditioner-rerank-specs.ts
+++ b/scripts/backfill-conditioner-rerank-specs.ts
@@ -258,9 +258,9 @@ async function main() {
   }
 
   const rows = conditioners.map((product) => {
-    if (product.suitable_concerns.length !== 1) {
+    if (product.suitable_concerns.length < 1) {
       throw new Error(
-        `${product.name} expected exactly one suitable_concern, got ${product.suitable_concerns.join(", ")}`,
+        `${product.name} expected at least one suitable_concern, got ${product.suitable_concerns.join(", ") || "<empty>"}`,
       )
     }
 

--- a/scripts/backfill-conditioner-rerank-specs.ts
+++ b/scripts/backfill-conditioner-rerank-specs.ts
@@ -1,6 +1,12 @@
 import { config as loadEnv } from "dotenv"
 import { createClient } from "@supabase/supabase-js"
 
+import type {
+  ConditionerIngredientFlag,
+  ConditionerRepairLevel,
+  ConditionerWeight,
+} from "@/lib/conditioner/constants"
+
 loadEnv({ path: ".env.local" })
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -17,59 +23,158 @@ const supabase = createClient(supabaseUrl, serviceRoleKey, {
   },
 })
 
-type ConditionerWeight = "light" | "medium" | "rich"
-type ConditionerRepairLevel = "low" | "medium" | "high"
 type ProductBalanceDirection = "protein" | "moisture" | "balanced"
 
 type ConditionerBackfillSpec = {
   weight: ConditionerWeight
   repair_level: ConditionerRepairLevel
+  ingredient_flags: ConditionerIngredientFlag[]
 }
 
 const CONDITIONER_BACKFILL_BY_NAME: Record<string, ConditionerBackfillSpec> = {
-  "Alverde Glanz": { weight: "light", repair_level: "low" },
-  "Balea Aqua Hyaluron": { weight: "light", repair_level: "low" },
-  "Balea Natural Beauty Hibiskus": { weight: "light", repair_level: "low" },
-  "Balea Oil Repair": { weight: "rich", repair_level: "high" },
-  "Balea Ultra Med Sensitive": { weight: "light", repair_level: "low" },
-  "Bali Curls Moisturising (Kokos)": { weight: "rich", repair_level: "medium" },
-  "Cantu Conditioner Cream (Kokos)": { weight: "rich", repair_level: "medium" },
-  "Cantu Repair Cream (Kokos)": { weight: "rich", repair_level: "high" },
-  "Dejan Garz The Foundation (Silikone)": { weight: "rich", repair_level: "medium" },
-  "Elvital Fiber Booster (Silikone)": { weight: "medium", repair_level: "medium" },
-  "Garnier Hair Food Macadamia (Kokos)": { weight: "medium", repair_level: "low" },
-  "Garnier Wahre Schätze Aloe Vera Spülung": { weight: "light", repair_level: "low" },
-  "Gliss Kur Aqua Revive (Silikone)": { weight: "light", repair_level: "low" },
-  "Gliss Ultimate Repair Spülung (Silikone)": { weight: "medium", repair_level: "high" },
-  "Guhl Bond+ (Silikone)": { weight: "medium", repair_level: "high" },
-  "Guhl Panthenol*": { weight: "medium", repair_level: "high" },
-  "Hair Biology Full & Shining": { weight: "light", repair_level: "medium" },
-  "Hask Curl Care": { weight: "rich", repair_level: "medium" },
-  "Hask Repairing Argan Oil (Kokos)": { weight: "rich", repair_level: "medium" },
-  "Herbal Essences Aloe Vera (Silikone)": { weight: "medium", repair_level: "low" },
-  "Isana Professional Argan": { weight: "rich", repair_level: "medium" },
-  "Jean&Len Repair Keratin/Mandel": { weight: "light", repair_level: "medium" },
-  "Langhaarmädchen Beautiful Curls": { weight: "medium", repair_level: "low" },
-  "Langhaarmädchen Lovely Long": { weight: "medium", repair_level: "medium" },
-  "Monday Moisture (Silikone / Kokos)": { weight: "rich", repair_level: "low" },
-  "Neqi Moisture Mystery (Silikone)": { weight: "medium", repair_level: "medium" },
-  "Neqi Repair Reveal  (Silikone)": { weight: "medium", repair_level: "high" },
-  "Neqi Volume Victory (Silikone)": { weight: "light", repair_level: "low" },
-  "Nivea Repair": { weight: "medium", repair_level: "medium" },
-  "Nivea Volumen & Kraft": { weight: "light", repair_level: "low" },
-  "OGX Biotin & Collagen (Silikone)": { weight: "light", repair_level: "low" },
-  "OGX Keratin & Protein (Silikone)": { weight: "rich", repair_level: "high" },
-  "OGX Renewing (Silikone / Kokos)": { weight: "rich", repair_level: "medium" },
-  "OGX Renewing Argan Oil (Silikone /Kokos)": { weight: "rich", repair_level: "medium" },
-  "Pantene Hydra Glow (Silikone)": { weight: "medium", repair_level: "medium" },
-  "Pantene Miracles Bond Repair (Silikone)": { weight: "medium", repair_level: "high" },
-  "Pomelo Molecular Repair (Silikone)": { weight: "medium", repair_level: "high" },
-  "Pomélo+Co Shine Therapy Conditioner": { weight: "rich", repair_level: "medium" },
-  "SANTE Deep Repair Conditioner (Kokos)": { weight: "rich", repair_level: "high" },
-  "Sante Intense Hydrating Conditioner": { weight: "medium", repair_level: "low" },
-  "Syoss Intense Curls (Silikone)": { weight: "medium", repair_level: "medium" },
-  "Syoss Intense Keratin (Silikone)": { weight: "medium", repair_level: "high" },
-  "Wahre Schätze Argan-Mandelcreme (Silikone)": { weight: "rich", repair_level: "medium" },
+  "Alverde Glanz": { weight: "light", repair_level: "low", ingredient_flags: [] },
+  "Balea Aqua Hyaluron": { weight: "light", repair_level: "low", ingredient_flags: [] },
+  "Balea Natural Beauty Hibiskus": { weight: "light", repair_level: "low", ingredient_flags: [] },
+  "Balea Oil Repair": { weight: "rich", repair_level: "high", ingredient_flags: [] },
+  "Balea Ultra Med Sensitive": { weight: "light", repair_level: "low", ingredient_flags: [] },
+  "Bali Curls Moisturising": { weight: "rich", repair_level: "medium", ingredient_flags: ["oils"] },
+  "Cantu Conditioner Cream": { weight: "rich", repair_level: "medium", ingredient_flags: ["oils"] },
+  "Cantu Repair Cream": { weight: "rich", repair_level: "high", ingredient_flags: ["oils"] },
+  "Dejan Garz The Foundation": {
+    weight: "rich",
+    repair_level: "medium",
+    ingredient_flags: ["silicones"],
+  },
+  "Elvital Fiber Booster": {
+    weight: "medium",
+    repair_level: "medium",
+    ingredient_flags: ["silicones"],
+  },
+  "Garnier Hair Food Macadamia": {
+    weight: "medium",
+    repair_level: "low",
+    ingredient_flags: ["oils"],
+  },
+  "Garnier Wahre Schätze Aloe Vera Spülung": {
+    weight: "light",
+    repair_level: "low",
+    ingredient_flags: [],
+  },
+  "Gliss Kur Aqua Revive": {
+    weight: "light",
+    repair_level: "low",
+    ingredient_flags: ["silicones"],
+  },
+  "Gliss Ultimate Repair Spülung": {
+    weight: "medium",
+    repair_level: "high",
+    ingredient_flags: ["silicones"],
+  },
+  "Guhl Bond+": { weight: "medium", repair_level: "high", ingredient_flags: ["silicones"] },
+  "Guhl Panthenol*": { weight: "medium", repair_level: "high", ingredient_flags: [] },
+  "Hair Biology Full & Shining": { weight: "light", repair_level: "medium", ingredient_flags: [] },
+  "Hask Curl Care": { weight: "rich", repair_level: "medium", ingredient_flags: [] },
+  "Hask Repairing Argan Oil": {
+    weight: "rich",
+    repair_level: "medium",
+    ingredient_flags: ["oils"],
+  },
+  "Herbal Essences Aloe Vera": {
+    weight: "medium",
+    repair_level: "low",
+    ingredient_flags: ["silicones"],
+  },
+  "Isana Professional Argan": { weight: "rich", repair_level: "medium", ingredient_flags: [] },
+  "Jean&Len Repair Keratin/Mandel": {
+    weight: "light",
+    repair_level: "medium",
+    ingredient_flags: [],
+  },
+  "Langhaarmädchen Beautiful Curls": {
+    weight: "medium",
+    repair_level: "low",
+    ingredient_flags: [],
+  },
+  "Langhaarmädchen Lovely Long": { weight: "medium", repair_level: "medium", ingredient_flags: [] },
+  "Monday Moisture": {
+    weight: "rich",
+    repair_level: "low",
+    ingredient_flags: ["silicones", "oils"],
+  },
+  "Neqi Moisture Mystery": {
+    weight: "medium",
+    repair_level: "medium",
+    ingredient_flags: ["silicones"],
+  },
+  "Neqi Repair Reveal": { weight: "medium", repair_level: "high", ingredient_flags: ["silicones"] },
+  "Neqi Volume Victory": { weight: "light", repair_level: "low", ingredient_flags: ["silicones"] },
+  "Nivea Repair": { weight: "medium", repair_level: "medium", ingredient_flags: [] },
+  "Nivea Volumen & Kraft": { weight: "light", repair_level: "low", ingredient_flags: [] },
+  "OGX Biotin & Collagen": {
+    weight: "light",
+    repair_level: "low",
+    ingredient_flags: ["silicones"],
+  },
+  "OGX Keratin & Protein": {
+    weight: "rich",
+    repair_level: "high",
+    ingredient_flags: ["silicones"],
+  },
+  "OGX Renewing": {
+    weight: "rich",
+    repair_level: "medium",
+    ingredient_flags: ["silicones", "oils"],
+  },
+  "OGX Renewing Argan Oil": {
+    weight: "rich",
+    repair_level: "medium",
+    ingredient_flags: ["silicones", "oils"],
+  },
+  "Pantene Hydra Glow": {
+    weight: "medium",
+    repair_level: "medium",
+    ingredient_flags: ["silicones"],
+  },
+  "Pantene Miracles Bond Repair": {
+    weight: "medium",
+    repair_level: "high",
+    ingredient_flags: ["silicones"],
+  },
+  "Pomelo Molecular Repair": {
+    weight: "medium",
+    repair_level: "high",
+    ingredient_flags: ["silicones"],
+  },
+  "Pomélo+Co Shine Therapy Conditioner": {
+    weight: "rich",
+    repair_level: "medium",
+    ingredient_flags: [],
+  },
+  "SANTE Deep Repair Conditioner": {
+    weight: "rich",
+    repair_level: "high",
+    ingredient_flags: ["oils"],
+  },
+  "Sante Intense Hydrating Conditioner": {
+    weight: "medium",
+    repair_level: "low",
+    ingredient_flags: [],
+  },
+  "Syoss Intense Curls": {
+    weight: "medium",
+    repair_level: "medium",
+    ingredient_flags: ["silicones"],
+  },
+  "Syoss Intense Keratin": {
+    weight: "medium",
+    repair_level: "high",
+    ingredient_flags: ["silicones"],
+  },
+  "Wahre Schätze Argan-Mandelcreme": {
+    weight: "rich",
+    repair_level: "medium",
+    ingredient_flags: ["silicones"],
+  },
 }
 
 function deriveBalanceDirection(suitableConcerns: string[]): ProductBalanceDirection {
@@ -169,27 +274,30 @@ async function main() {
 
   console.log("Final conditioner backfill table:")
   console.table(
-    rows.map(({ product_name, balance_direction, weight, repair_level }) => ({
+    rows.map(({ product_name, balance_direction, weight, repair_level, ingredient_flags }) => ({
       product_name,
       balance_direction,
       weight,
       repair_level,
+      ingredient_flags: ingredient_flags.join(",") || "(none)",
     })),
   )
 
   const includeBalanceDirection = await hasBalanceDirectionColumn()
 
   const payload = includeBalanceDirection
-    ? rows.map(({ product_id, weight, repair_level, balance_direction }) => ({
+    ? rows.map(({ product_id, weight, repair_level, balance_direction, ingredient_flags }) => ({
         product_id,
         weight,
         repair_level,
         balance_direction,
+        ingredient_flags,
       }))
-    : rows.map(({ product_id, weight, repair_level }) => ({
+    : rows.map(({ product_id, weight, repair_level, ingredient_flags }) => ({
         product_id,
         weight,
         repair_level,
+        ingredient_flags,
       }))
 
   const { error } = await supabase

--- a/scripts/convert_sources.py
+++ b/scripts/convert_sources.py
@@ -798,6 +798,54 @@ def convert_excel_matrices():
         convert_single_excel_matrix(xlsx_path)
 
 
+INGREDIENT_FLAG_TRAILING_PAREN = re.compile(
+    r"\s*\((Silikone|Kokos|Silikone\s*/\s*Kokos)\)\s*$",
+)
+
+
+def normalize_ingredient_paren(text: str) -> str:
+    """Normalize source typos in trailing ingredient parens.
+    'Silikon' (no trailing 'e') -> 'Silikone'. Idempotent.
+
+    Word-boundary match: only rewrite 'Silikon' followed by a non-letter
+    so we don't accidentally rewrite 'Silikone' itself.
+    """
+    return re.sub(r"\bSilikon(?![a-zA-Z])", "Silikone", text)
+
+
+def parse_ingredient_flags(name: str) -> tuple[str, list[str]]:
+    """Strip trailing (Silikone) / (Kokos) / (Silikone /Kokos) annotation
+    from a product name and return (stripped_name, flags).
+    Kokos maps to 'oils' per leave-in convention.
+
+    Assumes input has already been run through normalize_ingredient_paren()
+    so only the canonical 'Silikone' spelling is recognized.
+
+    Returns the original name and an empty list if no annotation matches.
+    """
+    m = INGREDIENT_FLAG_TRAILING_PAREN.search(name)
+    if not m:
+        return name, []
+    body = m.group(1)
+    flags: list[str] = []
+    if "Silikone" in body:
+        flags.append("silicones")
+    if "Kokos" in body:
+        flags.append("oils")
+    return name[: m.start()].rstrip(), flags
+
+
+# Module-level smoke asserts (run on import).
+assert normalize_ingredient_paren("OGX Biotin & Collagen (Silikon)") == "OGX Biotin & Collagen (Silikone)"
+assert normalize_ingredient_paren("Pomelo (Silikone)") == "Pomelo (Silikone)"  # idempotent
+assert parse_ingredient_flags("Pomelo Molecular Repair (Silikone)") == ("Pomelo Molecular Repair", ["silicones"])
+assert parse_ingredient_flags("Cantu Repair Cream (Kokos)") == ("Cantu Repair Cream", ["oils"])
+assert parse_ingredient_flags("OGX Renewing Argan Oil (Silikone /Kokos)") == ("OGX Renewing Argan Oil", ["silicones", "oils"])
+assert parse_ingredient_flags("Monday Moisture (Silikone / Kokos)") == ("Monday Moisture", ["silicones", "oils"])
+assert parse_ingredient_flags("Plain Name") == ("Plain Name", [])
+assert parse_ingredient_flags("Garnier (Drogerie)") == ("Garnier (Drogerie)", [])  # don't strip non-ingredient parens
+
+
 def parse_cell_products(cell_value) -> list[str]:
     """Extract product names from a cell value.
 
@@ -856,6 +904,7 @@ def convert_single_excel_matrix(xlsx_path: Path):
     """
     filename_stem = xlsx_path.stem  # e.g. "Produktliste Conditioner (Profi)"
     is_profi = "(Profi)" in filename_stem or "(profi)" in filename_stem
+    is_conditioner = "conditioner" in filename_stem.lower()
     category = filename_stem  # fallback: filename without extension
     print(f"\n  Processing: {filename_stem}")
 
@@ -921,6 +970,11 @@ def convert_single_excel_matrix(xlsx_path: Path):
 
         for col_idx, need_cat in enumerate(headers):
             cell_val = ws.cell(row=row, column=col_idx + 2).value
+            # Conditioner sheet only: normalize the 'Silikon' (typo, no trailing
+            # 'e') -> 'Silikone' before splitting, so the parser sees a single
+            # canonical spelling. Other matrices keep raw cell text untouched.
+            if is_conditioner and cell_val is not None:
+                cell_val = normalize_ingredient_paren(str(cell_val))
             for product_name in parse_cell_products(cell_val):
                 matrix[current_hair_texture][need_cat].append(product_name)
 
@@ -931,15 +985,19 @@ def convert_single_excel_matrix(xlsx_path: Path):
     )
     print(f"    {len(matrix)} hair textures, {len(headers)} need categories, {total_products} product entries")
 
-    generate_matrix_markdown(category, matrix)
-    generate_product_json(category, matrix)
+    generate_matrix_markdown(category, matrix, is_conditioner=is_conditioner)
+    generate_product_json(category, matrix, is_conditioner=is_conditioner)
 
 
-def generate_matrix_markdown(category: str, matrix: dict):
+def generate_matrix_markdown(category: str, matrix: dict, is_conditioner: bool = False):
     """Write one Markdown file per cell (hair_texture x concern) for precise RAG retrieval.
 
     Each file becomes a single chunk with rich metadata for hybrid search
     (metadata filtering + vector similarity).
+
+    For the conditioner matrix, trailing (Silikone)/(Kokos) annotations are
+    stripped from product names — the structured signal lives in the JSON
+    output's `ingredient_flags` field.
     """
     cat_slug = slugify(category)
     out_dir = MD_DIR / "products" / cat_slug
@@ -960,7 +1018,12 @@ def generate_matrix_markdown(category: str, matrix: dict):
             concern_display = concern_to_display(need_cat)
             filename = f"{hair_tag}-{concern_tag}.md"
 
-            product_list = ", ".join(products)
+            display_products = (
+                [parse_ingredient_flags(p)[0] for p in products]
+                if is_conditioner
+                else products
+            )
+            product_list = ", ".join(display_products)
             content = (
                 f"# {category} Produkte für {hair_display} bei {concern_display}\n\n"
                 f"Empfohlene {category}-Produkte für {hair_display} "
@@ -1001,8 +1064,13 @@ def guess_brand(product_name: str) -> str:
     return parts[0]
 
 
-def generate_product_json(category: str, matrix: dict):
-    """Write a JSON file for product catalog ingestion."""
+def generate_product_json(category: str, matrix: dict, is_conditioner: bool = False):
+    """Write a JSON file for product catalog ingestion.
+
+    For the conditioner matrix, the trailing (Silikone)/(Kokos) annotation is
+    stripped from `name` and surfaced as a structured `ingredient_flags` array
+    (`silicones` / `oils`). Empty array when no annotation was present.
+    """
     slug = slugify(category)
     out_dir = DATA_DIR / "products-from-excel"
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -1016,17 +1084,24 @@ def generate_product_json(category: str, matrix: dict):
             continue
         for need_cat, products in needs.items():
             concern_tag = concern_to_slug(need_cat)
-            for product_name in products:
-                if product_name not in product_map:
-                    product_map[product_name] = {
-                        "name": product_name,
-                        "brand": guess_brand(product_name),
+            for raw_name in products:
+                if is_conditioner:
+                    clean_name, flags = parse_ingredient_flags(raw_name)
+                else:
+                    clean_name, flags = raw_name, []
+                if clean_name not in product_map:
+                    entry = {
+                        "name": clean_name,
+                        "brand": guess_brand(clean_name),
                         "category": category,
                         "suitable_thicknesses": [],
                         "suitable_concerns": [],
                         "tags": [category.lower()],
                     }
-                entry = product_map[product_name]
+                    if is_conditioner:
+                        entry["ingredient_flags"] = flags
+                    product_map[clean_name] = entry
+                entry = product_map[clean_name]
                 if hair_tag not in entry["suitable_thicknesses"]:
                     entry["suitable_thicknesses"].append(hair_tag)
                 if concern_tag not in entry["suitable_concerns"]:

--- a/scripts/convert_sources.py
+++ b/scripts/convert_sources.py
@@ -1074,19 +1074,18 @@ def guess_brand(product_name: str) -> str:
     return parts[0]
 
 
-def generate_product_json(category: str, matrix: dict, is_conditioner_drogerie: bool = False):
-    """Write a JSON file for product catalog ingestion.
+def build_product_json_list(
+    category: str, matrix: dict, is_conditioner_drogerie: bool = False
+) -> list[dict]:
+    """Build the product JSON list (in memory, no IO).
 
     For the conditioner-drogerie matrix, the trailing (Silikone)/(Kokos)
     annotation is stripped from `name` and surfaced as a structured
     `ingredient_flags` array (`silicones` / `oils`). Empty array when no
-    annotation was present.
+    annotation was present. If the same stripped name appears in multiple
+    cells with DIFFERENT trailing parens, all flags are merged so the result
+    is order-independent.
     """
-    slug = slugify(category)
-    out_dir = DATA_DIR / "products-from-excel"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{slug}.json"
-
     product_map: dict[str, dict] = {}
 
     for hair_label, needs in matrix.items():
@@ -1110,15 +1109,84 @@ def generate_product_json(category: str, matrix: dict, is_conditioner_drogerie: 
                         "tags": [category.lower()],
                     }
                     if is_conditioner_drogerie:
-                        entry["ingredient_flags"] = flags
+                        entry["ingredient_flags"] = []
                     product_map[clean_name] = entry
                 entry = product_map[clean_name]
+                # Merge flags from this occurrence so that two cells with
+                # different trailing parens (e.g. one with (Silikone) and one
+                # with (Kokos)) both contribute to the product's flag list.
+                # This makes the parse order-independent.
+                if is_conditioner_drogerie:
+                    for f in flags:
+                        if f not in entry["ingredient_flags"]:
+                            entry["ingredient_flags"].append(f)
                 if hair_tag not in entry["suitable_thicknesses"]:
                     entry["suitable_thicknesses"].append(hair_tag)
                 if concern_tag not in entry["suitable_concerns"]:
                     entry["suitable_concerns"].append(concern_tag)
 
-    product_list = list(product_map.values())
+    return list(product_map.values())
+
+
+# Module-level smoke assert: same product appearing in two cells with different
+# trailing parens must merge both flags (order-independent parse).
+def _assert_ingredient_flags_merge_smoke():
+    matrix_two_cells = {
+        "Feine Haare": {
+            "Trockenheit": ["OGX Argan Oil (Silikone)"],
+            "Spliss": ["OGX Argan Oil (Kokos)"],
+        },
+    }
+    products = build_product_json_list(
+        "Conditioner (Drogerie)", matrix_two_cells, is_conditioner_drogerie=True
+    )
+    assert len(products) == 1, f"expected 1 merged product, got {len(products)}"
+    assert products[0]["name"] == "OGX Argan Oil"
+    # Both flags must be present after merge (set-equality — order depends on
+    # which cell is parsed first, but the latent bug was missing flags entirely,
+    # not flag ordering).
+    assert set(products[0]["ingredient_flags"]) == {"silicones", "oils"}, (
+        f"expected merged set {{silicones, oils}}, got {products[0]['ingredient_flags']}"
+    )
+
+    # Reverse cell order: same merge result.
+    matrix_reversed = {
+        "Feine Haare": {
+            "Spliss": ["OGX Argan Oil (Kokos)"],
+            "Trockenheit": ["OGX Argan Oil (Silikone)"],
+        },
+    }
+    products_rev = build_product_json_list(
+        "Conditioner (Drogerie)", matrix_reversed, is_conditioner_drogerie=True
+    )
+    assert set(products_rev[0]["ingredient_flags"]) == {"silicones", "oils"}
+
+    # Single-cell case: behavior unchanged — flags from that one cell are kept.
+    matrix_single = {
+        "Feine Haare": {
+            "Trockenheit": ["OGX Argan Oil (Silikone)"],
+        },
+    }
+    products_single = build_product_json_list(
+        "Conditioner (Drogerie)", matrix_single, is_conditioner_drogerie=True
+    )
+    assert products_single[0]["ingredient_flags"] == ["silicones"]
+
+
+_assert_ingredient_flags_merge_smoke()
+
+
+def generate_product_json(category: str, matrix: dict, is_conditioner_drogerie: bool = False):
+    """Write the product JSON file for catalog ingestion.
+
+    Wraps `build_product_json_list` with the file-writing side effect.
+    """
+    slug = slugify(category)
+    out_dir = DATA_DIR / "products-from-excel"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{slug}.json"
+
+    product_list = build_product_json_list(category, matrix, is_conditioner_drogerie=is_conditioner_drogerie)
     out_path.write_text(json.dumps(product_list, ensure_ascii=False, indent=2), encoding="utf-8")
     print(f"  -> {out_path.relative_to(BASE_DIR)} ({len(product_list)} products)")
 

--- a/scripts/convert_sources.py
+++ b/scripts/convert_sources.py
@@ -910,7 +910,11 @@ def convert_single_excel_matrix(xlsx_path: Path):
     """
     filename_stem = xlsx_path.stem  # e.g. "Produktliste Conditioner (Profi)"
     is_profi = "(Profi)" in filename_stem or "(profi)" in filename_stem
-    is_conditioner = "conditioner" in filename_stem.lower()
+    # Strip suffix + extract ingredient flags applies to the conditioner-drogerie matrix only.
+    # Profi conditioner sheets use a different convention; their parens (e.g. (Profi)) carry
+    # different meaning and must NOT be stripped by this parser.
+    stem = filename_stem.lower()
+    is_conditioner_drogerie = "conditioner" in stem and "drogerie" in stem
     category = filename_stem  # fallback: filename without extension
     print(f"\n  Processing: {filename_stem}")
 
@@ -976,10 +980,10 @@ def convert_single_excel_matrix(xlsx_path: Path):
 
         for col_idx, need_cat in enumerate(headers):
             cell_val = ws.cell(row=row, column=col_idx + 2).value
-            # Conditioner sheet only: normalize the 'Silikon' (typo, no trailing
-            # 'e') -> 'Silikone' before splitting, so the parser sees a single
-            # canonical spelling. Other matrices keep raw cell text untouched.
-            if is_conditioner and cell_val is not None:
+            # Conditioner-drogerie sheet only: normalize the 'Silikon' (typo, no
+            # trailing 'e') -> 'Silikone' before splitting, so the parser sees a
+            # single canonical spelling. Other matrices keep raw cell text untouched.
+            if is_conditioner_drogerie and cell_val is not None:
                 cell_val = normalize_ingredient_paren(str(cell_val))
             for product_name in parse_cell_products(cell_val):
                 matrix[current_hair_texture][need_cat].append(product_name)
@@ -991,18 +995,18 @@ def convert_single_excel_matrix(xlsx_path: Path):
     )
     print(f"    {len(matrix)} hair textures, {len(headers)} need categories, {total_products} product entries")
 
-    generate_matrix_markdown(category, matrix, is_conditioner=is_conditioner)
-    generate_product_json(category, matrix, is_conditioner=is_conditioner)
+    generate_matrix_markdown(category, matrix, is_conditioner_drogerie=is_conditioner_drogerie)
+    generate_product_json(category, matrix, is_conditioner_drogerie=is_conditioner_drogerie)
 
 
-def generate_matrix_markdown(category: str, matrix: dict, is_conditioner: bool = False):
+def generate_matrix_markdown(category: str, matrix: dict, is_conditioner_drogerie: bool = False):
     """Write one Markdown file per cell (hair_texture x concern) for precise RAG retrieval.
 
     Each file becomes a single chunk with rich metadata for hybrid search
     (metadata filtering + vector similarity).
 
-    For the conditioner matrix, trailing (Silikone)/(Kokos) annotations are
-    stripped from product names — the structured signal lives in the JSON
+    For the conditioner-drogerie matrix, trailing (Silikone)/(Kokos) annotations
+    are stripped from product names — the structured signal lives in the JSON
     output's `ingredient_flags` field.
     """
     cat_slug = slugify(category)
@@ -1026,7 +1030,7 @@ def generate_matrix_markdown(category: str, matrix: dict, is_conditioner: bool =
 
             display_products = (
                 [parse_ingredient_flags(p)[0] for p in products]
-                if is_conditioner
+                if is_conditioner_drogerie
                 else products
             )
             product_list = ", ".join(display_products)
@@ -1070,12 +1074,13 @@ def guess_brand(product_name: str) -> str:
     return parts[0]
 
 
-def generate_product_json(category: str, matrix: dict, is_conditioner: bool = False):
+def generate_product_json(category: str, matrix: dict, is_conditioner_drogerie: bool = False):
     """Write a JSON file for product catalog ingestion.
 
-    For the conditioner matrix, the trailing (Silikone)/(Kokos) annotation is
-    stripped from `name` and surfaced as a structured `ingredient_flags` array
-    (`silicones` / `oils`). Empty array when no annotation was present.
+    For the conditioner-drogerie matrix, the trailing (Silikone)/(Kokos)
+    annotation is stripped from `name` and surfaced as a structured
+    `ingredient_flags` array (`silicones` / `oils`). Empty array when no
+    annotation was present.
     """
     slug = slugify(category)
     out_dir = DATA_DIR / "products-from-excel"
@@ -1091,7 +1096,7 @@ def generate_product_json(category: str, matrix: dict, is_conditioner: bool = Fa
         for need_cat, products in needs.items():
             concern_tag = concern_to_slug(need_cat)
             for raw_name in products:
-                if is_conditioner:
+                if is_conditioner_drogerie:
                     clean_name, flags = parse_ingredient_flags(raw_name)
                 else:
                     clean_name, flags = raw_name, []
@@ -1104,7 +1109,7 @@ def generate_product_json(category: str, matrix: dict, is_conditioner: bool = Fa
                         "suitable_concerns": [],
                         "tags": [category.lower()],
                     }
-                    if is_conditioner:
+                    if is_conditioner_drogerie:
                         entry["ingredient_flags"] = flags
                     product_map[clean_name] = entry
                 entry = product_map[clean_name]

--- a/scripts/convert_sources.py
+++ b/scripts/convert_sources.py
@@ -799,7 +799,7 @@ def convert_excel_matrices():
 
 
 INGREDIENT_FLAG_TRAILING_PAREN = re.compile(
-    r"\s*\((Silikone|Kokos|Silikone\s*/\s*Kokos)\)\s*$",
+    r"\s*\(((?:Silikone|Kokos)(?:\s*/\s*(?:Silikone|Kokos))?)\)\s*$",
 )
 
 
@@ -842,6 +842,12 @@ assert parse_ingredient_flags("Pomelo Molecular Repair (Silikone)") == ("Pomelo 
 assert parse_ingredient_flags("Cantu Repair Cream (Kokos)") == ("Cantu Repair Cream", ["oils"])
 assert parse_ingredient_flags("OGX Renewing Argan Oil (Silikone /Kokos)") == ("OGX Renewing Argan Oil", ["silicones", "oils"])
 assert parse_ingredient_flags("Monday Moisture (Silikone / Kokos)") == ("Monday Moisture", ["silicones", "oils"])
+# Reverse-order annotation: body lookup is order-independent (Silikone-first then Kokos),
+# so the flags list stays in canonical [silicones, oils] order regardless of input order.
+assert parse_ingredient_flags("OGX (Kokos / Silikone)") == ("OGX", ["silicones", "oils"])
+assert parse_ingredient_flags("OGX (Kokos /Silikone)") == ("OGX", ["silicones", "oils"])
+assert parse_ingredient_flags("OGX (silikone)") == ("OGX (silikone)", [])  # case-sensitive: don't strip lowercase
+assert parse_ingredient_flags("OGX") == ("OGX", [])  # no parens
 assert parse_ingredient_flags("Plain Name") == ("Plain Name", [])
 assert parse_ingredient_flags("Garnier (Drogerie)") == ("Garnier (Drogerie)", [])  # don't strip non-ingredient parens
 

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -5,7 +5,10 @@ import { generateEmbedding } from "@/lib/openai/embeddings"
 import { ERR_UNAUTHORIZED, ERR_FORBIDDEN, ERR_INVALID_DATA, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
 import { isBondbuilderCategory, type ProductBondbuilderSpecs } from "@/lib/bondbuilder/constants"
-import { isConditionerCategory, type ProductConditionerSpecs } from "@/lib/conditioner/constants"
+import {
+  isConditionerCategory,
+  type ProductConditionerRerankSpecs,
+} from "@/lib/conditioner/constants"
 import {
   isDeepCleansingShampooCategory,
   type ProductDeepCleansingShampooSpecs,
@@ -77,7 +80,7 @@ export async function GET() {
     .filter((product) => isPeelingCategory(product.category))
     .map((product) => product.id)
 
-  let conditionerSpecsByProductId = new Map<string, ProductConditionerSpecs>()
+  let conditionerSpecsByProductId = new Map<string, ProductConditionerRerankSpecs>()
   let shampooPairsByProductId = new Map<string, ShampooBucketPair[]>()
   if (shampooIds.length > 0) {
     const adminClient = createAdminClient()
@@ -121,7 +124,7 @@ export async function GET() {
       .in("product_id", conditionerIds)
 
     conditionerSpecsByProductId = new Map(
-      ((specs || []) as ProductConditionerSpecs[]).map((spec) => [spec.product_id, spec]),
+      ((specs || []) as ProductConditionerRerankSpecs[]).map((spec) => [spec.product_id, spec]),
     )
   }
 

--- a/src/lib/conditioner/constants.ts
+++ b/src/lib/conditioner/constants.ts
@@ -38,3 +38,22 @@ export function isConditionerCategory(category: string | null | undefined): bool
   const normalized = category.trim().toLowerCase()
   return normalized.startsWith("conditioner")
 }
+
+export const CONDITIONER_INGREDIENT_FLAGS = [
+  "silicones",
+  "polymers",
+  "oils",
+  "proteins",
+  "humectants",
+] as const
+export type ConditionerIngredientFlag = (typeof CONDITIONER_INGREDIENT_FLAGS)[number]
+
+export interface ProductConditionerRerankSpecs {
+  product_id: string
+  weight: ConditionerWeight
+  repair_level: ConditionerRepairLevel
+  balance_direction: ProductBalanceTarget | null
+  ingredient_flags: ConditionerIngredientFlag[]
+  created_at?: string
+  updated_at?: string
+}

--- a/src/lib/recommendation-engine/selection.ts
+++ b/src/lib/recommendation-engine/selection.ts
@@ -16,7 +16,7 @@ import type {
   PeelingRecommendationMetadata,
   ShampooRecommendationMetadata,
 } from "@/lib/types"
-import type { ProductConditionerSpecs } from "@/lib/conditioner/constants"
+import type { ProductConditionerRerankSpecs } from "@/lib/conditioner/constants"
 import type { LeaveInNeedBucket } from "@/lib/leave-in/constants"
 import type { ProductMaskSpecs } from "@/lib/mask/constants"
 import { OIL_PURPOSE_LABELS, type OilPurpose, type OilSubtype } from "@/lib/oil/constants"
@@ -310,7 +310,7 @@ function buildConditionerUsageHint(decision: ConditionerCategoryDecision): strin
 
 export function rerankConditionerProductsWithEngine(params: {
   candidates: MatchedProduct[]
-  specs: ProductConditionerSpecs[]
+  specs: ProductConditionerRerankSpecs[]
   decision: ConditionerCategoryDecision
   hairProfile: HairProfile | null
 }): MatchedProduct[] {
@@ -1024,7 +1024,7 @@ export async function selectConditionerProductsWithEngine(params: {
 
   return rerankConditionerProductsWithEngine({
     candidates,
-    specs: (specs ?? []) as ProductConditionerSpecs[],
+    specs: (specs ?? []) as ProductConditionerRerankSpecs[],
     decision,
     hairProfile,
   })

--- a/supabase/migrations/20260428094913_add_conditioner_ingredient_flags.sql
+++ b/supabase/migrations/20260428094913_add_conditioner_ingredient_flags.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.product_conditioner_rerank_specs
+  ADD COLUMN ingredient_flags text[] NOT NULL DEFAULT '{}'
+  CHECK (
+    ingredient_flags <@ ARRAY['silicones','polymers','oils','proteins','humectants']
+  );

--- a/supabase/migrations/20260428134233_add_conditioner_ingredient_flags_gin_index.sql
+++ b/supabase/migrations/20260428134233_add_conditioner_ingredient_flags_gin_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_product_conditioner_rerank_specs_ingredient_flags
+  ON public.product_conditioner_rerank_specs USING gin (ingredient_flags);

--- a/tests/conditioner-chat-e2e.spec.ts
+++ b/tests/conditioner-chat-e2e.spec.ts
@@ -17,7 +17,7 @@ const admin = createClient(supabaseUrl, serviceRoleKey, {
 const SEEDED_CONDITIONER_NAMES = [
   "Balea Natural Beauty Hibiskus",
   "Sante Intense Hydrating Conditioner",
-  "Pantene Hydra Glow (Silikone)",
+  "Pantene Hydra Glow",
 ] as const
 
 type AssistantMessageRecord = {
@@ -236,7 +236,7 @@ test.describe.serial("Conditioner chat E2E", () => {
         repair_level: "high",
       },
       {
-        product_id: specsByName.get("Pantene Hydra Glow (Silikone)"),
+        product_id: specsByName.get("Pantene Hydra Glow"),
         weight: "rich",
         repair_level: "low",
       },

--- a/tests/recommendation-engine-selection.test.ts
+++ b/tests/recommendation-engine-selection.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import test from "node:test"
 
 import type { ProductBondbuilderSpecs } from "../src/lib/bondbuilder/constants"
-import type { ProductConditionerSpecs } from "../src/lib/conditioner/constants"
+import type { ProductConditionerRerankSpecs } from "../src/lib/conditioner/constants"
 import type { ProductDeepCleansingShampooSpecs } from "../src/lib/deep-cleansing-shampoo/constants"
 import type { ProductDryShampooSpecs } from "../src/lib/dry-shampoo/constants"
 import type { ProductLeaveInSpecs } from "../src/lib/leave-in/constants"
@@ -77,18 +77,20 @@ test("engine conditioner reranking prefers explicit target fit over higher seman
     createMatchedProduct("mismatch", "Conditioner", { combined_score: 0.88 }),
   ]
 
-  const specs: ProductConditionerSpecs[] = [
+  const specs: ProductConditionerRerankSpecs[] = [
     {
       product_id: "ideal",
       weight: "medium",
       repair_level: "high",
       balance_direction: "moisture",
+      ingredient_flags: [],
     },
     {
       product_id: "mismatch",
       weight: "rich",
       repair_level: "low",
       balance_direction: "protein",
+      ingredient_flags: [],
     },
   ]
 


### PR DESCRIPTION
## Summary

Moves `(Silikone)` / `(Kokos)` annotations out of `products.name` text and into a structured `ingredient_flags text[]` column on `product_conditioner_rerank_specs`, mirroring the existing leave-in pattern. Kokos→oils per leave-in convention. 26 of 43 active conditioner rows had suffixes; all renamed in DB; `ingredient_flags` populated.

## Why

The user asked for the same logic that exists for leave-ins to be applied to conditioners. Today the silicone/coconut indicator is text inside the product name, which is brittle for any future "silicone-free" filter and inconsistent with how leave-ins handle the same signal. This PR moves it to a typed column with a CHECK constraint and a GIN index.

## Changes

- **Schema (2 migrations)**: new `ingredient_flags text[] NOT NULL DEFAULT '{}'` column with CHECK over `silicones, polymers, oils, proteins, humectants`; GIN index for future queries.
- **Domain types**: new `CONDITIONER_INGREDIENT_FLAGS` const + `ProductConditionerRerankSpecs` interface in `src/lib/conditioner/constants.ts`. Two production callsites (`selection.ts`, `admin/products/route.ts`) now cast to the new type.
- **Python parser**: `normalize_ingredient_paren()` collapses `Silikon` → `Silikone` typo. `parse_ingredient_flags()` strips the trailing paren and returns `(stripped_name, flags)`. Wired into the conditioner-drogerie matrix only — does not affect other categories. Order-independent merge across multiple cell occurrences. Module-level smoke asserts run on every import.
- **Backfill script**: 26 keys lose their suffix; all 43 entries gain `ingredient_flags`. Strict `length === 1` assertion on `suitable_concerns` was relaxed to `length >= 1` (pre-existing over-strictness; the function only consumes `[0]`).
- **DB**: 26 `products.name` rows renamed via id-stable UPDATE with backup table `products_name_backup_2026_04_28` (retained until merge). Conditioner `content_chunks` rebuilt from regenerated JSON.
- **Tests**: `tests/conditioner-chat-e2e.spec.ts` updated to use stripped name.

## Live-DB state (verified)

| Check | Value | Expected |
|---|---|---|
| Suffixed conditioner names | 0 | 0 |
| Conditioners with `ingredient_flags` populated | 26 | 26 |
| Total active conditioners | 43 | 43 |
| Suffixed conditioner content_chunks | 0 | 0 |
| `silicones` only / `oils` only / both / empty | 17 / 6 / 3 / 17 | 17 / 6 / 3 / 17 |
| GIN index | present | present |
| Backup table rows | 43 | 43 |

## Reviews

- **Codex (`/codex:rescue` full-branch)**: code-level findings all OK; live-DB items unverifiable from its env, separately verified by me — all green.
- **`code-reviewer` agent**: APPROVED with optional fixes. All 5 worth-doing items applied:
  1. Multi-cell flag merge (order-independent)
  2. Tightened `is_conditioner_drogerie` filename match
  3. New type wired into 2 production callsites + test fixture
  4. Reverse-order `(Kokos / Silikone)` regex case + asserts
  5. GIN index migration

## Test plan

- [x] `npm run ci:verify` (typecheck + lint + build) — passes
- [ ] `npm run test:chat` — currently fails for ALL fixtures because of pre-existing Stripe paywall middleware redirecting eval traffic to `/pricing`. Not a regression from this PR (verified by `git diff origin/main...HEAD --stat` — no auth/middleware/eval changes). Should be filed as a separate ticket against the eval harness.
- [x] Manual sanity SQL checks (above table) — all green
- [ ] Verify in dev/prod that conditioner recommendations render clean names (no `(Silikone)` / `(Kokos)` in the chat UI)

## Out-of-scope follow-ups

1. Same cleanup for **leave-in / mask / oil** categories (28 / 2 / 18 rows still carry suffixes). The Python parser is gated to conditioner-drogerie only by design.
2. **Extend `scripts/ingest-products.ts`** to write `product_conditioner_rerank_specs` directly. Currently only the standalone backfill script populates this table. Discussed and deferred during planning.
3. **Drop `products_name_backup_2026_04_28`** after this merges and prod is verified.
4. **Fix `npm run test:chat`** infrastructure rot (Stripe paywall blocking eval users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)