### PR TITLE
fix(mobile): stabilize quiz and chat layouts

### DIFF
--- a/plans/2026-04-28-mobile-ux-optimization.md
+++ b/plans/2026-04-28-mobile-ux-optimization.md
@@ -1,0 +1,232 @@
+# Mobile UX Optimization Plan
+
+Date: 2026-04-28
+Branch: `codex/mobile-ux-optimization`
+Scope: mobile UX audit and implementation plan for the current Hair Concierge app, based on source review plus Playwright mobile checks at 375x667 and 390x844.
+
+## Audit Summary
+
+The app is not starting from zero on mobile. The quiz and onboarding use mobile-first cards, `100dvh`, touch-sized primary actions, mobile-only navigation, and safe-area padding in the chat input. The biggest mobile risks are inconsistent behavior across flows and dense desktop-derived surfaces rather than a missing responsive baseline.
+
+Observed journeys:
+
+- Public unauthenticated routes `/`, `/chat`, `/profile`, and `/onboarding` redirect to `/quiz`.
+- Full quiz journey through result was tested on iPhone SE and iPhone 13 viewports with quiz lead/analyze APIs intercepted.
+- Authenticated `/chat` and `/profile` were tested with a temporary Supabase user, seeded active subscription/profile data, mocked chat stream, and cleanup after the run.
+
+Top issues:
+
+1. Quiz step transitions preserve the old inner scroll-pane position. After selecting lower concern cards, the goals step opens mid-page with the heading and progress above the viewport. The fix must target the quiz layout scroll containers, not only `window`.
+2. Chat content can be cut off because flex children keep their default `min-width: auto`. The page may not show document-level horizontal overflow because the message pane clips it, but the visible symptom is a pushed-offscreen send button or clipped product cards after long prompts.
+3. Profile is technically responsive but too long and heavy for mobile. The measured 4,828px seeded complete profile is on top of the just-merged Profile Editorial v3 refactor (`588126f`, PR #51), so any profile work must preserve v3 intent and should not be bundled into the first mobile bugfix slice.
+4. The empty chat screen underuses the first viewport on small phones. Only one starter prompt is visible above the input on iPhone SE.
+5. Several secondary tap targets are under 44px high, especially feedback icons, consent secondary action, footer links, and small text links.
+6. Some authenticated UI copy still uses ASCII fallbacks (`zurueck`, `ungueltig`, `moeglich`). These are real German-correctness bugs, but they are not mobile-specific and should be split into a tiny separate PR.
+
+## Branch Hygiene
+
+Before implementation or push:
+
+1. Run `git fetch origin`.
+2. Rebase or recreate the worktree from `origin/main`.
+3. Confirm `git diff --stat origin/main...HEAD` only contains the intended mobile UX files.
+4. Keep the root checkout's unrelated backend work untouched.
+
+Current note: this planning worktree is based on `origin/main` and currently only adds this plan file. The hygiene step remains mandatory before converting the plan into an implementation branch.
+
+## Options
+
+| Approach | Complexity | Effort | Tradeoffs | Best when... |
+|----------|------------|--------|-----------|--------------|
+| A: Bugfix Pass | Low | 0.5-1 day | Fixes observed breakage quickly; does not improve first-viewport polish or profile density. | We need fast stabilization before continuing backend work. |
+| B: Flow Polish Sprint | Medium | 2-3 days | Fixes quiz/chat bugs, improves quiz/chat first-viewport quality, and adds mobile regression coverage. Profile v3 density is deferred. | We want visible mobile improvement without pausing product logic work. |
+| C: Mobile-First Redesign Pass | High | 1-2 weeks | Best long-term UX, but high review risk across quiz, chat, profile, auth, and result. | We are ready to treat mobile as the primary product surface before launch. |
+
+Recommended path: Approach B. It fixes the real blockers first, gives mobile users a much better first impression, and avoids colliding with the very recent Profile Editorial v3 work.
+
+## Implementation Plan
+
+### Phase 1: Mobile Correctness And Viewport Stability
+
+Goal: eliminate observed mobile breakage before visual redesign.
+
+- Add a centralized quiz step-change reset that targets the actual scroll containers.
+  - Current trigger points: `src/lib/quiz/store.ts` uses `STEP_ORDER` and `goNext`/`goBack`; quiz screens call those directly.
+  - Current scroll container: `src/app/quiz/layout.tsx` uses an inner pane (`w-full overflow-y-auto md:w-1/2`) for steps 1-10/12/14 and a separate result wrapper for step 11.
+  - Required implementation shape: give both quiz layout branches a scroll-container ref, listen to `step`, and call `containerRef.current?.scrollTo({ top: 0 })` after step changes. Keep `window.scrollTo({ top: 0 })` only as a fallback.
+  - Accessibility requirement: after the scroll reset, move focus to the new step heading with `preventScroll: true`. Add `tabIndex={-1}` to step headings through the shared shell or temporary programmatic focus handling. Do not leave screen-reader context on the previous step's `Weiter` button.
+  - Verify specifically: concerns selected near bottom -> Weiter -> goals step starts at progress/header, and the heading is visible in the first 200px of the scroll container.
+
+- Fix chat input flex clipping.
+  - Current source: `src/components/chat/chat-input.tsx`.
+  - Add `min-w-0` to the input row and textarea, keep the send button visible, and cap textarea height without forcing min-content width.
+  - Verification must include a long unbreakable token, not only normal German prose.
+
+- Constrain chat message/product card widths.
+  - Current source: `src/components/chat/chat-message.tsx`, `src/components/chat/product-card.tsx`, and the message wrapper in `src/components/chat/chat-container.tsx`.
+  - Add `min-w-0`/`w-full` constraints where message content and product cards nest; ensure product cards do not clip price or reason text.
+  - Increase feedback tap targets to at least 44x44 while keeping the icons visually quiet.
+
+- Do not spend Phase 1 on decorative radial overflow unless a failing measurement proves it is user-visible.
+  - `chat-container.tsx` already clips the message pane with `overflow-x-hidden`; the decorative `w-[120%]` layer should not drive scope.
+
+Verification for Phase 1:
+
+- Playwright mobile scripted journey at 375x667 and 390x844.
+- After the quiz reset, assert the scroll container is at top and the active step heading is within the first 200px of the visible pane.
+- For chat, assert the send button is visible and fully inside the viewport after typing a long unbreakable token.
+- Assert product cards and assistant text are not clipped inside the visible message area.
+- Assert key touch targets are at least 44px high except intentionally inline text links.
+
+### Phase 2: Quiz And Result Mobile Polish
+
+Goal: make the quiz feel intentionally mobile-first rather than just responsive. This phase starts only after Phase 1 chooses and implements the scroll-container strategy, because sticky actions depend on that container behavior.
+
+- Keep progress labels user-facing, not raw store-step-facing.
+  - Resolved decision: never expose raw `STEP_ORDER` numbers to users. The internal order (`1,2,3,4,5,7,6,8,12,9,10,11,14`) may remain internal.
+  - Question screens should continue to show question position over `QUIZ_TOTAL_QUESTIONS`. Non-question states should either show completion/full progress or no progress, never raw step numbers that appear to jump backward.
+
+- Make quiz step headers more compact on small phones.
+  - Current source: shared pattern in `src/components/quiz/quiz-question.tsx`, `quiz-scalp-question.tsx`, `quiz-concerns-question.tsx`, and `quiz-goals.tsx`.
+  - Extract a light shared question shell only if it reduces repeated progress/back/title/focus/scroll behavior. Do not create a broad design-system abstraction.
+
+- Stabilize primary actions on long quiz steps.
+  - Concern and goals steps can exceed one viewport.
+  - If sticky bottom actions are used, attach them to the chosen scroll pane and add bottom padding so content is not hidden under the action area.
+
+- Rework the goals step for small phones.
+  - Current two-column cards are large.
+  - Keep two columns if labels remain readable, but reduce vertical card height and remove redundant `Ziel` labels on every card. Selected state can use icon/check treatment instead.
+
+- Reduce landing-page vertical pressure.
+  - Current source: `src/components/quiz/quiz-landing.tsx`.
+  - On 375x667, the H1 and bullet stack push the login link to the bottom edge. Shorten the H1 line-height/size slightly on small phones or reduce bullet spacing so CTA, reassurance, and returning-user link breathe.
+
+- Check result cards for mobile scanability.
+  - Current source: `src/components/quiz/quiz-results-view.tsx`.
+  - The result is visually strong, but each spectrum card is dense. Prefer small spacing and text-density adjustments before introducing expand/collapse behavior.
+
+Verification for Phase 2:
+
+- Complete quiz on iPhone SE without hidden first content, clipped buttons, or inherited scroll.
+- Confirm progress copy never exposes raw store-step jumps.
+- Confirm result CTA remains visible after a reasonable first scroll and all result labels fit without overlap.
+
+### Phase 3: Chat Mobile Experience
+
+Goal: improve the mobile chat's first-use usefulness and keep conversation reading comfortable.
+
+- Compact the empty chat state.
+  - Current source: `src/components/chat/chat-container.tsx`.
+  - Reduce top hero height on small screens so at least 2-3 starter prompts are visible above the input on iPhone SE.
+  - Consider horizontal prompt chips or a two-row compact prompt list on mobile.
+
+- Make the mobile chat header do more work.
+  - Current source: app `Header` plus chat's own mobile header.
+  - The app header and chat subheader consume significant vertical space together. Evaluate whether `/chat` should use a more compact combined mobile header.
+
+- Improve product recommendations in chat.
+  - Current product cards must fit fully inside the assistant column.
+  - If product recommendations are core on mobile, consider a full-width recommendation stack below assistant text rather than inside the 80% bubble column.
+
+- Preserve input ergonomics.
+  - Keep safe-area padding.
+  - Do not drop mobile input/textarea font size below 16px; `text-base md:text-sm` prevents iOS focus zoom.
+  - Ensure send button remains visible for long typed messages and after sending.
+  - Confirm textarea does not occlude the latest assistant response.
+
+- Add live-state accessibility where chat updates are asynchronous.
+  - Ensure streaming/loading indicators use an appropriate `aria-live`/status pattern so mobile screen-reader users know a response is in progress.
+
+Verification for Phase 3:
+
+- Mobile chat with empty state, long user prompt, assistant paragraph, two product cards, feedback controls, and sidebar.
+- Manual visual review at 375x667 and 390x844.
+- Automated send-button bounds and card-clipping assertions, not only document `scrollWidth`.
+
+### Phase 4: Profile Editorial v3 Mobile Density Follow-Up
+
+Status: defer from Approach B unless separately approved after Tom Review.
+
+Goal: make `/profile` more usable on mobile without undoing the just-shipped Profile Editorial v3 hierarchy.
+
+Context:
+
+- Profile Editorial v3 was just merged in `588126f` / PR #51.
+- `src/app/profile/page.tsx` is large and sensitive; a restructure is not a 2-3 day mobile polish add-on.
+- Existing visual reference: `docs/mockups/profile-editorial-v3-applied.html`.
+
+Recommended direction for the follow-up:
+
+- Treat this as a v3 mobile-density pass, not a redesign.
+- Preserve v3 typography, section hierarchy, and editorial intent.
+- Use a compact dashboard of section status rows at the top, then keep v3 detail sections behind mobile accordions. Avoid bottom-sheet editing as the first version unless Tom Review specifically wants it.
+- Keep direct editing, but place edit controls inside the relevant expanded section.
+
+Required decision before implementation:
+
+- Confirm the profile pattern: compact dashboard plus mobile accordions is the recommended default. If Tom Review chooses detail pages or bottom-sheet editing instead, write a separate profile-specific plan and effort estimate.
+
+Verification for the follow-up:
+
+- Capture baseline heights for both a seeded complete profile and a partial/new-user profile before changing anything.
+- Seeded complete profile at iPhone SE should show profile title plus multiple section statuses in the first viewport.
+- Full profile height should drop materially from the current roughly 4,828px seeded complete-profile run without losing access to v3 details.
+- Editing routes from product, goals, and quiz fields still land on the correct screens and return to profile.
+
+### Phase 5: Shared Mobile QA Harness
+
+Goal: keep the mobile work from regressing while backend logic evolves.
+
+- Add a focused Playwright mobile smoke spec.
+  - Existing `playwright.config.ts` currently uses a single chromium desktop-like project and `trace: "on-first-retry"`; add explicit mobile viewports/devices for this focused spec rather than assuming screenshots are already configured.
+  - Public path: quiz landing -> several steps -> long concern selection -> goals transition.
+  - Authenticated path: seeded ready user -> chat empty -> mocked chat response -> profile first viewport.
+
+- Add utility assertions:
+  - Quiz active scroll container resets and heading lands within the first 200px.
+  - Chat send button remains fully in viewport after a long unbreakable token.
+  - Product recommendation cards are not clipped.
+  - Visible action buttons are at least 44px high where they are standalone controls.
+
+- Save screenshots on failure or targeted local audit runs; do not add noisy always-on screenshot artifacts to CI.
+
+## File Map
+
+- Quiz shell and flow: `src/app/quiz/layout.tsx`, `src/lib/quiz/store.ts`, `src/components/quiz/*`
+- Quiz result: `src/components/quiz/quiz-results-view.tsx`
+- Chat layout: `src/components/chat/chat-container.tsx`
+- Chat input: `src/components/chat/chat-input.tsx`
+- Chat messages and recommendations: `src/components/chat/chat-message.tsx`, `src/components/chat/product-card.tsx`, `src/components/chat/product-detail-drawer.tsx`
+- Profile v3 follow-up: `src/app/profile/page.tsx`, `docs/mockups/profile-editorial-v3-applied.html`
+- Header/auth polish: `src/components/layout/header.tsx`, `src/app/auth/page.tsx`, `src/components/auth/auth-form.tsx`
+- Tests: new focused mobile Playwright spec under `tests/`
+
+## Non-Goals
+
+- Do not redesign backend recommendation logic in this mobile UX pass.
+- Do not change product recommendation rules unless a mobile UI issue exposes missing metadata.
+- Do not rebuild the whole design system. Use local patterns and only extract shared shells where they reduce duplication across quiz screens.
+- Do not add external UI libraries for mobile behavior.
+- Do not bundle ASCII-fallback German copy cleanup into the mobile branch; handle it as a separate small PR.
+- Do not restructure Profile Editorial v3 in Approach B; keep that as a follow-up after Tom Review.
+
+## Resolved Decisions
+
+- First implementation path: Approach B without Profile Phase 4.
+- Quiz scroll reset must target the inner quiz scroll containers and manage heading focus.
+- Chat clipping is a flex shrink/min-width bug; document-level horizontal overflow assertions are insufficient.
+- Progress labels must represent user-facing question position, not raw internal store steps.
+- Profile work defaults to a v3 mobile-density follow-up using compact dashboard plus accordions, pending Tom Review.
+
+## Recommended First Implementation Slice
+
+Implement Phases 1, 2, 3, and 5. Keep Phase 4 as a separately reviewed v3 follow-up.
+
+1. Add quiz step scroll reset on the actual layout scroll containers, plus heading focus management.
+2. Fix chat input and message/product-card flex clipping.
+3. Increase feedback and secondary standalone touch targets where they are currently under 44px.
+4. Add focused Playwright mobile regression coverage for the exact observed bugs.
+5. Make modest quiz/chat first-viewport polish only after the correctness fixes are green.
+
+This is the smallest slice that removes observed broken states and gives us reliable test coverage before larger profile/result design work.

--- a/src/app/quiz/layout.tsx
+++ b/src/app/quiz/layout.tsx
@@ -2,14 +2,39 @@
 
 import { useQuizStore } from "@/lib/quiz/store"
 import { QuizBrandPanel } from "@/components/quiz/quiz-brand-panel"
+import { useEffect, useRef } from "react"
 
 export default function QuizLayout({ children }: { children: React.ReactNode }) {
   const step = useQuizStore((s) => s.step)
+  const standardScrollRef = useRef<HTMLDivElement>(null)
+  const resultScrollRef = useRef<HTMLDivElement>(null)
+  const previousStepRef = useRef(step)
+
+  useEffect(() => {
+    if (previousStepRef.current === step) return
+    previousStepRef.current = step
+
+    const frame = window.requestAnimationFrame(() => {
+      const container = step === 11 ? resultScrollRef.current : standardScrollRef.current
+      container?.scrollTo({ top: 0 })
+      window.scrollTo({ top: 0 })
+
+      const heading = container?.querySelector<HTMLElement>("h1, h2")
+      if (heading) {
+        if (!heading.hasAttribute("tabindex")) {
+          heading.setAttribute("tabindex", "-1")
+        }
+        heading.focus({ preventScroll: true })
+      }
+    })
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [step])
 
   // Results page (step 11): full-width centered layout, no brand panel
   if (step === 11) {
     return (
-      <div className="min-h-[100dvh] bg-background overflow-y-auto">
+      <div ref={resultScrollRef} className="min-h-[100dvh] overflow-y-auto bg-background">
         <div className="mx-auto max-w-[960px] px-5 py-8 md:px-10 md:py-12">{children}</div>
       </div>
     )
@@ -23,7 +48,7 @@ export default function QuizLayout({ children }: { children: React.ReactNode }) 
       </div>
 
       {/* Right panel — quiz content (full-width on mobile) */}
-      <div className="w-full overflow-y-auto md:w-1/2">
+      <div ref={standardScrollRef} className="w-full overflow-y-auto md:w-1/2">
         <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">{children}</div>
       </div>
     </div>

--- a/src/components/chat/chat-container.tsx
+++ b/src/components/chat/chat-container.tsx
@@ -216,7 +216,7 @@ export function ChatContainer() {
       )}
 
       {/* Main Chat Area */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         {/* Mobile header */}
         <div className="flex items-center gap-2 border-b p-3 md:hidden">
           <button
@@ -232,7 +232,7 @@ export function ChatContainer() {
         </div>
 
         {/* Messages */}
-        <div className="relative flex-1 overflow-y-auto overflow-x-hidden">
+        <div className="relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
           {/* Atmospheric layers */}
           <div
             className="pointer-events-none absolute inset-0 opacity-[0.015]"
@@ -290,7 +290,7 @@ export function ChatContainer() {
               </div>
             </div>
           ) : (
-            <div className="relative z-[1] mx-auto max-w-3xl space-y-4 p-4">
+            <div className="relative z-[1] mx-auto w-full max-w-3xl space-y-4 p-4">
               {messages.map((msg, idx) => {
                 // Don't render empty assistant placeholder — streaming indicator handles it
                 if (msg.role === "assistant" && !msg.content) return null

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -41,7 +41,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
 
   return (
     <div className="bg-background p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-[0_-2px_12px_rgba(0,0,0,0.04)]">
-      <div className="flex items-end gap-2">
+      <div className="flex min-w-0 items-end gap-2">
         {/* Text input */}
         <textarea
           ref={textareaRef}
@@ -52,7 +52,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           onInput={handleTextareaInput}
           placeholder="Stelle eine Frage zu deinen Haaren..."
           disabled={disabled}
-          className="max-h-[200px] min-h-[40px] flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-base md:text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          className="max-h-[200px] min-h-[40px] min-w-0 flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-base md:text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
           rows={1}
         />
 

--- a/src/components/chat/chat-loading-indicator.tsx
+++ b/src/components/chat/chat-loading-indicator.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { CombIcon } from "@/components/ui/comb-icon"
+import { useMemo } from "react"
 
 const LOADING_MESSAGES = [
   "Durchkämmen...",
@@ -20,10 +21,10 @@ function pickRandomMessage() {
 }
 
 export function ChatLoadingIndicator() {
-  const message = pickRandomMessage()
+  const message = useMemo(() => pickRandomMessage(), [])
 
   return (
-    <div className="flex gap-3 animate-fade-in-up-fast">
+    <div className="flex animate-fade-in-up-fast gap-3" role="status" aria-live="polite">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-[0_2px_8px_rgba(var(--brand-plum-rgb),0.25)]">
         <CombIcon className="h-4 w-4 text-primary-foreground" />
       </div>

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -295,7 +295,7 @@ export function ChatMessage({
   return (
     <div
       data-testid={isUser ? "message-user" : "message-assistant"}
-      className={`flex gap-3 ${isUser ? "flex-row-reverse" : "flex-row"}${isNew ? " animate-fade-in-up-fast" : ""}`}
+      className={`flex min-w-0 gap-3 ${isUser ? "flex-row-reverse" : "flex-row"}${isNew ? " animate-fade-in-up-fast" : ""}`}
     >
       {/* Avatar */}
       <div
@@ -310,19 +310,19 @@ export function ChatMessage({
 
       {/* Content */}
       <div
-        className={`flex max-w-[80%] flex-col space-y-2 ${isUser ? "items-end" : "items-start"}`}
+        className={`flex min-w-0 max-w-[80%] flex-col space-y-2 ${isUser ? "items-end" : "items-start"}`}
       >
         {/* Text content */}
         {message.content && (
           <div
-            className={`rounded-2xl px-4 py-2.5 shadow-sm ${
+            className={`max-w-full overflow-hidden rounded-2xl px-4 py-2.5 shadow-sm ${
               isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
             }`}
           >
             {isUser ? (
-              <p className="type-body-sm whitespace-pre-wrap">{message.content}</p>
+              <p className="type-body-sm whitespace-pre-wrap break-words">{message.content}</p>
             ) : (
-              <div className="prose prose-sm max-w-none">
+              <div className="prose prose-sm max-w-none break-words">
                 <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                   {renumberedContent}
                 </ReactMarkdown>
@@ -350,11 +350,11 @@ export function ChatMessage({
 
         {/* Product recommendation cards */}
         {products.length > 0 && onProductClick && (
-          <div className="flex flex-col gap-1.5 pt-1">
+          <div className="flex w-full min-w-0 max-w-full flex-col gap-1.5 pt-1">
             {visibleProducts.map((p, i) => (
               <div
                 key={p.id}
-                className="animate-fade-in-up-fast"
+                className="min-w-0 animate-fade-in-up-fast"
                 style={{ animationDelay: `${i * 100}ms` }}
               >
                 <ProductCard product={p} onClick={onProductClick} />
@@ -374,7 +374,7 @@ export function ChatMessage({
 
         {/* Timestamp */}
         {message.created_at && (
-          <div className="flex items-center gap-2 px-1">
+          <div className="flex min-w-0 items-center gap-2 px-1">
             <span className="type-caption text-muted-foreground">
               {format(new Date(message.created_at), "HH:mm")}
             </span>
@@ -390,7 +390,7 @@ export function ChatMessage({
                       setIsSubmittingFeedback(false)
                     }
                   }}
-                  className={`rounded-full p-1 transition-colors ${
+                  className={`flex h-11 w-11 items-center justify-center rounded-full transition-colors ${
                     message.user_feedback_score === 1
                       ? "bg-emerald-500/10 text-emerald-700"
                       : "text-muted-foreground hover:bg-accent hover:text-foreground"
@@ -410,7 +410,7 @@ export function ChatMessage({
                       setIsSubmittingFeedback(false)
                     }
                   }}
-                  className={`rounded-full p-1 transition-colors ${
+                  className={`flex h-11 w-11 items-center justify-center rounded-full transition-colors ${
                     message.user_feedback_score === -1
                       ? "bg-rose-500/10 text-rose-700"
                       : "text-muted-foreground hover:bg-accent hover:text-foreground"

--- a/src/components/chat/product-card.tsx
+++ b/src/components/chat/product-card.tsx
@@ -38,7 +38,7 @@ export function ProductCard({ product, onClick }: ProductCardProps) {
     <button
       type="button"
       onClick={() => onClick(product)}
-      className="flex w-full cursor-pointer items-center gap-3 rounded-xl border border-border bg-card p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
+      className="flex w-full min-w-0 cursor-pointer items-center gap-3 overflow-hidden rounded-xl border border-border bg-card p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
     >
       {/* Category icon */}
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[var(--brand-plum-ice)]">
@@ -53,7 +53,11 @@ export function ProductCard({ product, onClick }: ProductCardProps) {
         {product.brand && (
           <p className="truncate text-[11px] text-[var(--text-caption)]">{product.brand}</p>
         )}
-        {topReason && <p className="mt-0.5 truncate text-[11px] text-primary">{topReason}</p>}
+        {topReason && (
+          <p className="mt-0.5 whitespace-normal break-words text-[11px] leading-snug text-primary">
+            {topReason}
+          </p>
+        )}
       </div>
 
       {/* Price */}

--- a/tests/mobile-ux.spec.ts
+++ b/tests/mobile-ux.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test, type Page } from "@playwright/test"
+import { createClient } from "@supabase/supabase-js"
+
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000"
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error(
+    "NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required for mobile UX tests",
+  )
+}
+
+const admin = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+async function completeQuizToConcerns(page: Page) {
+  await page.goto(`${baseUrl}/quiz`, { waitUntil: "networkidle" })
+
+  await page.getByRole("button", { name: /QUIZ STARTEN/i }).click()
+  await page.getByText("Wellig").first().click()
+  await page.getByText("Mittel").first().click()
+  await page.getByText("Leicht uneben").click()
+  await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
+
+  await page.locator(".quiz-card", { hasText: "Naturhaar" }).click()
+  await page.locator(".quiz-card", { hasText: "Gefärbt / Getönt" }).click()
+  await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+  await page
+    .locator(".quiz-card")
+    .filter({ has: page.getByText(/^Trocken$/) })
+    .click()
+  await page.getByRole("button", { name: "NEIN" }).click()
+
+  await expect(page.getByRole("heading", { name: /Welche Haarprobleme/i })).toBeVisible()
+}
+
+async function quizScrollPaneTop(page: Page) {
+  return page.evaluate(() => {
+    const panes = Array.from(document.querySelectorAll<HTMLElement>(".overflow-y-auto"))
+    const pane = panes.find((element) => element.scrollHeight > element.clientHeight)
+    return Math.max(pane?.scrollTop ?? 0, window.scrollY)
+  })
+}
+
+function expectBoxInsideViewport(
+  box: { x: number; y: number; width: number; height: number } | null,
+  viewport: { width: number; height: number },
+) {
+  expect(box).not.toBeNull()
+  expect(box!.x).toBeGreaterThanOrEqual(0)
+  expect(box!.y).toBeGreaterThanOrEqual(0)
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width)
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height)
+}
+
+const mobileViewports = [
+  { name: "small", label: "375x667", viewport: { width: 375, height: 667 } },
+  { name: "regular", label: "390x844", viewport: { width: 390, height: 844 } },
+]
+
+for (const mobileViewport of mobileViewports) {
+  test.describe.serial(`mobile UX regressions (${mobileViewport.label})`, () => {
+    test.use({
+      viewport: mobileViewport.viewport,
+      isMobile: true,
+      hasTouch: true,
+    })
+
+    const email = `playwright-mobile-${mobileViewport.name}-${Date.now()}@hairconscierge.test`
+    const password = "Playwright123!"
+    let userId: string | null = null
+
+    test.beforeAll(async () => {
+      const { data, error } = await admin.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: { full_name: "Mobile UX" },
+      })
+
+      if (error) throw error
+      userId = data.user?.id ?? null
+      if (!userId) throw new Error("Failed to create mobile UX user")
+
+      const { error: profileError } = await admin.from("profiles").upsert(
+        {
+          id: userId,
+          email,
+          full_name: "Mobile UX",
+          onboarding_completed: true,
+          onboarding_step: "celebration",
+          subscription_status: "active",
+          current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+        { onConflict: "id" },
+      )
+      if (profileError) throw profileError
+
+      const { error: hairProfileError } = await admin.from("hair_profiles").upsert(
+        {
+          user_id: userId,
+          hair_texture: "wavy",
+          thickness: "fine",
+          density: "medium",
+          concerns: ["frizz"],
+          cuticle_condition: "rough",
+          protein_moisture_balance: "stretches_bounces",
+          scalp_type: "balanced",
+          scalp_condition: null,
+          chemical_treatment: ["colored"],
+          goals: ["less_frizz"],
+          desired_volume: "balanced",
+          wash_frequency: "every_2_3_days",
+          heat_styling: "never",
+          styling_tools: [],
+          night_protection: [],
+          uses_heat_protection: false,
+        },
+        { onConflict: "user_id" },
+      )
+      if (hairProfileError) throw hairProfileError
+    })
+
+    test.afterAll(async () => {
+      if (!userId) return
+
+      await admin.from("user_product_usage").delete().eq("user_id", userId)
+      await admin.from("hair_profiles").delete().eq("user_id", userId)
+      await admin.from("profiles").delete().eq("id", userId)
+      await admin.auth.admin.deleteUser(userId)
+    })
+
+    test("quiz step changes reset the mobile scroll pane and focus the new heading", async ({
+      page,
+    }) => {
+      await completeQuizToConcerns(page)
+
+      const scrollTopBefore = await page.evaluate(() => {
+        const panes = Array.from(document.querySelectorAll<HTMLElement>(".overflow-y-auto"))
+        const pane = panes.find((element) => element.scrollHeight > element.clientHeight)
+        pane?.scrollTo({ top: pane.scrollHeight })
+        window.scrollTo({ top: document.documentElement.scrollHeight })
+        return Math.max(pane?.scrollTop ?? 0, window.scrollY)
+      })
+
+      expect(scrollTopBefore).toBeGreaterThan(0)
+
+      await page.getByText("Trockenheit").click()
+      await page.getByText("Frizz").click()
+      await page.getByRole("button", { name: /^Weiter$/i }).click()
+
+      const goalsHeading = page.getByRole("heading", { name: /Deine Haarziele/i })
+      await expect(goalsHeading).toBeVisible()
+      await expect.poll(() => quizScrollPaneTop(page)).toBe(0)
+
+      const headingBox = await goalsHeading.boundingBox()
+      expect(headingBox).not.toBeNull()
+      expect(headingBox!.y).toBeGreaterThanOrEqual(0)
+      expect(headingBox!.y).toBeLessThanOrEqual(200)
+
+      const activeElementText = await page.evaluate(() => document.activeElement?.textContent ?? "")
+      expect(activeElementText).toContain("Was sind deine Haarziele?")
+    })
+
+    test("chat keeps long input, product cards, and feedback controls inside mobile bounds", async ({
+      page,
+    }) => {
+      await page.route("**/api/chat", async (route) => {
+        if (route.request().method() === "GET") {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ conversations: [] }),
+          })
+          return
+        }
+
+        const events = [
+          { type: "conversation_id", data: "mobile-conversation" },
+          {
+            type: "content_delta",
+            data: "Nimm zuerst ein leichtes Leave-in und prüfe danach, ob die Längen weicher fallen.",
+          },
+          {
+            type: "product_recommendations",
+            data: [
+              {
+                id: "product-mobile-1",
+                name: "Ultra Lightweight Frizz Control Leave-in Conditioner With Long Name",
+                brand: "Hair Concierge",
+                category: "leave_in",
+                price_eur: 18.9,
+                recommendation_meta: {
+                  top_reasons: [
+                    "Leicht genug für feines Haar mit sehr langer Begründung ohne Layoutbruch",
+                  ],
+                },
+              },
+            ],
+          },
+          { type: "assistant_message", data: { id: "assistant-mobile-1" } },
+          { type: "done", data: { category_decision: null } },
+        ]
+
+        const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")
+
+        await route.fulfill({
+          contentType: "text/event-stream",
+          body,
+        })
+      })
+
+      await page.goto(`${baseUrl}/auth?email=${encodeURIComponent(email)}`, {
+        waitUntil: "networkidle",
+      })
+      const emailInput = page.locator('input[type="email"]:visible')
+      const passwordInput = page.locator('input[type="password"]:visible')
+      await emailInput.fill("")
+      await emailInput.pressSequentially(email)
+      await passwordInput.fill("")
+      await passwordInput.pressSequentially(password)
+      const loginButton = page.getByRole("button", { name: /^Anmelden$/ })
+      await expect(emailInput).toHaveValue(email)
+      await expect(passwordInput).toHaveValue(password)
+      await expect(loginButton).toBeEnabled()
+      await loginButton.click()
+      await page.waitForURL(/\/chat(\?.*)?$/, { timeout: 30_000 })
+
+      const longToken = "haarlaengen".repeat(32)
+      const chatInput = page.getByTestId("chat-input")
+      await chatInput.fill(longToken)
+
+      const viewport = page.viewportSize()
+      expect(viewport).not.toBeNull()
+      expectBoxInsideViewport(await page.getByTestId("chat-send").boundingBox(), viewport!)
+
+      await page.getByTestId("chat-send").click()
+
+      const productCard = page.getByRole("button", {
+        name: /Ultra Lightweight Frizz Control/i,
+      })
+      await expect(productCard).toBeVisible()
+      expectBoxInsideViewport(await productCard.boundingBox(), viewport!)
+
+      const reasonText = page.getByText(
+        "Leicht genug für feines Haar mit sehr langer Begründung ohne Layoutbruch",
+      )
+      await expect(reasonText).toBeVisible()
+      await expect
+        .poll(async () =>
+          reasonText.evaluate((element) => element.scrollWidth <= element.clientWidth),
+        )
+        .toBe(true)
+
+      for (const label of ["Antwort positiv bewerten", "Antwort negativ bewerten"]) {
+        const box = await page.getByRole("button", { name: label }).boundingBox()
+        expect(box).not.toBeNull()
+        expect(box!.width).toBeGreaterThanOrEqual(44)
+        expect(box!.height).toBeGreaterThanOrEqual(44)
+        expectBoxInsideViewport(box, viewport!)
+      }
+    })
+  })
+}


### PR DESCRIPTION
## Summary

Stabilizes the mobile quiz and chat experience so narrow viewports no longer inherit stale scroll state or clip core chat content.

## What Changed

- Reset the actual quiz scroll pane on step changes and move focus to the new step heading.
- Added mobile flex-width constraints around chat containers, input, message bubbles, product cards, and feedback controls.
- Preserved product recommendation reason text on mobile instead of truncating it.
- Added a focused Playwright mobile regression spec for `375x667` and `390x844` viewports.
- Documented the mobile UX audit and implementation plan.

## Verification

- `PLAYWRIGHT_BASE_URL=http://localhost:3168 npx playwright test tests/mobile-ux.spec.ts --project=chromium --reporter=line --timeout=60000` → 4 passed
- `npm run typecheck` → passed
- `npm run lint` → 0 errors, 4 pre-existing warnings
- `npm run build` → passed
- `git diff --check` → passed
- Superpowers code review requested; important product-card clipping finding was fixed and reverified

## Notes

- This does not include the deferred Profile Editorial v3 mobile-density follow-up.
- Lint warnings are existing unrelated issues in header/avatar/mask-reranker/brush-tools.
