### PR TITLE
feat(quiz): collect hair density

### DIFF
--- a/docs/quiz-onboarding-data-collection-inventory.md
+++ b/docs/quiz-onboarding-data-collection-inventory.md
@@ -1,6 +1,6 @@
 # Quiz And Onboarding Data Collection Inventory
 
-Checked against the current UI code plus the live Supabase schema on March 23, 2026.
+Checked against the current UI code plus the live Supabase schema on April 29, 2026.
 
 Scope notes:
 - Quiz lead-capture fields (`name`, `email`, `marketingConsent`) are excluded.
@@ -12,6 +12,7 @@ Scope notes:
 |---|---|---|---|
 | `WAS IST DEINE NATUERLICHE HAARTEXTUR?` | `Glatt` (`straight`), `Wellig` (`wavy`), `Lockig` (`curly`), `Kraus` (`coily`) | Raw: `public.leads.quiz_answers` key `structure`<br>Final: `public.hair_profiles.hair_texture` | Raw: `straight`, `wavy`, `curly`, `coily`<br>Final: `straight`, `wavy`, `curly`, `coily` |
 | `WIE DICK SIND DEINE EINZELNEN HAARE?` | `Fein` (`fine`), `Mittel` (`normal`), `Dick` (`coarse`) | Raw: `public.leads.quiz_answers` key `thickness`<br>Final: `public.hair_profiles.thickness` | Raw: `fine`, `normal`, `coarse`<br>Final: `fine`, `normal`, `coarse` |
+| `Wie dicht ist dein Haar insgesamt?` | `Wenig Haare` (`low`), `Mittlere Dichte` (`medium`), `Viele Haare` (`high`) | Raw: `public.leads.quiz_answers` key `density`<br>Final: `public.hair_profiles.density` | Raw: `low`, `medium`, `high`<br>Final: `low`, `medium`, `high` |
 | `DER OBERFLAECHENTEST` | `Glatt wie Glas` (`glatt`), `Leicht uneben` (`leicht_uneben`), `Richtig rau und huckelig` (`rau`) | Raw: `public.leads.quiz_answers` key `fingertest`<br>Final: `public.hair_profiles.cuticle_condition` | Raw: `glatt`, `leicht_uneben`, `rau`<br>Final from mapping: `smooth`, `slightly_rough`, `rough` |
 | `DER ZUGTEST` | `Dehnt sich und geht zurueck` (`stretches_bounces`), `Dehnt sich, bleibt ausgeleiert` (`stretches_stays`), `Reisst sofort` (`snaps`) | Raw: `public.leads.quiz_answers` key `pulltest`<br>Final: `public.hair_profiles.protein_moisture_balance` | Raw: `stretches_bounces`, `stretches_stays`, `snaps`<br>Final: `stretches_bounces`, `stretches_stays`, `snaps` |
 | `WIE IST DEIN KOPFHAUTTYP?` | `Fettig` (`fettig`), `Ausgeglichen` (`ausgeglichen`), `Trocken` (`trocken`) | Raw: `public.leads.quiz_answers` key `scalp_type`<br>Final: `public.hair_profiles.scalp_type` | Raw: `fettig`, `ausgeglichen`, `trocken`<br>Final from mapping: `oily`, `balanced`, `dry` |
@@ -21,11 +22,10 @@ Scope notes:
 
 ## B. Onboarding Flow
 
-Current code path is `density -> mechanical stress -> routine -> goals`.
+Current code path is `mechanical stress -> routine -> goals`. Density is now collected in quiz Q3, not owned by onboarding.
 
 | Question | Options shown to user | Storage in DB | Possible stored values |
 |---|---|---|---|
-| `Wie dicht ist dein {adjective} Haar?` | `Wenig Haare` (`low`), `Mittlere Dichte` (`medium`), `Viele Haare` (`high`) | Raw: none; writes direct<br>Final: `public.hair_profiles.density` | `low`, `medium`, `high` |
 | `Wie beanspruchst du dein Haar mechanisch?` | Multi-select: `Enge Frisuren (Zoepfe, Dutts, Extensions)` (`tight_hairstyles`), `Haeufiges oder grobes Buersten` (`rough_brushing`), `Handtuch-Rubbeln statt Tupfen` (`towel_rubbing`) | Raw: none; writes direct<br>Final: `public.hair_profiles.mechanical_stress_factors` (`text[]`) | `[]` or any subset of `tight_hairstyles`, `rough_brushing`, `towel_rubbing` |
 | `Wie oft waeschst du deine Haare?` | `Täglich` (`daily`), `Alle 2-3 Tage` (`every_2_3_days`), `1x pro Woche` (`once_weekly`), `Seltener` (`rarely`) | Raw: none; writes direct<br>Final: `public.hair_profiles.wash_frequency` | Current flow writes `daily`, `every_2_3_days`, `once_weekly`, `rarely` |
 | `Welche Produkte nutzt du aktuell?` | Multi-select: `Shampoo`, `Conditioner`, `Leave-in`, `Oel`, `Maske`, `Hitzeschutz`, `Serum`, `Scrub` | Raw: none; writes direct<br>Final: `public.hair_profiles.current_routine_products` (`text[]`) | `[]` or any subset of `shampoo`, `conditioner`, `leave_in`, `oil`, `mask`, `heat_protectant`, `serum`, `scrub` |
@@ -40,5 +40,6 @@ Current code path is `density -> mechanical stress -> routine -> goals`.
 - Current code and the live DB were more reliable than the tests here. `tests/onboarding-goal-flow.test.ts` still expects a smaller straight-hair goal set than the current UI in `src/lib/vocabulary/onboarding-goals.ts`. `tests/quiz-onboarding-e2e.spec.ts` also reflects an older onboarding path.
 - The live DB does not currently enforce all final scalar enums on `hair_profiles`. For `cuticle_condition`, `protein_moisture_balance`, `scalp_type`, `scalp_condition`, `wash_frequency`, `heat_styling`, `chemical_treatment`, and `goals`, the values above come from the current UI and mapping code, not from hard DB checks.
 - Quiz answers have a two-step lifecycle: they are first captured in `public.leads.quiz_answers`, then mapped into `public.hair_profiles` by `src/lib/quiz/link-to-profile.ts`.
+- Historical/test profiles with `public.hair_profiles.density IS NULL` are backfilled once to `medium`; future quiz completions should populate density from the user's Q3 answer rather than relying on a permanent database default.
 - Saving the final onboarding goals screen also flips `public.profiles.onboarding_completed = true`, but that flag is a side effect, not a user-selected property.
 - The broader goal enum still includes values like `color_protection`, but the current onboarding UI does not collect that value.

