### PR TITLE
fix(eval-chat): seed active subscription so paywall doesn't 307 eval users

### DIFF
--- a/scripts/eval-chat/client.ts
+++ b/scripts/eval-chat/client.ts
@@ -120,11 +120,14 @@ export async function createTestSession(
 
   const userId = userData.user.id
 
-  // Ensure profile exists with onboarding_completed (middleware requires it)
+  // Ensure profile exists with onboarding_completed and an active subscription —
+  // both are required by the middleware paywall (src/lib/supabase/middleware.ts).
+  // Without subscription_status="active", every /api/chat request 307s to /pricing.
   await admin.from("profiles").upsert({
     id: userId,
     full_name: "Eval Test User",
     onboarding_completed: true,
+    subscription_status: "active",
   })
 
   // Sign in to get session tokens


### PR DESCRIPTION
## Summary

\`createTestSession\` in \`scripts/eval-chat/client.ts\` was upserting test profiles with only \`onboarding_completed=true\`, so every eval scenario got 307'd to \`/pricing?reason=resubscribe\` by the paywall middleware (added in PR #43). This restored the chat eval to a working state — verified by running it locally against this branch.

## Change

One-line addition: \`subscription_status: \"active\"\` in the profile upsert. The cleanup at the bottom of \`createTestSession\` already deletes the profile row, so no leak.

\`\`\`diff
   await admin.from(\"profiles\").upsert({
     id: userId,
     full_name: \"Eval Test User\",
     onboarding_completed: true,
+    subscription_status: \"active\",
   })
\`\`\`

Considered alternatives:
- Middleware bypass for eval users — rejected (permanent test-only branch in security-critical code, easy to misuse)
- \`EVAL_MODE\` env flag — rejected (one stray prod env leak = paywall disabled)

This is the smallest change with no production-code surface.

## Test plan

- [x] \`npm run ci:verify\` (typecheck + lint + build) — passes
- [x] \`npm run test:chat\` — **13/13 scenarios pass, 71/71 assertions pass** (vs. 0/13 before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)