### PR TITLE
Add layered routine recommendations

### DIFF
--- a/plans/2026-05-04-routine-layered-flow.md
+++ b/plans/2026-05-04-routine-layered-flow.md
@@ -1,0 +1,407 @@
+# Routine Layered Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:test-driven-development` for the tests-first loop. Use `superpowers:subagent-driven-development` if splitting routine planner, orchestration, and prompt work across independent files; otherwise use `superpowers:executing-plans`.
+
+**Spec Source:** Planning conversation from May 3-4, 2026 plus production `origin/main` conversation-state implementation at `db2b1b8`.
+
+**User Situation:** Tester feedback shows the first routine answer is too long on mobile and feels like an exhaustive add-on dump. Multi-turn routine follow-ups should feel like a natural consultation: basics first, then goal/problem layers, then focused deep dives, with product cards only when explicitly requested.
+
+**Promised End-State:** A fresh routine request produces a concise, natural German `basics` answer with Shampoo, Conditioner, and one highest-priority lever. Follow-up turns reveal only the relevant layer (`goals`, `problems`, or `deep_dive`) using conversation state. Routine product cards are withheld unless the user explicitly asks for concrete products.
+
+**Architecture:** Keep one deterministic full `RoutinePlan`, but introduce a routine turn resolver and layer projection before synthesis. Conversation state owns the active routine layer and pending offer. The routine planner owns priority ranking and layer slot selection. The synthesizer receives only the projected routine layer for the current turn. Product selection is gated by explicit product-request intent, not by routine slot presence.
+
+---
+
+## Alignment Summary
+
+### Locked Decisions
+
+- Apply the layered routine flow to fresh routine requests, including starter-card routine prompts.
+- The first answer should be concise but explanatory, not a rigid script.
+- `basics` always mentions Shampoo and Conditioner:
+  - briefly and positively when they already fit,
+  - as an adjustment when their focus should change,
+  - as a missing base when absent.
+- `basics` adds one highest-priority lever.
+- Priority is care-risk first, but ranked from hair failure modes, not from easiest detection:
+  1. buildup/overload/reset blockage if it prevents care from working
+  2. active severe breakage or structural failure
+  3. mechanical stress as supporting guardrail, or main lever only when clearly dominant
+  4. ongoing chemical/heat exposure that is likely worsening damage
+  5. scalp issues that change routine safety
+  6. strong dryness/frizz/tangling cluster
+  7. stated cosmetic goal
+  8. optional/advanced modules only when explicit or strongly justified
+- For severe damage/breakage, choose care-product-first:
+  1. Conditioner upgrade
+  2. Leave-in / Finish
+  3. Mask cadence
+  4. Bond Builder
+  5. Reset first only when buildup is blocking care
+- Behavior signals are included as supporting guardrails when present.
+- `goals` and `problems` layers show only the top 2-3 relevant levers.
+- `deep_dive` focuses one category/module, such as Leave-in, Maske, OWC, Bond Builder, Reset, etc.
+- Next-step offers should be natural and profile-based, not internal taxonomy labels.
+- Routine product cards should appear only when the user explicitly asks for concrete products.
+
+### Non-Goals
+
+- Do not build a saved routine artifact.
+- Do not replace the merged conversation-state system.
+- Do not create a second routine-specific persistence table.
+- Do not hardcode full answer prose templates.
+- Do not show product cards from routine slots unless the current turn is an explicit product ask.
+- Do not attempt a full conversation-frame v2 migration in this plan.
+
+### Current Production Constraints
+
+- Production state has `routine_layer`, `pending_offer`, `answered_slots`, and `last_assistant_action`.
+- Today, `basics` mainly means "assistant asked for missing routine basics." This plan changes semantics so `basics` can also mean "assistant answered the first routine layer."
+- The orchestrator currently passes the previous loaded state into synthesis, even after computing `conversationStateTransition`. Layered routine answers need an effective current state, usually the transition's `next_state`.
+- `attachProductsToRoutinePlan()` currently attaches routine products by default. This must be gated.
+- A vague routine follow-up such as "Und Leave-in?" should stay in routine deep-dive mode. An explicit product ask such as "Welches Leave-in empfiehlst du konkret?" should use product recommendation mode and product cards.
+
+---
+
+## Target File Map
+
+| Path | Responsibility |
+| --- | --- |
+| `src/lib/types.ts` | Add routine priority/layer projection types and routine turn policy trace fields if needed |
+| `src/lib/routines/planner.ts` | Compute priority lever, layer membership, top 2-3 slots, projected routine plan |
+| `src/lib/routines/product-attachments.ts` | Accept an explicit attachment policy so routine cards are skipped by default |
+| `src/lib/rag/conversation-state.ts` | Refine routine state transitions for answered basics and category follow-ups |
+| `src/lib/rag/orchestrator/conversation-orchestrator.ts` | Derive effective routine turn, pass projected plan/state to synthesis, gate product selection |
+| `src/lib/rag/synthesizer.ts` | Prompt the LLM to compose only the current routine layer naturally |
+| `src/lib/rag/debug-trace.ts` | Include enough trace data to debug layer choice/product gating if new fields are added |
+| `tests/routine-planner.spec.ts` | Priority ranking, layer projection, product-linkable slots not auto-attached |
+| `tests/conversation-state.spec.ts` | State transition semantics for answered basics, layer choices, product-vs-deep-dive boundary |
+| `tests/chat-debug-trace.spec.ts` | Trace includes routine layer/product gate data if trace schema changes |
+| `tests/agent-production-chat-pipeline.spec.ts` or focused chat pipeline tests | End-to-end routing for routine basics, "Und Leave-in?", and explicit product ask |
+
+---
+
+## Task 1: Lock Routine Layer Contracts With Failing Tests
+
+**Goal:** Establish the expected routine layers before production code changes.
+
+**Files:**
+- Test: `tests/routine-planner.spec.ts`
+- Modify later: `src/lib/types.ts`
+- Modify later: `src/lib/routines/planner.ts`
+
+- [ ] Add tests proving a fresh complete routine request exposes `initial_slot_ids` or equivalent projected slots:
+  - `base-shampoo`
+  - `base-conditioner`
+  - exactly one priority lever
+- [ ] Add a test for damage/breakage priority:
+  - profile has breakage/damage/rough cuticle
+  - selected lever is care-product-first
+  - conditioner upgrade wins before mask/bond builder unless reset blockage is present
+- [ ] Add a test for reset preemption:
+  - waxy/coated/heavy product rotation/hard water signals
+  - reset lever can win over cosmetic goals
+- [ ] Add a test for stated goal fallback:
+  - no strong care risk
+  - curl definition / frizz / shine goal picks the matching goal lever
+- [ ] Add tests that `goals` and `problems` projections return no more than 2-3 visible levers.
+- [ ] Add a deep-dive projection test for "Und Leave-in?" style category follow-up.
+
+Run:
+
+```bash
+npx playwright test tests/routine-planner.spec.ts
+```
+
+Expected first run: fails because layer projection and priority-lever contracts do not exist yet.
+
+---
+
+## Task 2: Add Routine Priority And Layer Projection
+
+**Goal:** The planner should build the full routine internally, then expose only the layer needed for the current turn.
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/routines/planner.ts`
+- Test: `tests/routine-planner.spec.ts`
+
+- [ ] Add minimal public types:
+  - `RoutinePriorityLeverSource = "care_risk" | "stated_goal" | "inferred_need"`
+  - `RoutinePriorityLever`
+  - `RoutineLayer = "basics" | "goals" | "problems" | "deep_dive"`
+  - `RoutineLayerProjection` or equivalent selected-slot metadata
+- [ ] Implement `selectRoutinePriorityLever(...)` after full slot construction.
+- [ ] Encode the v2 risk order:
+  - reset blockage may preempt when strong
+  - severe breakage/structural damage picks care-product-first
+  - mechanical signals add guardrails and only win if dominant
+  - heat/chemical exposure is high priority when ongoing but does not automatically outrank active damage
+  - stated goal wins when no stronger risk exists
+- [ ] For severe damage, implement care-product category order:
+  1. Conditioner upgrade
+  2. Leave-in / Finish
+  3. Mask cadence
+  4. Bond Builder
+  5. Reset only when blocking care
+- [ ] Implement `projectRoutinePlanForLayer(...)`:
+  - `basics`: Shampoo + Conditioner + priority lever
+  - `goals`: top 2-3 goal-directed levers
+  - `problems`: top 2-3 concern/risk-directed levers
+  - `deep_dive`: one requested category/topic/module, with only necessary supporting guardrails
+- [ ] Preserve existing full-plan behavior for internal retrieval/debug if needed, but do not expose all slots to synthesis for the first answer.
+- [ ] Keep routine display copy data structural: labels, reasons, caveats, next-offer hints. Do not hardcode final paragraphs.
+
+Run:
+
+```bash
+npx playwright test tests/routine-planner.spec.ts
+```
+
+---
+
+## Task 3: Update Conversation State Semantics For Routine Layers
+
+**Goal:** The merged state system should represent the actual routine answer layer, not only missing-frame clarification.
+
+**Files:**
+- Modify: `src/lib/rag/conversation-state.ts`
+- Test: `tests/conversation-state.spec.ts`
+
+- [ ] Add/adjust tests for a complete first routine answer:
+  - classification is `routine_help` / `routine`
+  - router does not clarify
+  - assistant action is `answered_routine_basics`
+  - next state is `active_topic = "routine"`, `routine_layer = "basics"`, `pending_offer = "routine_goals_or_problems"`
+- [ ] Keep the existing "asked missing routine basics" behavior for incomplete routine frames.
+- [ ] Add tests for choosing next layer:
+  - user replies with goal direction -> `routine_layer = "goals"`
+  - user replies with problem direction -> `routine_layer = "problems"`
+  - `pending_offer` advances to `routine_other_layer` or `routine_deep_dive` according to the answer shape
+- [ ] Add tests for vague category follow-up inside routine:
+  - previous state is routine
+  - user says "Und Leave-in?"
+  - next state becomes `routine_layer = "deep_dive"`
+  - `last_product_category = "leave_in"`
+  - no product recommendation override is forced
+- [ ] Keep explicit product requests as product mode:
+  - "Welches Leave-in empfiehlst du mir konkret?"
+  - classification remains `product_recommendation` / `leave_in`
+  - state may switch to `active_topic = "leave_in"` while preserving recent routine context through history/state trace
+
+Run:
+
+```bash
+npx playwright test tests/conversation-state.spec.ts
+```
+
+---
+
+## Task 4: Add A Routine Turn Resolver In The Orchestrator
+
+**Goal:** One small adapter should decide the current routine layer, visible plan, and product-card policy before retrieval/products/synthesis.
+
+**Files:**
+- Modify: `src/lib/rag/orchestrator/conversation-orchestrator.ts`
+- Optional create: `src/lib/rag/routine-turn.ts` if the logic becomes too large
+- Test: `tests/agent-production-chat-pipeline.spec.ts` or a focused pipeline test
+
+- [ ] Add failing tests for three chat turns:
+  - fresh complete routine request -> projected `basics`, no routine product cards
+  - active routine + "Und Leave-in?" -> projected `deep_dive`, no product cards
+  - active routine + "Welches Leave-in empfiehlst du konkret?" -> normal product recommendation with product cards allowed
+- [ ] Compute `conversationStateTransition` before final routine projection and synthesis.
+- [ ] Use an effective state for response composition:
+  - usually `conversationStateTransition.next_state`
+  - avoid passing stale previous state when the current turn just entered `basics`
+- [ ] Introduce a routine turn policy object:
+
+```ts
+interface RoutineTurnPolicy {
+  shouldPlanRoutine: boolean
+  layer: "basics" | "goals" | "problems" | "deep_dive" | null
+  requestedDeepDiveCategory: ProductCategory | null
+  allowProductAttachments: boolean
+  nextOffer: "goals_or_problems" | "other_layer" | "deep_dive" | null
+}
+```
+
+- [ ] Treat vague category mentions inside active routine as `shouldPlanRoutine = true` even when intent is `followup` and category is `leave_in`, `mask`, `bondbuilder`, etc.
+- [ ] Do not fight explicit product recommendation classification. Let product mode handle "welches Produkt" wording.
+- [ ] Pass the projected routine plan, not the full routine dump, into `composeResponse`.
+
+Run focused pipeline tests after implementation.
+
+---
+
+## Task 5: Gate Routine Product Attachments
+
+**Goal:** Routine answers remain category-level unless the user explicitly asks for concrete products.
+
+**Files:**
+- Modify: `src/lib/routines/product-attachments.ts`
+- Modify: `src/lib/rag/orchestrator/conversation-orchestrator.ts`
+- Test: `tests/routine-planner.spec.ts`
+- Test: pipeline test from Task 4
+
+- [ ] Add tests proving `attachProductsToRoutinePlan` is skipped for normal routine basics/goals/problems/deep-dive answers.
+- [ ] Allow product cards only when the current user message is an explicit product request, normally handled by existing product-selection path.
+- [ ] If a future routine-specific explicit product path is needed, pass an explicit `allowProductAttachments: true`; do not infer it from `product_linkable`.
+- [ ] Keep `product_linkable` on slots because it remains useful metadata for future product asks and debug traces.
+- [ ] Ensure `matched_products` is empty for routine logic-only turns.
+
+Run:
+
+```bash
+npx playwright test tests/routine-planner.spec.ts
+```
+
+---
+
+## Task 6: Update Synthesis Prompt For Natural Layered Answers
+
+**Goal:** The LLM should turn structured layer data into natural German Beratung, without stiff templates or hidden add-on dumps.
+
+**Files:**
+- Modify: `src/lib/rag/synthesizer.ts`
+- Test: `tests/routine-planner.spec.ts`
+- Optional test: `tests/agent-final-render-prompt.spec.ts` if this repo keeps prompt-contract tests there
+
+- [ ] Add prompt contract for routine layers:
+  - explain Shampoo and Conditioner as basics
+  - keep already-fitting basics positive and short
+  - explain the priority lever and why it matters
+  - do not enumerate hidden add-ons
+  - no product names/cards unless provided by explicit product mode
+  - offer the next step naturally based on profile, not as "goal-oriented/problem-oriented" labels
+- [ ] Include layer metadata in `formatRoutinePlan` or equivalent projected-plan formatting:
+  - current layer
+  - visible slots
+  - priority lever reason
+  - allowed next offer
+  - hidden slots are not displayed as answer material
+- [ ] Keep exact German prose flexible. The prompt should constrain content/density, not dictate full paragraphs.
+- [ ] Add prompt tests for:
+  - "Erste Routine-Antwort" or equivalent layer marker
+  - no "zaehle alle Add-ons auf" behavior
+  - natural next-offer instruction
+  - product cards absent for routine logic-only turns
+
+Run:
+
+```bash
+npx playwright test tests/routine-planner.spec.ts
+```
+
+---
+
+## Task 7: Trace And Debug The Layer Decision
+
+**Goal:** When routine behavior feels wrong in testing, admin traces should show whether the issue was classification, state transition, layer projection, or synthesis.
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/rag/debug-trace.ts`
+- Modify: `src/app/admin/conversations/[id]/page.tsx` only if current trace UI needs a readable summary
+- Test: `tests/chat-debug-trace.spec.ts`
+
+- [ ] Add trace fields only if existing `routine_plan` + `conversation_state` are not enough.
+- [ ] Recommended trace shape:
+
+```ts
+routine_turn_policy?: {
+  layer: "basics" | "goals" | "problems" | "deep_dive" | null
+  visible_slot_ids: string[]
+  priority_lever_slot_id: string | null
+  allow_product_attachments: boolean
+  next_offer: string | null
+}
+```
+
+- [ ] Add trace tests proving:
+  - fresh routine basics logs visible slots and product gate false
+  - "Und Leave-in?" logs deep dive and product gate false
+  - explicit product ask logs product mode / product gate true through existing product trace
+- [ ] Keep admin UI copy German if new UI copy is added.
+
+---
+
+## Task 8: Add End-To-End Routine Flow Regressions
+
+**Goal:** Prove the behavior users complained about is fixed, not just the isolated helpers.
+
+**Files:**
+- Test: `tests/agent-production-chat-pipeline.spec.ts` or `tests/chat-response.spec.ts`
+- Optional manual chat smoke
+
+- [ ] Add an integration fixture for:
+  1. user asks "Welche Routine passt am besten zu meinem Haarprofil?"
+  2. first answer uses only Shampoo, Conditioner, priority lever
+  3. no product cards
+  4. answer offers a natural next step
+- [ ] Add follow-up fixture:
+  1. previous state is routine basics with pending offer
+  2. user says "Dann eher Richtung Definition"
+  3. answer shows only top 2-3 goal levers
+- [ ] Add problem layer fixture:
+  1. user says "Und was gegen Frizz und trockene Spitzen?"
+  2. answer shows only top 2-3 problem/risk levers
+- [ ] Add deep-dive fixture:
+  1. user says "Und Leave-in?"
+  2. answer explains Leave-in's routine role
+  3. no product cards
+- [ ] Add explicit product fixture:
+  1. user says "Welches Leave-in empfiehlst du mir konkret?"
+  2. product recommendation path runs
+  3. product cards can appear
+
+---
+
+## Verification
+
+Run focused tests first:
+
+```bash
+npx playwright test tests/routine-planner.spec.ts
+npx playwright test tests/conversation-state.spec.ts
+npx playwright test tests/chat-debug-trace.spec.ts
+npx tsx --test tests/agent-production-chat-pipeline.spec.ts
+```
+
+Then run broader checks:
+
+```bash
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Manual smoke test in local chat:
+
+1. Start a mobile-sized chat with "Welche Routine passt am besten zu meinem Haarprofil?"
+2. Confirm the first response is short enough for mobile and includes only basics + one lever.
+3. Continue with a goal direction.
+4. Continue with a problem direction.
+5. Ask "Und Leave-in?"
+6. Ask "Welches Leave-in empfiehlst du mir konkret?"
+7. Inspect admin trace for `conversation_state`, visible layer, and product-card gating.
+
+Because this touches recommendation behavior, copy, and trust, run `ready-check` before shipping.
+
+---
+
+## Definition Of Done
+
+- The first routine answer no longer dumps Shampoo, Conditioner, CWC, Leave-in, brushes, masks, reset, oiling, bond builder, and other modules at once.
+- The first answer still feels like real Beratung: it explains why Shampoo and Conditioner are the base and why the chosen lever matters.
+- Goal/problem follow-ups show only 2-3 relevant levers.
+- Vague category follow-ups inside routine produce routine deep dives, not product cards.
+- Explicit product requests produce product recommendations/cards with routine context available.
+- Conversation traces make layer choice and product gating diagnosable.
+- All focused and broader verification commands pass, or any remaining warnings/gaps are documented before handoff.
+
+## Execution Handoff
+
+Start implementation in a fresh repo-local worktree from `origin/main`.
+
+Recommended next skill: `superpowers:subagent-driven-development` if splitting planner/orchestrator/prompt tasks; otherwise `superpowers:executing-plans`.

--- a/src/components/quiz/quiz-landing.tsx
+++ b/src/components/quiz/quiz-landing.tsx
@@ -57,7 +57,7 @@ export function QuizLanding() {
           Dauert ca. 2 Minuten. Wir führen dich Schritt für Schritt durch.
         </p>
         <p className="text-center text-sm text-muted-foreground pt-2">
-          <a href="/auth" className="underline hover:text-foreground transition-colors">
+          <a href="/auth?force=login" className="underline hover:text-foreground transition-colors">
             Du hast bereits ein Konto? Hier anmelden
           </a>
         </p>

--- a/src/lib/agent/orchestrator/prompt.ts
+++ b/src/lib/agent/orchestrator/prompt.ts
@@ -56,9 +56,9 @@ Regeln:
 - product_response_policy=caution_without_products: normale Kosmetikprodukte nicht als medizinische Loesung darstellen; fuer Shampoo von Einordnung, Schuppen-Reduktion, beruhigender Kopfhautpflege oder passenden Optionen sprechen, nicht von Therapie. In einem Satz sagen, dass anhaltende/starke Reizung professionell oder dermatologisch abgeklaert werden sollte. Wenn es um Schuppen/Juckreiz geht, nicht als Sackgasse antworten: frage knapp, ob der Fokus eher Schuppen-Reduktion oder gereizte/empfindliche Kopfhaut ist, und sage, dass danach passende Shampoo-Optionen moeglich sind.
 - product_response_policy=needs_more_info: maximal eine gezielte Rueckfrage.
 - product_response_policy=no_catalog_match: keine Produkte erfinden.
-- Produkte mit caveat beginnend mit "Fallback:" sind schwaechere Fallback-Optionen, keine normalen Empfehlungen.
-- Wenn Fallback-Produkte im Packet sind, erst Primaerempfehlungen nennen und Fallbacks nur nachgeordnet mit klar schwacher Formulierung.
-- Bei product_response_policy=recommend musst du alle Produkte aus selected_products.products in der gegebenen Reihenfolge behandeln. Reduziere nicht eigenmaechtig von drei Tool-Produkten auf zwei; wenn ein Produkt ein Fallback ist, nenne es als klar schwaechere oder caveated Option statt es wegzulassen.
+- Caveats koennen intern mit "Fallback:" markiert sein. Den Marker und das Wort "Fallback" nie in der Nutzerantwort ausgeben.
+- Wenn intern schwaechere Optionen im Packet sind, erst Primaerempfehlungen nennen und die schwaecheren Optionen nur nachgeordnet natuerlich einordnen.
+- Bei product_response_policy=recommend musst du alle Produkte aus selected_products.products in der gegebenen Reihenfolge behandeln. Reduziere nicht eigenmaechtig von drei Tool-Produkten auf zwei; wenn ein Produkt intern als schwaechere Option markiert ist, nenne es als klar schwaechere oder caveated Option statt es wegzulassen.
 - Wenn das Packet nur Primaerprodukte enthaelt, keine weiteren Optionen erfinden oder auf drei Empfehlungen auffuellen.
 - Wenn die Route usage ist, bleibe bei Anwendung, Dosierung, Reihenfolge und Technik.
 - Wenn trockene Laengen in einer Shampoo-Frage vorkommen, Shampoo nicht als Hauptloesung framen; Fokus auf Kopfhaut waschen, Laengen schuetzen und Conditioner/Leave-in als Laengenhebel.
@@ -74,7 +74,7 @@ Regeln:
 - Wenn nach exakten Hitzeschutz-Temperaturen gefragt wird, immer die unsupported_requested_signals-Caveat nennen und nur allgemeine strukturierte Hitzeschutz-Eignung bewerten.
 - Wenn profile_basis oder category_guidance sagt, dass der Nutzer bereits separaten Hitzeschutz hat, das direkt anerkennen: Das Leave-in muss dann beim Foehnen nicht zwingend selbst Hitzeschutz liefern. Wenn selected_products ein Produkt mit Hitzeschutz liefert, verwende im Einstieg ausdruecklich die Formulierung "ein Produkt weniger in der Routine": Diese Zwei-in-eins-Route buendelt Leave-in-Pflege plus Foehnschutz in einem Produkt. Sage auch, dass der Nutzer den separaten Hitzeschutz behalten kann; dann sind Leave-ins ohne eigenen Hitzeschutz weiterhin normale Pflege-Booster. Begruende die Auswahl danach ueber Pflege-, Gewichts- und Rollen-Fit.
 - Bei Fragen, ob Leave-in Conditioner ersetzen kann: zuerst sagen, dass das in manchen Faellen moeglich ist; danach anhand der Tool-Daten erklaeren, ob es fuer dieses Profil eher Ersatz oder Booster ist.
-- Bei Spray-vs-Creme-Leave-in-Vergleichen: zuerst kurz den Form-Unterschied erklaeren, dann die belegten Spray- und Creme-Optionen aus den Tool-Daten gegenueberstellen. Nenne ein Produkt nur Spray oder Creme, wenn Format in supported_claims oder comparison_facts steht; Fallback-Produkte klar schwaecher framen.
+- Bei Spray-vs-Creme-Leave-in-Vergleichen: zuerst kurz den Form-Unterschied erklaeren, dann die belegten Spray- und Creme-Optionen aus den Tool-Daten gegenueberstellen. Nenne ein Produkt nur Spray oder Creme, wenn Format in supported_claims oder comparison_facts steht; intern schwaechere Optionen klar schwaecher framen.
 - Wenn selected_products.products bei einem Spray-vs-Creme-Vergleich zuerst ein Spray und dann eine Creme liefert, bewahre diese Gegenueberstellung. Ersetze das Spray nicht durch eine Lotion, nur weil die Lotion einen staerkeren allgemeinen Fit hat.
 - Wuensche wie silikonfrei, kokosfrei, proteinfrei, humectants oder oelfrei sind fuer Leave-ins in v1 nicht sicher geprueft, ausser selected_products weist sie ausdruecklich als supported_claims aus. Sonst die unsupported_requested_signals-Caveat verwenden.
 - Bei Masken-Antworten sind Gewicht, Balance-Richtung, Intensitaet/Konzentration und Fit-Status nur dann Produktclaims, wenn sie in supported_claims stehen. Maske als Zusatzpflege fuer Laengen/Spitzen framen, nicht als Conditioner-Ersatz, Kopfhautbehandlung oder Schadenspraevention.
@@ -92,14 +92,16 @@ Regeln:
 - Wenn ein einzelnes Produkt unsupported_requested_signals hat, behaupte fuer dieses Produkt genau diese Eigenschaft nicht.
 - Wenn scalp_condition=irritated unsupported ist, nicht sagen "passt fuer empfindliche Kopfhaut", "sanft zur empfindlichen Kopfhaut" oder "schonend fuer deine Kopfhaut". Eine sanfte Reinigungsintensitaet darf nur als mildere Reinigung beschrieben werden, nicht als Spezial-Eignung fuer empfindliche Kopfhaut.
 - Bei Vergleichen: nutze comparison_facts und supported_claims, damit jedes Produkt eine echte, belegte Differenz bekommt.
-- Wenn comparison_facts kaum Unterschiede zeigen, sage das offen und tue nicht so, als gaebe es grosse fachliche Kontraste. Preis nur nennen, wenn er wirklich als Fallback gebraucht wird.
+- Wenn comparison_facts kaum Unterschiede zeigen, sage das offen und tue nicht so, als gaebe es grosse fachliche Kontraste. Preis nur nennen, wenn er wirklich als nachgeordnetes Entscheidungskriterium gebraucht wird.
 - Bei Bondbuilder-Antworten: Wenn K18 vs OLAPLEX/Epres im Raum steht, erklaere zuerst die Lane-Entscheidung aus profile_basis, category_guidance oder comparison_facts. OLAPLEX/Epres = Disulfid-/Crosslink-Lane eher bei Blondierung, Coloration oder chemischem Stress; K18 = Peptid-/Leave-in-Lane eher bei Bruch, Snapping, starker Hitze oder Peptid-/Laengsstruktur-Signalen. Wenn kein klarer K18-vs-OLAPLEX-Treiber sichtbar ist, sage das offen und frame die Produkte als optionalen Vergleich.
 
 Antwortform:
 - Bei Produktantworten: zuerst ein kurzer, profilbezogener Satz, dann 1-3 klar unterschiedliche Empfehlungen mit je einem eigenen Grund.
 - Bei Shampoo-Produktantworten: Profilbasis natuerlich nennen, z.B. Haardicke + Kopfhaut; "normal" bei Haardicke nicht als "normales Haar" formulieren, sondern als "mitteldickes/mittelstarkes Haar".
 - Bei Shampoo-Produktantworten: mit einem knappen Anwendungssatz enden: Shampoo vor allem auf die Kopfhaut geben und gruendlich ausspuelen.
-- Bei Routineantworten: klar trennen in beibehalten, hinzufuegen, reduzieren und optional.
+- Bei Routineantworten: nur die aktuelle Routine-Ebene aus packet.routine_plan.steps beantworten. Nicht alle moeglichen Routine-Bloecke ergaenzen. Bei basics kurz Shampoo, Conditioner und den hoechsten Zusatzhebel erklaeren; bei goals/problems nur die 2-3 sichtbaren Hebel; bei deep_dive genau den angefragten Baustein.
+- Bei Routine-basics: am Ende knapp und natuerlich fragen, ob der Nutzer als Naechstes eher sehen moechte, was ihn seinem Ziel naeherbringt, oder was gegen seine Probleme hilft. Keine internen Begriffe wie Ziel-Hebel oder Problem-Hebel verwenden. Bei goals/problems analog nur eine kurze passende Anschlussfrage stellen.
+- Bei Routineantworten ohne selected_products: keine konkreten Produktlisten oder Produktkarten formulieren; erklaere die Routine-Logik auf Kategorie-/Schritt-Ebene.
 - Bei Problem- oder Anwendungfragen: erst die wahrscheinlichste Ursache, Technik oder naechste Handlung erklaeren; nicht automatisch in Produktempfehlungen springen.
 - Bei Conditioner-Problemen wie platt, beschwert, Spliss, trockene Spitzen oder strohigem Gefuehl: erst zuhoeren und kurz einordnen, dann nur bei klarer Produktfrage in Empfehlungen springen.
 - Halte Unterschiede sichtbar, statt dieselbe Begruendung fuer mehrere Optionen zu wiederholen.`

