### PR TITLE
feat(leave-in/mask/oil): structured ingredient_flags (mirror PR #52)

### DIFF
--- a/scripts/backfill-leave-in-specs.ts
+++ b/scripts/backfill-leave-in-specs.ts
@@ -72,7 +72,7 @@ function spec(
 }
 
 const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
-  "Acina Hyaluron 2.0 (Silikone)": spec(
+  "Acina Hyaluron 2.0": spec(
     "lotion",
     "light",
     ["extension_conditioner"],
@@ -90,7 +90,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     [],
     ["towel_dry"],
   ),
-  "Authentic Beauty Concept Hydrate Spray (Silikone)": spec(
+  "Authentic Beauty Concept Hydrate Spray": spec(
     "spray",
     "light",
     ["extension_conditioner"],
@@ -108,7 +108,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["humectants"],
     ["towel_dry"],
   ),
-  "Cantu Leave-In Conditioning Repair Cream (Kokos)": spec(
+  "Cantu Leave-In Conditioning Repair Cream": spec(
     "cream",
     "rich",
     ["extension_conditioner"],
@@ -117,7 +117,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["oils"],
     ["towel_dry"],
   ),
-  "Cantu Leave-In Repair Cream (Kokos)": spec(
+  "Cantu Leave-In Repair Cream": spec(
     "cream",
     "rich",
     ["extension_conditioner"],
@@ -126,7 +126,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["oils"],
     ["towel_dry"],
   ),
-  "Color WOW Money Mist (Silikone)": spec(
+  "Color WOW Money Mist": spec(
     "spray",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -162,7 +162,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["proteins"],
     ["towel_dry"],
   ),
-  "Elvital Öl Magique Serum (Silikone)": spec(
+  "Elvital Öl Magique Serum": spec(
     "serum",
     "rich",
     ["oil_replacement"],
@@ -171,7 +171,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones", "oils"],
     ["towel_dry", "dry_hair", "post_style"],
   ),
-  "EVO Day of Grace Leave-In (Silikone)": spec(
+  "EVO Day of Grace Leave-In": spec(
     "lotion",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -181,7 +181,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["towel_dry", "pre_heat"],
     221,
   ),
-  "EVO Happy Campers (Silikone)": spec(
+  "EVO Happy Campers": spec(
     "lotion",
     "medium",
     ["extension_conditioner", "styling_prep"],
@@ -190,7 +190,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "EVO Head Mistress (Silikone)": spec(
+  "EVO Head Mistress": spec(
     "cream",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -235,7 +235,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["humectants"],
     ["towel_dry"],
   ),
-  "It’s a 10 Miracle Leave-In  (Silikone)": spec(
+  "It’s a 10 Miracle Leave-In": spec(
     "spray",
     "medium",
     ["extension_conditioner", "styling_prep"],
@@ -244,7 +244,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry", "pre_heat"],
   ),
-  "It’s a 10 Miracle Leave-In Lite (Silikone)": spec(
+  "It’s a 10 Miracle Leave-In Lite": spec(
     "spray",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -262,7 +262,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     [],
     ["towel_dry"],
   ),
-  "Kevin Murphy Young Again (Silikone)": spec(
+  "Kevin Murphy Young Again": spec(
     "serum",
     "medium",
     ["oil_replacement"],
@@ -289,7 +289,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["oils"],
     ["towel_dry"],
   ),
-  "Maria Nila Structure Repair (Silikone)": spec(
+  "Maria Nila Structure Repair": spec(
     "lotion",
     "medium",
     ["extension_conditioner"],
@@ -298,7 +298,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "Maria Nila Structure Repair Leave-In (Silikone)": spec(
+  "Maria Nila Structure Repair Leave-In": spec(
     "lotion",
     "light",
     ["extension_conditioner"],
@@ -316,7 +316,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["oils"],
     ["towel_dry"],
   ),
-  "Moroccanoil All In One Leave In Conditioner (Silikone)": spec(
+  "Moroccanoil All In One Leave In Conditioner": spec(
     "spray",
     "medium",
     ["extension_conditioner", "styling_prep"],
@@ -325,7 +325,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry", "pre_heat"],
   ),
-  "Neqi Moisture Mystery (Silikone)": spec(
+  "Neqi Moisture Mystery": spec(
     "lotion",
     "medium",
     ["extension_conditioner"],
@@ -334,7 +334,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones", "humectants"],
     ["towel_dry"],
   ),
-  "Olaplex No.5 Leave-In (Silikone)": spec(
+  "Olaplex No.5 Leave-In": spec(
     "lotion",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -344,7 +344,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["towel_dry", "pre_heat"],
     232,
   ),
-  "Olaplex No.6 Bond Smoother (Silikone)": spec(
+  "Olaplex No.6 Bond Smoother": spec(
     "cream",
     "medium",
     ["extension_conditioner", "styling_prep"],
@@ -354,7 +354,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["towel_dry", "pre_heat"],
     232,
   ),
-  "OUAI Leave In Conditioner (Silikone)": spec(
+  "OUAI Leave In Conditioner": spec(
     "spray",
     "medium",
     ["extension_conditioner", "styling_prep"],
@@ -364,7 +364,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["towel_dry", "pre_heat"],
     232,
   ),
-  "Pantene Bonding Leave-In (Silikone)": spec(
+  "Pantene Bonding Leave-In": spec(
     "lotion",
     "medium",
     ["extension_conditioner"],
@@ -373,7 +373,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "Pantene Hydra Glow Leave-In (Silikone)": spec(
+  "Pantene Hydra Glow Leave-In": spec(
     "lotion",
     "medium",
     ["extension_conditioner"],
@@ -382,7 +382,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "Pantene Pro-V Keratin Protect 10-in-1 Spray (Silikone)": spec(
+  "Pantene Pro-V Keratin Protect 10-in-1 Spray": spec(
     "spray",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -400,7 +400,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     [],
     ["towel_dry"],
   ),
-  "Redken Acidic Color Gloss Leave-In (Silikone)": spec(
+  "Redken Acidic Color Gloss Leave-In": spec(
     "spray",
     "light",
     ["extension_conditioner", "styling_prep"],
@@ -410,7 +410,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["towel_dry", "pre_heat"],
     230,
   ),
-  "Redken All Soft Mega Curls Leave-In (Silikone)": spec(
+  "Redken All Soft Mega Curls Leave-In": spec(
     "lotion",
     "rich",
     ["extension_conditioner", "styling_prep"],
@@ -419,7 +419,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "Redken Extreme Anti-Snap (Silikone)": spec(
+  "Redken Extreme Anti-Snap": spec(
     "lotion",
     "medium",
     ["extension_conditioner"],
@@ -428,7 +428,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "Redken One United (Silikone)": spec(
+  "Redken One United": spec(
     "spray",
     "light",
     ["extension_conditioner", "replacement_conditioner", "styling_prep"],
@@ -438,7 +438,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["towel_dry", "dry_hair", "pre_heat", "post_style"],
     230,
   ),
-  "Urban Alchemy Repair (Silikone)": spec(
+  "Urban Alchemy Repair": spec(
     "lotion",
     "medium",
     ["extension_conditioner"],
@@ -447,7 +447,7 @@ const LEAVE_IN_BACKFILL_BY_NAME: Record<string, LeaveInBackfillSpec> = {
     ["silicones"],
     ["towel_dry"],
   ),
-  "Wella Ultimate Repair Leave-In (Silikone)": spec(
+  "Wella Ultimate Repair Leave-In": spec(
     "lotion",
     "medium",
     ["extension_conditioner", "styling_prep"],

--- a/scripts/backfill-mask-specs.ts
+++ b/scripts/backfill-mask-specs.ts
@@ -1,5 +1,6 @@
 import { config as loadEnv } from "dotenv"
 import { createClient } from "@supabase/supabase-js"
+import type { MaskIngredientFlag } from "../src/lib/mask/constants"
 
 loadEnv({ path: ".env.local" })
 
@@ -25,6 +26,7 @@ type MaskBackfillSpec = {
   balance_direction: ProductBalanceDirection
   weight: MaskWeight
   concentration: MaskConcentration
+  ingredient_flags?: MaskIngredientFlag[]
 }
 
 const DUPLICATE_MASK_NAME = "Neqi Build & Boost"
@@ -75,10 +77,11 @@ const MASK_BACKFILL_BY_NAME: Record<string, MaskBackfillSpec> = {
     weight: "medium",
     concentration: "high",
   },
-  "Bali Curls Deep Hydration (Kokos)": {
+  "Bali Curls Deep Hydration": {
     balance_direction: "moisture",
     weight: "rich",
     concentration: "medium",
+    ingredient_flags: ["oils"],
   },
   "Bali Curls SOS Protein Treatment": {
     balance_direction: "protein",
@@ -105,10 +108,11 @@ const MASK_BACKFILL_BY_NAME: Record<string, MaskBackfillSpec> = {
     weight: "light",
     concentration: "medium",
   },
-  "Glisskur Liquid Silk (Silikone)": {
+  "Glisskur Liquid Silk": {
     balance_direction: "protein",
     weight: "light",
     concentration: "medium",
+    ingredient_flags: ["silicones"],
   },
   "Guhl 30 sec. Feuchtigkeit": {
     balance_direction: "moisture",
@@ -294,12 +298,15 @@ async function main() {
     })),
   )
 
-  const payload = rows.map(({ product_id, weight, concentration, balance_direction }) => ({
-    product_id,
-    weight,
-    concentration,
-    balance_direction,
-  }))
+  const payload = rows.map(
+    ({ product_id, weight, concentration, balance_direction, ingredient_flags }) => ({
+      product_id,
+      weight,
+      concentration,
+      balance_direction,
+      ingredient_flags: ingredient_flags ?? [],
+    }),
+  )
 
   const { error } = await supabase
     .from("product_mask_specs")

--- a/scripts/backfill-mask-specs.ts
+++ b/scripts/backfill-mask-specs.ts
@@ -26,7 +26,7 @@ type MaskBackfillSpec = {
   balance_direction: ProductBalanceDirection
   weight: MaskWeight
   concentration: MaskConcentration
-  ingredient_flags?: MaskIngredientFlag[]
+  ingredient_flags: MaskIngredientFlag[]
 }
 
 const DUPLICATE_MASK_NAME = "Neqi Build & Boost"
@@ -36,46 +36,55 @@ const MASK_BACKFILL_BY_NAME: Record<string, MaskBackfillSpec> = {
     balance_direction: "balanced",
     weight: "medium",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Balea 3 in 1 Intensivmaske": {
     balance_direction: "moisture",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Balea Aqua Hyaluron 3 in 1": {
     balance_direction: "moisture",
     weight: "light",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Balea Natural Beauty 3in1 Locken": {
     balance_direction: "moisture",
     weight: "rich",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Balea Natural Beauty reparierend.": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Balea Plex Care": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Balea Professional Glow & Shine": {
     balance_direction: "balanced",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Balea Professionel Plexcare": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Bali Curls Bond Repair": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Bali Curls Deep Hydration": {
     balance_direction: "moisture",
@@ -87,26 +96,31 @@ const MASK_BACKFILL_BY_NAME: Record<string, MaskBackfillSpec> = {
     balance_direction: "protein",
     weight: "rich",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Fructis Hair Food Aloe Vera": {
     balance_direction: "moisture",
     weight: "light",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Fructis Hair Food Papaya": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Gliss Aqua Revive": {
     balance_direction: "balanced",
     weight: "light",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Gliss Liquid Silk": {
     balance_direction: "balanced",
     weight: "light",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Glisskur Liquid Silk": {
     balance_direction: "protein",
@@ -118,96 +132,115 @@ const MASK_BACKFILL_BY_NAME: Record<string, MaskBackfillSpec> = {
     balance_direction: "moisture",
     weight: "medium",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Guhl Panthenol +": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Haarkur Lamination Intense Glaze": {
     balance_direction: "balanced",
     weight: "medium",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Hask Argan Deep Conditioning Treatment": {
     balance_direction: "moisture",
     weight: "rich",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Isana 3in1 Michprotein & Mandel": {
     balance_direction: "protein",
     weight: "rich",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Jean&Len Tiefenreparatur Haarkur": {
     balance_direction: "balanced",
     weight: "rich",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Neqi Build Boost": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Neqi Gloss Glaze": {
     balance_direction: "balanced",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Neqi Peptide Power": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Neqi Repair Reveal": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Pantene Bond Repair": {
     balance_direction: "protein",
     weight: "medium",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Pantene Hydra Glow": {
     balance_direction: "moisture",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Pantene Keratin Repair & Care": {
     balance_direction: "protein",
     weight: "rich",
     concentration: "high",
+    ingredient_flags: [],
   },
   "Pomélo+Co Shine Therapy": {
     balance_direction: "balanced",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Sante Intense Hydration": {
     balance_direction: "moisture",
     weight: "light",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Schaebens Argan-Öl Haarmaske": {
     balance_direction: "balanced",
     weight: "medium",
     concentration: "medium",
+    ingredient_flags: [],
   },
   "Syoss Intense Keratin": {
     balance_direction: "protein",
     weight: "rich",
     concentration: "high",
+    ingredient_flags: [],
   },
   "WAHRE SCHÄTZE 1-MINUTE HAARKUR Argan": {
     balance_direction: "moisture",
     weight: "medium",
     concentration: "low",
+    ingredient_flags: [],
   },
   "Wahre Schätze Avocado": {
     balance_direction: "moisture",
     weight: "rich",
     concentration: "medium",
+    ingredient_flags: [],
   },
 }
 
@@ -304,7 +337,7 @@ async function main() {
       weight,
       concentration,
       balance_direction,
-      ingredient_flags: ingredient_flags ?? [],
+      ingredient_flags,
     }),
   )
 

--- a/scripts/backfill-oil-specs.ts
+++ b/scripts/backfill-oil-specs.ts
@@ -122,6 +122,31 @@ async function main() {
     )
   }
 
+  // Validate the manual lookup maps against the live DB. Catches stale keys
+  // from product renames in either direction so the backfill fails fast
+  // instead of silently writing [] / falling through to subtype-derivation.
+  const knownProductNames = new Set(products.map((product) => product.name))
+  const orphanFlagKeys = Object.keys(OIL_INGREDIENT_FLAGS_BY_NAME).filter(
+    (name) => !knownProductNames.has(name),
+  )
+  const orphanOverrideKeys = Object.keys(OIL_PURPOSE_OVERRIDE_BY_NAME).filter(
+    (name) => !knownProductNames.has(name),
+  )
+  if (orphanFlagKeys.length > 0 || orphanOverrideKeys.length > 0) {
+    throw new Error(
+      [
+        orphanFlagKeys.length > 0
+          ? `Stale OIL_INGREDIENT_FLAGS_BY_NAME keys (no DB match): ${orphanFlagKeys.join(", ")}`
+          : null,
+        orphanOverrideKeys.length > 0
+          ? `Stale OIL_PURPOSE_OVERRIDE_BY_NAME keys (no DB match): ${orphanOverrideKeys.join(", ")}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" | "),
+    )
+  }
+
   const exportRows: OilExportRow[] = products.map((product) => {
     const source_subtypes = [
       ...new Set(

--- a/scripts/backfill-oil-specs.ts
+++ b/scripts/backfill-oil-specs.ts
@@ -1,7 +1,7 @@
 import { config as loadEnv } from "dotenv"
-import { writeFile } from "node:fs/promises"
+import { readFile, writeFile } from "node:fs/promises"
 import { createClient } from "@supabase/supabase-js"
-import type { OilIngredientFlag } from "../src/lib/oil/constants"
+import { OIL_INGREDIENT_FLAGS, type OilIngredientFlag } from "../src/lib/oil/constants"
 
 loadEnv({ path: ".env.local" })
 
@@ -122,9 +122,10 @@ async function main() {
     )
   }
 
-  // Validate the manual lookup maps against the live DB. Catches stale keys
-  // from product renames in either direction so the backfill fails fast
-  // instead of silently writing [] / falling through to subtype-derivation.
+  // Validate the manual lookup maps against both the live DB and the
+  // parser-emitted JSON. Catches name drift in either direction so the
+  // backfill fails fast instead of silently writing [] / falling through
+  // to subtype-derivation.
   const knownProductNames = new Set(products.map((product) => product.name))
   const orphanFlagKeys = Object.keys(OIL_INGREDIENT_FLAGS_BY_NAME).filter(
     (name) => !knownProductNames.has(name),
@@ -144,6 +145,52 @@ async function main() {
       ]
         .filter(Boolean)
         .join(" | "),
+    )
+  }
+
+  // Cross-check against parser-emitted JSON: every oil product that the
+  // parser flagged with non-empty ingredient_flags must be in the script's
+  // map. Catches "Excel updated, parser regenerated, script forgot to sync"
+  // so we can't silently overwrite ingredient_flags with [].
+  type OilJsonEntry = { name: string; ingredient_flags?: string[] }
+  const oilJsonRaw = await readFile("data/products-from-excel/oele.json", "utf8")
+  const oilJson = JSON.parse(oilJsonRaw) as OilJsonEntry[]
+  const allowedFlags = new Set<string>(OIL_INGREDIENT_FLAGS)
+  const expectedFlagBearers = oilJson.filter((entry) => (entry.ingredient_flags ?? []).length > 0)
+  const unmappedFlagged = expectedFlagBearers
+    .filter((entry) => !(entry.name in OIL_INGREDIENT_FLAGS_BY_NAME))
+    .map((entry) => `${entry.name} -> ${(entry.ingredient_flags ?? []).join(",")}`)
+  const flagsetMismatches = expectedFlagBearers
+    .filter((entry) => entry.name in OIL_INGREDIENT_FLAGS_BY_NAME)
+    .filter((entry) => {
+      const expected = (entry.ingredient_flags ?? []).slice().sort().join(",")
+      const actual = (OIL_INGREDIENT_FLAGS_BY_NAME[entry.name] ?? []).slice().sort().join(",")
+      return expected !== actual
+    })
+    .map(
+      (entry) =>
+        `${entry.name}: parser=${(entry.ingredient_flags ?? []).join(",")} script=${(OIL_INGREDIENT_FLAGS_BY_NAME[entry.name] ?? []).join(",")}`,
+    )
+  const invalidParserFlags = expectedFlagBearers.flatMap((entry) =>
+    (entry.ingredient_flags ?? [])
+      .filter((flag) => !allowedFlags.has(flag))
+      .map((flag) => `${entry.name}:${flag}`),
+  )
+  if (unmappedFlagged.length > 0 || flagsetMismatches.length > 0 || invalidParserFlags.length > 0) {
+    throw new Error(
+      [
+        unmappedFlagged.length > 0
+          ? `Parser flagged products missing from OIL_INGREDIENT_FLAGS_BY_NAME: ${unmappedFlagged.join(" | ")}`
+          : null,
+        flagsetMismatches.length > 0
+          ? `Flag set drift between parser JSON and script map: ${flagsetMismatches.join(" | ")}`
+          : null,
+        invalidParserFlags.length > 0
+          ? `Parser emitted flag value not in OIL_INGREDIENT_FLAGS enum: ${invalidParserFlags.join(", ")}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" || "),
     )
   }
 

--- a/scripts/backfill-oil-specs.ts
+++ b/scripts/backfill-oil-specs.ts
@@ -1,6 +1,7 @@
 import { config as loadEnv } from "dotenv"
 import { writeFile } from "node:fs/promises"
 import { createClient } from "@supabase/supabase-js"
+import type { OilIngredientFlag } from "../src/lib/oil/constants"
 
 loadEnv({ path: ".env.local" })
 
@@ -40,7 +41,32 @@ type OilExportRow = {
 }
 
 const OIL_PURPOSE_OVERRIDE_BY_NAME: Partial<Record<string, OilPurpose>> = {
-  "Olaplex No.7 Bonding Oil (Silikone)": "styling_finish",
+  "Olaplex No.7 Bonding Oil": "styling_finish",
+}
+
+// ingredient_flags per product, derived from the regenerated oil JSON
+// (data/products-from-excel/oele.json — parser strips trailing (Silikone)/(Kokos)
+// annotations and emits the structured flags here). Products not listed get [].
+const OIL_INGREDIENT_FLAGS_BY_NAME: Partial<Record<string, OilIngredientFlag[]>> = {
+  "Balea Oil Repair Haaröl": ["silicones"],
+  "Balea Traumlocken Öl": ["silicones"],
+  "Garnier Fructis Sleek & Stay Öl": ["silicones"],
+  "Garnier Fructis Wunderöl": ["silicones"],
+  "Garnier Wahre Schätze Curl Revival Öl": ["silicones"],
+  "Jean&Len Repair Keratin & Mandel": ["silicones"],
+  "L’Oréal Elvital Öl Magique Jojoba": ["silicones"],
+  "Maria Nila True Soft Argan Oil": ["silicones"],
+  "Neqi Opulent Oil": ["silicones"],
+  "OGX Argan Oil": ["silicones"],
+  "OGX Argan weightless Öl": ["silicones"],
+  "OGX Bond Protein Repair": ["silicones", "oils"],
+  "OGX Miracle Coconut Oil": ["silicones", "oils"],
+  "Olaplex No.7 Bonding Oil": ["silicones"],
+  "Pantene Pro-V 7in1 Spray": ["silicones"],
+  "Pantene Pro-V Coconut Oil": ["silicones", "oils"],
+  "Pantene Pro-V Keratin Protect Öl": ["silicones", "oils"],
+  "Shiseido Fino Oil": ["silicones"],
+  "Urban Alchemy Smooth Serum": ["silicones"],
 }
 
 function deriveOilPurpose(productName: string, subtypes: OilSubtype[]): OilPurpose {
@@ -133,6 +159,7 @@ async function main() {
       thickness: row.thickness,
       oil_subtype: row.oil_subtype,
       oil_purpose,
+      ingredient_flags: OIL_INGREDIENT_FLAGS_BY_NAME[product.name] ?? [],
     }
   })
 

--- a/scripts/convert_sources.py
+++ b/scripts/convert_sources.py
@@ -799,7 +799,9 @@ def convert_excel_matrices():
 
 
 INGREDIENT_FLAG_TRAILING_PAREN = re.compile(
-    r"\s*\(((?:Silikone|Kokos)(?:\s*/\s*(?:Silikone|Kokos))?)\)\s*$",
+    # Combined-form separator is either '/' (PR #52 conditioner data) or '+'
+    # (oil sheet, e.g. 'OGX Bond Protein Repair (Silikone + Kokos)').
+    r"\s*\(((?:Silikone|Kokos)(?:\s*[/+]\s*(?:Silikone|Kokos))?)\)\s*$",
 )
 
 
@@ -842,6 +844,9 @@ assert parse_ingredient_flags("Pomelo Molecular Repair (Silikone)") == ("Pomelo 
 assert parse_ingredient_flags("Cantu Repair Cream (Kokos)") == ("Cantu Repair Cream", ["oils"])
 assert parse_ingredient_flags("OGX Renewing Argan Oil (Silikone /Kokos)") == ("OGX Renewing Argan Oil", ["silicones", "oils"])
 assert parse_ingredient_flags("Monday Moisture (Silikone / Kokos)") == ("Monday Moisture", ["silicones", "oils"])
+# '+' separator variant — appears in oil sheet (e.g. OGX Bond Protein Repair).
+assert parse_ingredient_flags("OGX Bond Protein Repair (Silikone + Kokos)") == ("OGX Bond Protein Repair", ["silicones", "oils"])
+assert parse_ingredient_flags("OGX (Silikone+Kokos)") == ("OGX", ["silicones", "oils"])
 # Reverse-order annotation: body lookup is order-independent (Silikone-first then Kokos),
 # so the flags list stays in canonical [silicones, oils] order regardless of input order.
 assert parse_ingredient_flags("OGX (Kokos / Silikone)") == ("OGX", ["silicones", "oils"])

--- a/scripts/convert_sources.py
+++ b/scripts/convert_sources.py
@@ -910,11 +910,21 @@ def convert_single_excel_matrix(xlsx_path: Path):
     """
     filename_stem = xlsx_path.stem  # e.g. "Produktliste Conditioner (Profi)"
     is_profi = "(Profi)" in filename_stem or "(profi)" in filename_stem
-    # Strip suffix + extract ingredient flags applies to the conditioner-drogerie matrix only.
-    # Profi conditioner sheets use a different convention; their parens (e.g. (Profi)) carry
-    # different meaning and must NOT be stripped by this parser.
+    # Strip suffix + extract ingredient flags applies to the four drogerie-style matrices
+    # whose trailing parens encode silicone/coconut signals: conditioner-drogerie, leave-in,
+    # mask-drogerie, and oil sheets. Profi conditioner sheets use a different convention
+    # ((Profi)) and must NOT be stripped by this parser.
     stem = filename_stem.lower()
     is_conditioner_drogerie = "conditioner" in stem and "drogerie" in stem
+    is_leave_in = "leave-in" in stem or "leave_in" in stem
+    is_mask_drogerie = ("maske" in stem or "mask" in stem) and "drogerie" in stem
+    is_oil = "oils" in stem or "öle" in stem or "oele" in stem
+    uses_ingredient_flags = (
+        is_conditioner_drogerie
+        or is_leave_in
+        or is_mask_drogerie
+        or is_oil
+    )
     category = filename_stem  # fallback: filename without extension
     print(f"\n  Processing: {filename_stem}")
 
@@ -980,10 +990,11 @@ def convert_single_excel_matrix(xlsx_path: Path):
 
         for col_idx, need_cat in enumerate(headers):
             cell_val = ws.cell(row=row, column=col_idx + 2).value
-            # Conditioner-drogerie sheet only: normalize the 'Silikon' (typo, no
-            # trailing 'e') -> 'Silikone' before splitting, so the parser sees a
-            # single canonical spelling. Other matrices keep raw cell text untouched.
-            if is_conditioner_drogerie and cell_val is not None:
+            # Drogerie-style sheets (conditioner-drogerie, leave-in, mask-drogerie,
+            # oil): normalize the 'Silikon' (typo, no trailing 'e') -> 'Silikone'
+            # before splitting, so the parser sees a single canonical spelling.
+            # Other matrices keep raw cell text untouched.
+            if uses_ingredient_flags and cell_val is not None:
                 cell_val = normalize_ingredient_paren(str(cell_val))
             for product_name in parse_cell_products(cell_val):
                 matrix[current_hair_texture][need_cat].append(product_name)
@@ -995,19 +1006,20 @@ def convert_single_excel_matrix(xlsx_path: Path):
     )
     print(f"    {len(matrix)} hair textures, {len(headers)} need categories, {total_products} product entries")
 
-    generate_matrix_markdown(category, matrix, is_conditioner_drogerie=is_conditioner_drogerie)
-    generate_product_json(category, matrix, is_conditioner_drogerie=is_conditioner_drogerie)
+    generate_matrix_markdown(category, matrix, uses_ingredient_flags=uses_ingredient_flags)
+    generate_product_json(category, matrix, uses_ingredient_flags=uses_ingredient_flags)
 
 
-def generate_matrix_markdown(category: str, matrix: dict, is_conditioner_drogerie: bool = False):
+def generate_matrix_markdown(category: str, matrix: dict, uses_ingredient_flags: bool = False):
     """Write one Markdown file per cell (hair_texture x concern) for precise RAG retrieval.
 
     Each file becomes a single chunk with rich metadata for hybrid search
     (metadata filtering + vector similarity).
 
-    For the conditioner-drogerie matrix, trailing (Silikone)/(Kokos) annotations
-    are stripped from product names — the structured signal lives in the JSON
-    output's `ingredient_flags` field.
+    For matrices whose trailing parens encode ingredient flags (conditioner-drogerie,
+    leave-in, mask-drogerie, oil), those (Silikone)/(Kokos) annotations are stripped
+    from product names — the structured signal lives in the JSON output's
+    `ingredient_flags` field.
     """
     cat_slug = slugify(category)
     out_dir = MD_DIR / "products" / cat_slug
@@ -1030,7 +1042,7 @@ def generate_matrix_markdown(category: str, matrix: dict, is_conditioner_drogeri
 
             display_products = (
                 [parse_ingredient_flags(p)[0] for p in products]
-                if is_conditioner_drogerie
+                if uses_ingredient_flags
                 else products
             )
             product_list = ", ".join(display_products)
@@ -1075,16 +1087,16 @@ def guess_brand(product_name: str) -> str:
 
 
 def build_product_json_list(
-    category: str, matrix: dict, is_conditioner_drogerie: bool = False
+    category: str, matrix: dict, uses_ingredient_flags: bool = False
 ) -> list[dict]:
     """Build the product JSON list (in memory, no IO).
 
-    For the conditioner-drogerie matrix, the trailing (Silikone)/(Kokos)
-    annotation is stripped from `name` and surfaced as a structured
-    `ingredient_flags` array (`silicones` / `oils`). Empty array when no
-    annotation was present. If the same stripped name appears in multiple
-    cells with DIFFERENT trailing parens, all flags are merged so the result
-    is order-independent.
+    For matrices whose trailing parens encode ingredient flags (conditioner-drogerie,
+    leave-in, mask-drogerie, oil), the trailing (Silikone)/(Kokos) annotation is
+    stripped from `name` and surfaced as a structured `ingredient_flags` array
+    (`silicones` / `oils`). Empty array when no annotation was present. If the
+    same stripped name appears in multiple cells with DIFFERENT trailing parens,
+    all flags are merged so the result is order-independent.
     """
     product_map: dict[str, dict] = {}
 
@@ -1095,7 +1107,7 @@ def build_product_json_list(
         for need_cat, products in needs.items():
             concern_tag = concern_to_slug(need_cat)
             for raw_name in products:
-                if is_conditioner_drogerie:
+                if uses_ingredient_flags:
                     clean_name, flags = parse_ingredient_flags(raw_name)
                 else:
                     clean_name, flags = raw_name, []
@@ -1108,7 +1120,7 @@ def build_product_json_list(
                         "suitable_concerns": [],
                         "tags": [category.lower()],
                     }
-                    if is_conditioner_drogerie:
+                    if uses_ingredient_flags:
                         entry["ingredient_flags"] = []
                     product_map[clean_name] = entry
                 entry = product_map[clean_name]
@@ -1116,7 +1128,7 @@ def build_product_json_list(
                 # different trailing parens (e.g. one with (Silikone) and one
                 # with (Kokos)) both contribute to the product's flag list.
                 # This makes the parse order-independent.
-                if is_conditioner_drogerie:
+                if uses_ingredient_flags:
                     for f in flags:
                         if f not in entry["ingredient_flags"]:
                             entry["ingredient_flags"].append(f)
@@ -1138,7 +1150,7 @@ def _assert_ingredient_flags_merge_smoke():
         },
     }
     products = build_product_json_list(
-        "Conditioner (Drogerie)", matrix_two_cells, is_conditioner_drogerie=True
+        "Conditioner (Drogerie)", matrix_two_cells, uses_ingredient_flags=True
     )
     assert len(products) == 1, f"expected 1 merged product, got {len(products)}"
     assert products[0]["name"] == "OGX Argan Oil"
@@ -1157,7 +1169,7 @@ def _assert_ingredient_flags_merge_smoke():
         },
     }
     products_rev = build_product_json_list(
-        "Conditioner (Drogerie)", matrix_reversed, is_conditioner_drogerie=True
+        "Conditioner (Drogerie)", matrix_reversed, uses_ingredient_flags=True
     )
     assert set(products_rev[0]["ingredient_flags"]) == {"silicones", "oils"}
 
@@ -1168,7 +1180,7 @@ def _assert_ingredient_flags_merge_smoke():
         },
     }
     products_single = build_product_json_list(
-        "Conditioner (Drogerie)", matrix_single, is_conditioner_drogerie=True
+        "Conditioner (Drogerie)", matrix_single, uses_ingredient_flags=True
     )
     assert products_single[0]["ingredient_flags"] == ["silicones"]
 
@@ -1176,7 +1188,7 @@ def _assert_ingredient_flags_merge_smoke():
 _assert_ingredient_flags_merge_smoke()
 
 
-def generate_product_json(category: str, matrix: dict, is_conditioner_drogerie: bool = False):
+def generate_product_json(category: str, matrix: dict, uses_ingredient_flags: bool = False):
     """Write the product JSON file for catalog ingestion.
 
     Wraps `build_product_json_list` with the file-writing side effect.
@@ -1186,7 +1198,7 @@ def generate_product_json(category: str, matrix: dict, is_conditioner_drogerie: 
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / f"{slug}.json"
 
-    product_list = build_product_json_list(category, matrix, is_conditioner_drogerie=is_conditioner_drogerie)
+    product_list = build_product_json_list(category, matrix, uses_ingredient_flags=uses_ingredient_flags)
     out_path.write_text(json.dumps(product_list, ensure_ascii=False, indent=2), encoding="utf-8")
     print(f"  -> {out_path.relative_to(BASE_DIR)} ({len(product_list)} products)")
 

--- a/scripts/ingest-products.ts
+++ b/scripts/ingest-products.ts
@@ -362,7 +362,10 @@ function inferLeaveInSpecs(
 
 function inferMaskSpecs(
   product: ProductInput,
-): Omit<ProductMaskSpecs, "product_id" | "created_at" | "updated_at"> {
+): Omit<ProductMaskSpecs, "product_id" | "created_at" | "updated_at" | "ingredient_flags"> {
+  // ingredient_flags is intentionally omitted: this script does not write that column.
+  // The backfill scripts are the canonical writer for ingredient_flags, and Supabase
+  // upserts only touch the columns provided — so existing values are preserved on UPDATE.
   const existing = product.mask_specs
   const normalizedName = product.name.toLowerCase()
   const concerns = new Set(product.suitable_concerns ?? [])

--- a/src/lib/mask/constants.ts
+++ b/src/lib/mask/constants.ts
@@ -6,11 +6,21 @@ export type MaskWeight = (typeof MASK_WEIGHTS)[number]
 export const MASK_CONCENTRATIONS = ["low", "medium", "high"] as const
 export type MaskConcentration = (typeof MASK_CONCENTRATIONS)[number]
 
+export const MASK_INGREDIENT_FLAGS = [
+  "silicones",
+  "polymers",
+  "oils",
+  "proteins",
+  "humectants",
+] as const
+export type MaskIngredientFlag = (typeof MASK_INGREDIENT_FLAGS)[number]
+
 export interface ProductMaskSpecs {
   product_id: string
   weight: MaskWeight
   concentration: MaskConcentration
   balance_direction: ProductBalanceTarget | null
+  ingredient_flags: MaskIngredientFlag[]
   created_at?: string
   updated_at?: string
 }

--- a/src/lib/oil/constants.ts
+++ b/src/lib/oil/constants.ts
@@ -1,5 +1,14 @@
 import type { HairThickness } from "@/lib/vocabulary"
 
+export const OIL_INGREDIENT_FLAGS = [
+  "silicones",
+  "polymers",
+  "oils",
+  "proteins",
+  "humectants",
+] as const
+export type OilIngredientFlag = (typeof OIL_INGREDIENT_FLAGS)[number]
+
 export const OIL_DB_CATEGORIES = ["Öle"] as const
 
 export const OIL_SUBTYPES = ["natuerliches-oel", "styling-oel", "trocken-oel"] as const
@@ -41,6 +50,16 @@ export type OilNoRecommendationReason = (typeof OIL_NO_RECOMMENDATION_REASONS)[n
 export const OIL_NO_RECOMMENDATION_LABELS: Record<OilNoRecommendationReason, string> = {
   better_non_oil_category: "Ein anderes Produkt passt hier besser als ein Oel.",
   therapy_oil_missing: "Das passende Therapie-/Kopfhautoel ist aktuell nicht in der Datenbank.",
+}
+
+export interface ProductOilEligibility {
+  product_id: string
+  thickness: HairThickness
+  oil_subtype: OilSubtype
+  oil_purpose: OilPurpose | null
+  ingredient_flags: OilIngredientFlag[]
+  created_at?: string
+  updated_at?: string
 }
 
 export function isOilCategory(category: string | null | undefined): boolean {

--- a/src/lib/oil/constants.ts
+++ b/src/lib/oil/constants.ts
@@ -52,16 +52,6 @@ export const OIL_NO_RECOMMENDATION_LABELS: Record<OilNoRecommendationReason, str
   therapy_oil_missing: "Das passende Therapie-/Kopfhautoel ist aktuell nicht in der Datenbank.",
 }
 
-export interface ProductOilEligibility {
-  product_id: string
-  thickness: HairThickness
-  oil_subtype: OilSubtype
-  oil_purpose: OilPurpose | null
-  ingredient_flags: OilIngredientFlag[]
-  created_at?: string
-  updated_at?: string
-}
-
 export function isOilCategory(category: string | null | undefined): boolean {
   if (!category) return false
   const normalized = category.trim().toLowerCase()

--- a/supabase/migrations/20260429073505_add_mask_ingredient_flags.sql
+++ b/supabase/migrations/20260429073505_add_mask_ingredient_flags.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.product_mask_specs
+  ADD COLUMN ingredient_flags text[] NOT NULL DEFAULT '{}'
+  CHECK (
+    ingredient_flags <@ ARRAY['silicones','polymers','oils','proteins','humectants']
+  );
+
+CREATE INDEX IF NOT EXISTS idx_product_mask_specs_ingredient_flags
+  ON public.product_mask_specs USING gin (ingredient_flags);

--- a/supabase/migrations/20260429073528_add_oil_ingredient_flags.sql
+++ b/supabase/migrations/20260429073528_add_oil_ingredient_flags.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.product_oil_eligibility
+  ADD COLUMN ingredient_flags text[] NOT NULL DEFAULT '{}'
+  CHECK (
+    ingredient_flags <@ ARRAY['silicones','polymers','oils','proteins','humectants']
+  );
+
+CREATE INDEX IF NOT EXISTS idx_product_oil_eligibility_ingredient_flags
+  ON public.product_oil_eligibility USING gin (ingredient_flags);

--- a/supabase/migrations/20260429081904_add_leave_in_ingredient_flags_gin_index.sql
+++ b/supabase/migrations/20260429081904_add_leave_in_ingredient_flags_gin_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_product_leave_in_specs_ingredient_flags
+  ON public.product_leave_in_specs USING gin (ingredient_flags);

--- a/tests/mask-flow.spec.ts
+++ b/tests/mask-flow.spec.ts
@@ -74,6 +74,7 @@ function createSpec(
     weight: "medium",
     concentration: "medium",
     balance_direction: null,
+    ingredient_flags: [],
     ...overrides,
   }
 }

--- a/tests/recommendation-engine-selection.test.ts
+++ b/tests/recommendation-engine-selection.test.ts
@@ -120,12 +120,14 @@ test("engine mask reranking rewards complete fit metadata over unknown balance",
       weight: "medium",
       concentration: "high",
       balance_direction: null,
+      ingredient_flags: [],
     },
     {
       product_id: "ideal",
       weight: "medium",
       concentration: "high",
       balance_direction: "moisture",
+      ingredient_flags: [],
     },
   ]
 


### PR DESCRIPTION
## Summary

- Extends PR #52's `(Silikone)`/`(Kokos)` → structured `ingredient_flags` cleanup from conditioner to the remaining 3 product categories: leave-in (28 renames), mask (2), oil (19) — 49 total.
- Adds per-category `ingredient_flags text[]` columns + GIN indexes (mask, oil), backfills the existing leave-in column's missing GIN index for parity.
- Generalizes the parser gate in `convert_sources.py` from `is_conditioner_drogerie` to a per-category boolean union, picks up a new `+` separator variant in oil sheet (`Silikone + Kokos`), and inherits PR #52's multi-cell flag-merge logic for free.

## Changes

- **Schema (3 migrations)**:
  - `20260429073505_add_mask_ingredient_flags.sql`
  - `20260429073528_add_oil_ingredient_flags.sql`
  - `20260429081904_add_leave_in_ingredient_flags_gin_index.sql` (parity with the other 3 ingredient_flags tables)

- **Domain types** — per-category constants in `src/lib/{mask,oil}/constants.ts`. `ProductMaskSpecs` extended with required `ingredient_flags`; new `OIL_INGREDIENT_FLAGS` const + type for backfill.

- **Parser** — `scripts/convert_sources.py`:
  - `is_conditioner_drogerie` → `uses_ingredient_flags` (union of 4 per-category booleans).
  - Combined-form regex generalized: `[/+]` covers both `Silikone / Kokos` and `Silikone + Kokos` annotations.
  - New smoke asserts for `+` cases.

- **DB** — 49 `products.name` rows renamed via id-stable UPDATE with per-category backup tables (`products_name_backup_{leavein,mask,oil}_2026_04_29`, retained until merge + soak). Content_chunks rebuilt from regenerated JSON.

- **Backfill scripts**:
  - `backfill-leave-in-specs.ts`: 28 keymap entries renamed; idempotent rerun confirms column was already populated correctly.
  - `backfill-mask-specs.ts`: 2 keymap renames + `ingredient_flags` populated for all 35 mask spec rows (33 empty, 1 `["silicones"]`, 1 `["oils"]`). Type strictness matches conditioner pattern.
  - `backfill-oil-specs.ts`: 19 keymap renames + new `OIL_INGREDIENT_FLAGS_BY_NAME` lookup + `OIL_PURPOSE_OVERRIDE_BY_NAME` re-keyed to stripped Olaplex name. Validates lookup map against both live DB (orphan-key check) and parser-emitted JSON (drift check) — fails fast on any name-set mismatch.

- **Defer ingest-products.ts → ingredient_flags integration**: `inferMaskSpecs` Omits the column from its return type so admin/ingestion upserts don't clobber the values written by the backfill (Supabase upsert only touches columns provided).

- **Tests** — `ingredient_flags: []` defaults added to `ProductMaskSpecs` test fixtures.

## Live-DB state (verified 2026-04-29)

| Check | Value | Expected |
|---|---|---|
| Suffixed leave-in / mask / oil names | 0 / 0 / 0 | 0 / 0 / 0 |
| Per-category totals | 42 / 35 / 41 | 42 / 35 / 41 |
| product_leave_in_specs has_silicones / has_oils / empty | 26 / 7 / 4 | matches script truth table |
| product_mask_specs silicones-only / oils-only / both / empty | 1 / 1 / 0 / 33 | 1 / 1 / 0 / 33 |
| product_oil_eligibility per-product silicones-only / both / empty | 15 / 4 / 22 | 15 / 4 / 22 |
| GIN indexes on ingredient_flags (4 tables) | present | present |
| Backup tables (leavein / mask / oil) | 42 / 35 / 41 rows | 42 / 35 / 41 |

## Reviews

- **Codex (`codex:codex-rescue` full-branch)**: NEEDS-REVISION on first pass — flagged silent data loss risk on oil name drift, mask type strictness regression, migration rerun-safety. First two addressed in `c073465` + `88407fe`; third deferred (matches conditioner precedent and Supabase migration tracking).
- **`code-reviewer` agent**: APPROVED-WITH-CONCERNS — flagged dead `ProductOilEligibility` interface, hardcoded oil flags vs JSON, missing oil validation. All addressed.
- **Plan-level Codex review** (pre-implementation): NEEDS-MAJOR-REVISION on first pass; all 12 findings addressed in plan revision before code was written.

## Test plan

- [x] `npm run ci:verify` (typecheck + lint + build) — passes
- [x] `npx tsx scripts/backfill-{leave-in,mask,oil}-specs.ts` — idempotent reruns produce same DB state
- [x] Live-DB sanity SQL (zero suffixed names, all 4 GIN indexes, backup tables intact)
- [ ] `npm run test:chat` — defer to post-merge (chat eval was failing on origin/main pre-this-PR per the Stripe paywall middleware redirect; not a regression from this PR)
- [ ] Manual smoke: open chat, ask for a leave-in / mask / oil rec, confirm clean names render

## Post-merge

- Drop the 3 backup tables after prod soak.
- Eventually retire the deferred `ingest-products.ts` integration to write `ingredient_flags` into spec tables (still keyed via the backfill scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)