### PR TITLE
chore: limit Dependabot dev tooling majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,9 @@ updates:
           - "@sentry/*"
       lint-format-tooling:
         dependency-type: development
+        update-types:
+          - patch
+          - minor
         patterns:
           - "eslint"
           - "eslint-*"
@@ -61,12 +64,18 @@ updates:
           - "husky"
       test-tooling:
         dependency-type: development
+        update-types:
+          - patch
+          - minor
         patterns:
           - "@playwright/*"
           - "playwright"
           - "start-server-and-test"
       typescript-tooling:
         dependency-type: development
+        update-types:
+          - patch
+          - minor
         patterns:
           - "typescript"
           - "tsx"


### PR DESCRIPTION
## Summary
- restrict Dependabot dev tooling groups to patch/minor updates
- keeps ESLint, test tooling, and TypeScript major upgrades out of grouped weekly PRs until the repo intentionally moves tooling/runtime lines

## Verification
- git diff --check
- npx prettier --check .github/dependabot.yml
- commit hook: npm run typecheck