--- a/plans/2026-04-29-density-onboarding-page.md
+++ b/plans/2026-04-29-density-onboarding-page.md
@@ -1,0 +1,394 @@
+# Density Quiz Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add hair density as the third physical hair attribute in the quiz, persist it to `hair_profiles.density`, and show/edit it in the user-facing profile page.
+
+**Architecture:** Quiz owns "what your hair is"; onboarding owns "what you do with it." Add a new quiz step immediately after strand thickness, store the answer in `leads.quiz_answers.density`, map it through `linkQuizToProfile`, and reuse the existing `hair_profiles.density` field consumed by recommendations. Backfill existing null profile rows to `medium` in a one-time Supabase migration, but do not add a permanent DB default. Do not add onboarding steps, onboarding milestones, or new profile edit routes.
+
+**Tech Stack:** Next.js App Router, React 19, Zustand quiz store, Supabase `leads` + `hair_profiles`, Zod validators, Playwright + Node test runner.
+
+---
+
+## Decision
+
+Use quiz-first placement.
+
+Why:
+- `hair_texture`, `thickness`, and `density` are the same conceptual family: physical hair attributes.
+- The user has just answered "single strand thickness," so the contrast with "overall amount of hair" is easiest to explain immediately.
+- The anonymous public quiz will capture density for lead/cohort analysis.
+- Existing users who retake the quiz will be asked density naturally.
+- The write path already exists: quiz answer -> `leads.quiz_answers` -> `linkQuizToProfile` -> `hair_profiles`.
+- This avoids a one-step onboarding section, progress milestone churn, and an orphan profile-only field.
+- Historical/test rows with missing density can be backfilled to `medium`; going forward the quiz is the source of truth.
+
+Rejected alternative:
+- Onboarding after welcome. This works technically, but it puts a physical attribute in the "what you do" flow and creates UI/progress weight for one page. Do not implement that path.
+
+## Current State
+
+Already present:
+- DB column/check: `hair_profiles.density` with `low | medium | high` in `supabase/migrations/20260314210546_add_density_and_conditioner_rerank_specs.sql`.
+- Vocabulary: `HAIR_DENSITIES`, `HairDensity`, `HAIR_DENSITY_LABELS`, `HAIR_DENSITY_OPTIONS` in `src/lib/vocabulary/profile-labels.ts`.
+- Profile/types/validators: `HairProfile.density`, recommendation input `density`, and `validators/index.ts`.
+- Consumers:
+  - Conditioner: `src/lib/recommendation-engine/categories/shared.ts`, `src/lib/recommendation-engine/categories/conditioner.ts`, `src/lib/rag/conditioner-decision.ts`.
+  - Leave-in: `src/lib/recommendation-engine/categories/leave-in.ts`, `src/lib/rag/leave-in-decision.ts`.
+  - Mask: `src/lib/recommendation-engine/categories/mask.ts`.
+  - Routine: `src/lib/routines/planner.ts`.
+  - Chat/product context: `src/lib/rag/synthesizer.ts`, `src/components/chat/product-detail-drawer.tsx`.
+  - Suggested prompts: `src/lib/suggested-prompts.ts`.
+
+Missing:
+- Quiz type, questions, validators, normalization, and lead/profile linking do not include `density`.
+- `/profile` does not display density in `PROFILE_FIELD_CONFIG`.
+- E2E fixtures often manually seed density, but the real quiz path never collects it.
+- Existing rows may have `density = null`; these should be backfilled once, not silently defaulted forever.
+
+## Product Spec
+
+Quiz placement:
+- Add density as the new Q3, immediately after thickness.
+- Renumber later quiz questions so total quiz questions become 9.
+- Keep scalp progressive disclosure as a single numbered question.
+
+User-facing German copy:
+- Title: `Wie dicht ist dein Haar insgesamt?`
+- Instruction: `Jetzt geht es nicht mehr um ein einzelnes Haar, sondern um die Haarmenge auf dem Kopf. Schau zum Beispiel auf Scheitel, Zopf-Umfang und wie viel Kopfhaut sichtbar ist.`
+- Options:
+  - `Wenig Haare` (`low`): `Der Scheitel wirkt breiter oder die Kopfhaut scheint schnell durch.`
+  - `Mittlere Dichte` (`medium`): `Du hast weder auffällig wenig noch auffällig viele Haare.`
+  - `Viele Haare` (`high`): `Dein Haar fühlt sich insgesamt voll an, ein Zopf wirkt eher dick.`
+
+Profile display:
+- Show `Haardichte` near `Haar-Dicke` in the Haar-Check section.
+- Route profile edit for density through the existing inline Haar-Check editor in `/profile`; do not send users to onboarding for this field.
+
+Non-goals:
+- Do not infer density from thickness, texture, goals, or photos.
+- Do not add new recommendation rules.
+- Do not add an onboarding `hair_density` step or `Profil` milestone.
+- Do not add a permanent database default for density.
+
+## Target File Map
+
+- Modify `src/lib/quiz/types.ts`: add a quiz step id and `QuizAnswers.density`.
+- Modify `src/lib/quiz/questions.ts`: add density question, update total count, renumber later questions/motivation.
+- Modify `src/lib/quiz/store.ts`: insert the new step after thickness.
+- Modify `src/components/quiz/quiz-question.tsx`: map the new density step to `answers.density`.
+- Modify `src/app/quiz/page.tsx`: add `STEP_NAMES` entry and ensure standard question rendering includes the new step.
+- Modify `src/lib/quiz/brand-panel-content.ts`: add the density step and update total/progress-complete counts from 8 to 9.
+- Modify `src/components/quiz/quiz-brand-panel.tsx`: change desktop progress dot count from 8 to `QUIZ_TOTAL_QUESTIONS` or 9.
+- Modify `src/components/quiz/quiz-scalp-question.tsx`, `quiz-goals.tsx`, `quiz-lead-capture.tsx`: verify they already derive total from `QUIZ_TOTAL_QUESTIONS`; update hardcoded current numbers where needed.
+- Modify `src/lib/quiz/normalization.ts`: add `QUIZ_DENSITY_VALUES`, normalize stored answers, canonicalize/dedupe with density.
+- Modify `src/lib/quiz/validators.ts`: require `density` in quiz answers.
+- Modify `src/lib/quiz/link-to-profile.ts`: map `answers.density` to `profileData.density`.
+- Create Supabase migration: backfill `hair_profiles.density IS NULL` to `medium`, without adding a column default.
+- Modify `src/lib/quiz/completion.ts`: require density as part of completed quiz diagnostics after the backfill.
+- Modify `src/lib/profile/section-config.ts`: show density in the Haar-Check section.
+- Modify `src/app/profile/page.tsx`: include density in inline quiz draft/save if editing from the profile page.
+- Modify `tests/quiz-onboarding-e2e.spec.ts`: collect/assert density.
+- Modify `tests/profile-page-smoke.spec.ts`: seed/show/edit density and verify route/edit behavior.
+- Modify `tests/auth-intake-state.test.ts`: verify completed quiz diagnostics include density.
+- Modify `docs/quiz-onboarding-data-collection-inventory.md`: document density as quiz Q3 and remove stale onboarding-density claims.
+
+## Tasks
+
+### Task 1: Extend Quiz Types And Step Order
+
+**Files:**
+- Modify: `src/lib/quiz/types.ts`
+- Modify: `src/lib/quiz/store.ts`
+
+- [ ] Add numeric step `13` for density to avoid renumbering existing internal step ids:
+
+```ts
+export type QuizStep =
+  | 1
+  | 2 // haartextur
+  | 3 // haarstaerke
+  | 13 // haardichte
+  | 4 // oberflaeche
+  // existing steps unchanged
+```
+
+- [ ] Add `density?: string` to `QuizAnswers`.
+- [ ] Insert step `13` immediately after `3`:
+
+```ts
+const STEP_ORDER: QuizStep[] = [1, 2, 3, 13, 4, 5, 7, 6, 8, 12, 9, 10, 11, 14]
+```
+
+Acceptance:
+- Back/next from thickness goes to density, then surface.
+- Existing internal step ids stay stable for old tracking references.
+
+### Task 2: Add The Density Quiz Question
+
+**Files:**
+- Modify: `src/lib/quiz/questions.ts`
+- Modify: `src/components/quiz/quiz-question.tsx`
+- Modify: `src/app/quiz/page.tsx`
+
+- [ ] Change `QUIZ_TOTAL_QUESTIONS` from `8` to `9`.
+- [ ] Add the density question after thickness:
+
+```ts
+{
+  step: 13,
+  questionNumber: 3,
+  title: "Wie dicht ist dein Haar insgesamt?",
+  instruction:
+    "Jetzt geht es nicht mehr um ein einzelnes Haar, sondern um die Haarmenge auf dem Kopf. Schau zum Beispiel auf Scheitel, Zopf-Umfang und wie viel Kopfhaut sichtbar ist.",
+  options: [
+    {
+      value: "low",
+      label: "Wenig Haare",
+      description: "Der Scheitel wirkt breiter oder die Kopfhaut scheint schnell durch.",
+      icon: "hair-fine",
+    },
+    {
+      value: "medium",
+      label: "Mittlere Dichte",
+      description: "Du hast weder auffällig wenig noch auffällig viele Haare.",
+      icon: "hair-normal",
+    },
+    {
+      value: "high",
+      label: "Viele Haare",
+      description: "Dein Haar fühlt sich insgesamt voll an, ein Zopf wirkt eher dick.",
+      icon: "hair-coarse",
+    },
+  ],
+  selectionMode: "single",
+  motivation: "Genau — jetzt kennen wir die wichtigsten Grunddaten.",
+}
+```
+
+- [ ] Increment later `questionNumber` values by one.
+- [ ] Update motivation copy where it references remaining counts.
+- [ ] Add `13: "density"` to `ANSWER_KEY_MAP`.
+- [ ] Add `13: "hair_density"` to `STEP_NAMES`.
+- [ ] Ensure the standard quiz question rendering includes step 13. Current `if (step >= 2 && step <= 8)` will not include 13. Keep the custom scalp/concerns guards first, then render any configured standard question:
+
+```ts
+if (step === 6) return <QuizScalpQuestion />
+if (step === 8) return <QuizConcernsQuestion />
+
+const question = getQuestionByStep(step)
+if (question) return <QuizQuestion key={question.step} question={question} />
+```
+
+Icon decision:
+- Use the existing strand icons (`hair-fine`, `hair-normal`, `hair-coarse`) for the first version. Do not add new icons in this task; the text carries the distinction.
+
+### Task 3: Update Quiz Progress And Brand Panel
+
+**Files:**
+- Modify: `src/lib/quiz/brand-panel-content.ts`
+- Modify: `src/components/quiz/quiz-brand-panel.tsx`
+- Modify: `src/components/quiz/quiz-scalp-question.tsx`
+- Review: `src/components/quiz/quiz-goals.tsx`, `src/components/quiz/quiz-lead-capture.tsx`
+
+- [ ] Add step 13 to `QUESTION_PANEL_CONTENT`:
+
+```ts
+13: { questionNumber: 3, description: "Wie voll dein Haar insgesamt ist." },
+```
+
+- [ ] Increment later `questionNumber` values.
+- [ ] Replace hardcoded `VON 8`, `progressCurrent: 8`, and dot count `length: 8` with `QUIZ_TOTAL_QUESTIONS`, or change them to 9 consistently.
+- [ ] Update `QuizScalpQuestion` hardcoded current progress from `6` to the new scalp question number.
+- [ ] Verify `QuizGoals` and `QuizLeadCapture` already use `QUIZ_TOTAL_QUESTIONS`; no change needed if they do.
+
+### Task 4: Persist Density Through Lead And Profile Mapping
+
+**Files:**
+- Modify: `src/lib/quiz/normalization.ts`
+- Modify: `src/lib/quiz/validators.ts`
+- Modify: `src/lib/quiz/link-to-profile.ts`
+
+- [ ] Add density allowed values:
+
+```ts
+export const QUIZ_DENSITY_VALUES = ["low", "medium", "high"] as const
+```
+
+- [ ] Normalize stored quiz density:
+
+```ts
+density: isAllowedValue(source.density, QUIZ_DENSITY_VALUES) ? source.density : undefined,
+```
+
+- [ ] Add `density: z.enum(QUIZ_DENSITY_VALUES)` to `quizAnswersSchema`.
+- [ ] Map density in `linkQuizToProfile`:
+
+```ts
+if (answers.density) profileData.density = answers.density
+```
+
+Acceptance:
+- `leads.quiz_answers.density` stores `low | medium | high`.
+- `hair_profiles.density` is populated when auth/lead linking runs.
+- Retaking the quiz updates density on the existing hair profile.
+
+### Task 5: Backfill Existing Profiles And Require Density In Quiz Completion
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_backfill_hair_profile_density.sql`
+- Modify: `src/lib/quiz/completion.ts`
+- Modify: `tests/auth-intake-state.test.ts`
+
+- [ ] Create a Supabase migration that backfills existing null density rows to `medium`:
+
+```sql
+-- Historical/test profiles predate the quiz density question.
+-- Backfill to a neutral value so recommendation logic receives a complete
+-- physical-hair profile, but do not add a permanent default for future rows.
+UPDATE public.hair_profiles
+SET density = 'medium'
+WHERE density IS NULL;
+```
+
+- [ ] Confirm the migration does not add `ALTER COLUMN density SET DEFAULT`.
+- [ ] Add `density?: string | null` to `PersistedQuizDiagnosticsProfile`.
+- [ ] Require `density` in `hasCompletedQuizDiagnostics`:
+
+```ts
+hasNonEmptyString(profile.density) &&
+```
+
+- [ ] Update `completeQuizProfile` in `tests/auth-intake-state.test.ts` with `density: "medium"`.
+- [ ] Add or update tests:
+
+```ts
+test("hasQuizDiagnostics requires density", () => {
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, density: null }), false)
+})
+
+test("hasQuizDiagnostics accepts complete quiz profiles with density", () => {
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, density: "medium" }), true)
+})
+```
+
+Rationale:
+- After the migration, existing profiles are normalized to `medium`; new quiz submissions require density. A future missing density should be treated as a data bug, not silently completed.
+
+### Task 6: Show And Edit Density In Profile
+
+**Files:**
+- Modify: `src/lib/profile/section-config.ts`
+- Modify: `src/app/profile/page.tsx`
+- Modify: `tests/profile-page-smoke.spec.ts`
+
+- [ ] Import `HAIR_DENSITY_OPTIONS` in `section-config.ts`.
+- [ ] Add the profile field near thickness:
+
+```ts
+{
+  key: "density",
+  label: "Haardichte",
+  sectionKey: "quiz",
+  editTarget: { kind: "quiz" },
+  getValue: (profile) => optionLabel(profile?.density, HAIR_DENSITY_OPTIONS),
+}
+```
+
+- [ ] Add density to `QuizDraft`, `createQuizDraft`, and `handleSaveQuiz` in `src/app/profile/page.tsx`.
+- [ ] Add `density` to the `Pick<HairProfile, ...>` payload type in `handleSaveQuiz`.
+- [ ] Add a `quizFieldRefs.current.density` editor block directly after `thickness`.
+- [ ] Render density with `SegmentedControl` using `HAIR_DENSITY_OPTIONS`, title `Haardichte`, and helper text `Wie viele Haare du insgesamt hast - nicht wie dick ein einzelnes Haar ist.`
+- [ ] Verify the profile completion denominator before changing the smoke assertion. If the Haar-Check count is derived from `PROFILE_FIELD_CONFIG`, update `8/8 vollständig` to `9/9 vollständig`; otherwise update to the actual computed value.
+- [ ] In `tests/profile-page-smoke.spec.ts`, seed `density: "medium"`.
+- [ ] Assert profile shows `Haardichte` and `Mittlere Dichte`.
+- [ ] Edit density through the inline Haar-Check editor and assert Supabase value changes to `high`.
+
+### Task 7: E2E Quiz-To-Profile Persistence
+
+**Files:**
+- Modify: `tests/quiz-onboarding-e2e.spec.ts`
+- Review: `tests/mobile-ux.spec.ts`, `tests/auth-intake-routing.e2e.spec.ts`
+
+- [ ] Add the density step after thickness in the quiz E2E.
+- [ ] Select `Mittlere Dichte`.
+- [ ] Update all visible progress assertions from 8-total to 9-total.
+- [ ] Assert linked hair profile includes `density: "medium"`:
+
+```ts
+const profile = await fetchHairProfile()
+expect(profile?.density).toBe("medium")
+```
+
+- [ ] Update mobile/auth intake tests only where they assert quiz progress text or question count.
+
+### Task 8: Verify Density Consumers And Fallback Tests
+
+**Files:**
+- Usually no code changes. Update only if a consumer no longer receives persisted `hair_profiles.density`.
+
+- [ ] Confirm persistence adapter maps `profile.density` in `src/lib/recommendation-engine/adapters/from-persistence.ts`.
+- [ ] Confirm runtime normalization maps density in `src/lib/recommendation-engine/normalize.ts`.
+- [ ] Confirm conditioner target weight uses `deriveTargetWeight(profile)`.
+- [ ] Keep existing null-density fallback tests as bug guards, even though migration + required quiz should make null density rare:
+  - `tests/conditioner-reranker.spec.ts`: `missing density falls back safely and keeps weight scoring neutral`
+  - `tests/conditioner-chat-e2e.spec.ts`: `missing density still returns conditioner recommendations via soft fallback`
+  - `tests/leave-in-decision.spec.ts`: missing fields include `density`
+- [ ] Add mask/routine null-density coverage only if the existing test suite lacks any fallback coverage for those consumers and implementation changes touch that behavior.
+- [ ] Confirm chat context includes density when present in `src/lib/rag/synthesizer.ts`.
+- [ ] Confirm product detail drawer renders matched density metadata when present.
+- [ ] Confirm suggested prompts still treat density as a meaningful profile signal.
+
+Targeted commands:
+
+```bash
+npx playwright test tests/conditioner-reranker.spec.ts tests/leave-in-decision.spec.ts tests/routine-planner.spec.ts tests/mask-flow.spec.ts
+node --import tsx --test tests/suggested-prompts.test.ts tests/auth-intake-state.test.ts
+```
+
+### Task 9: Update Docs
+
+**Files:**
+- Modify: `docs/quiz-onboarding-data-collection-inventory.md`
+
+- [ ] Move density from onboarding to the quiz table as Q3:
+
+```md
+| `Wie dicht ist dein Haar insgesamt?` | `Wenig Haare` (`low`), `Mittlere Dichte` (`medium`), `Viele Haare` (`high`) | Raw: `public.leads.quiz_answers` key `density`<br>Final: `public.hair_profiles.density` | `low`, `medium`, `high` |
+```
+
+- [ ] Remove stale claims that current onboarding starts with density.
+- [ ] Note that historical/test profiles are backfilled to `medium`, while new quiz completions populate density from the user's answer.
+
+### Task 10: Full Verification
+
+Run:
+
+```bash
+npm run typecheck
+npm run lint
+npx playwright test tests/quiz-onboarding-e2e.spec.ts
+npx playwright test tests/profile-page-smoke.spec.ts
+npx playwright test tests/conditioner-reranker.spec.ts tests/leave-in-decision.spec.ts tests/routine-planner.spec.ts tests/mask-flow.spec.ts
+node --import tsx --test tests/suggested-prompts.test.ts tests/auth-intake-state.test.ts
+```
+
+Manual checks:
+- Desktop/mobile quiz: density appears immediately after thickness, copy distinguishes strand thickness vs overall density, no text overlap.
+- Back navigation: density back goes to thickness; density next goes to surface test.
+- Anonymous lead: `leads.quiz_answers.density` is stored.
+- Auth/linking: `hair_profiles.density` is populated.
+- Migration: local/test profiles with null density become `medium`; schema has no permanent density default.
+- Profile: `Haardichte` displays in Haar-Check and inline edit updates the DB.
+- Conditioner spot check: `thickness = fine`, `density = low` produces light target/matched weight; missing density still follows the tested soft fallback.
+
+## Open Risks
+
+- Adding one quiz question may affect public funnel completion. Keep copy short and place it beside thickness where cognitive load is lowest.
+- Density self-assessment is imperfect. The implementation should not turn density into a hard medical or hair-loss signal.
+
+## Ready Check
+
+Because this touches quiz, profile display, German copy, persisted recommendation inputs, and onboarding handoff tests, run `ready-check` before shipping.
+
+Next workflow skill: `superpowers:subagent-driven-development` for implementation, or `superpowers:executing-plans` for a single-agent pass.

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -28,6 +28,7 @@ import type { ChemicalTreatment, HairProfile, ProfileConcern, UserMemoryEntry } 
 import {
   CHEMICAL_TREATMENT_LABELS,
   PROFILE_CONCERN_LABELS,
+  HAIR_DENSITY_OPTIONS,
   HAIR_TEXTURE_OPTIONS,
   HAIR_THICKNESS_OPTIONS,
   SCALP_CONDITION_LABELS,
@@ -71,6 +72,7 @@ type ProductDetailRow = {
 type QuizDraft = {
   hair_texture: string
   thickness: string
+  density: string
   cuticle_condition: string
   protein_moisture_balance: string
   chemical_treatment: ChemicalTreatment[]
@@ -167,6 +169,7 @@ function createQuizDraft(profile: HairProfile | null): QuizDraft {
   return {
     hair_texture: profile?.hair_texture ?? "",
     thickness: profile?.thickness ?? "",
+    density: profile?.density ?? "",
     cuticle_condition: profile?.cuticle_condition ?? "",
     protein_moisture_balance: profile?.protein_moisture_balance ?? "",
     chemical_treatment: profile?.chemical_treatment ?? [],
@@ -804,6 +807,7 @@ export default function ProfilePage() {
       HairProfile,
       | "hair_texture"
       | "thickness"
+      | "density"
       | "cuticle_condition"
       | "protein_moisture_balance"
       | "concerns"
@@ -813,6 +817,7 @@ export default function ProfilePage() {
     > & { updated_at: string } = {
       hair_texture: (quizDraft.hair_texture || null) as HairProfile["hair_texture"],
       thickness: (quizDraft.thickness || null) as HairProfile["thickness"],
+      density: (quizDraft.density || null) as HairProfile["density"],
       cuticle_condition: (quizDraft.cuticle_condition || null) as HairProfile["cuticle_condition"],
       protein_moisture_balance: (quizDraft.protein_moisture_balance ||
         null) as HairProfile["protein_moisture_balance"],
@@ -1061,6 +1066,25 @@ export default function ProfilePage() {
                             value={quizDraft.thickness}
                             onChange={(value) =>
                               setQuizDraft((current) => ({ ...current, thickness: value }))
+                            }
+                          />
+                        </QuizEditorField>
+                      </div>
+
+                      <div
+                        ref={(node) => {
+                          quizFieldRefs.current.density = node
+                        }}
+                      >
+                        <QuizEditorField
+                          title="Haardichte"
+                          text="Wie viele Haare du insgesamt hast - nicht wie dick ein einzelnes Haar ist."
+                        >
+                          <SegmentedControl
+                            options={HAIR_DENSITY_OPTIONS}
+                            value={quizDraft.density}
+                            onChange={(value) =>
+                              setQuizDraft((current) => ({ ...current, density: value }))
                             }
                           />
                         </QuizEditorField>

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -18,6 +18,7 @@ const STEP_NAMES: Record<number, string> = {
   1: "landing",
   2: "hair_texture",
   3: "hair_thickness",
+  13: "hair_density",
   4: "surface_test",
   5: "pull_test",
   6: "scalp",
@@ -45,10 +46,8 @@ export default function QuizPage() {
   if (step === 8) return <QuizConcernsQuestion />
 
   // Standard quiz question cards
-  if (step >= 2 && step <= 8) {
-    const question = getQuestionByStep(step)
-    if (question) return <QuizQuestion key={question.step} question={question} />
-  }
+  const question = getQuestionByStep(step)
+  if (question) return <QuizQuestion key={question.step} question={question} />
 
   switch (step) {
     case 1:

--- a/src/components/quiz/quiz-brand-panel.tsx
+++ b/src/components/quiz/quiz-brand-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useQuizStore } from "@/lib/quiz/store"
 import { getQuizBrandPanelContent } from "@/lib/quiz/brand-panel-content"
+import { QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
 
 export function QuizBrandPanel() {
   const step = useQuizStore((s) => s.step)
@@ -100,7 +101,7 @@ function JourneyPanel({
 function DesktopJourneyProgress({ current, complete }: { current: number; complete: boolean }) {
   return (
     <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
-      {Array.from({ length: 8 }, (_, index) => {
+      {Array.from({ length: QUIZ_TOTAL_QUESTIONS }, (_, index) => {
         const stepNumber = index + 1
         const isCurrent = !complete && stepNumber === current
         const isDone = complete || stepNumber < current

--- a/src/components/quiz/quiz-question.tsx
+++ b/src/components/quiz/quiz-question.tsx
@@ -13,6 +13,7 @@ import { QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
 const ANSWER_KEY_MAP: Record<number, keyof import("@/lib/quiz/types").QuizAnswers> = {
   2: "structure",
   3: "thickness",
+  13: "density",
   4: "fingertest",
   5: "pulltest",
   7: "treatment",

--- a/src/components/quiz/quiz-scalp-question.tsx
+++ b/src/components/quiz/quiz-scalp-question.tsx
@@ -166,10 +166,10 @@ export function QuizScalpQuestion() {
           <ArrowLeft className="h-5 w-5" />
         </button>
         <div className="flex-1">
-          <QuizProgressBar current={6} total={QUIZ_TOTAL_QUESTIONS} />
+          <QuizProgressBar current={7} total={QUIZ_TOTAL_QUESTIONS} />
         </div>
         <span className="text-sm text-[var(--text-caption)] tabular-nums">
-          6/{QUIZ_TOTAL_QUESTIONS}
+          7/{QUIZ_TOTAL_QUESTIONS}
         </span>
       </div>
 
@@ -273,9 +273,7 @@ export function QuizScalpQuestion() {
       </div>
 
       {/* Motivation text — always anchored at bottom */}
-      <p className="mt-3 text-center text-sm text-[var(--text-caption)]">
-        Letzte Frage — gleich siehst du dein Profil.
-      </p>
+      <p className="mt-3 text-center text-sm text-[var(--text-caption)]">Gut — noch 2 Fragen.</p>
     </div>
   )
 }

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -3,6 +3,7 @@ import {
   PROFILE_CONCERN_LABELS,
   CUTICLE_CONDITION_LABELS,
   GOAL_LABELS,
+  HAIR_DENSITY_OPTIONS,
   HAIR_TEXTURE_OPTIONS,
   HAIR_THICKNESS_OPTIONS,
   HEAT_STYLING_OPTIONS,
@@ -143,6 +144,13 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
     sectionKey: "quiz",
     editTarget: { kind: "quiz" },
     getValue: (profile) => optionLabel(profile?.thickness, HAIR_THICKNESS_OPTIONS),
+  },
+  {
+    key: "density",
+    label: "Haardichte",
+    sectionKey: "quiz",
+    editTarget: { kind: "quiz" },
+    getValue: (profile) => optionLabel(profile?.density, HAIR_DENSITY_OPTIONS),
   },
   {
     key: "cuticle_condition",

--- a/src/lib/quiz/brand-panel-content.ts
+++ b/src/lib/quiz/brand-panel-content.ts
@@ -1,4 +1,5 @@
 import type { LeadCaptureSubStep, QuizStep } from "./types"
+import { QUIZ_TOTAL_QUESTIONS } from "./questions"
 
 export interface QuizBrandPanelContent {
   eyebrow: string | null
@@ -13,12 +14,13 @@ const QUESTION_PANEL_CONTENT: Partial<
 > = {
   2: { questionNumber: 1, description: "Deine natürliche Basis." },
   3: { questionNumber: 2, description: "Wie fein dein Haar ist." },
-  4: { questionNumber: 3, description: "Wie sich die Oberfläche anfühlt." },
-  5: { questionNumber: 4, description: "Wie belastbar die Längen sind." },
-  7: { questionNumber: 5, description: "Wie stark dein Haar behandelt ist." },
-  6: { questionNumber: 6, description: "Was an der Kopfhaut mitspielt." },
-  8: { questionNumber: 7, description: "Was dich gerade ausbremst." },
-  12: { questionNumber: 8, description: "Worauf wir hinarbeiten." },
+  13: { questionNumber: 3, description: "Wie voll dein Haar insgesamt ist." },
+  4: { questionNumber: 4, description: "Wie sich die Oberfläche anfühlt." },
+  5: { questionNumber: 5, description: "Wie belastbar die Längen sind." },
+  7: { questionNumber: 6, description: "Wie stark dein Haar behandelt ist." },
+  6: { questionNumber: 7, description: "Was an der Kopfhaut mitspielt." },
+  8: { questionNumber: 8, description: "Was dich gerade ausbremst." },
+  12: { questionNumber: 9, description: "Worauf wir hinarbeiten." },
 }
 
 export function getQuizBrandPanelContent(
@@ -40,7 +42,7 @@ export function getQuizBrandPanelContent(
   const questionContent = QUESTION_PANEL_CONTENT[step]
   if (questionContent) {
     return {
-      eyebrow: `FRAGE ${questionContent.questionNumber} VON 8`,
+      eyebrow: `FRAGE ${questionContent.questionNumber} VON ${QUIZ_TOTAL_QUESTIONS}`,
       description: questionContent.description,
       progressCurrent: questionContent.questionNumber,
       progressComplete: false,
@@ -52,7 +54,7 @@ export function getQuizBrandPanelContent(
     return {
       eyebrow: "FAST GESCHAFFT",
       description: "Gleich zeigen wir dir dein Profil.",
-      progressCurrent: 8,
+      progressCurrent: QUIZ_TOTAL_QUESTIONS,
       progressComplete: true,
       variant: "journey",
     }
@@ -62,7 +64,7 @@ export function getQuizBrandPanelContent(
     return {
       eyebrow: "ANALYSE",
       description: "Wir setzen alles zusammen.",
-      progressCurrent: 8,
+      progressCurrent: QUIZ_TOTAL_QUESTIONS,
       progressComplete: true,
       variant: "journey",
     }
@@ -72,7 +74,7 @@ export function getQuizBrandPanelContent(
     return {
       eyebrow: "WILLKOMMEN",
       description: "Dein nächster Schritt.",
-      progressCurrent: 8,
+      progressCurrent: QUIZ_TOTAL_QUESTIONS,
       progressComplete: true,
       variant: "journey",
     }

--- a/src/lib/quiz/completion.ts
+++ b/src/lib/quiz/completion.ts
@@ -1,6 +1,7 @@
 type PersistedQuizDiagnosticsProfile = {
   hair_texture?: string | null
   thickness?: string | null
+  density?: string | null
   cuticle_condition?: string | null
   protein_moisture_balance?: string | null
   scalp_type?: string | null
@@ -28,6 +29,7 @@ export function hasCompletedQuizDiagnostics(profile: PersistedQuizDiagnosticsPro
   return (
     hasNonEmptyString(profile.hair_texture) &&
     hasNonEmptyString(profile.thickness) &&
+    hasNonEmptyString(profile.density) &&
     hasNonEmptyString(profile.cuticle_condition) &&
     hasNonEmptyString(profile.protein_moisture_balance) &&
     hasCompletedScalpStep(profile) &&

--- a/src/lib/quiz/link-to-profile.ts
+++ b/src/lib/quiz/link-to-profile.ts
@@ -2,6 +2,24 @@ import { createAdminClient } from "@/lib/supabase/admin"
 import type { QuizAnswers } from "./types"
 import { normalizeStoredQuizAnswers } from "./normalization"
 
+export function resolveProfileDensityFromQuizAnswers(answers: QuizAnswers): string | undefined {
+  if (answers.density) return answers.density
+
+  const hasCompleteLegacyDiagnostics =
+    Boolean(answers.structure) &&
+    Boolean(answers.thickness) &&
+    Boolean(answers.fingertest) &&
+    Boolean(answers.pulltest) &&
+    Boolean(answers.scalp_type) &&
+    typeof answers.has_scalp_issue === "boolean" &&
+    (!answers.has_scalp_issue || Boolean(answers.scalp_condition)) &&
+    Array.isArray(answers.treatment) &&
+    answers.treatment.length > 0 &&
+    Array.isArray(answers.concerns)
+
+  return hasCompleteLegacyDiagnostics ? "medium" : undefined
+}
+
 /**
  * After a user authenticates, link their quiz lead data to their profile.
  *
@@ -83,6 +101,8 @@ export async function linkQuizToProfile(
 
   if (answers.structure) profileData.hair_texture = answers.structure
   if (answers.thickness) profileData.thickness = answers.thickness
+  const density = resolveProfileDensityFromQuizAnswers(answers)
+  if (density) profileData.density = density
   // Map quiz cuticle condition keys to English
   const CUTICLE_MAP: Record<string, string> = {
     glatt: "smooth",

--- a/src/lib/quiz/normalization.ts
+++ b/src/lib/quiz/normalization.ts
@@ -5,6 +5,7 @@ const MAX_GOALS = 5
 
 export const QUIZ_STRUCTURE_VALUES = ["straight", "wavy", "curly", "coily"] as const
 export const QUIZ_THICKNESS_VALUES = ["fine", "normal", "coarse"] as const
+export const QUIZ_DENSITY_VALUES = ["low", "medium", "high"] as const
 export const QUIZ_FINGERTEST_VALUES = ["glatt", "leicht_uneben", "rau"] as const
 export const QUIZ_PULLTEST_VALUES = ["stretches_bounces", "stretches_stays", "snaps"] as const
 export const QUIZ_SCALP_TYPE_VALUES = ["fettig", "ausgeglichen", "trocken"] as const
@@ -202,6 +203,7 @@ export function normalizeStoredQuizAnswers(
     thickness: isAllowedValue(source.thickness, QUIZ_THICKNESS_VALUES)
       ? source.thickness
       : undefined,
+    density: isAllowedValue(source.density, QUIZ_DENSITY_VALUES) ? source.density : undefined,
     fingertest: isAllowedValue(source.fingertest, QUIZ_FINGERTEST_VALUES)
       ? source.fingertest
       : undefined,

--- a/src/lib/quiz/questions.ts
+++ b/src/lib/quiz/questions.ts
@@ -1,6 +1,6 @@
 import type { QuizQuestion } from "./types"
 
-export const QUIZ_TOTAL_QUESTIONS = 8
+export const QUIZ_TOTAL_QUESTIONS = 9
 
 export const quizQuestions: QuizQuestion[] = [
   {
@@ -36,7 +36,7 @@ export const quizQuestions: QuizQuestion[] = [
       },
     ],
     selectionMode: "single",
-    motivation: "Super — noch 6 kurze Fragen.",
+    motivation: "Super — noch 7 kurze Fragen.",
   },
   {
     step: 3,
@@ -68,8 +68,37 @@ export const quizQuestions: QuizQuestion[] = [
     motivation: "Klasse — schon ein besseres Bild.",
   },
   {
-    step: 4,
+    step: 13,
     questionNumber: 3,
+    title: "Wie dicht ist dein Haar insgesamt?",
+    instruction:
+      "Jetzt geht es nicht mehr um ein einzelnes Haar, sondern um die Haarmenge auf dem Kopf. Schau zum Beispiel auf Scheitel, Zopf-Umfang und wie viel Kopfhaut sichtbar ist.",
+    options: [
+      {
+        value: "low",
+        label: "Wenig Haare",
+        description: "Der Scheitel wirkt breiter oder die Kopfhaut scheint schnell durch.",
+        icon: "hair-fine",
+      },
+      {
+        value: "medium",
+        label: "Mittlere Dichte",
+        description: "Du hast weder auffällig wenig noch auffällig viele Haare.",
+        icon: "hair-normal",
+      },
+      {
+        value: "high",
+        label: "Viele Haare",
+        description: "Dein Haar fühlt sich insgesamt voll an, ein Zopf wirkt eher dick.",
+        icon: "hair-coarse",
+      },
+    ],
+    selectionMode: "single",
+    motivation: "Genau — jetzt kennen wir die wichtigsten Grunddaten.",
+  },
+  {
+    step: 4,
+    questionNumber: 4,
     title: "Wie fühlt sich dein Haar an?",
     instruction:
       "Nimm ein gewaschenes, trockenes Haar aus deiner Bürste \u2013 es darf kein Produkt mehr drauf sein. Schließ die Augen und fahre ganz langsam mit zwei Fingern von der Wurzel zur Spitze. Konzentrier dich darauf, was du fühlst:",
@@ -94,11 +123,11 @@ export const quizQuestions: QuizQuestion[] = [
       },
     ],
     selectionMode: "single",
-    motivation: "Top — über die Hälfte geschafft.",
+    motivation: "Top — weiter geht's.",
   },
   {
     step: 5,
-    questionNumber: 4,
+    questionNumber: 5,
     title: "Wie elastisch ist dein Haar?",
     instruction:
       "Nimm dasselbe Haar. Klemm es zwischen Ringfinger und Zeigefinger auf der einen Seite und zwischen Ringfinger und Mittelfinger auf der anderen. Zieh jetzt vorsichtig \u2013 wirklich mit Gefühl, nicht reißen. Beobachte genau, was passiert:\n\nZiehe nur leicht. Uns geht es um die Tendenz, nicht um Perfektion.",
@@ -123,11 +152,11 @@ export const quizQuestions: QuizQuestion[] = [
       },
     ],
     selectionMode: "single",
-    motivation: "Gut gemacht — noch 3 Fragen.",
+    motivation: "Gut gemacht — noch 4 Fragen.",
   },
   {
     step: 7,
-    questionNumber: 5,
+    questionNumber: 6,
     title: "Sind deine Haare chemisch behandelt?",
     instruction:
       "Chemische Prozesse wie Blondieren oder Färben verändern die innere Struktur deiner Haare grundlegend. Blondieren bricht Brückenverbindungen auf und entzieht Protein \u2013 das muss in der Pflege ausgeglichen werden.",
@@ -156,7 +185,7 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 8,
-    questionNumber: 7,
+    questionNumber: 8,
     title: "Welche Haarprobleme beschäftigen dich gerade am meisten?",
     instruction:
       "Wähle bis zu 3 Punkte aus, die aktuell am besten zu deinen Längen und Spitzen passen.",

--- a/src/lib/quiz/store.ts
+++ b/src/lib/quiz/store.ts
@@ -24,7 +24,7 @@ interface QuizState {
   reset: () => void
 }
 
-const STEP_ORDER: QuizStep[] = [1, 2, 3, 4, 5, 7, 6, 8, 12, 9, 10, 11, 14]
+const STEP_ORDER: QuizStep[] = [1, 2, 3, 13, 4, 5, 7, 6, 8, 12, 9, 10, 11, 14]
 
 function nextStep(current: QuizStep): QuizStep {
   const idx = STEP_ORDER.indexOf(current)

--- a/src/lib/quiz/types.ts
+++ b/src/lib/quiz/types.ts
@@ -2,6 +2,7 @@ export type QuizStep =
   | 1 // landing
   | 2 // haartextur
   | 3 // haarstaerke
+  | 13 // haardichte
   | 4 // oberflaeche
   | 5 // zugtest
   | 6 // kopfhaut
@@ -41,6 +42,7 @@ export interface QuizQuestion {
 export interface QuizAnswers {
   structure?: string
   thickness?: string
+  density?: string
   fingertest?: string
   pulltest?: string
   scalp_type?: string

--- a/src/lib/quiz/validators.ts
+++ b/src/lib/quiz/validators.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import {
   QUIZ_STRUCTURE_VALUES,
   QUIZ_THICKNESS_VALUES,
+  QUIZ_DENSITY_VALUES,
   QUIZ_FINGERTEST_VALUES,
   QUIZ_PULLTEST_VALUES,
   QUIZ_CONCERN_VALUES,
@@ -15,6 +16,7 @@ export const quizAnswersSchema = z
   .object({
     structure: z.enum(QUIZ_STRUCTURE_VALUES),
     thickness: z.enum(QUIZ_THICKNESS_VALUES),
+    density: z.enum(QUIZ_DENSITY_VALUES),
     fingertest: z.enum(QUIZ_FINGERTEST_VALUES),
     pulltest: z.enum(QUIZ_PULLTEST_VALUES),
     scalp_type: z.enum(QUIZ_SCALP_TYPE_VALUES),

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -120,7 +120,7 @@ export async function updateSession(request: NextRequest) {
     const { data: hairProfile } = await supabase
       .from("hair_profiles")
       .select(
-        "hair_texture, thickness, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment, concerns",
+        "hair_texture, thickness, density, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment, concerns",
       )
       .eq("user_id", user.id)
       .maybeSingle()

--- a/supabase/migrations/20260429120000_backfill_hair_profile_density.sql
+++ b/supabase/migrations/20260429120000_backfill_hair_profile_density.sql
@@ -1,0 +1,22 @@
+-- Historical/test profiles predate the quiz density question.
+-- Backfill to a neutral value so recommendation logic receives a complete
+-- physical-hair profile, but do not add a permanent default for future rows.
+UPDATE public.hair_profiles
+SET density = 'medium'
+WHERE density IS NULL;
+
+-- Historical captured/analyzed leads may not have been linked into profiles
+-- yet. Give those otherwise-complete legacy quiz answers the same neutral
+-- density so post-payment/auth lead linking does not send users back to quiz.
+UPDATE public.leads
+SET quiz_answers = jsonb_set(quiz_answers, '{density}', '"medium"'::jsonb, true)
+WHERE quiz_answers IS NOT NULL
+  AND NOT (quiz_answers ? 'density')
+  AND quiz_answers ? 'structure'
+  AND quiz_answers ? 'thickness'
+  AND quiz_answers ? 'fingertest'
+  AND quiz_answers ? 'pulltest'
+  AND quiz_answers ? 'scalp_type'
+  AND quiz_answers ? 'has_scalp_issue'
+  AND quiz_answers ? 'treatment'
+  AND quiz_answers ? 'concerns';

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -23,7 +23,7 @@ test.describe.serial("Authenticated intake routing", () => {
   async function fetchLatestLead() {
     const { data, error } = await admin
       .from("leads")
-      .select("id, status, user_id")
+      .select("id, status, user_id, quiz_answers")
       .eq("email", email)
       .order("created_at", { ascending: false })
       .limit(1)
@@ -31,6 +31,19 @@ test.describe.serial("Authenticated intake routing", () => {
 
     if (error) throw error
     return data
+  }
+
+  async function fetchHairProfileDensity() {
+    if (!userId) return null
+
+    const { data, error } = await admin
+      .from("hair_profiles")
+      .select("density")
+      .eq("user_id", userId)
+      .maybeSingle()
+
+    if (error) throw error
+    return data?.density ?? null
   }
 
   test.beforeAll(async () => {
@@ -53,6 +66,9 @@ test.describe.serial("Authenticated intake routing", () => {
         id: userId,
         email,
         full_name: fullName,
+        stripe_customer_id: `cus_intake_${userId}`,
+        subscription_status: "active",
+        current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
       },
       { onConflict: "id" },
     )
@@ -114,6 +130,7 @@ test.describe.serial("Authenticated intake routing", () => {
     await page.getByRole("button", { name: /Quiz starten/i }).click()
     await page.getByText("Wellig").first().click()
     await page.getByText("Mittel").first().click()
+    await page.getByText("Mittlere Dichte").click()
     await page.getByText("Leicht uneben").click()
     await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
 
@@ -192,5 +209,9 @@ test.describe.serial("Authenticated intake routing", () => {
         { timeout: 30_000 },
       )
       .toBe("linked")
+
+    const latestLead = await fetchLatestLead()
+    expect(latestLead?.quiz_answers).toMatchObject({ density: "medium" })
+    await expect.poll(fetchHairProfileDensity, { timeout: 30_000 }).toBe("medium")
   })
 })

--- a/tests/auth-intake-state.test.ts
+++ b/tests/auth-intake-state.test.ts
@@ -10,6 +10,7 @@ import {
 const completeQuizProfile = {
   hair_texture: "wavy",
   thickness: "normal",
+  density: "medium",
   cuticle_condition: "slightly_rough",
   protein_moisture_balance: "stretches_stays",
   scalp_type: "dry",
@@ -27,6 +28,11 @@ test("hasQuizDiagnostics accepts a completed no-issue scalp answer", () => {
 })
 
 test("hasQuizDiagnostics requires every other quiz-written field", () => {
+  const missingDensityProfile: Partial<typeof completeQuizProfile> = { ...completeQuizProfile }
+  delete missingDensityProfile.density
+
+  assert.equal(hasQuizDiagnostics(missingDensityProfile), false)
+  assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, density: null }), false)
   assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, chemical_treatment: [] }), false)
   assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, concerns: null }), false)
   assert.equal(hasQuizDiagnostics({ ...completeQuizProfile, concerns: undefined }), false)

--- a/tests/profile-page-smoke.spec.ts
+++ b/tests/profile-page-smoke.spec.ts
@@ -75,6 +75,7 @@ test.describe.serial("@ci Profile page smoke", () => {
       user_id: userId,
       hair_texture: "wavy",
       thickness: "fine",
+      density: "medium",
       concerns: [],
       wash_frequency: "once_weekly",
       heat_styling: "once_weekly",
@@ -168,7 +169,13 @@ test.describe.serial("@ci Profile page smoke", () => {
     await expect(page.getByText("Weitere Produkte")).toHaveCount(0)
     await expect(page.getByText("Aus Haar-Check")).toHaveCount(0)
     await expect(page.getByText("Aus Onboarding")).toHaveCount(0)
-    await expect(page.locator("#profile-section-quiz").getByText("8/8 vollständig")).toBeVisible()
+    await expect(page.locator("#profile-section-quiz").getByText("9/9 vollständig")).toBeVisible()
+    await expect(
+      page
+        .getByRole("button")
+        .filter({ hasText: "Haardichte" })
+        .filter({ hasText: "Mittlere Dichte" }),
+    ).toBeVisible()
 
     const memorySwitch = page.getByRole("switch", { name: "Erinnerungen aktivieren" })
     await expect(memorySwitch).toHaveAttribute("aria-checked", "true")
@@ -181,15 +188,28 @@ test.describe.serial("@ci Profile page smoke", () => {
     await expect(page).toHaveURL(`${baseUrl}/profile`)
     await expect(page.getByText("Haar-Check direkt im Profil aktualisieren")).toBeVisible()
     await expect(page.getByRole("button", { name: "Haar-Check speichern" })).toBeVisible()
+    await page.getByRole("radio", { name: "Viele Haare" }).click()
     await page.getByRole("button", { name: "Keine Beschwerden" }).click()
     await page.getByRole("button", { name: "Naturhaar" }).click()
     await page.getByRole("button", { name: "Haar-Check speichern" }).click()
     await expect(page.getByText("Haar-Check gespeichert").first()).toBeVisible()
+    await expect(
+      page.getByRole("button").filter({ hasText: "Haardichte" }).getByText("Viele Haare"),
+    ).toBeVisible()
     await expect(page.getByText("Keine Beschwerden")).toBeVisible()
     await expect(page.getByText("Naturhaar")).toBeVisible()
     await expect(
       page.getByRole("button").filter({ hasText: "Haar-Bedenken" }).getByText("Nichts davon"),
     ).toBeVisible()
+
+    const { data: densityRow, error: densityError } = await admin
+      .from("hair_profiles")
+      .select("density")
+      .eq("user_id", userId!)
+      .single()
+
+    if (densityError) throw densityError
+    expect(densityRow?.density).toBe("high")
 
     await page.getByRole("button", { name: "Ziele bearbeiten", exact: true }).click()
     await page.waitForURL(/\/profile\/edit\/goals(\?.*)?$/, { timeout: 15000 })

--- a/tests/quiz-brand-panel-content.test.ts
+++ b/tests/quiz-brand-panel-content.test.ts
@@ -3,21 +3,21 @@ import test from "node:test"
 
 import { getQuizBrandPanelContent } from "../src/lib/quiz/brand-panel-content"
 
-test("question seven keeps the desktop rail with concise concerns copy", () => {
+test("question eight keeps the desktop rail with concise concerns copy", () => {
   const content = getQuizBrandPanelContent(8, "name")
 
-  assert.equal(content.eyebrow, "FRAGE 7 VON 8")
+  assert.equal(content.eyebrow, "FRAGE 8 VON 9")
   assert.equal(content.description, "Was dich gerade ausbremst.")
-  assert.equal(content.progressCurrent, 7)
+  assert.equal(content.progressCurrent, 8)
   assert.equal(content.progressComplete, false)
 })
 
-test("goals step becomes question eight in the desktop rail", () => {
+test("goals step becomes question nine in the desktop rail", () => {
   const content = getQuizBrandPanelContent(12, "name")
 
-  assert.equal(content.eyebrow, "FRAGE 8 VON 8")
+  assert.equal(content.eyebrow, "FRAGE 9 VON 9")
   assert.equal(content.description, "Worauf wir hinarbeiten.")
-  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressCurrent, 9)
   assert.equal(content.progressComplete, false)
 })
 
@@ -26,7 +26,7 @@ test("lead capture uses a short finalization message with completed progress", (
 
   assert.equal(content.eyebrow, "FAST GESCHAFFT")
   assert.equal(content.description, "Gleich zeigen wir dir dein Profil.")
-  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressCurrent, 9)
   assert.equal(content.progressComplete, true)
 })
 
@@ -35,6 +35,6 @@ test("analysis keeps the same desktop rail shell with concise processing copy", 
 
   assert.equal(content.eyebrow, "ANALYSE")
   assert.equal(content.description, "Wir setzen alles zusammen.")
-  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressCurrent, 9)
   assert.equal(content.progressComplete, true)
 })

--- a/tests/quiz-link-to-profile.test.ts
+++ b/tests/quiz-link-to-profile.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { resolveProfileDensityFromQuizAnswers } from "../src/lib/quiz/link-to-profile"
+
+test("linking uses the explicit quiz density when present", () => {
+  assert.equal(resolveProfileDensityFromQuizAnswers({ density: "high" }), "high")
+})
+
+test("linking backfills otherwise complete legacy quiz answers to medium density", () => {
+  assert.equal(
+    resolveProfileDensityFromQuizAnswers({
+      structure: "wavy",
+      thickness: "normal",
+      fingertest: "leicht_uneben",
+      pulltest: "stretches_stays",
+      scalp_type: "trocken",
+      has_scalp_issue: false,
+      concerns: [],
+      treatment: ["gefaerbt"],
+    }),
+    "medium",
+  )
+})
+
+test("linking does not invent density for sparse or partial answers", () => {
+  assert.equal(
+    resolveProfileDensityFromQuizAnswers({
+      structure: "wavy",
+      thickness: "normal",
+    }),
+    undefined,
+  )
+})

--- a/tests/quiz-normalization.test.ts
+++ b/tests/quiz-normalization.test.ts
@@ -25,6 +25,7 @@ test("legacy pulltest values are normalized", () => {
   const normalized = normalizeStoredQuizAnswers({
     structure: "curly",
     thickness: "normal",
+    density: "medium",
     fingertest: "leicht_uneben",
     pulltest: "ueberdehnt",
     scalp_type: "trocken",
@@ -33,6 +34,13 @@ test("legacy pulltest values are normalized", () => {
   })
 
   assert.equal(normalized.pulltest, "stretches_stays")
+})
+
+test("density values are normalized and invalid values are removed", () => {
+  assert.equal(normalizeStoredQuizAnswers({ density: "low" }).density, "low")
+  assert.equal(normalizeStoredQuizAnswers({ density: "medium" }).density, "medium")
+  assert.equal(normalizeStoredQuizAnswers({ density: "high" }).density, "high")
+  assert.equal(normalizeStoredQuizAnswers({ density: "unknown" }).density, undefined)
 })
 
 test("legacy scalp values still map to type and condition", () => {
@@ -112,6 +120,7 @@ test("canonicalization drops invalid natur conflicts", () => {
   const canonical = canonicalizeQuizAnswers({
     structure: "straight",
     thickness: "fine",
+    density: "low",
     fingertest: "glatt",
     pulltest: "stretches_bounces",
     scalp_type: "ausgeglichen",
@@ -122,6 +131,7 @@ test("canonicalization drops invalid natur conflicts", () => {
   })
 
   assert.equal(canonical.has_scalp_issue, false)
+  assert.equal(canonical.density, "low")
   assert.equal(canonical.scalp_condition, undefined)
   assert.deepEqual(canonical.concerns, ["breakage", "dryness", "frizz"])
   assert.equal(canonical.concerns_other_text, undefined)

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -82,6 +82,9 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         id: userId,
         email,
         full_name: fullName,
+        stripe_customer_id: `cus_quiz_${userId}`,
+        subscription_status: "active",
+        current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
       },
       { onConflict: "id" },
     )
@@ -110,16 +113,19 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       ).toBeVisible()
 
       await page.getByText("Wellig").first().click()
-      await expect(page.getByText("2/8")).toBeVisible()
+      await expect(page.getByText("2/9")).toBeVisible()
 
       await page.getByText("Mittel").first().click()
-      await expect(page.getByText("3/8")).toBeVisible()
+      await expect(page.getByText("3/9")).toBeVisible()
+
+      await page.getByText("Mittlere Dichte").click()
+      await expect(page.getByText("4/9")).toBeVisible()
 
       await page.getByText("Leicht uneben").click()
-      await expect(page.getByText("4/8")).toBeVisible()
+      await expect(page.getByText("5/9")).toBeVisible()
 
       await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
-      await expect(page.getByText("5/8")).toBeVisible()
+      await expect(page.getByText("6/9")).toBeVisible()
 
       await expect(
         page.getByRole("heading", { name: /Sind deine Haare chemisch behandelt/i }),
@@ -139,8 +145,8 @@ test.describe.serial("Quiz to onboarding E2E", () => {
 
       await page.getByRole("button", { name: /^Weiter$/i }).click()
 
-      // Scalp question (6/7)
-      await expect(page.getByText("6/8")).toBeVisible()
+      // Scalp question (7/9)
+      await expect(page.getByText("7/9")).toBeVisible()
       await expect(
         page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
       ).toBeVisible()
@@ -156,7 +162,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.getByRole("button", { name: "JA" }).click()
       await page.getByText("Trockene Schuppen").click()
 
-      await expect(page.getByText("7/8")).toBeVisible()
+      await expect(page.getByText("8/9")).toBeVisible()
       await expect(page.getByText(/Welche Haarprobleme/i)).toBeVisible()
       await page.getByText("Trockenheit").click()
       await page.getByText("Frizz").click()
@@ -208,23 +214,33 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await expect(
         page.getByRole("heading", { name: /Was dein Haar jetzt braucht/i }),
       ).toBeVisible()
-      await expect(page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i })).toBeVisible()
+      await expect(page.getByRole("button", { name: /PLAN FREISCHALTEN/i })).toBeVisible()
     })
 
     await test.step("Authenticate via inline auth on quiz-welcome", async () => {
-      // Advance from results to welcome (step 14 — inline auth)
-      await page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }).click()
-
-      // Welcome page now shows inline dark auth form
-      await expect(page.getByText("PROFIL SPEICHERN", { exact: false })).toBeVisible({
+      // Public result CTA now hands anonymous users to pricing. The test then
+      // uses the auth page directly with the latest lead id so it can verify
+      // quiz-to-profile linking without exercising Stripe checkout.
+      await page.getByRole("button", { name: /PLAN FREISCHALTEN/i }).click()
+      await page.waitForURL(/\/pricing(\?.*)?$/, {
         timeout: 15_000,
+        waitUntil: "domcontentloaded",
       })
 
-      // Switch to login tab and authenticate
-      await page.getByRole("tab", { name: "Anmelden" }).click()
-      await page.locator('input[type="email"]:visible').fill(email)
-      await page.locator('input[type="password"]:visible').fill(password)
-      await page.getByRole("button", { name: /^Anmelden$/ }).click()
+      const latestLead = await fetchLatestLead()
+      expect(latestLead?.id).toBeTruthy()
+      await page.goto(`/auth?next=/onboarding&lead=${latestLead!.id}`, {
+        waitUntil: "networkidle",
+      })
+
+      // Authenticate on the login form
+      await page.getByPlaceholder("E-Mail-Adresse").fill(email)
+      await expect(page.getByPlaceholder("E-Mail-Adresse")).toHaveValue(email)
+      await page.getByPlaceholder("Passwort").fill(password)
+      await expect(page.getByPlaceholder("Passwort")).toHaveValue(password)
+      const loginButton = page.getByRole("button", { name: /^Anmelden$/ })
+      await expect(loginButton).toBeEnabled()
+      await loginButton.click()
 
       // Should land on onboarding (single-page flow)
       await page.waitForURL(/\/onboarding(\?.*)?$/, {
@@ -342,6 +358,11 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         .not.toBeNull()
 
       // Verify hair profile data
+      const latestLead = await fetchLatestLead()
+      expect(latestLead?.quiz_answers).toMatchObject({
+        density: "medium",
+      })
+
       await expect
         .poll(
           async () => {
@@ -357,6 +378,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       expect(hairProfile).toMatchObject({
         hair_texture: "wavy",
         thickness: "normal",
+        density: "medium",
         cuticle_condition: "slightly_rough",
         protein_moisture_balance: "stretches_stays",
         scalp_type: "dry",
@@ -383,6 +405,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       expect(initialProfile).toMatchObject({
         hair_texture: "wavy",
         thickness: "normal",
+        density: "medium",
         cuticle_condition: "slightly_rough",
         protein_moisture_balance: "stretches_stays",
         scalp_type: "dry",
@@ -402,8 +425,13 @@ test.describe.serial("Quiz to onboarding E2E", () => {
 
       await page.getByRole("button", { name: /QUIZ STARTEN/i }).click()
       await page.getByText("Glatt").first().click()
-      await page.getByText("Fein").first().click()
+      await expect(page.getByText("2/9")).toBeVisible()
+      await page.getByRole("button", { name: /Fein Kaum spürbar/i }).click()
+      await expect(page.getByText("3/9")).toBeVisible()
+      await page.getByText("Wenig Haare").click()
+      await expect(page.getByText("4/9")).toBeVisible()
       await page.getByText("Glatt wie Glas").click()
+      await expect(page.getByText("5/9")).toBeVisible()
       await page.getByText("Reißt sofort").click()
 
       await expect(
@@ -419,7 +447,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await naturCard.click()
 
       await page.getByRole("button", { name: /^Weiter$/i }).click()
-      await expect(page.getByText("6/8")).toBeVisible()
+      await expect(page.getByText("7/9")).toBeVisible()
       await expect(
         page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
       ).toBeVisible()
@@ -428,8 +456,9 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         .filter({ has: page.getByText(/^Fettig$/) })
         .click()
       await page.getByRole("button", { name: "NEIN" }).click()
-      await expect(page.getByText("7/8")).toBeVisible()
-      await page.getByLabel("Etwas anderes?").fill("verklebt schnell")
+      await expect(page.getByText("8/9")).toBeVisible()
+      await page.getByRole("button", { name: "Etwas anderes ergänzen" }).click()
+      await page.getByLabel("Eigene Notiz").fill("verklebt schnell")
       await page.getByRole("button", { name: /^Weiter$/i }).click()
 
       // New step 12: Goals — sits between concerns and lead capture. Picks
@@ -460,22 +489,32 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await expect(
         page.getByRole("heading", { name: /Was dein Haar jetzt braucht/i }),
       ).toBeVisible()
-      await expect(page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i })).toBeVisible()
+      await expect(page.getByRole("button", { name: /PLAN FREISCHALTEN/i })).toBeVisible()
     })
 
     await test.step("Log back in via inline auth and relink the new lead", async () => {
-      // Advance from results into the welcome/auth step
-      await page.getByRole("button", { name: /MEINE ROUTINE STARTEN/i }).click()
-
-      await expect(page.getByText("PROFIL SPEICHERN", { exact: false })).toBeVisible({
+      // Advance from public results to pricing, then authenticate directly with
+      // the latest lead id to verify relinking without exercising Stripe checkout.
+      await page.getByRole("button", { name: /PLAN FREISCHALTEN/i }).click()
+      await page.waitForURL(/\/pricing(\?.*)?$/, {
         timeout: 15_000,
+        waitUntil: "domcontentloaded",
+      })
+
+      const latestLead = await fetchLatestLead()
+      expect(latestLead?.id).toBeTruthy()
+      await page.goto(`/auth?next=/onboarding&lead=${latestLead!.id}`, {
+        waitUntil: "networkidle",
       })
 
       // Log in with existing credentials
-      await page.getByRole("tab", { name: "Anmelden" }).click()
-      await page.locator('input[type="email"]:visible').fill(email)
-      await page.locator('input[type="password"]:visible').fill(password)
-      await page.getByRole("button", { name: /^Anmelden$/ }).click()
+      await page.getByPlaceholder("E-Mail-Adresse").fill(email)
+      await expect(page.getByPlaceholder("E-Mail-Adresse")).toHaveValue(email)
+      await page.getByPlaceholder("Passwort").fill(password)
+      await expect(page.getByPlaceholder("Passwort")).toHaveValue(password)
+      const loginButton = page.getByRole("button", { name: /^Anmelden$/ })
+      await expect(loginButton).toBeEnabled()
+      await loginButton.click()
 
       // Returning user with completed onboarding: lead is linked during the
       // /onboarding server-side load, then redirect to /chat since onboarding_completed is true
@@ -522,6 +561,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
 
       const latestLead = await fetchLatestLead()
       expect(latestLead?.quiz_answers).toMatchObject({
+        density: "low",
         concerns: [],
         concerns_other_text: "verklebt schnell",
       })
@@ -542,6 +582,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       expect(hairProfile).toMatchObject({
         hair_texture: "straight",
         thickness: "fine",
+        density: "low",
         cuticle_condition: "smooth",
         protein_moisture_balance: "snaps",
         scalp_type: "oily",

--- a/tests/quiz-validators.test.ts
+++ b/tests/quiz-validators.test.ts
@@ -7,6 +7,7 @@ function createBaseAnswers() {
   return {
     structure: "wavy",
     thickness: "normal",
+    density: "medium",
     fingertest: "leicht_uneben",
     pulltest: "stretches_stays",
     scalp_type: "trocken",
@@ -22,6 +23,13 @@ test("quiz schema accepts an empty concern array with a negative scalp gate", ()
   assert.deepEqual(parsed.concerns, [])
   assert.equal(parsed.has_scalp_issue, false)
   assert.equal(parsed.scalp_condition, undefined)
+})
+
+test("quiz schema requires density as the third physical hair attribute", () => {
+  const answers = createBaseAnswers()
+  delete (answers as Partial<typeof answers>).density
+
+  assert.throws(() => quizAnswersSchema.parse(answers))
 })
 
 test("quiz schema accepts free-text-only concern notes", () => {


### PR DESCRIPTION
## Summary
- add hair density as a full quiz question after strand thickness
- persist density through quiz answers, lead linking, profile display/edit, and authenticated routing
- backfill existing null profile/legacy lead density to medium via Supabase migration

## Verification
- npm run typecheck
- npm run lint
- node --import tsx --test tests/quiz-link-to-profile.test.ts tests/quiz-normalization.test.ts tests/quiz-validators.test.ts tests/auth-intake-state.test.ts
- PLAYWRIGHT_BASE_URL=http://localhost:3544 npx playwright test tests/auth-intake-routing.e2e.spec.ts --project=chromium
- PLAYWRIGHT_BASE_URL=http://localhost:3544 npx playwright test tests/profile-page-smoke.spec.ts --project=chromium
- prior local run: quiz onboarding E2E and recommendation category specs

## Notes
- Merge should wait for GitHub CI to pass.