--- a/src/lib/agent/orchestrator/route-packet.ts
+++ b/src/lib/agent/orchestrator/route-packet.ts
@@ -13,6 +13,7 @@ import type {
   RoutineObjective,
 } from "@/lib/agent/tools/build-or-fix-routine"
 import type { SelectedProductsProjection } from "@/lib/agent/tools/select-products"
+import type { RoutineLayer } from "@/lib/types"
 
 export const AGENT_USER_JOBS = [
   "product_pick",
@@ -98,6 +99,8 @@ export interface AgentRoutePacket {
   guidance_ids: GuidanceId[]
   tool_plan: AgentRouteToolName[]
   routine_objective: RoutineObjective | null
+  routine_layer?: RoutineLayer | null
+  routine_requested_category?: SelectableProductCategory | null
   validation_warnings: string[]
 }
 
@@ -844,6 +847,36 @@ function buildFinalInstructions(
     instructions.push("Bleibe bei Anwendung, Dosierung, Reihenfolge und Technik.")
   }
 
+  if (route.user_job === "routine_structure") {
+    instructions.push(
+      "Beantworte nur die aktuelle Routine-Ebene aus routine_plan.steps; keine weiteren Routine-Bloecke ergaenzen.",
+    )
+    instructions.push(
+      "Nenne keine konkreten Produktkarten oder Produktlisten, solange selected_products leer ist.",
+    )
+
+    if (route.routine_layer === "basics") {
+      instructions.push(
+        "Fuer basics kurz Shampoo und Conditioner erklaeren und nur den hoechsten Zusatzhebel nennen.",
+      )
+      instructions.push(
+        "Schliesse basics mit einer kurzen natuerlichen Frage, ob der Nutzer als Naechstes eher sehen moechte, was ihn seinem Ziel naeherbringt, oder was gegen seine Probleme hilft. Vermeide interne Begriffe wie Ziel-Hebel oder Problem-Hebel.",
+      )
+    } else if (route.routine_layer === "goals") {
+      instructions.push("Fuer goals nur die zielbezogenen Routine-Hebel erklaeren.")
+      instructions.push(
+        "Schliesse goals mit einer kurzen natuerlichen Frage, ob der Nutzer noch konkrete Probleme angehen oder einen Baustein im Detail ansehen moechte.",
+      )
+    } else if (route.routine_layer === "problems") {
+      instructions.push("Fuer problems nur die problembezogenen Routine-Hebel erklaeren.")
+      instructions.push(
+        "Schliesse problems mit einer kurzen natuerlichen Frage, ob der Nutzer noch seine Ziele optimieren oder einen Baustein im Detail ansehen moechte.",
+      )
+    } else if (route.routine_layer === "deep_dive") {
+      instructions.push("Fuer deep_dive fokussiert genau den angefragten Baustein erklaeren.")
+    }
+  }
+
   if (route.user_job === "unsupported_or_unclear") {
     instructions.push(
       "Stelle hoechstens eine gezielte Rueckfrage oder gib sichere Kategorie-Hilfe.",
@@ -968,6 +1001,8 @@ export function buildAgentRoutePacket(params: {
     tool_plan: toolPlan,
     routine_objective:
       userJob === "routine_structure" ? inferRoutineObjective(params.message) : null,
+    routine_layer: userJob === "routine_structure" ? "basics" : null,
+    routine_requested_category: null,
     validation_warnings: warnings,
   }
 }

--- a/src/lib/agent/orchestrator/run-shadow-agent-turn.ts
+++ b/src/lib/agent/orchestrator/run-shadow-agent-turn.ts
@@ -15,7 +15,7 @@ import type { UserContextProjection } from "@/lib/agent/tools/get-user-context"
 import type { SelectedProductsProjection } from "@/lib/agent/tools/select-products"
 import type { BuildOrFixRoutineProjection } from "@/lib/agent/tools/build-or-fix-routine"
 import { shouldApplyPendingRoutineAnswerOverride } from "@/lib/rag/conversation-state"
-import type { ConversationState } from "@/lib/types"
+import type { ConversationState, RoutineLayer } from "@/lib/types"
 
 function nextRuntimeToolId(toolCalls: AgentToolCallHistory[]): string {
   return `runtime-${toolCalls.length + 1}`
@@ -27,6 +27,56 @@ export function deriveRequestedGoal(message: string): "shine" | null {
 
 function hasFallbackCaveat(product: SelectedProductsProjection["products"][number]): boolean {
   return /^fallback:/i.test(product.caveat?.trim() ?? "")
+}
+
+function stripFallbackMarker(value: string | null): string | null {
+  if (!value) return value
+
+  const stripped = value.replace(/^fallback:\s*/i, "").trim()
+  return stripped.length > 0 ? stripped : null
+}
+
+function sanitizeComparisonFactForRender(fact: string): string | null {
+  if (/^fallback:\s*(?:ja|nein)?$/i.test(fact.trim())) {
+    return null
+  }
+
+  return stripFallbackMarker(fact)
+}
+
+function sanitizeComparisonFactsForRender(
+  comparisonFacts: SelectedProductsProjection["comparison_facts"],
+): SelectedProductsProjection["comparison_facts"] {
+  if (!comparisonFacts) {
+    return null
+  }
+
+  const sanitized = Object.fromEntries(
+    Object.entries(comparisonFacts)
+      .map(([productId, facts]) => [
+        productId,
+        facts
+          .map((fact) => sanitizeComparisonFactForRender(fact))
+          .filter((fact): fact is string => Boolean(fact)),
+      ])
+      .filter(([, facts]) => facts.length > 0),
+  )
+
+  return Object.keys(sanitized).length > 0 ? sanitized : null
+}
+
+function sanitizeSelectedProductsForRender(
+  projection: SelectedProductsProjection,
+): SelectedProductsProjection {
+  return {
+    ...projection,
+    products: projection.products.map((product) => ({
+      ...product,
+      fit_reason: stripFallbackMarker(product.fit_reason) ?? product.fit_reason,
+      caveat: stripFallbackMarker(product.caveat),
+    })),
+    comparison_facts: sanitizeComparisonFactsForRender(projection.comparison_facts),
+  }
 }
 
 function filterComparisonFactsForProducts(
@@ -63,20 +113,120 @@ function collectUnsupportedRequestedSignalsForProducts(
   return result
 }
 
+function normalizeMessageForRoutinePolicy(message: string): string {
+  return message
+    .toLocaleLowerCase("de-DE")
+    .replace(/ß/g, "ss")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+}
+
+function hasExplicitProductAskSignal(message: string): boolean {
+  const normalized = normalizeMessageForRoutinePolicy(message)
+
+  return /\b(?:welch\w*|empfiehl\w*|empfehl\w*|konkret|produkt\w*|kaufen|nehmen|auswaehlen|waehlen|passt\s+am\s+besten|gutes?|beste[nsr]?)\b/.test(
+    normalized,
+  )
+}
+
+function shouldOverrideVagueRoutineCategoryFollowup(params: {
+  state: ConversationState | null | undefined
+  classification: Awaited<ReturnType<AgentModelClient["classifyRoute"]>>
+  message: string
+}): boolean {
+  return Boolean(
+    params.state?.active_topic === "routine" &&
+    params.classification.product_category &&
+    ["product_pick", "compare_or_decide", "usage", "troubleshoot"].includes(
+      params.classification.user_job,
+    ) &&
+    !hasExplicitProductAskSignal(params.message),
+  )
+}
+
+function shouldSelectRoutineLayerFromBasics(state: ConversationState | null | undefined): boolean {
+  return Boolean(
+    state?.active_topic === "routine" &&
+    state.routine_layer === "basics" &&
+    state.pending_offer === "routine_goals_or_problems" &&
+    state.last_assistant_action === "answered_routine_basics",
+  )
+}
+
+function hasRoutineGoalLayerSignal(message: string): boolean {
+  const normalized = normalizeMessageForRoutinePolicy(message)
+
+  return /\b(?:ziel|ziele|goal|goals|wunsch|wuensche|moechte|will|richtung|mehr volumen|volumen|glanz|definition|definier|weniger|reduzier|baendigen|wachstum)\b/.test(
+    normalized,
+  )
+}
+
+function hasRoutineProblemLayerSignal(message: string): boolean {
+  const normalized = normalizeMessageForRoutinePolicy(message)
+
+  return /\b(?:problem|probleme|concern|concerns|sorge|sorgen|thema|themen|fixen|loesen|verbessern|reparieren|angehen|frizz|trocken|spliss|bruch|kaputt|juck|schupp|fettig|kopfhaut|verknot|knoten)\b/.test(
+    normalized,
+  )
+}
+
+function deriveRoutineLayerForTurn(params: {
+  state: ConversationState | null | undefined
+  classification: Awaited<ReturnType<AgentModelClient["classifyRoute"]>>
+  message: string
+}): RoutineLayer | null {
+  if (!shouldSelectRoutineLayerFromBasics(params.state)) {
+    return null
+  }
+
+  if (hasRoutineGoalLayerSignal(params.message)) {
+    return "goals"
+  }
+
+  if (hasRoutineProblemLayerSignal(params.message)) {
+    return "problems"
+  }
+
+  return null
+}
+
+function buildEffectiveUserContextForRender(params: {
+  userContext: UserContextProjection
+  conversationState: ConversationState | null | undefined
+  route: AgentRoutePacket
+}): UserContextProjection {
+  if (params.route.user_job !== "routine_structure" || !params.route.routine_layer) {
+    return params.userContext
+  }
+
+  return {
+    ...params.userContext,
+    conversation_state: {
+      ...(params.conversationState ?? {}),
+      ...(typeof (params.userContext as { conversation_state?: unknown }).conversation_state ===
+      "object"
+        ? ((params.userContext as { conversation_state?: ConversationState }).conversation_state ??
+          {})
+        : {}),
+      active_topic: "routine",
+      routine_layer: params.route.routine_layer,
+    },
+  } as UserContextProjection
+}
+
 function prepareSelectedProductsForRender(
   projection: SelectedProductsProjection | null,
 ): SelectedProductsProjection | null {
   if (!projection || projection.products.length < 2) {
-    return projection
+    return projection ? sanitizeSelectedProductsForRender(projection) : projection
   }
 
   if (projection.category === "leave_in") {
-    return projection
+    return sanitizeSelectedProductsForRender(projection)
   }
 
   const primaryProducts = projection.products.filter((product) => !hasFallbackCaveat(product))
   if (primaryProducts.length === 0 || primaryProducts.length === projection.products.length) {
-    return projection
+    return sanitizeSelectedProductsForRender(projection)
   }
 
   const products = primaryProducts.map((product, index) => ({
@@ -84,12 +234,12 @@ function prepareSelectedProductsForRender(
     rank: index + 1,
   }))
 
-  return {
+  return sanitizeSelectedProductsForRender({
     ...projection,
     products,
     comparison_facts: filterComparisonFactsForProducts(projection.comparison_facts, products),
     unsupported_requested_signals: collectUnsupportedRequestedSignalsForProducts(products),
-  }
+  })
 }
 
 async function runRuntimeTool(params: {
@@ -146,8 +296,25 @@ export async function runShadowAgentTurn(params: {
       userMessage: params.message,
     }),
   )
+  const shouldOverrideVagueRoutineCategory = shouldOverrideVagueRoutineCategoryFollowup({
+    state: params.conversationState,
+    classification: modelClassification,
+    message: params.message,
+  })
+  const routineLayerOverride = deriveRoutineLayerForTurn({
+    state: params.conversationState,
+    classification: modelClassification,
+    message: params.message,
+  })
   const classificationOverride = shouldOverridePendingRoutineAnswer
     ? "conversation_state_pending_routine_answer"
+    : shouldOverrideVagueRoutineCategory
+      ? "conversation_state_routine_category_deep_dive"
+      : routineLayerOverride && modelClassification.user_job !== "routine_structure"
+        ? "conversation_state_routine_layer_selected"
+        : null
+  const routineRequestedCategory = shouldOverrideVagueRoutineCategory
+    ? modelClassification.product_category
     : null
   const classification = shouldOverridePendingRoutineAnswer
     ? {
@@ -164,12 +331,54 @@ export async function runShadowAgentTurn(params: {
         ],
         ambiguity: null,
       }
-    : modelClassification
-  const route = buildAgentRoutePacket({
+    : shouldOverrideVagueRoutineCategory
+      ? {
+          ...modelClassification,
+          user_job: "routine_structure" as const,
+          product_category: null,
+          requested_overlay_ids: [],
+          requested_topic_ids: [],
+          requested_routine_id: null,
+          confidence: Math.max(modelClassification.confidence, 0.75),
+          evidence: [
+            ...modelClassification.evidence.slice(0, 3),
+            "Conversation state treats this vague category follow-up as a routine deep dive.",
+          ],
+          ambiguity: null,
+        }
+      : routineLayerOverride && modelClassification.user_job !== "routine_structure"
+        ? {
+            ...modelClassification,
+            user_job: "routine_structure" as const,
+            product_category: null,
+            requested_overlay_ids: [],
+            requested_topic_ids: [],
+            requested_routine_id: null,
+            confidence: Math.max(modelClassification.confidence, 0.75),
+            evidence: [
+              ...modelClassification.evidence.slice(0, 3),
+              "Conversation state treats this as a selected routine layer.",
+            ],
+            ambiguity: null,
+          }
+        : modelClassification
+  const routeBase = buildAgentRoutePacket({
     message: params.message,
     userContext,
     classification,
   })
+  const route = shouldOverrideVagueRoutineCategory
+    ? {
+        ...routeBase,
+        routine_layer: "deep_dive" as RoutineLayer,
+        routine_requested_category: routineRequestedCategory,
+      }
+    : routineLayerOverride
+      ? {
+          ...routeBase,
+          routine_layer: routineLayerOverride,
+        }
+      : routeBase
   const guidance = route.guidance_ids.length
     ? ((await runRuntimeTool({
         name: "load_guidance",
@@ -202,7 +411,11 @@ export async function runShadowAgentTurn(params: {
     if (toolName === "build_or_fix_routine") {
       routinePlan = (await runRuntimeTool({
         name: "build_or_fix_routine",
-        input: { objective: route.routine_objective },
+        input: {
+          objective: route.routine_objective,
+          layer: route.routine_layer,
+          requestedCategory: route.routine_requested_category,
+        },
         tools: params.tools,
         toolCalls: tool_calls,
       })) as BuildOrFixRoutineProjection
@@ -211,7 +424,11 @@ export async function runShadowAgentTurn(params: {
 
   const packet = buildAgentRuntimePacket({
     route,
-    userContext,
+    userContext: buildEffectiveUserContextForRender({
+      userContext,
+      conversationState: params.conversationState,
+      route,
+    }),
     guidance,
     selectedProducts: prepareSelectedProductsForRender(selectedProducts),
     routinePlan,

--- a/src/lib/agent/production/chat-pipeline.ts
+++ b/src/lib/agent/production/chat-pipeline.ts
@@ -81,6 +81,7 @@ interface ProductionAgentPipelineDeps {
   getUserContext?: (userId: string) => Promise<UserContextProjection>
   loadUserMemoryContext?: (userId: string) => Promise<UserMemoryContext>
   loadConversationState?: (conversationId: string) => Promise<ConversationState>
+  createSelectProductsTool?: typeof createSelectProductsTool
 }
 
 async function measureAsync<T>(work: () => Promise<T>): Promise<{ result: T; durationMs: number }> {
@@ -117,6 +118,16 @@ function normalizeSelectableCategory(value: unknown): SelectableProductCategory 
 
 function normalizeRoutineObjective(value: unknown): RoutineObjective | null {
   return value === "build_routine" || value === "fix_routine" ? value : null
+}
+
+function normalizeRoutineLayer(value: unknown) {
+  return value === "basics" || value === "goals" || value === "problems" || value === "deep_dive"
+    ? value
+    : null
+}
+
+function normalizeRoutineProductCategory(value: unknown) {
+  return typeof value === "string" && isSelectableProductCategory(value) ? value : null
 }
 
 function normalizeAgentUserJob(value: unknown): AgentUserJob | null {
@@ -361,8 +372,9 @@ function makeAgentTools(params: {
   userContext: ProductionUserContext
   memoryContext: UserMemoryContext
   onSelectProducts: (result: SelectProductsToolResult) => void
+  createSelectProductsTool?: typeof createSelectProductsTool
 }): Record<AgentToolName, (input: Record<string, unknown>) => Promise<unknown>> {
-  const selectProducts = createSelectProductsTool({
+  const selectProducts = (params.createSelectProductsTool ?? createSelectProductsTool)({
     onResult: params.onSelectProducts,
   })
   const buildOrFixRoutine = createBuildOrFixRoutineTool()
@@ -387,6 +399,8 @@ function makeAgentTools(params: {
         objective: normalizeRoutineObjective(input.objective),
         message: params.message,
         hairProfile: params.userContext.profile,
+        layer: normalizeRoutineLayer(input.layer),
+        requestedCategory: normalizeRoutineProductCategory(input.requestedCategory),
       }),
   }
 }
@@ -437,6 +451,7 @@ export async function runProductionAgentPipeline(
       onSelectProducts: (selection) => {
         selectedProductsHolder.current = selection
       },
+      createSelectProductsTool: deps.createSelectProductsTool,
     }),
   })
   const agentMs = Math.round(performance.now() - agentStart)
@@ -465,7 +480,9 @@ export async function runProductionAgentPipeline(
         ? "asked_routine_basics"
         : "asked_clarification"
       : shouldPlanRoutine
-        ? "answered_routine"
+        ? route.routine_layer === "basics"
+          ? "answered_routine_basics"
+          : "answered_routine"
         : "answered_direct"
   const conversationStateTransition = computeConversationStateTransition({
     previousState: conversationState,
@@ -474,7 +491,7 @@ export async function runProductionAgentPipeline(
     userMessage: message,
     assistantAction,
     hairProfile: userContext.profile,
-    matchedProductCategory: productCategory,
+    matchedProductCategory: route.routine_requested_category ?? productCategory,
     classifierOverride: result.classification_override,
   })
   const matchedProducts = productsForRenderedPacket({
@@ -544,7 +561,7 @@ export async function runProductionAgentPipeline(
       fallback_reason: null,
       rendering_path: null,
       plan_type: "agent_v1",
-      attachment_mode: null,
+      attachment_mode: matchedProducts.length > 0 ? "cards" : "text_only",
     },
     latencies_ms: {
       classification_ms: agentMs,

--- a/src/lib/agent/tools/build-or-fix-routine.ts
+++ b/src/lib/agent/tools/build-or-fix-routine.ts
@@ -1,5 +1,15 @@
-import { buildRoutinePlan, deriveRoutineContext } from "@/lib/routines/planner"
-import type { HairProfile, RoutinePlan, RoutineSlotAdvice } from "@/lib/types"
+import {
+  buildRoutinePlan,
+  deriveRoutineContext,
+  projectRoutinePlanForLayer,
+} from "@/lib/routines/planner"
+import type {
+  HairProfile,
+  RoutineLayer,
+  RoutinePlan,
+  RoutineProductCategory,
+  RoutineSlotAdvice,
+} from "@/lib/types"
 
 export type BuildOrFixRoutineAction = "keep" | "add" | "adjust" | "remove"
 export type RoutineObjective = "build_routine" | "fix_routine"
@@ -35,6 +45,8 @@ export interface BuildOrFixRoutineToolInput {
   objective?: RoutineObjective | null
   message?: string | null
   hairProfile: HairProfile | null
+  layer?: RoutineLayer | null
+  requestedCategory?: RoutineProductCategory | null
 }
 
 function normalizeText(value: string | null | undefined): string | null {
@@ -100,6 +112,34 @@ function projectStep(slot: RoutineSlotAdvice): BuildOrFixRoutineStep {
     caveats: slot.caveats,
     fillable: slot.product_linkable,
   }
+}
+
+function findRoutineSlot(plan: RoutinePlan, id: string): RoutineSlotAdvice | null {
+  for (const section of plan.sections) {
+    const slot = section.slots.find((candidate) => candidate.id === id)
+    if (slot) return slot
+  }
+
+  return null
+}
+
+function projectRoutineSteps(params: {
+  plan: RoutinePlan
+  layer: RoutineLayer | null
+  requestedCategory: RoutineProductCategory | null
+}): BuildOrFixRoutineStep[] {
+  if (!params.layer) {
+    return params.plan.sections.flatMap((section) => section.slots.map(projectStep))
+  }
+
+  const projection = projectRoutinePlanForLayer(params.plan, params.layer, {
+    requestedCategory: params.requestedCategory,
+  })
+
+  return projection.visible_slot_ids
+    .map((slotId) => findRoutineSlot(params.plan, slotId))
+    .filter((slot): slot is RoutineSlotAdvice => Boolean(slot))
+    .map(projectStep)
 }
 
 function buildMissingInfo(params: {
@@ -168,6 +208,8 @@ export function projectRoutinePlan(params: {
   hairProfile: HairProfile | null
   message?: string | null
   usesBondBuilder?: boolean
+  layer?: RoutineLayer | null
+  requestedCategory?: RoutineProductCategory | null
 }): BuildOrFixRoutineProjection {
   const objective = normalizeObjective(params.objective)
   const prompt = buildPlannerPrompt({
@@ -189,7 +231,11 @@ export function projectRoutinePlan(params: {
 
   return {
     objective,
-    steps: plan.sections.flatMap((section) => section.slots.map(projectStep)),
+    steps: projectRoutineSteps({
+      plan,
+      layer: params.layer ?? null,
+      requestedCategory: params.requestedCategory ?? null,
+    }),
     missing_info: buildMissingInfo({ objective, hairProfile: params.hairProfile, context }),
     confidence: Math.round((completed / denominator) * 100) / 100,
   }

--- a/src/lib/rag/conversation-state.ts
+++ b/src/lib/rag/conversation-state.ts
@@ -111,6 +111,9 @@ export function computeConversationStateTransition(params: {
   const classifiedProductTopic = toSupportedProductTopic(params.classification.product_category)
   const matchedProductTopic = toSupportedProductTopic(params.matchedProductCategory)
   const productTopic = matchedProductTopic ?? classifiedProductTopic
+  const requestedRoutineLayer = shouldSelectRoutineLayerFromBasics(previousState)
+    ? getRequestedRoutineLayer(params.userMessage)
+    : null
   const isUnsupportedStandaloneCategorySwitch =
     params.classification.intent === "product_recommendation" &&
     params.classification.product_category !== null &&
@@ -149,6 +152,16 @@ export function computeConversationStateTransition(params: {
       last_product_category: productTopic,
     }
     reason = "routine_category_deep_dive"
+  } else if (requestedRoutineLayer !== null) {
+    nextState = {
+      ...nextState,
+      active_topic: "routine",
+      routine_layer: requestedRoutineLayer.layer,
+      pending_offer: requestedRoutineLayer.includesBoth
+        ? "routine_deep_dive"
+        : "routine_other_layer",
+    }
+    reason = requestedRoutineLayer.reason
   } else if (isRoutineClassification(params.classification)) {
     const answeredSlots = mergeAnsweredSlots(
       previousState.answered_slots,
@@ -172,6 +185,10 @@ export function computeConversationStateTransition(params: {
         nextState.routine_layer = "basics"
         nextState.pending_offer = "routine_goals_or_problems"
         reason = "routine_started"
+      } else if (params.assistantAction === "answered_routine_basics") {
+        nextState.routine_layer = "basics"
+        nextState.pending_offer = "routine_goals_or_problems"
+        reason = "routine_basics_answered"
       } else if (answeredSlots.length > 0) {
         nextState.routine_layer = answeredSlots.includes("problem") ? "deep_dive" : "goals"
         nextState.pending_offer = answeredSlots.includes("problem") ? null : "routine_deep_dive"
@@ -288,6 +305,66 @@ function hasProblemOrGoalSignal(lower: string): boolean {
       lower,
     )
   )
+}
+
+function hasGoalSignal(lower: string): boolean {
+  return /\b(ziel|ziele|goal|goals|wunsch|wünsche|wuensche|möchte|moechte|will|richtung|mehr volumen|volumen|glanz|definition|definier|weniger|reduzier|bändigen|baendigen|wachstum)\b/.test(
+    lower,
+  )
+}
+
+function hasProblemLayerSignal(lower: string): boolean {
+  return (
+    hasProblemSignal(lower) ||
+    /\b(problem|probleme|concern|concerns|sorge|sorgen|thema|themen|fixen|lösen|loesen|verbessern|reparieren|angehen)\b/.test(
+      lower,
+    )
+  )
+}
+
+function shouldSelectRoutineLayerFromBasics(state: ConversationState): boolean {
+  return (
+    state.active_topic === "routine" &&
+    state.routine_layer === "basics" &&
+    state.pending_offer === "routine_goals_or_problems" &&
+    state.last_assistant_action === "answered_routine_basics"
+  )
+}
+
+function getRequestedRoutineLayer(message: string): {
+  layer: Exclude<RoutineConversationLayer, null>
+  includesBoth: boolean
+  reason: string
+} | null {
+  const lower = message.trim().toLowerCase()
+  const asksForGoals = hasGoalSignal(lower)
+  const asksForProblems = hasProblemLayerSignal(lower)
+
+  if (asksForGoals && asksForProblems) {
+    return {
+      layer: "goals",
+      includesBoth: true,
+      reason: "routine_goal_and_problem_layers_selected",
+    }
+  }
+
+  if (asksForGoals) {
+    return {
+      layer: "goals",
+      includesBoth: false,
+      reason: "routine_goal_layer_selected",
+    }
+  }
+
+  if (asksForProblems) {
+    return {
+      layer: "problems",
+      includesBoth: false,
+      reason: "routine_problem_layer_selected",
+    }
+  }
+
+  return null
 }
 
 function hasAcknowledgementSignal(lower: string): boolean {

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -27,9 +27,13 @@ import type {
   HairProfile,
   RoutineContext,
   RoutineDecisionContext,
+  RoutineLayer,
+  RoutineLayerProjection,
   RoutineFocus,
   RoutinePlan,
   RoutinePlanSection,
+  RoutinePriorityLever,
+  RoutineProductCategory,
   RoutineSlotAction,
   RoutineSlotAdvice,
   RoutineTopicActivation,
@@ -1679,6 +1683,402 @@ function buildRoutineSlots(
   return sections
 }
 
+function getRoutineSlots(plan: Pick<RoutinePlan, "sections">): RoutineSlotAdvice[] {
+  return plan.sections.flatMap((section) => section.slots)
+}
+
+function findRoutineSlot(
+  plan: Pick<RoutinePlan, "sections">,
+  slotId: string,
+): RoutineSlotAdvice | undefined {
+  return getRoutineSlots(plan).find((slot) => slot.id === slotId)
+}
+
+function isActionableRoutineSlot(slot: RoutineSlotAdvice): boolean {
+  return slot.action === "add" || slot.action === "adjust" || slot.action === "upgrade"
+}
+
+function createPriorityLever(params: {
+  id: RoutinePriorityLever["id"]
+  source: RoutinePriorityLever["source"]
+  slot: RoutineSlotAdvice
+  reason: string
+  score: number
+  supportingSlots?: RoutineSlotAdvice[]
+}): RoutinePriorityLever {
+  const supportingSlotIds = (params.supportingSlots ?? [])
+    .map((slot) => slot.id)
+    .filter((slotId, index, ids) => slotId !== params.slot.id && ids.indexOf(slotId) === index)
+
+  return {
+    id: params.id,
+    source: params.source,
+    slot_id: params.slot.id,
+    label: params.slot.label,
+    reason: params.reason,
+    score: params.score,
+    topic_ids: params.slot.topic_ids,
+    supporting_slot_ids: supportingSlotIds,
+  }
+}
+
+function hasSevereActiveDamageSignals(
+  profile: HairProfile | null,
+  context: RoutineContext,
+): boolean {
+  const concerns = new Set(context.concerns)
+
+  if (context.protein_moisture_balance === "snaps") return true
+  if (
+    concerns.has("breakage") &&
+    (concerns.has("hair_damage") ||
+      concerns.has("split_ends") ||
+      context.cuticle_condition === "rough" ||
+      context.chemical_treatment.includes("bleached"))
+  ) {
+    return true
+  }
+
+  return countDamageSignals(profile) >= 3
+}
+
+function hasStrongResetBlockageSignals(context: RoutineContext): boolean {
+  if (!context.has_hair_reset_signals) return false
+
+  const routineText = normalizeText(context.products_used ?? "")
+  const heavyRoutineProductCount = context.current_routine_products.filter((entry) =>
+    HEAVY_ROUTINE_PRODUCTS.has(entry),
+  ).length
+  const hasBlockingLanguage =
+    includesAny(routineText, UNDERPERFORMING_ROUTINE_TERMS) ||
+    includesAny(routineText, HAIR_RESET_TERMS)
+  const hasExplicitResetWithLoad =
+    context.explicit_topic_ids.includes("tiefenreinigung") &&
+    (heavyRoutineProductCount >= 2 ||
+      includesAny(routineText, HARD_WATER_TERMS) ||
+      includesAny(routineText, SWIMMING_TERMS) ||
+      includesAny(routineText, CO_WASH_TERMS) ||
+      includesAny(routineText, HEAVY_STYLING_TERMS))
+
+  return context.has_hard_reset_signals || hasBlockingLanguage || hasExplicitResetWithLoad
+}
+
+function findFirstSlot(
+  plan: Pick<RoutinePlan, "sections">,
+  slotIds: string[],
+): RoutineSlotAdvice | undefined {
+  for (const slotId of slotIds) {
+    const slot = findRoutineSlot(plan, slotId)
+    if (slot) return slot
+  }
+  return undefined
+}
+
+export function selectRoutinePriorityLever(
+  profile: HairProfile | null,
+  context: RoutineContext,
+  plan: Pick<RoutinePlan, "sections" | "primary_focuses">,
+): RoutinePriorityLever | null {
+  const resetSlot = findFirstSlot(plan, ["occasional-hair-reset", "occasional-hard-reset"])
+  if (hasStrongResetBlockageSignals(context) && resetSlot) {
+    const hardResetSlot = findRoutineSlot(plan, "occasional-hard-reset")
+
+    return createPriorityLever({
+      id: "reset-blockage",
+      source: "care_risk",
+      slot: resetSlot,
+      reason:
+        "Rueckstaende, Mineralien oder Ueberlagerung koennen verhindern, dass Pflege sauber greift.",
+      score: 100,
+      supportingSlots: hardResetSlot ? [hardResetSlot] : [],
+    })
+  }
+
+  if (hasSevereActiveDamageSignals(profile, context)) {
+    const orderedCareSlots = [
+      findRoutineSlot(plan, "base-conditioner"),
+      findRoutineSlot(plan, "maintenance-leave-in"),
+      findRoutineSlot(plan, "occasional-mask"),
+      findRoutineSlot(plan, "occasional-bond-builder"),
+      context.has_hair_reset_signals ? resetSlot : undefined,
+    ].filter(
+      (slot): slot is RoutineSlotAdvice => slot !== undefined && isActionableRoutineSlot(slot),
+    )
+    const selectedSlot = orderedCareSlots[0]
+
+    if (selectedSlot) {
+      return createPriorityLever({
+        id: "care-product-first",
+        source: "care_risk",
+        slot: selectedSlot,
+        reason:
+          "Bei aktivem Bruch oder strukturellem Schaden kommt die Pflegebasis vor zusaetzlichen Extras.",
+        score: 90,
+        supportingSlots: orderedCareSlots.slice(1),
+      })
+    }
+  }
+
+  const mechanicalSlot = findRoutineSlot(plan, "maintenance-brush-tools")
+  const mechanicalDominant =
+    mechanicalSlot &&
+    (context.explicit_topic_ids.includes("brush_tools") ||
+      (!context.has_damage_signals &&
+        !context.has_dryness_damage_signals &&
+        context.goals.length === 0))
+  if (mechanicalDominant) {
+    return createPriorityLever({
+      id: "mechanical-guardrail",
+      source: "care_risk",
+      slot: mechanicalSlot,
+      reason:
+        "Mechanische Belastung ist hier das staerkste erkennbare Signal und sollte als Guardrail zuerst sitzen.",
+      score: 80,
+    })
+  }
+
+  const hasOngoingExposure =
+    hasFrequentUnprotectedHeat(profile) ||
+    context.chemical_treatment.some((treatment) => treatment !== "natural")
+  if (hasOngoingExposure) {
+    const exposureSlot = findFirstSlot(plan, [
+      "maintenance-leave-in",
+      "base-conditioner",
+      "occasional-bond-builder",
+      "occasional-mask",
+    ])
+    if (exposureSlot && isActionableRoutineSlot(exposureSlot)) {
+      return createPriorityLever({
+        id: "exposure-protection",
+        source: "care_risk",
+        slot: exposureSlot,
+        reason:
+          "Hitze oder chemische Belastung spricht fuer Schutz und Pflege, ohne aktive Schaeden zu ueberstimmen.",
+        score: 70,
+      })
+    }
+  }
+
+  const scalpSlot = findRoutineSlot(plan, "occasional-scalp-clarify")
+  if (scalpSlot && isActionableRoutineSlot(scalpSlot)) {
+    return createPriorityLever({
+      id: "scalp-safety",
+      source: "care_risk",
+      slot: scalpSlot,
+      reason: "Kopfhaut-Signale veraendern, wie sicher und gezielt die Routine reinigen sollte.",
+      score: 60,
+    })
+  }
+
+  const hasDrynessFrizzCluster = ["dryness", "frizz", "tangling"].some((concern) =>
+    context.concerns.includes(concern as HairProfile["concerns"][number]),
+  )
+  if (hasDrynessFrizzCluster) {
+    const drySlot = findFirstSlot(plan, [
+      "maintenance-leave-in",
+      "occasional-mask",
+      "base-owc-oil",
+      "occasional-oil",
+    ])
+    if (drySlot && isActionableRoutineSlot(drySlot)) {
+      return createPriorityLever({
+        id: "dryness-frizz-control",
+        source: "inferred_need",
+        slot: drySlot,
+        reason:
+          "Trockenheit, Frizz oder Verhaken brauchen zuerst einen leichten Pflege- oder Finish-Hebel.",
+        score: 50,
+      })
+    }
+  }
+
+  if (context.goals.length > 0) {
+    const goalSlot = findFirstSlot(plan, [
+      "maintenance-leave-in",
+      "maintenance-refresh",
+      "occasional-mask",
+      "base-cwc-technique",
+      "base-owc-technique",
+      "occasional-oil",
+    ])
+    if (goalSlot && isActionableRoutineSlot(goalSlot)) {
+      return createPriorityLever({
+        id: "stated-goal",
+        source: "stated_goal",
+        slot: goalSlot,
+        reason: "Ohne staerkeren Risiko-Hebel fuehrt das ausdrueckliche Ziel die Routine.",
+        score: 40,
+      })
+    }
+  }
+
+  const inferredSlot = getRoutineSlots(plan).find(
+    (slot) =>
+      slot.id !== "base-shampoo" && slot.id !== "base-conditioner" && isActionableRoutineSlot(slot),
+  )
+  if (!inferredSlot) return null
+
+  return createPriorityLever({
+    id: "inferred-need",
+    source: "inferred_need",
+    slot: inferredSlot,
+    reason: "Der sichtbarste zusaetzliche Routine-Baustein ergibt sich aus den Profilsignalen.",
+    score: 10,
+  })
+}
+
+function sortProjectionSlots(plan: RoutinePlan, slots: RoutineSlotAdvice[]): RoutineSlotAdvice[] {
+  return [...slots].sort((a, b) => {
+    if (a.id === plan.priority_lever?.slot_id) return -1
+    if (b.id === plan.priority_lever?.slot_id) return 1
+    return a.attachment_priority - b.attachment_priority
+  })
+}
+
+function isGoalDirectedSlot(plan: RoutinePlan, slot: RoutineSlotAdvice): boolean {
+  const goalCodes = new Set(
+    plan.primary_focuses.filter((focus) => focus.kind === "goal").map((focus) => focus.code),
+  )
+  if (goalCodes.size === 0) return false
+
+  if (slot.id === "maintenance-refresh" && goalCodes.has("curl_definition")) return true
+  if (
+    slot.category === "leave_in" &&
+    ["less_frizz", "curl_definition", "moisture", "shine"].some((goal) => goalCodes.has(goal))
+  ) {
+    return true
+  }
+  if (
+    slot.category === "mask" &&
+    ["moisture", "healthier_hair", "less_split_ends"].some((goal) => goalCodes.has(goal))
+  ) {
+    return true
+  }
+  if (slot.category === "oil" && ["moisture", "shine"].some((goal) => goalCodes.has(goal))) {
+    return true
+  }
+
+  return (
+    (slot.topic_ids.includes("cwc") || slot.topic_ids.includes("owc")) &&
+    ["moisture", "healthier_hair"].some((goal) => goalCodes.has(goal))
+  )
+}
+
+function isProblemDirectedSlot(plan: RoutinePlan, slot: RoutineSlotAdvice): boolean {
+  const concernCodes = new Set(
+    plan.primary_focuses.filter((focus) => focus.kind === "concern").map((focus) => focus.code),
+  )
+
+  if (
+    slot.topic_ids.some((topicId) =>
+      ["tiefenreinigung", "bond_builder", "brush_tools"].includes(topicId),
+    )
+  ) {
+    return true
+  }
+
+  if (
+    slot.category === "leave_in" &&
+    ["frizz", "dryness", "tangling", "breakage", "hair_damage"].some((concern) =>
+      concernCodes.has(concern),
+    )
+  ) {
+    return true
+  }
+
+  if (
+    (slot.category === "mask" || slot.category === "oil") &&
+    ["dryness", "breakage", "hair_damage", "split_ends"].some((concern) =>
+      concernCodes.has(concern),
+    )
+  ) {
+    return true
+  }
+
+  return false
+}
+
+function topicForDeepDiveCategory(category: RoutineProductCategory | null): RoutineTopicId | null {
+  switch (category) {
+    case "bondbuilder":
+      return "bond_builder"
+    case "deep_cleansing_shampoo":
+    case "peeling":
+      return "tiefenreinigung"
+    case "oil":
+      return "hair_oiling"
+    default:
+      return null
+  }
+}
+
+export function projectRoutinePlanForLayer(
+  plan: RoutinePlan,
+  layer: RoutineLayer,
+  options: {
+    requestedCategory?: RoutineProductCategory | null
+    requestedTopicId?: RoutineTopicId | null
+  } = {},
+): RoutineLayerProjection {
+  const slots = getRoutineSlots(plan)
+  const nonBaseActionableSlots = slots.filter(
+    (slot) =>
+      slot.id !== "base-shampoo" && slot.id !== "base-conditioner" && isActionableRoutineSlot(slot),
+  )
+  let visibleSlots: RoutineSlotAdvice[]
+
+  if (layer === "basics") {
+    visibleSlots = [
+      findRoutineSlot(plan, "base-shampoo"),
+      findRoutineSlot(plan, "base-conditioner"),
+      plan.priority_lever ? findRoutineSlot(plan, plan.priority_lever.slot_id) : undefined,
+    ].filter((slot, index, selected): slot is RoutineSlotAdvice => {
+      return (
+        Boolean(slot) && selected.findIndex((candidate) => candidate?.id === slot?.id) === index
+      )
+    })
+  } else if (layer === "goals") {
+    const goalSlots = nonBaseActionableSlots.filter((slot) => isGoalDirectedSlot(plan, slot))
+    visibleSlots = sortProjectionSlots(
+      plan,
+      goalSlots.length > 0 ? goalSlots : nonBaseActionableSlots,
+    ).slice(0, 3)
+  } else if (layer === "problems") {
+    const problemSlots = nonBaseActionableSlots.filter((slot) => isProblemDirectedSlot(plan, slot))
+    visibleSlots = sortProjectionSlots(
+      plan,
+      problemSlots.length > 0 ? problemSlots : nonBaseActionableSlots,
+    ).slice(0, 3)
+  } else {
+    const requestedCategory = options.requestedCategory ?? null
+    const requestedTopicId = options.requestedTopicId ?? topicForDeepDiveCategory(requestedCategory)
+    const categorySlot =
+      requestedCategory === null
+        ? undefined
+        : slots.find((slot) => slot.category === requestedCategory)
+    const topicSlot =
+      requestedTopicId === null
+        ? undefined
+        : nonBaseActionableSlots.find((slot) => slot.topic_ids.includes(requestedTopicId))
+    const prioritySlot = plan.priority_lever
+      ? findRoutineSlot(plan, plan.priority_lever.slot_id)
+      : undefined
+
+    visibleSlots = [categorySlot ?? topicSlot ?? prioritySlot ?? nonBaseActionableSlots[0]].filter(
+      (slot): slot is RoutineSlotAdvice => Boolean(slot),
+    )
+  }
+
+  return {
+    layer,
+    visible_slot_ids: visibleSlots.map((slot) => slot.id),
+    priority_lever: plan.priority_lever ?? null,
+    requested_category: options.requestedCategory ?? null,
+    requested_topic_id:
+      options.requestedTopicId ?? topicForDeepDiveCategory(options.requestedCategory ?? null),
+  }
+}
+
 export function buildRoutinePlan(
   profile: HairProfile | null,
   message: string,
@@ -1707,13 +2107,28 @@ export function buildRoutinePlan(
     }))
     .filter((section) => section.phase === "base_wash" || section.slots.length > 0)
 
-  return {
+  const planWithoutPriority: Omit<RoutinePlan, "priority_lever" | "layer_projections"> = {
     base_topic_id: getBaseRoutineTopicId(profile),
     primary_focuses: context.primary_focuses,
     active_topics: activeTopics,
     compare_cwc_owc: compareMode,
     sections,
     decision_context: decisionContext,
+  }
+  const planWithPriority: RoutinePlan = {
+    ...planWithoutPriority,
+    priority_lever: selectRoutinePriorityLever(profile, context, planWithoutPriority),
+  }
+  const layerProjections = {
+    basics: projectRoutinePlanForLayer(planWithPriority, "basics"),
+    goals: projectRoutinePlanForLayer(planWithPriority, "goals"),
+    problems: projectRoutinePlanForLayer(planWithPriority, "problems"),
+    deep_dive: projectRoutinePlanForLayer(planWithPriority, "deep_dive"),
+  }
+
+  return {
+    ...planWithPriority,
+    layer_projections: layerProjections,
   }
 }
 

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -34,6 +34,8 @@ export async function updateSession(request: NextRequest) {
 
   const { pathname } = request.nextUrl
   const isQuizRetake = pathname === "/quiz" && request.nextUrl.searchParams.get("mode") === "retake"
+  const isForcedAuthLogin =
+    pathname === "/auth" && request.nextUrl.searchParams.get("force") === "login"
   const needsAuthenticatedAppRouting =
     pathname === "/auth" || pathname === "/quiz" || pathname === "/chat" || pathname === "/"
 
@@ -76,6 +78,10 @@ export async function updateSession(request: NextRequest) {
 
   // All checks below require an authenticated user
   if (!user) {
+    return supabaseResponse
+  }
+
+  if (isForcedAuthLogin) {
     return supabaseResponse
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -578,6 +578,8 @@ export type RoutineSlotAction = "keep" | "adjust" | "add" | "upgrade" | "avoid"
 export type RoutinePlanPhase = "base_wash" | "maintenance" | "occasional"
 export type RoutineSlotKind = "product_slot" | "instruction"
 export type RoutineProductCategory = Exclude<ProductCategory, "routine" | null>
+export type RoutinePriorityLeverSource = "care_risk" | "stated_goal" | "inferred_need"
+export type RoutineLayer = "basics" | "goals" | "problems" | "deep_dive"
 
 export interface RoutineFocus {
   kind: RoutineFocusKind
@@ -646,6 +648,33 @@ export interface RoutineSlotAdvice {
   attached_products?: Product[]
 }
 
+export interface RoutinePriorityLever {
+  id:
+    | "reset-blockage"
+    | "care-product-first"
+    | "mechanical-guardrail"
+    | "exposure-protection"
+    | "scalp-safety"
+    | "dryness-frizz-control"
+    | "stated-goal"
+    | "inferred-need"
+  source: RoutinePriorityLeverSource
+  slot_id: string
+  label: string
+  reason: string
+  score: number
+  topic_ids: RoutineTopicId[]
+  supporting_slot_ids: string[]
+}
+
+export interface RoutineLayerProjection {
+  layer: RoutineLayer
+  visible_slot_ids: string[]
+  priority_lever: RoutinePriorityLever | null
+  requested_category: RoutineProductCategory | null
+  requested_topic_id: RoutineTopicId | null
+}
+
 export interface RoutinePlanSection {
   phase: RoutinePlanPhase
   title: string
@@ -666,6 +695,8 @@ export interface RoutinePlan {
   active_topics: RoutineTopicActivation[]
   compare_cwc_owc: boolean
   sections: RoutinePlanSection[]
+  priority_lever?: RoutinePriorityLever | null
+  layer_projections?: Record<RoutineLayer, RoutineLayerProjection>
   decision_context: RoutineDecisionContext
 }
 

--- a/tests/agent-final-render-prompt.spec.ts
+++ b/tests/agent-final-render-prompt.spec.ts
@@ -23,6 +23,12 @@ test("final render prompt preserves all selected product options in order", () =
   assert.match(AGENT_FINAL_RENDER_PROMPT, /nicht eigenmaechtig von drei Tool-Produkten auf zwei/)
 })
 
+test("final render prompt hides internal fallback markers from users", () => {
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /intern mit "Fallback:" markiert/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /nie in der Nutzerantwort ausgeben/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /schwaecheren Optionen nur nachgeordnet/)
+})
+
 test("final render prompt preserves spray versus cream leave-in comparisons", () => {
   assert.match(AGENT_FINAL_RENDER_PROMPT, /Spray-vs-Creme-Leave-in/)
   assert.match(AGENT_FINAL_RENDER_PROMPT, /Ersetze das Spray nicht durch eine Lotion/)

--- a/tests/agent-production-chat-pipeline.spec.ts
+++ b/tests/agent-production-chat-pipeline.spec.ts
@@ -9,6 +9,7 @@ import {
   productsForRenderedPacket,
   runProductionAgentPipeline,
 } from "../src/lib/agent/production/chat-pipeline"
+import { buildRecommendationEngineRuntimeForChat } from "../src/lib/recommendation-engine"
 import type { AgentModelClient } from "../src/lib/agent/orchestrator/model-client"
 import { createChatPostHandler } from "../src/app/api/chat/route"
 import { createDefaultConversationState } from "../src/lib/rag/conversation-state"
@@ -17,7 +18,7 @@ import type {
   AgentRuntimePacket,
 } from "../src/lib/agent/orchestrator/route-packet"
 import type { SelectedProductsProjection } from "../src/lib/agent/tools/select-products"
-import type { Product } from "../src/lib/types"
+import type { HairProfile, Product } from "../src/lib/types"
 import type { ConversationState, ConversationStateTransition } from "../src/lib/types"
 
 function createRoute(overrides: Partial<AgentRoutePacket> = {}): AgentRoutePacket {
@@ -36,6 +37,8 @@ function createRoute(overrides: Partial<AgentRoutePacket> = {}): AgentRoutePacke
     guidance_ids: ["playbook:recommend_products"],
     tool_plan: ["select_products"],
     routine_objective: null,
+    routine_layer: null,
+    routine_requested_category: null,
     validation_warnings: [],
     ...overrides,
   }
@@ -62,6 +65,41 @@ function createProduct(id: string): Product {
     recommendation_meta: null,
     created_at: "2026-04-29T00:00:00.000Z",
     updated_at: "2026-04-29T00:00:00.000Z",
+  }
+}
+
+function createCompleteHairProfile(overrides: Partial<HairProfile> = {}): HairProfile {
+  return {
+    id: "profile-1",
+    user_id: "user-1",
+    hair_texture: "wavy",
+    thickness: "fine",
+    density: "medium",
+    concerns: ["frizz"],
+    products_used: null,
+    wash_frequency: "every_2_3_days",
+    heat_styling: "rarely",
+    styling_tools: [],
+    goals: ["curl_definition"],
+    cuticle_condition: "rough",
+    protein_moisture_balance: "stretches_bounces",
+    scalp_type: "balanced",
+    scalp_condition: null,
+    chemical_treatment: ["natural"],
+    desired_volume: "balanced",
+    routine_preference: "balanced",
+    current_routine_products: ["shampoo", "conditioner"],
+    towel_material: null,
+    towel_technique: null,
+    drying_method: "air_dry",
+    brush_type: null,
+    night_protection: [],
+    uses_heat_protection: false,
+    additional_notes: null,
+    conversation_memory: null,
+    created_at: "2026-04-29T00:00:00.000Z",
+    updated_at: "2026-04-29T00:00:00.000Z",
+    ...overrides,
   }
 }
 
@@ -340,6 +378,801 @@ test("production agent first-turn routine clarification creates pending routine 
   assert.equal(renderPackets[0]?.routine_plan?.missing_info.length, 2)
 })
 
+test("production agent first complete routine answer renders only routine basics", async () => {
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "routine_structure",
+        product_category: null,
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.9,
+        evidence: ["User asks for a complete routine."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Ich starte mit Shampoo, Conditioner und einem passenden Fokus."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Welche Routine passt am besten zu meinem Haarprofil?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile(),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => createDefaultConversationState(),
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(result.routerDecision.response_mode, "answer_direct")
+  assert.equal(result.conversationStateTransition.reason, "routine_basics_answered")
+  assert.equal(result.conversationStateTransition.next_state.active_topic, "routine")
+  assert.equal(result.conversationStateTransition.next_state.routine_layer, "basics")
+  assert.equal(
+    result.conversationStateTransition.next_state.pending_offer,
+    "routine_goals_or_problems",
+  )
+  assert.deepEqual(
+    renderedPacket.routine_plan?.steps.map((step) => step.id),
+    ["base-shampoo", "base-conditioner", "maintenance-leave-in"],
+  )
+  assert.equal(renderedPacket.selected_products, null)
+  assert.deepEqual(result.matchedProducts, [])
+  assert.ok(
+    renderedPacket.final_instructions.includes(
+      "Fuer basics kurz Shampoo und Conditioner erklaeren und nur den hoechsten Zusatzhebel nennen.",
+    ),
+  )
+  assert.ok(
+    renderedPacket.final_instructions.includes(
+      "Schliesse basics mit einer kurzen natuerlichen Frage, ob der Nutzer als Naechstes eher sehen moechte, was ihn seinem Ziel naeherbringt, oder was gegen seine Probleme hilft. Vermeide interne Begriffe wie Ziel-Hebel oder Problem-Hebel.",
+    ),
+  )
+  assert.equal(result.debugTrace.response_composition.attachment_mode, "text_only")
+  const promptMessage = result.debugTrace.prompt.messages.find((message) => message.role === "user")
+  assert.ok(promptMessage)
+  const promptPayload = JSON.parse(promptMessage.content) as { packet: AgentRuntimePacket }
+  assert.equal(promptPayload.packet.route.routine_layer, "basics")
+  assert.equal(promptPayload.packet.selected_products, null)
+})
+
+test("production agent projects goals layer when user accepts routine goal follow-up", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "routine_structure",
+        product_category: null,
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.88,
+        evidence: ["User chooses the routine goals layer."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Dann schauen wir auf deine Ziele."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Ja, zeig mir bitte, was fuer meine Ziele und mehr Definition hilft.",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile({
+          hair_texture: "curly",
+          concerns: ["dryness", "frizz", "tangling"],
+          goals: ["curl_definition", "less_frizz", "moisture"],
+        }),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  const renderedStepIds = renderedPacket.routine_plan?.steps.map((step) => step.id) ?? []
+  assert.equal(renderedPacket.route.user_job, "routine_structure")
+  assert.equal(renderedPacket.route.routine_layer, "goals")
+  assert.ok(renderedStepIds.includes("maintenance-leave-in"))
+  assert.ok(
+    renderedStepIds.some(
+      (stepId) => stepId === "maintenance-refresh" || stepId === "occasional-mask",
+    ),
+  )
+  assert.ok(!renderedStepIds.includes("base-shampoo"))
+  assert.ok(!renderedStepIds.includes("base-conditioner"))
+  assert.equal(renderedPacket.selected_products, null)
+  assert.deepEqual(result.matchedProducts, [])
+  assert.ok(
+    renderedPacket.final_instructions.includes(
+      "Fuer goals nur die zielbezogenen Routine-Hebel erklaeren.",
+    ),
+  )
+  assert.equal(
+    (renderedPacket.user_context as { conversation_state?: ConversationState }).conversation_state
+      ?.routine_layer,
+    "goals",
+  )
+  assert.equal(result.conversationStateTransition.reason, "routine_goal_layer_selected")
+})
+
+test("production agent overrides unclear goal-layer replies inside active routine", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "unsupported_or_unclear",
+        product_category: null,
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.43,
+        evidence: ["Short reply."],
+        ambiguity: "unclear short answer",
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Dann schauen wir auf deine Ziele."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Ja, die Ziele bitte.",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile({
+          hair_texture: "curly",
+          concerns: ["dryness", "frizz"],
+          goals: ["curl_definition", "less_frizz"],
+        }),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(renderedPacket.route.user_job, "routine_structure")
+  assert.equal(renderedPacket.route.routine_layer, "goals")
+  assert.equal(renderedPacket.selected_products, null)
+  assert.ok(
+    result.routerDecision.policy_overrides.includes("conversation_state_routine_layer_selected"),
+  )
+  assert.equal(
+    result.debugTrace.conversation_state.classifier_override,
+    "conversation_state_routine_layer_selected",
+  )
+  assert.equal(result.conversationStateTransition.reason, "routine_goal_layer_selected")
+})
+
+test("production agent projects problems layer when user accepts routine problem follow-up", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "routine_structure",
+        product_category: null,
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.88,
+        evidence: ["User chooses the routine problems layer."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Dann schauen wir auf Frizz und trockene Spitzen."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Lieber die Probleme: wie kann ich Frizz und trockene Spitzen fixen?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile({
+          hair_texture: "curly",
+          concerns: ["dryness", "frizz", "tangling"],
+          goals: ["curl_definition", "less_frizz", "moisture"],
+        }),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  const renderedStepIds = renderedPacket.routine_plan?.steps.map((step) => step.id) ?? []
+  assert.equal(renderedPacket.route.user_job, "routine_structure")
+  assert.equal(renderedPacket.route.routine_layer, "problems")
+  assert.ok(renderedStepIds.includes("maintenance-leave-in"))
+  assert.ok(
+    renderedStepIds.some(
+      (stepId) => stepId === "occasional-mask" || stepId === "base-owc-technique",
+    ),
+  )
+  assert.ok(!renderedStepIds.includes("base-shampoo"))
+  assert.ok(!renderedStepIds.includes("base-conditioner"))
+  assert.equal(renderedPacket.selected_products, null)
+  assert.deepEqual(result.matchedProducts, [])
+  assert.ok(
+    renderedPacket.final_instructions.includes(
+      "Fuer problems nur die problembezogenen Routine-Hebel erklaeren.",
+    ),
+  )
+  assert.equal(
+    (renderedPacket.user_context as { conversation_state?: ConversationState }).conversation_state
+      ?.routine_layer,
+    "problems",
+  )
+  assert.equal(result.conversationStateTransition.reason, "routine_problem_layer_selected")
+})
+
+test("production agent keeps vague category follow-up inside routine as deep dive", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "product_pick",
+        product_category: "leave_in",
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.82,
+        evidence: ["User mentions Leave-in."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Leave-in ist hier der naechste Routine-Hebel."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Und Leave-in?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile(),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(renderedPacket.route.user_job, "routine_structure")
+  assert.equal(renderedPacket.route.product_category, null)
+  assert.deepEqual(
+    renderedPacket.routine_plan?.steps.map((step) => step.id),
+    ["maintenance-leave-in"],
+  )
+  assert.equal(renderedPacket.selected_products, null)
+  assert.deepEqual(result.matchedProducts, [])
+  assert.ok(
+    renderedPacket.final_instructions.includes(
+      "Fuer deep_dive fokussiert genau den angefragten Baustein erklaeren.",
+    ),
+  )
+  assert.equal(result.debugTrace.response_composition.attachment_mode, "text_only")
+  assert.equal(result.conversationStateTransition.reason, "routine_category_deep_dive")
+  assert.equal(result.conversationStateTransition.next_state.routine_layer, "deep_dive")
+  assert.equal(result.conversationStateTransition.next_state.last_product_category, "leave_in")
+})
+
+test("production agent keeps non-product category concept follow-up inside routine as deep dive", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "compare_or_decide",
+        product_category: "leave_in",
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.8,
+        evidence: ["User asks if Leave-in is needed."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Leave-in ist hier als Routine-Baustein sinnvoll."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Brauche ich Leave-in?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile(),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(renderedPacket.route.user_job, "routine_structure")
+  assert.equal(renderedPacket.route.routine_layer, "deep_dive")
+  assert.deepEqual(
+    renderedPacket.routine_plan?.steps.map((step) => step.id),
+    ["maintenance-leave-in"],
+  )
+  assert.equal(renderedPacket.selected_products, null)
+  assert.deepEqual(result.matchedProducts, [])
+  assert.equal(
+    result.debugTrace.conversation_state.classifier_override,
+    "conversation_state_routine_category_deep_dive",
+  )
+})
+
+test("production agent can deep dive base conditioner inside active routine", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "product_pick",
+        product_category: "conditioner",
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.79,
+        evidence: ["User mentions Conditioner."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Conditioner ist der zweite Basisanker."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Und Conditioner?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile({
+          concerns: ["hair_damage"],
+          goals: [],
+        }),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(renderedPacket.route.user_job, "routine_structure")
+  assert.equal(renderedPacket.route.routine_layer, "deep_dive")
+  assert.deepEqual(
+    renderedPacket.routine_plan?.steps.map((step) => step.id),
+    ["base-conditioner"],
+  )
+  assert.equal(renderedPacket.selected_products, null)
+  assert.deepEqual(result.matchedProducts, [])
+  assert.equal(result.conversationStateTransition.next_state.last_product_category, "conditioner")
+})
+
+test("production agent lets explicit routine follow-up product asks show product cards", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const matchedLeaveIn = {
+    ...createProduct("leave-in-1"),
+    name: "Leave-in 1",
+    category: "Leave-in",
+    similarity: 0.91,
+  }
+  const leaveInProjection: SelectedProductsProjection = {
+    category: "leave_in",
+    decision: "recommended",
+    product_response_policy: "recommend",
+    policy_reason: "Explicit product ask.",
+    profile_basis: [],
+    category_guidance: "Leave-in passt als konkrete Produktempfehlung.",
+    products: [
+      {
+        rank: 1,
+        product_id: matchedLeaveIn.id,
+        name: matchedLeaveIn.name,
+        brand: matchedLeaveIn.brand,
+        price_eur: matchedLeaveIn.price_eur,
+        currency: matchedLeaveIn.currency,
+        fit_reason: "Passt als leichter Leave-in-Fokus.",
+        caveat: null,
+        supported_claims: [],
+        unsupported_requested_signals: [],
+      },
+    ],
+    comparison_facts: null,
+    missing_info: [],
+    unsupported_requested_signals: [],
+  }
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "product_pick",
+        product_category: "leave_in",
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.9,
+        evidence: ["User asks for a concrete Leave-in recommendation."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Hier sind konkrete Leave-in-Produkte."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Welches Leave-in empfiehlst du mir konkret?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile(),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+      createSelectProductsTool:
+        (options = {}) =>
+        async () => {
+          const effectiveHairProfile = createCompleteHairProfile()
+          options.onResult?.({
+            projection: leaveInProjection,
+            products: [matchedLeaveIn],
+            effectiveHairProfile,
+            runtime: buildRecommendationEngineRuntimeForChat({
+              hairProfile: effectiveHairProfile,
+              routineItems: [],
+              productCategory: "leave_in",
+              message: "Welches Leave-in empfiehlst du mir konkret?",
+            }),
+          })
+          return leaveInProjection
+        },
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(renderedPacket.route.user_job, "product_pick")
+  assert.equal(renderedPacket.route.product_category, "leave_in")
+  assert.equal(renderedPacket.routine_plan, null)
+  assert.equal(renderedPacket.selected_products?.category, "leave_in")
+  assert.ok(renderedPacket.selected_products.products.length > 0)
+  assert.ok(result.matchedProducts.length > 0)
+  assert.equal(result.debugTrace.response_composition.attachment_mode, "cards")
+  assert.equal(result.conversationStateTransition.reason, "category_switch")
+  assert.equal(result.conversationStateTransition.next_state.active_topic, "leave_in")
+})
+
+test("production agent keeps natural explicit good-product wording in product mode", async () => {
+  const loadedConversationState: ConversationState = {
+    ...createDefaultConversationState(),
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    last_assistant_action: "answered_routine_basics",
+  }
+  const renderPackets: AgentRuntimePacket[] = []
+  const matchedLeaveIn = {
+    ...createProduct("leave-in-good"),
+    name: "Gutes Leave-in",
+    category: "Leave-in",
+    similarity: 0.9,
+  }
+  const leaveInProjection: SelectedProductsProjection = {
+    category: "leave_in",
+    decision: "recommended",
+    product_response_policy: "recommend",
+    policy_reason: "Explicit good-product wording.",
+    profile_basis: [],
+    category_guidance: "Konkrete Leave-in-Auswahl.",
+    products: [
+      {
+        rank: 1,
+        product_id: matchedLeaveIn.id,
+        name: matchedLeaveIn.name,
+        brand: matchedLeaveIn.brand,
+        price_eur: matchedLeaveIn.price_eur,
+        currency: matchedLeaveIn.currency,
+        fit_reason: "Passt als Leave-in.",
+        caveat: null,
+        supported_claims: [],
+        unsupported_requested_signals: [],
+      },
+    ],
+    comparison_facts: null,
+    missing_info: [],
+    unsupported_requested_signals: [],
+  }
+  const fakeModel: AgentModelClient = {
+    async classifyRoute() {
+      return {
+        user_job: "product_pick",
+        product_category: "leave_in",
+        requested_overlay_ids: [],
+        requested_topic_ids: [],
+        requested_routine_id: null,
+        concerns: [],
+        confidence: 0.87,
+        evidence: ["User asks for a good Leave-in."],
+        ambiguity: null,
+      }
+    },
+    async renderFinalAnswer(params) {
+      renderPackets.push(params.packet)
+      return "Hier ist ein gutes Leave-in."
+    },
+  }
+
+  const result = await runProductionAgentPipeline(
+    {
+      message: "Was ist ein gutes Leave-in fuer mich?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-1",
+    },
+    {
+      modelClient: fakeModel,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: createCompleteHairProfile(),
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async () => loadedConversationState,
+      createSelectProductsTool:
+        (options = {}) =>
+        async () => {
+          const effectiveHairProfile = createCompleteHairProfile()
+          options.onResult?.({
+            projection: leaveInProjection,
+            products: [matchedLeaveIn],
+            effectiveHairProfile,
+            runtime: buildRecommendationEngineRuntimeForChat({
+              hairProfile: effectiveHairProfile,
+              routineItems: [],
+              productCategory: "leave_in",
+              message: "Was ist ein gutes Leave-in fuer mich?",
+            }),
+          })
+          return leaveInProjection
+        },
+    },
+  )
+  const renderedPacket = renderPackets[0]
+  assert.ok(renderedPacket)
+
+  assert.equal(renderedPacket.route.user_job, "product_pick")
+  assert.equal(renderedPacket.route.product_category, "leave_in")
+  assert.equal(renderedPacket.routine_plan, null)
+  assert.equal(renderedPacket.selected_products?.category, "leave_in")
+  assert.ok(result.matchedProducts.length > 0)
+  assert.equal(result.conversationStateTransition.reason, "category_switch")
+})
+
 test("production agent product cards follow the renderer packet order", () => {
   const selectedProducts = [createProduct("fallback"), createProduct("primary")]
   const runtimePacket = {
@@ -422,7 +1255,7 @@ test("production agent pipeline marks debug trace as agent final render", async 
     fallback_reason: null,
     rendering_path: null,
     plan_type: "agent_v1",
-    attachment_mode: null,
+    attachment_mode: "text_only",
   })
 })
 

--- a/tests/agent-shadow.spec.ts
+++ b/tests/agent-shadow.spec.ts
@@ -178,6 +178,7 @@ test("runShadowAgentTurn filters fallback products only from the renderer packet
         packet.selected_products?.products.map((product) => product.product_id),
         ["p-1"],
       )
+      assert.equal(JSON.stringify(packet.selected_products).includes("Fallback:"), false)
       assert.equal(packet.selected_products?.comparison_facts, null)
       assert.deepEqual(packet.selected_products?.unsupported_requested_signals, [])
       return "Ich zeige nur den sicheren Treffer."
@@ -287,6 +288,11 @@ test("runShadowAgentTurn preserves leave-in fallback products for caveated compa
         "p-2": ["Format: Creme"],
         "p-3": ["Format: Spray"],
       })
+      assert.equal(
+        packet.selected_products?.products.find((product) => product.product_id === "p-3")?.caveat,
+        "Balance-Richtung ist nur als caveated Option passend.",
+      )
+      assert.equal(JSON.stringify(packet.selected_products).includes("Fallback:"), false)
       return "Ich zeige alle Leave-in-Optionen mit Caveat."
     },
   }
@@ -328,9 +334,9 @@ test("runShadowAgentTurn preserves leave-in fallback products for caveated compa
           {
             rank: 3,
             product_id: "p-3",
-            name: "Fallback Spray",
+            name: "Spray Leave-in",
             brand: null,
-            fit_reason: "Fallback-Treffer.",
+            fit_reason: "Nachgeordneter Treffer.",
             caveat: "Fallback: Balance-Richtung ist nur als caveated Option passend.",
             supported_claims: [],
             unsupported_requested_signals: [],

--- a/tests/conversation-state.spec.ts
+++ b/tests/conversation-state.spec.ts
@@ -130,7 +130,7 @@ test("routine request opens routine basics state", () => {
   expect(transition.reason).toBe("routine_started")
 })
 
-test("complete first routine request does not leave pending routine basics", () => {
+test("complete first routine answer stays on routine basics and offers next layers", () => {
   const transition = computeConversationStateTransition({
     previousState: createDefaultConversationState(),
     classification: createClassification(),
@@ -143,16 +143,16 @@ test("complete first routine request does not leave pending routine basics", () 
     },
     userMessage:
       "Ich wasche alle 3 Tage mit Shampoo und Conditioner, aber meine Spitzen sind trocken.",
-    assistantAction: "answered_routine",
+    assistantAction: "answered_routine_basics",
     hairProfile: createProfile(),
     matchedProductCategory: null,
   })
 
   expect(transition.next_state.active_topic).toBe("routine")
-  expect(transition.next_state.routine_layer).not.toBe("basics")
-  expect(transition.next_state.pending_offer).not.toBe("routine_goals_or_problems")
+  expect(transition.next_state.routine_layer).toBe("basics")
+  expect(transition.next_state.pending_offer).toBe("routine_goals_or_problems")
   expect(transition.next_state.answered_slots).toEqual(["routine", "products_tried", "problem"])
-  expect(transition.reason).toBe("routine_started_with_frame")
+  expect(transition.reason).toBe("routine_basics_answered")
 })
 
 test("short answer to pending routine basics keeps route in routine context", () => {
@@ -281,6 +281,38 @@ test("pending routine override requires the assistant to have asked routine basi
   expect(corrected.override).toBeNull()
 })
 
+test("pending routine override does not apply after routine basics were answered", () => {
+  const answeredBasicsState: ConversationState = {
+    version: 1,
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    answered_slots: ["routine", "products_tried"],
+    last_assistant_action: "answered_routine_basics",
+    last_product_category: null,
+  }
+  const classification = createClassification({
+    intent: "followup",
+    product_category: "leave_in",
+    router_confidence: 0.72,
+  })
+
+  const corrected = applyConversationStateToClassification({
+    state: answeredBasicsState,
+    classification,
+    userMessage: "Und Leave-in?",
+  })
+
+  expect(corrected.classification).toBe(classification)
+  expect(corrected.override).toBeNull()
+  expect(
+    shouldApplyPendingRoutineAnswerOverride({
+      state: answeredBasicsState,
+      userMessage: "Und Leave-in?",
+    }),
+  ).toBe(false)
+})
+
 test("unrelated short general messages do not override pending routine context", () => {
   const previousState: ConversationState = {
     version: 1,
@@ -396,6 +428,117 @@ test("standalone support-category recommendation switches conversation topic", (
   expect(transition.reason).toBe("category_switch")
 })
 
+test("goal follow-up after routine basics advances to goal layer", () => {
+  const previousState: ConversationState = {
+    version: 1,
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    answered_slots: ["routine", "products_tried"],
+    last_assistant_action: "answered_routine_basics",
+    last_product_category: null,
+  }
+
+  const transition = computeConversationStateTransition({
+    previousState,
+    classification: createClassification({
+      intent: "followup",
+      product_category: null,
+      router_confidence: 0.74,
+    }),
+    routerDecision: {
+      retrieval_mode: "hybrid",
+      response_mode: "answer_direct",
+      slot_completeness: 1,
+      confidence: 0.74,
+      policy_overrides: [],
+    },
+    userMessage: "Ja, zeig mir bitte, was für meine Ziele und mehr Definition hilft.",
+    assistantAction: "answered_routine_goals",
+    hairProfile: createProfile(),
+    matchedProductCategory: null,
+  })
+
+  expect(transition.next_state.active_topic).toBe("routine")
+  expect(transition.next_state.routine_layer).toBe("goals")
+  expect(transition.next_state.pending_offer).toBe("routine_other_layer")
+  expect(transition.reason).toBe("routine_goal_layer_selected")
+})
+
+test("problem follow-up after routine basics advances to problem layer", () => {
+  const previousState: ConversationState = {
+    version: 1,
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    answered_slots: ["routine", "products_tried"],
+    last_assistant_action: "answered_routine_basics",
+    last_product_category: null,
+  }
+
+  const transition = computeConversationStateTransition({
+    previousState,
+    classification: createClassification({
+      intent: "followup",
+      product_category: null,
+      router_confidence: 0.74,
+    }),
+    routerDecision: {
+      retrieval_mode: "hybrid",
+      response_mode: "answer_direct",
+      slot_completeness: 1,
+      confidence: 0.74,
+      policy_overrides: [],
+    },
+    userMessage: "Lieber die Probleme: wie kann ich Frizz und trockene Spitzen fixen?",
+    assistantAction: "answered_routine_problems",
+    hairProfile: createProfile(),
+    matchedProductCategory: null,
+  })
+
+  expect(transition.next_state.active_topic).toBe("routine")
+  expect(transition.next_state.routine_layer).toBe("problems")
+  expect(transition.next_state.pending_offer).toBe("routine_other_layer")
+  expect(transition.reason).toBe("routine_problem_layer_selected")
+})
+
+test("combined goal and problem follow-up after routine basics offers deep dive next", () => {
+  const previousState: ConversationState = {
+    version: 1,
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    answered_slots: ["routine", "products_tried"],
+    last_assistant_action: "answered_routine_basics",
+    last_product_category: null,
+  }
+
+  const transition = computeConversationStateTransition({
+    previousState,
+    classification: createClassification({
+      intent: "followup",
+      product_category: null,
+      router_confidence: 0.74,
+    }),
+    routerDecision: {
+      retrieval_mode: "hybrid",
+      response_mode: "answer_direct",
+      slot_completeness: 1,
+      confidence: 0.74,
+      policy_overrides: [],
+    },
+    userMessage: "Gerne beides: Ziele und auch die Probleme angehen.",
+    assistantAction: "answered_routine_goals_and_problems",
+    hairProfile: createProfile(),
+    matchedProductCategory: null,
+  })
+
+  expect(transition.next_state.active_topic).toBe("routine")
+  expect(transition.next_state.routine_layer).toBe("goals")
+  expect(transition.next_state.pending_offer).toBe("routine_deep_dive")
+  expect(transition.reason).toBe("routine_goal_and_problem_layers_selected")
+})
+
 test("explicit category mention inside routine becomes routine deep dive", () => {
   const previousState: ConversationState = {
     version: 1,
@@ -431,6 +574,89 @@ test("explicit category mention inside routine becomes routine deep dive", () =>
   expect(transition.next_state.routine_layer).toBe("deep_dive")
   expect(transition.next_state.last_product_category).toBe("leave_in")
   expect(transition.reason).toBe("routine_category_deep_dive")
+})
+
+test("vague category mention after routine basics becomes routine deep dive", () => {
+  const previousState: ConversationState = {
+    version: 1,
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    answered_slots: ["routine", "products_tried"],
+    last_assistant_action: "answered_routine_basics",
+    last_product_category: null,
+  }
+
+  const transition = computeConversationStateTransition({
+    previousState,
+    classification: createClassification({
+      intent: "followup",
+      product_category: "leave_in",
+      router_confidence: 0.8,
+    }),
+    routerDecision: {
+      retrieval_mode: "hybrid",
+      response_mode: "answer_direct",
+      slot_completeness: 1,
+      confidence: 0.8,
+      policy_overrides: [],
+    },
+    userMessage: "Und Leave-in?",
+    assistantAction: "answered_routine_deep_dive",
+    hairProfile: createProfile(),
+    matchedProductCategory: "leave_in",
+  })
+
+  expect(transition.next_state.active_topic).toBe("routine")
+  expect(transition.next_state.routine_layer).toBe("deep_dive")
+  expect(transition.next_state.pending_offer).toBeNull()
+  expect(transition.next_state.last_product_category).toBe("leave_in")
+  expect(transition.reason).toBe("routine_category_deep_dive")
+})
+
+test("explicit product request inside routine switches to product category", () => {
+  const previousState: ConversationState = {
+    version: 1,
+    active_topic: "routine",
+    routine_layer: "basics",
+    pending_offer: "routine_goals_or_problems",
+    answered_slots: ["routine", "products_tried"],
+    last_assistant_action: "answered_routine_basics",
+    last_product_category: null,
+  }
+
+  const classification = createClassification({
+    intent: "product_recommendation",
+    product_category: "leave_in",
+    router_confidence: 0.86,
+  })
+  const corrected = applyConversationStateToClassification({
+    state: previousState,
+    classification,
+    userMessage: "Welches Leave-in empfiehlst du mir konkret?",
+  })
+  const transition = computeConversationStateTransition({
+    previousState,
+    classification: corrected.classification,
+    routerDecision: {
+      retrieval_mode: "product_sql_plus_hybrid",
+      response_mode: "answer_direct",
+      slot_completeness: 1,
+      confidence: 0.86,
+      policy_overrides: ["category_product_mode"],
+    },
+    userMessage: "Welches Leave-in empfiehlst du mir konkret?",
+    assistantAction: "answered_product_recommendation",
+    hairProfile: createProfile(),
+    matchedProductCategory: "leave_in",
+  })
+
+  expect(corrected.override).toBeNull()
+  expect(transition.next_state.active_topic).toBe("leave_in")
+  expect(transition.next_state.routine_layer).toBeNull()
+  expect(transition.next_state.pending_offer).toBeNull()
+  expect(transition.next_state.last_product_category).toBe("leave_in")
+  expect(transition.reason).toBe("category_switch")
 })
 
 test("state store builds stable upsert payload", () => {

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -6,6 +6,7 @@ import {
   deriveRoutineContext,
   detectStylingProductKind,
   getRoutineAutofillSlots,
+  projectRoutinePlanForLayer,
 } from "../src/lib/routines/planner"
 import { applyConversationStateToClassification } from "../src/lib/rag/conversation-state"
 import { evaluateRoute } from "../src/lib/rag/router"
@@ -1464,6 +1465,177 @@ test.describe("Routine planner", () => {
 
       expect(plan.active_topics.map((topic) => topic.id)).toContain("brush_tools")
       expect(brushSlot?.rationale.some((line) => line.includes("Spruehflasche"))).toBe(true)
+    })
+  })
+
+  test.describe("Layered routine projections", () => {
+    test("basics projection keeps shampoo, conditioner, and exactly one separate priority lever when available", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          concerns: ["frizz"],
+          goals: ["less_frizz"],
+          current_routine_products: ["shampoo", "conditioner"],
+        }),
+        "Welche Routine empfiehlst du gegen Frizz?",
+      )
+
+      const projection = projectRoutinePlanForLayer(plan, "basics")
+
+      expect(plan.priority_lever?.slot_id).toBe("maintenance-leave-in")
+      expect(projection.priority_lever?.slot_id).toBe("maintenance-leave-in")
+      expect(projection.visible_slot_ids).toEqual([
+        "base-shampoo",
+        "base-conditioner",
+        "maintenance-leave-in",
+      ])
+    })
+
+    test("severe active damage selects care-product-first and starts with the conditioner upgrade", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          concerns: ["breakage", "hair_damage", "split_ends"],
+          cuticle_condition: "rough",
+          chemical_treatment: ["bleached"],
+          protein_moisture_balance: "snaps",
+          current_routine_products: ["shampoo", "conditioner"],
+        }),
+        "Meine Haare sind blondiert, rau und brechen aktiv ab.",
+      )
+
+      expect(plan.priority_lever).toMatchObject({
+        id: "care-product-first",
+        source: "care_risk",
+        slot_id: "base-conditioner",
+      })
+      expect(plan.priority_lever?.supporting_slot_ids).toEqual(
+        expect.arrayContaining([
+          "maintenance-leave-in",
+          "occasional-mask",
+          "occasional-bond-builder",
+        ]),
+      )
+    })
+
+    test("severe active damage still selects care-product-first when reset signal is weak oil usage", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          concerns: ["breakage", "hair_damage", "split_ends"],
+          cuticle_condition: "rough",
+          chemical_treatment: ["bleached"],
+          protein_moisture_balance: "snaps",
+          current_routine_products: ["shampoo", "conditioner", "oil"],
+        }),
+        "Meine Haare sind blondiert, rau und brechen aktiv ab.",
+      )
+
+      expect(plan.priority_lever).toMatchObject({
+        id: "care-product-first",
+        source: "care_risk",
+        slot_id: "base-conditioner",
+      })
+    })
+
+    test("strong reset blockage can preempt cosmetic goals", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          goals: ["shine", "curl_definition"],
+          products_used:
+            "Hartes Wasser, Gel und viele Produkte in Rotation; die Haare fuehlen sich wachsig an und nichts zieht mehr ein.",
+          current_routine_products: ["shampoo", "conditioner", "leave_in", "mask", "oil"],
+        }),
+        "Ich will mehr Glanz, aber meine Haare sind wachsig und beschwert.",
+      )
+
+      expect(plan.priority_lever).toMatchObject({
+        id: "reset-blockage",
+        source: "care_risk",
+        slot_id: "occasional-hair-reset",
+      })
+    })
+
+    test("stated goal wins when no stronger care risk is present", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          hair_texture: "curly",
+          concerns: [],
+          goals: ["curl_definition"],
+          cuticle_condition: "smooth",
+          chemical_treatment: ["natural"],
+          current_routine_products: ["shampoo", "conditioner"],
+        }),
+        "Ich moechte vor allem mehr Definition.",
+      )
+
+      expect(plan.priority_lever).toMatchObject({
+        id: "stated-goal",
+        source: "stated_goal",
+        slot_id: "maintenance-leave-in",
+      })
+    })
+
+    test("goals and problems projections expose only the top two to three relevant levers", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          hair_texture: "curly",
+          concerns: ["dryness", "frizz", "tangling", "hair_damage"],
+          goals: ["less_frizz", "curl_definition", "moisture", "healthier_hair"],
+          cuticle_condition: "rough",
+          chemical_treatment: ["colored"],
+          current_routine_products: ["shampoo", "conditioner"],
+        }),
+        "Welche Routine passt fuer definierte, weniger trockene Locken?",
+      )
+
+      const goalsProjection = projectRoutinePlanForLayer(plan, "goals")
+      const problemsProjection = projectRoutinePlanForLayer(plan, "problems")
+
+      expect(goalsProjection.visible_slot_ids).toHaveLength(3)
+      expect(problemsProjection.visible_slot_ids).toHaveLength(3)
+      expect(goalsProjection.visible_slot_ids).toEqual(
+        expect.arrayContaining(["maintenance-leave-in", "occasional-mask"]),
+      )
+      expect(problemsProjection.visible_slot_ids).toEqual(
+        expect.arrayContaining(["maintenance-leave-in", "occasional-mask"]),
+      )
+      expect(goalsProjection.visible_slot_ids).not.toContain("base-shampoo")
+      expect(goalsProjection.visible_slot_ids).not.toContain("base-conditioner")
+      expect(problemsProjection.visible_slot_ids).not.toContain("base-shampoo")
+      expect(problemsProjection.visible_slot_ids).not.toContain("base-conditioner")
+    })
+
+    test("deep dive projection focuses the requested category follow-up", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          concerns: ["frizz"],
+          goals: ["less_frizz"],
+          current_routine_products: ["shampoo", "conditioner"],
+        }),
+        "Welche Routine passt zu mir?",
+      )
+
+      const projection = projectRoutinePlanForLayer(plan, "deep_dive", {
+        requestedCategory: "leave_in",
+      })
+
+      expect(projection.visible_slot_ids).toEqual(["maintenance-leave-in"])
+      expect(projection.requested_category).toBe("leave_in")
+    })
+
+    test("deep dive projection can focus base wash categories", () => {
+      const plan = buildRoutinePlan(
+        createProfile({
+          concerns: ["hair_damage"],
+          current_routine_products: ["shampoo", "conditioner"],
+        }),
+        "Welche Routine passt zu mir?",
+      )
+
+      const projection = projectRoutinePlanForLayer(plan, "deep_dive", {
+        requestedCategory: "conditioner",
+      })
+
+      expect(projection.visible_slot_ids).toEqual(["base-conditioner"])
+      expect(projection.requested_category).toBe("conditioner")
     })
   })
 })


### PR DESCRIPTION
## Why
Tester feedback showed that the first routine answer was too long on mobile and that routine follow-ups could re-trigger broad routine dumps instead of continuing the conversation naturally. During local testing we also found the quiz login link could not bypass the authenticated quiz redirect.

## What changed
- Adds layered routine planning: basics first, then goal/problem layers, then focused deep dives.
- Ranks the first priority lever from profile risk, with care-product-first handling for breakage/damage and reset preemption only for stronger blockage signals.
- Wires conversation state into agent routing so vague routine category follow-ups stay in routine deep-dive mode, while explicit product asks still enter product recommendation mode.
- Keeps routine answers category-level unless concrete products are explicitly requested.
- Strips internal weaker-option markers before final rendering so user-facing messages never show `Fallback:`.
- Lets returning users open `/auth?force=login` from the quiz landing link.

## Verification
- `npx playwright test tests/routine-planner.spec.ts`
- `npx playwright test tests/conversation-state.spec.ts`
- `npx tsx --test tests/agent-production-chat-pipeline.spec.ts tests/agent-shadow.spec.ts tests/agent-final-render-prompt.spec.ts tests/agent-routine-tool.spec.ts`
- `npm run typecheck`
- `git diff --check`
- Manual local smoke testing on `http://localhost:3210` for routine basics/follow-ups and quiz login bypass

## Notes
- This PR does not merge or deploy anything.
- The local dev server is still available for continued testing in this worktree.