### PR TITLE
chore(ci): make Dependabot updates reviewable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,85 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     groups:
-      production-dependencies:
+      stripe-dependencies:
         dependency-type: production
-      development-dependencies:
+        patterns:
+          - "stripe"
+          - "@stripe/*"
+      next-react-dependencies:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+          - "eslint-config-next"
+          - "@types/react"
+          - "@types/react-dom"
+      supabase-dependencies:
+        patterns:
+          - "@supabase/*"
+          - "supabase"
+      ai-observability-dependencies:
+        dependency-type: production
+        patterns:
+          - "openai"
+          - "cohere-ai"
+          - "@langfuse/*"
+          - "@opentelemetry/*"
+          - "@sentry/*"
+      production-patch-minor:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+        exclude-patterns:
+          - "stripe"
+          - "@stripe/*"
+          - "next"
+          - "react"
+          - "react-dom"
+          - "@supabase/*"
+          - "openai"
+          - "cohere-ai"
+          - "@langfuse/*"
+          - "@opentelemetry/*"
+          - "@sentry/*"
+      lint-format-tooling:
         dependency-type: development
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "prettier"
+          - "lint-staged"
+          - "husky"
+      test-tooling:
+        dependency-type: development
+        patterns:
+          - "@playwright/*"
+          - "playwright"
+          - "start-server-and-test"
+      typescript-tooling:
+        dependency-type: development
+        patterns:
+          - "typescript"
+          - "tsx"
+          - "@types/node"
+      development-patch-minor:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "prettier"
+          - "lint-staged"
+          - "husky"
+          - "@playwright/*"
+          - "playwright"
+          - "start-server-and-test"
+          - "typescript"
+          - "tsx"
+          - "@types/node"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder' }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-placeholder' }}
       COHERE_API_KEY: ${{ secrets.COHERE_API_KEY || 'placeholder' }}
+      HAS_LIVE_SUPABASE_SECRETS: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL != '' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY != '' && secrets.SUPABASE_SERVICE_ROLE_KEY != '' }}
+      HAS_LIVE_AI_SECRETS: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL != '' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY != '' && secrets.SUPABASE_SERVICE_ROLE_KEY != '' && secrets.OPENAI_API_KEY != '' && secrets.COHERE_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,13 +55,17 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run Playwright smoke tests
+        if: env.HAS_LIVE_SUPABASE_SECRETS == 'true'
         run: npx start-server-and-test 'npm run start' http://localhost:3000 'npx playwright test --grep @ci --project=chromium'
+      - name: Skip Playwright smoke tests
+        if: env.HAS_LIVE_SUPABASE_SECRETS != 'true'
+        run: echo "Live Supabase secrets are unavailable; skipping Supabase-backed Playwright smoke tests"
       - name: Run live chat smoke eval
-        if: steps.changes.outputs.chat_eval == 'true'
+        if: steps.changes.outputs.chat_eval == 'true' && env.HAS_LIVE_AI_SECRETS == 'true'
         run: npx start-server-and-test 'npm run start' http://localhost:3000 'npm run test:chat:ci'
       - name: Skip live chat smoke eval
-        if: steps.changes.outputs.chat_eval != 'true'
-        run: echo "No AI/chat/recommendation paths changed; skipping live chat smoke eval"
+        if: steps.changes.outputs.chat_eval != 'true' || env.HAS_LIVE_AI_SECRETS != 'true'
+        run: echo "No AI/chat/recommendation paths changed, or live AI/Supabase secrets are unavailable; skipping live chat smoke eval"
       - name: Run retrieval metrics gate
         if: steps.changes.outputs.retrieval_eval == 'true'
         run: npm run test:retrieval:ci


### PR DESCRIPTION
## Why
Dependabot's open action-update PRs are failing because the required quality job runs Supabase-backed smoke tests with placeholder secrets. The broad npm dependency groups also create large PRs that mix risky framework/tooling changes with low-risk patch bumps.

## What changed
- Keep deterministic CI checks required for every PR, including Dependabot PRs.
- Skip Supabase-backed Playwright smoke tests when live Supabase secrets are unavailable.
- Skip live chat smoke eval when live AI/Supabase secrets are unavailable.
- Split Dependabot npm grouping into narrower buckets for Stripe, Next/React, Supabase, AI/observability, lint tooling, test tooling, TypeScript tooling, and low-risk patch/minor updates.

## Verification
- Parsed both changed YAML files with Ruby YAML.
- Ran `git diff --check`.
- Ran `node scripts/ci/changed-paths.mjs`.
- Ran `npm run typecheck`.
- Ran `npm run lint` (passes with existing warnings only).
- Ran `npm run build`.

## Follow-ups
- After this merges, rerun/merge Dependabot PRs #61, #62, and #63 if quality goes green.
- Track #64 as a focused Stripe production dependency update instead of a broad grouped PR.
- Track #65 as focused dev-tooling updates instead of a broad grouped PR.
