### PR TITLE
feat(auth): activate paid accounts after checkout

### DIFF
--- a/src/app/api/auth/send-setup-link/route.ts
+++ b/src/app/api/auth/send-setup-link/route.ts
@@ -1,67 +1,20 @@
 import { NextResponse } from "next/server"
-import { getStripe } from "@/lib/stripe/client"
-import { createAdminClient } from "@/lib/supabase/admin"
-import { checkRateLimit, SEND_AUTH_LINK_RATE_LIMIT } from "@/lib/rate-limit"
 
-export async function POST(request: Request) {
-  let body: unknown
-  try {
-    body = await request.json()
-  } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+const DEPRECATED_SETUP_LINK_ERROR =
+  "Dieser Link wird nicht mehr verwendet. Bitte kehre zur Kontoaktivierung zurück."
+
+type RouteResult = {
+  status: number
+  body: Record<string, unknown>
+}
+
+export function POST() {
+  return NextResponse.json({ error: DEPRECATED_SETUP_LINK_ERROR }, { status: 410 })
+}
+
+export function handleSendSetupLink(): RouteResult {
+  return {
+    status: 410,
+    body: { error: DEPRECATED_SETUP_LINK_ERROR },
   }
-
-  if (
-    typeof body !== "object" ||
-    body === null ||
-    typeof (body as Record<string, unknown>).email !== "string" ||
-    typeof (body as Record<string, unknown>).session_id !== "string"
-  ) {
-    return NextResponse.json({ error: "Missing email or session_id" }, { status: 400 })
-  }
-
-  const { email, session_id } = body as { email: string; session_id: string }
-
-  const rateCheck = await checkRateLimit(session_id, SEND_AUTH_LINK_RATE_LIMIT)
-  if (!rateCheck.allowed) {
-    const status = rateCheck.error === "service_unavailable" ? 503 : 429
-    return NextResponse.json({ error: "Zu viele Anfragen. Bitte warte kurz." }, { status })
-  }
-
-  // Verify email matches the Stripe checkout session to prevent abuse
-  try {
-    const stripe = getStripe()
-    const session = await stripe.checkout.sessions.retrieve(session_id)
-    if (session.status !== "complete") {
-      return NextResponse.json({ error: "Zahlung nicht abgeschlossen" }, { status: 403 })
-    }
-    const sessionEmail = session.customer_details?.email
-    if (!sessionEmail || sessionEmail.toLowerCase() !== email.toLowerCase()) {
-      return NextResponse.json({ error: "E-Mail stimmt nicht ueberein" }, { status: 403 })
-    }
-  } catch (err) {
-    console.error("[send-setup-link] Stripe verification failed:", err)
-    return NextResponse.json({ error: "Verifizierung fehlgeschlagen" }, { status: 500 })
-  }
-
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
-  const supabase = createAdminClient()
-
-  const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    // Must route through /auth/confirm — only allow-listed destination in
-    // supabase/config.toml. Pass `next` explicitly because PKCE flow does not
-    // propagate the `type=recovery` query param; relying on that broke in
-    // practice. /auth/confirm exchanges the code then redirects to `next`.
-    redirectTo: `${siteUrl}/auth/confirm?next=/auth/update-password`,
-  })
-
-  if (error) {
-    console.error("[send-setup-link] resetPasswordForEmail failed:", error.message)
-    return NextResponse.json(
-      { error: "E-Mail konnte nicht gesendet werden. Bitte versuche es erneut." },
-      { status: 500 },
-    )
-  }
-
-  return NextResponse.json({ ok: true })
 }

--- a/src/app/api/auth/set-checkout-password/route.ts
+++ b/src/app/api/auth/set-checkout-password/route.ts
@@ -7,8 +7,8 @@ import {
   claimCheckoutActivation,
   releaseCheckoutActivationClaim,
 } from "@/lib/auth/checkout-activation-claim"
+import { checkRateLimit, SET_CHECKOUT_PASSWORD_RATE_LIMIT } from "@/lib/rate-limit"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
-import { checkRateLimit, SEND_AUTH_LINK_RATE_LIMIT } from "@/lib/rate-limit"
 import {
   CheckoutActivationError,
   ensureCheckoutAccount,
@@ -17,28 +17,29 @@ import {
 
 export const runtime = "nodejs"
 
-const INVALID_REQUEST_ERROR = "Bitte öffne den Aktivierungslink erneut."
-const RATE_LIMIT_ERROR = "Zu viele Anfragen. Bitte warte kurz."
+const INVALID_REQUEST_ERROR = "Bitte sende eine gültige Checkout-Session und ein Passwort."
+const WEAK_PASSWORD_ERROR = "Das Passwort muss mindestens 8 Zeichen lang sein."
+const RATE_LIMIT_ERROR = "Zu viele Versuche. Bitte warte kurz und versuche es erneut."
 const RATE_LIMIT_UNAVAILABLE_ERROR =
-  "Login-Link kann gerade nicht gesendet werden. Bitte versuche es gleich erneut."
-const INCOMPLETE_PAYMENT_ERROR =
-  "Deine Zahlung ist noch nicht abgeschlossen. Bitte schließe den Checkout zuerst ab."
+  "Passwort kann gerade nicht gesetzt werden. Bitte versuche es gleich erneut."
+const EXISTING_ACCOUNT_ERROR =
+  "Für diese E-Mail gibt es bereits ein Konto. Bitte melde dich an oder nutze den Login-Link."
+const EXPIRED_ACTIVATION_ERROR =
+  "Diese Passwort-Aktivierung ist nicht mehr gültig. Bitte melde dich an oder nutze den Login-Link."
 const INVALID_SESSION_ERROR =
   "Checkout konnte nicht bestätigt werden. Bitte öffne den Link aus deiner Bestellbestätigung erneut."
-const SEND_ERROR = "Login-Link konnte nicht gesendet werden. Bitte versuche es erneut."
-const EXPIRED_ACTIVATION_ERROR =
-  "Diese Kontoaktivierung ist nicht mehr gültig. Bitte melde dich an oder nutze den Login-Link."
-const SERVER_ERROR = "Kontoaktivierung konnte nicht abgeschlossen werden. Bitte versuche es erneut."
+const INCOMPLETE_PAYMENT_ERROR =
+  "Deine Zahlung ist noch nicht abgeschlossen. Bitte schließe den Checkout zuerst ab."
+const SERVER_ERROR = "Passwort konnte nicht gesetzt werden. Bitte versuche es später erneut."
 
 type RateLimitResult = { allowed: boolean; error?: string }
 
-export interface SendMagicLinkDeps {
+export interface SetCheckoutPasswordDeps {
   stripe: Stripe
   supabase: SupabaseClient
-  siteUrl: string
   checkRateLimit: (
     identifier: string,
-    config: typeof SEND_AUTH_LINK_RATE_LIMIT,
+    config: typeof SET_CHECKOUT_PASSWORD_RATE_LIMIT,
   ) => Promise<RateLimitResult>
   verifyCheckoutSessionForActivation: (
     sessionId: string,
@@ -65,17 +66,22 @@ export async function POST(request: Request) {
     return toNextResponse({ status: 400, body: { error: INVALID_REQUEST_ERROR } })
   }
 
-  return toNextResponse(await handleSendMagicLink(body, await createSendMagicLinkDeps()))
+  return toNextResponse(
+    await handleSetCheckoutPassword(body, await createSetCheckoutPasswordDeps()),
+  )
 }
 
-export async function handleSendMagicLink(
+export async function handleSetCheckoutPassword(
   body: unknown,
-  deps: SendMagicLinkDeps,
+  deps: SetCheckoutPasswordDeps,
 ): Promise<RouteResult> {
   const parsed = parseBody(body)
   if (!parsed.ok) return { status: 400, body: { error: INVALID_REQUEST_ERROR } }
 
-  const rateCheck = await deps.checkRateLimit(parsed.sessionId, SEND_AUTH_LINK_RATE_LIMIT)
+  const { sessionId, password } = parsed
+  if (password.length < 8) return { status: 400, body: { error: WEAK_PASSWORD_ERROR } }
+
+  const rateCheck = await deps.checkRateLimit(sessionId, SET_CHECKOUT_PASSWORD_RATE_LIMIT)
   if (!rateCheck.allowed) {
     return {
       status: rateCheck.error === "service_unavailable" ? 503 : 429,
@@ -89,7 +95,7 @@ export async function handleSendMagicLink(
   }
 
   try {
-    const session = await deps.verifyCheckoutSessionForActivation(parsed.sessionId, deps.stripe)
+    const session = await deps.verifyCheckoutSessionForActivation(sessionId, deps.stripe)
     const premiumTierId = await (deps.getPremiumTierId ?? getPremiumTierId)(deps.supabase)
     const account = await deps.ensureCheckoutAccount(session, {
       supabase: deps.supabase,
@@ -98,34 +104,45 @@ export async function handleSendMagicLink(
       linkQuizToProfile: deps.linkQuizToProfile,
     })
 
+    if (!account.canSetInitialPassword) {
+      return { status: 409, body: { error: EXISTING_ACCOUNT_ERROR } }
+    }
+
+    const metadata = await loadCurrentAppMetadata(deps.supabase, account.userId)
+    if (!isActivationStillValid(metadata, sessionId)) {
+      return { status: 409, body: { error: EXPIRED_ACTIVATION_ERROR } }
+    }
+
     const claimed = await (deps.claimCheckoutActivation ?? claimCheckoutActivation)(
       deps.supabase,
-      parsed.sessionId,
+      sessionId,
       account.userId,
-      "passwordless",
+      "password",
     )
     if (!claimed) {
       return { status: 409, body: { error: EXPIRED_ACTIVATION_ERROR } }
     }
 
-    const { error } = await deps.supabase.auth.signInWithOtp({
-      email: account.email,
-      options: {
-        emailRedirectTo: `${deps.siteUrl}/auth/confirm?next=/onboarding`,
-        shouldCreateUser: false,
-      },
+    const mergedMetadata: Record<string, unknown> = {
+      ...metadata,
+      password_initialized_at: (deps.now ?? (() => new Date()))().toISOString(),
+    }
+    delete mergedMetadata.checkout_activation_session_hash
+
+    const { error: updateError } = await deps.supabase.auth.admin.updateUserById(account.userId, {
+      password,
+      email_confirm: true,
+      app_metadata: mergedMetadata,
     })
 
-    if (error) {
-      console.error("[send-magic-link] signInWithOtp failed:", error.message)
+    if (updateError) {
+      console.error("[set-checkout-password] updateUserById failed:", updateError.message)
       await (deps.releaseCheckoutActivationClaim ?? releaseCheckoutActivationClaim)(
         deps.supabase,
-        parsed.sessionId,
+        sessionId,
       )
-      return { status: 500, body: { error: SEND_ERROR } }
+      return { status: 500, body: { error: SERVER_ERROR } }
     }
-
-    await consumeCheckoutPasswordMarker(deps, account.userId, parsed.sessionId)
 
     return { status: 200, body: { ok: true, email: account.email } }
   } catch (err) {
@@ -140,18 +157,17 @@ export async function handleSendMagicLink(
       }
     }
 
-    console.error("[send-magic-link] failed:", err)
+    console.error("[set-checkout-password] failed:", err)
     return { status: 500, body: { error: SERVER_ERROR } }
   }
 }
 
-async function createSendMagicLinkDeps(): Promise<SendMagicLinkDeps> {
+async function createSetCheckoutPasswordDeps(): Promise<SetCheckoutPasswordDeps> {
   const { getStripe } = await import("@/lib/stripe/client")
 
   return {
     stripe: getStripe(),
     supabase: createAdminClient(),
-    siteUrl: process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000",
     checkRateLimit,
     verifyCheckoutSessionForActivation,
     ensureCheckoutAccount,
@@ -168,35 +184,33 @@ async function getPremiumTierId(supabase: SupabaseClient): Promise<string> {
   return premium
 }
 
-async function consumeCheckoutPasswordMarker(
-  deps: SendMagicLinkDeps,
+async function loadCurrentAppMetadata(
+  supabase: SupabaseClient,
   userId: string,
-  sessionId: string,
-) {
-  const { data, error } = await deps.supabase.auth.admin.getUserById(userId)
+): Promise<Record<string, unknown>> {
+  const { data, error } = await supabase.auth.admin.getUserById(userId)
   if (error) throw new Error(`getUserById failed: ${error.message}`)
 
   const metadata = data.user?.app_metadata
-  const appMetadata = isRecord(metadata) ? { ...metadata } : {}
-  if (appMetadata.checkout_activation_session_hash !== checkoutSessionHash(sessionId)) return
-
-  delete appMetadata.checkout_activation_session_hash
-  appMetadata.activation_method = "passwordless"
-  appMetadata.passwordless_login_sent_at = (deps.now ?? (() => new Date()))().toISOString()
-
-  const { error: updateError } = await deps.supabase.auth.admin.updateUserById(userId, {
-    app_metadata: appMetadata,
-  })
-  if (updateError) {
-    console.error("[send-magic-link] activation marker cleanup failed:", updateError.message)
-  }
+  return isRecord(metadata) ? { ...metadata } : {}
 }
 
-function parseBody(body: unknown): { ok: true; sessionId: string } | { ok: false } {
+function isActivationStillValid(metadata: Record<string, unknown>, sessionId: string): boolean {
+  if (Object.prototype.hasOwnProperty.call(metadata, "password_initialized_at")) return false
+  return metadata.checkout_activation_session_hash === checkoutSessionHash(sessionId)
+}
+
+function parseBody(
+  body: unknown,
+): { ok: true; sessionId: string; password: string } | { ok: false } {
   if (!isRecord(body)) return { ok: false }
+
   const sessionId = body.session_id
+  const password = body.password
   if (typeof sessionId !== "string" || sessionId.trim() === "") return { ok: false }
-  return { ok: true, sessionId: sessionId.trim() }
+  if (typeof password !== "string") return { ok: false }
+
+  return { ok: true, sessionId: sessionId.trim(), password }
 }
 
 function isPaymentIncompleteError(code: CheckoutActivationError["code"]): boolean {

--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -3,14 +3,40 @@ import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import { NextResponse } from "next/server"
 import type { EmailOtpType } from "@supabase/supabase-js"
 
+export function sanitizeAuthRedirectPath(rawNext: string | null) {
+  if (!rawNext) return "/chat"
+  if (!rawNext.startsWith("/") || rawNext.startsWith("//") || rawNext.includes("\\")) {
+    return "/chat"
+  }
+  return rawNext
+}
+
+export function resolveAuthRedirectPath(searchParams: URLSearchParams, origin: string) {
+  const next = searchParams.get("next")
+  if (next) return sanitizeAuthRedirectPath(next)
+
+  const redirectTo = searchParams.get("redirect_to")
+  if (!redirectTo) return "/chat"
+
+  try {
+    const redirectUrl = new URL(redirectTo)
+    if (redirectUrl.origin !== origin) return "/chat"
+    if (redirectUrl.pathname === "/auth/confirm") {
+      return sanitizeAuthRedirectPath(redirectUrl.searchParams.get("next"))
+    }
+    return sanitizeAuthRedirectPath(`${redirectUrl.pathname}${redirectUrl.search}`)
+  } catch {
+    return sanitizeAuthRedirectPath(redirectTo)
+  }
+}
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get("code")
   const tokenHash = searchParams.get("token_hash")
   const type = searchParams.get("type") as EmailOtpType | null
   const leadId = searchParams.get("lead") ?? undefined
-  const rawNext = searchParams.get("next") ?? "/chat"
-  const next = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/chat"
+  const next = resolveAuthRedirectPath(searchParams, origin)
 
   const supabase = await createClient()
   let verified = false

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -34,7 +34,7 @@ export default function UpdatePasswordPage() {
       return
     }
     if (password !== confirmPassword) {
-      setError("Passwoerter stimmen nicht ueberein.")
+      setError("Passwörter stimmen nicht überein.")
       return
     }
 
@@ -45,7 +45,7 @@ export default function UpdatePasswordPage() {
 
     if (error) {
       console.error("Update password error:", error)
-      setError("Passwort konnte nicht geaendert werden. Bitte versuche es erneut.")
+      setError("Passwort konnte nicht geändert werden. Bitte versuche es erneut.")
       setLoading(false)
     } else {
       setSuccess(true)
@@ -66,10 +66,10 @@ export default function UpdatePasswordPage() {
       <div className="w-full max-w-md space-y-8 text-center">
         <div className="space-y-2">
           <h1 className="font-header text-4xl tracking-tight text-foreground">
-            Neues Passwort setzen
+            Passwort zurücksetzen
           </h1>
           <p className="text-lg text-muted-foreground">
-            Waehle ein neues Passwort fuer dein Konto.
+            Wähle ein neues Passwort für dein Konto.
           </p>
         </div>
 
@@ -82,7 +82,7 @@ export default function UpdatePasswordPage() {
                 </svg>
               </div>
               <h2 className="text-lg font-semibold text-foreground">
-                Passwort erfolgreich geaendert!
+                Passwort erfolgreich geändert!
               </h2>
               <p className="text-sm text-muted-foreground">
                 Du wirst gleich weitergeleitet...
@@ -109,7 +109,7 @@ export default function UpdatePasswordPage() {
                 />
                 <Input
                   type="password"
-                  placeholder="Passwort bestaetigen"
+                  placeholder="Passwort wiederholen"
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   disabled={loading}
@@ -122,7 +122,7 @@ export default function UpdatePasswordPage() {
                   disabled={loading || !password || !confirmPassword}
                   className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
                 >
-                  {loading ? "Wird gespeichert..." : "Passwort aendern"}
+                  {loading ? "Wird gespeichert..." : "Passwort ändern"}
                 </button>
               </form>
             </div>

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
 import { getStripe } from "@/lib/stripe/client"
+import {
+  CheckoutActivationError,
+  verifyCheckoutSessionForActivation,
+} from "@/lib/stripe/checkout-activation"
 import { WelcomeClient } from "./welcome-client"
 
 export const dynamic = "force-dynamic"
@@ -13,11 +18,24 @@ export default async function WelcomePage({
   if (!session_id) redirect("/")
 
   const stripe = getStripe()
-  const session = await stripe.checkout.sessions.retrieve(session_id)
-  if (session.status !== "complete") redirect("/pricing")
+  let session
+  try {
+    session = await verifyCheckoutSessionForActivation(session_id, stripe)
+  } catch (err) {
+    if (err instanceof CheckoutActivationError) redirect("/pricing")
+    throw err
+  }
 
   const email = session.customer_details?.email
   if (!email) redirect("/")
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (user?.email?.toLowerCase() === email.toLowerCase()) {
+    redirect("/onboarding")
+  }
 
   return <WelcomeClient email={email} sessionId={session_id} />
 }

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -1,69 +1,107 @@
 "use client"
 
 import { CheckCircle, Mail } from "lucide-react"
-import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { useState, type FormEvent } from "react"
+import { Input } from "@/components/ui/input"
+import { createClient } from "@/lib/supabase/client"
 
 interface WelcomeClientProps {
   email: string
   sessionId: string
 }
 
-type ScreenState =
-  | { view: "choice" }
-  | { view: "sent"; mode: "password" | "magic_link" }
-  | { view: "error"; message: string }
+type LoadingState = "password" | "magic_link" | null
+type ScreenState = { view: "choice" } | { view: "sent" }
+
+const SIGN_IN_AFTER_PASSWORD_ERROR =
+  "Passwort wurde erstellt, aber die Anmeldung hat nicht geklappt. Bitte melde dich mit deiner E-Mail und deinem Passwort an."
+const NETWORK_ERROR =
+  "Verbindung fehlgeschlagen. Bitte prüfe deine Internet-Verbindung und versuche es erneut."
+const UNKNOWN_ERROR = "Unbekannter Fehler"
+const MAGIC_LINK_BODY =
+  "Wir senden dir einen sicheren Login-Link. Du klickst ihn im Postfach an und bist direkt angemeldet."
 
 export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
-  const [state, setState] = useState<ScreenState>({ view: "choice" })
-  const [loading, setLoading] = useState<"password" | "magic_link" | null>(null)
+  const router = useRouter()
+  const supabase = createClient()
 
-  async function handleSetupPassword() {
+  const [state, setState] = useState<ScreenState>({ view: "choice" })
+  const [loading, setLoading] = useState<LoadingState>(null)
+  const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
+  const [message, setMessage] = useState<string | null>(null)
+  const [highlightMagicLink, setHighlightMagicLink] = useState(false)
+
+  async function handleCreatePassword(e: FormEvent) {
+    e.preventDefault()
+    setMessage(null)
+    setHighlightMagicLink(false)
+
+    if (password.length < 8) {
+      setMessage("Passwort muss mindestens 8 Zeichen lang sein.")
+      return
+    }
+
+    if (password !== confirmPassword) {
+      setMessage("Passwörter stimmen nicht überein.")
+      return
+    }
+
     setLoading("password")
     try {
-      const res = await fetch("/api/auth/send-setup-link", {
+      const res = await fetch("/api/auth/set-checkout-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, session_id: sessionId }),
+        body: JSON.stringify({ session_id: sessionId, password }),
       })
+      const body = await res.json().catch(() => ({}))
+
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}))
-        throw new Error(body.error ?? "Unbekannter Fehler")
+        const errorMessage = typeof body.error === "string" ? body.error : UNKNOWN_ERROR
+        if (res.status === 409 || errorMessage.includes("Login-Link")) {
+          setHighlightMagicLink(true)
+        }
+        throw new Error(errorMessage)
       }
-      setState({ view: "sent", mode: "password" })
+
+      const signInEmail = typeof body.email === "string" ? body.email : email
+      const { error } = await supabase.auth.signInWithPassword({
+        email: signInEmail,
+        password,
+      })
+
+      if (error) {
+        setMessage(SIGN_IN_AFTER_PASSWORD_ERROR)
+        return
+      }
+
+      router.replace("/onboarding")
     } catch (err) {
-      const message =
-        err instanceof TypeError && err.message.toLowerCase().includes("fetch")
-          ? "Verbindung fehlgeschlagen. Bitte prüfe deine Internet-Verbindung und versuche es erneut."
-          : err instanceof Error
-            ? err.message
-            : "Unbekannter Fehler"
-      setState({ view: "error", message })
+      setMessage(normalizeError(err))
     } finally {
       setLoading(null)
     }
   }
 
   async function handleMagicLink() {
+    setMessage(null)
+    setHighlightMagicLink(false)
     setLoading("magic_link")
+
     try {
       const res = await fetch("/api/auth/send-magic-link", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, session_id: sessionId }),
+        body: JSON.stringify({ session_id: sessionId }),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
-        throw new Error(body.error ?? "Unbekannter Fehler")
+        throw new Error(typeof body.error === "string" ? body.error : UNKNOWN_ERROR)
       }
-      setState({ view: "sent", mode: "magic_link" })
+      setState({ view: "sent" })
     } catch (err) {
-      const message =
-        err instanceof TypeError && err.message.toLowerCase().includes("fetch")
-          ? "Verbindung fehlgeschlagen. Bitte prüfe deine Internet-Verbindung und versuche es erneut."
-          : err instanceof Error
-            ? err.message
-            : "Unbekannter Fehler"
-      setState({ view: "error", message })
+      setMessage(normalizeError(err))
     } finally {
       setLoading(null)
     }
@@ -71,88 +109,145 @@ export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
 
   if (state.view === "sent") {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-10">
         <div className="w-full max-w-md space-y-6 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
             <Mail className="h-6 w-6 text-primary" />
           </div>
           <h1 className="font-header text-3xl">Check deine E-Mails</h1>
           <p className="text-base text-muted-foreground">
-            {state.mode === "password"
-              ? "Wir haben dir einen Link geschickt, um dein Passwort einzurichten."
-              : "Wir haben dir einen Login-Link geschickt."}
+            Wir haben dir einen Login-Link geschickt.
           </p>
           <p className="text-xs text-muted-foreground">
-            Keine E-Mail erhalten? Pruefe deinen Spam-Ordner oder warte 1–2 Minuten.
+            Keine E-Mail erhalten? Prüfe deinen Spam-Ordner oder warte 1-2 Minuten.
           </p>
         </div>
       </main>
     )
   }
 
-  if (state.view === "error") {
-    return (
-      <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-        <div className="w-full max-w-md space-y-6 text-center">
-          <h1 className="font-header text-3xl">Zahlung erfolgreich</h1>
-          <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {state.message}
-          </div>
-          <button
-            onClick={() => setState({ view: "choice" })}
-            className="text-sm text-primary hover:underline"
-          >
-            Zurueck
-          </button>
-        </div>
-      </main>
-    )
-  }
-
-  // Choice screen
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center space-y-3">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8">
+      <div className="w-full max-w-4xl space-y-6">
+        <div className="space-y-4 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
             <CheckCircle className="h-6 w-6 text-green-600" />
           </div>
-          <h1 className="font-header text-3xl">Zahlung erfolgreich</h1>
-          <p className="text-base text-muted-foreground">
-            Wie moechtest du dich in Zukunft anmelden?
-          </p>
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-primary">Zahlung erfolgreich</p>
+            <h1 className="font-header text-3xl text-foreground sm:text-4xl">Konto aktivieren</h1>
+            <p className="text-base text-muted-foreground">
+              Wähle, wie du dich bei Hair Concierge anmelden möchtest.
+            </p>
+          </div>
         </div>
 
-        <div className="space-y-3">
-          {/* Primary: set up password */}
-          <div className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
-            <button
-              onClick={handleSetupPassword}
-              disabled={loading !== null}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
-            >
-              {loading === "password" ? "Wird gesendet..." : "Passwort festlegen"}
-            </button>
-            <p className="text-xs text-muted-foreground text-center">
-              Du erhaeltst eine E-Mail, um dein Passwort einzurichten.
-            </p>
-          </div>
+        <div className="mx-auto w-full max-w-md space-y-2">
+          <label htmlFor="checkout-email" className="text-sm font-medium text-foreground">
+            E-Mail aus deinem Checkout
+          </label>
+          <Input
+            id="checkout-email"
+            value={email}
+            readOnly
+            aria-readonly="true"
+            className="h-11 bg-muted/60 text-center"
+          />
+        </div>
 
-          {/* Secondary: magic link */}
-          <div className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
-            <button
-              onClick={handleMagicLink}
-              disabled={loading !== null}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-border bg-transparent px-6 py-3 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
-            >
-              {loading === "magic_link" ? "Wird gesendet..." : "Login-Link zuschicken"}
-            </button>
-            <p className="text-xs text-muted-foreground text-center">
-              Einmaliger Link zum Anmelden ohne Passwort.
-            </p>
+        {message && (
+          <div className="mx-auto w-full max-w-2xl rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
+            {message}
           </div>
+        )}
+
+        <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
+          <section className="flex min-h-[360px] flex-col rounded-lg border bg-card p-5 shadow-sm">
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold text-foreground">Mit Passwort fortfahren</h2>
+              <p className="min-h-[72px] text-sm leading-6 text-muted-foreground">
+                Erstelle ein Passwort und melde dich künftig direkt mit deiner E-Mail an.
+              </p>
+            </div>
+
+            <form onSubmit={handleCreatePassword} className="mt-5 flex flex-1 flex-col">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <label htmlFor="password" className="text-sm font-medium text-foreground">
+                    Passwort
+                  </label>
+                  <Input
+                    id="password"
+                    type="password"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    disabled={loading !== null}
+                    minLength={8}
+                    required
+                    autoComplete="new-password"
+                    className="h-11"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="confirm-password" className="text-sm font-medium text-foreground">
+                    Passwort wiederholen
+                  </label>
+                  <Input
+                    id="confirm-password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(event) => setConfirmPassword(event.target.value)}
+                    disabled={loading !== null}
+                    minLength={8}
+                    required
+                    autoComplete="new-password"
+                    className="h-11"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading !== null || !password || !confirmPassword}
+                className="mt-auto inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-primary bg-transparent px-6 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+              >
+                {loading === "password" ? "Wird erstellt..." : "Passwort erstellen"}
+              </button>
+            </form>
+          </section>
+
+          <section
+            className={[
+              "flex min-h-[360px] flex-col rounded-lg border bg-card p-5 shadow-sm transition-colors",
+              highlightMagicLink ? "border-primary bg-primary/5" : "",
+            ].join(" ")}
+          >
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold text-foreground">Ohne Passwort fortfahren</h2>
+              <p className="min-h-[72px] text-sm leading-6 text-muted-foreground">
+                {MAGIC_LINK_BODY}
+              </p>
+            </div>
+
+            <div className="mt-5 flex flex-1 flex-col justify-end">
+              <button
+                type="button"
+                onClick={handleMagicLink}
+                disabled={loading !== null}
+                className="inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-primary bg-transparent px-6 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+              >
+                {loading === "magic_link" ? "Wird gesendet..." : "Login-Link senden"}
+              </button>
+            </div>
+          </section>
         </div>
       </div>
     </main>
   )
+}
+
+function normalizeError(err: unknown): string {
+  if (err instanceof TypeError && err.message.toLowerCase().includes("fetch")) return NETWORK_ERROR
+  if (err instanceof Error) return err.message
+  return UNKNOWN_ERROR
 }

--- a/src/lib/auth/checkout-activation-claim.ts
+++ b/src/lib/auth/checkout-activation-claim.ts
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto"
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export type CheckoutActivationMethod = "password" | "passwordless"
+
+export async function claimCheckoutActivation(
+  supabase: SupabaseClient,
+  sessionId: string,
+  userId: string,
+  method: CheckoutActivationMethod,
+): Promise<boolean> {
+  const { error } = await supabase.from("checkout_activation_claims").insert({
+    session_hash: checkoutSessionHash(sessionId),
+    user_id: userId,
+    method,
+  })
+
+  if (!error) return true
+  if (isUniqueViolation(error)) return false
+  throw new Error(`checkout activation claim failed: ${error.message}`)
+}
+
+export async function releaseCheckoutActivationClaim(
+  supabase: SupabaseClient,
+  sessionId: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from("checkout_activation_claims")
+    .delete()
+    .eq("session_hash", checkoutSessionHash(sessionId))
+
+  if (error) throw new Error(`checkout activation claim release failed: ${error.message}`)
+}
+
+export function checkoutSessionHash(sessionId: string): string {
+  return createHash("sha256").update(sessionId).digest("hex")
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const err = error as { code?: unknown; message?: unknown }
+  const text = String(err.message ?? "").toLowerCase()
+  return err.code === "23505" || text.includes("duplicate") || text.includes("unique")
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -55,3 +55,10 @@ export const SEND_AUTH_LINK_RATE_LIMIT: RateLimitConfig = {
   limit: 3,
   windowMs: 5 * 60_000,
 }
+
+// 8 password attempts per 10 minutes per Stripe checkout session_id.
+export const SET_CHECKOUT_PASSWORD_RATE_LIMIT: RateLimitConfig = {
+  prefix: "set-checkout-password",
+  limit: 8,
+  windowMs: 10 * 60_000,
+}

--- a/src/lib/stripe/checkout-activation.ts
+++ b/src/lib/stripe/checkout-activation.ts
@@ -1,0 +1,352 @@
+import { createHash } from "node:crypto"
+import type Stripe from "stripe"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { intervalFromPrice } from "./intervals"
+
+export interface CheckoutActivationDeps {
+  supabase: SupabaseClient
+  stripe: Stripe
+  premiumTierId: string
+  linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
+}
+
+export type CheckoutActivationErrorCode =
+  | "checkout_session_id_missing"
+  | "checkout_session_missing_id"
+  | "checkout_session_incomplete"
+  | "checkout_session_email_missing"
+  | "checkout_session_customer_missing"
+  | "checkout_session_subscription_missing"
+  | "checkout_session_unpaid"
+  | "checkout_user_race_unresolved"
+
+export class CheckoutActivationError extends Error {
+  code: CheckoutActivationErrorCode
+
+  constructor(code: CheckoutActivationErrorCode, message: string) {
+    super(message)
+    this.name = "CheckoutActivationError"
+    this.code = code
+  }
+}
+
+export interface CheckoutAccountResult {
+  userId: string
+  email: string
+  canSetInitialPassword: boolean
+}
+
+interface ProfileRow {
+  id: string
+  email?: string | null
+  stripe_customer_id?: string | null
+}
+
+interface SubscriptionProfilePatch {
+  email: string
+  stripe_customer_id: string
+  stripe_subscription_id: string
+  subscription_status: "active"
+  subscription_interval: string | null
+  current_period_end: string
+  subscription_tier_id: string
+}
+
+/** Shape we actually read from the retrieved subscription. */
+export interface RetrievedSub {
+  id: string
+  current_period_end?: number
+  items: {
+    data: Array<{
+      current_period_end?: number
+      price: {
+        interval?: string
+        interval_count?: number
+        recurring?: { interval: string; interval_count: number }
+      }
+    }>
+  }
+}
+
+interface ValidCheckoutSession {
+  id: string
+  email: string
+  customerId: string
+  subscriptionId: string
+}
+
+export async function verifyCheckoutSessionForActivation(
+  sessionId: string,
+  stripe?: Stripe,
+): Promise<Stripe.Checkout.Session> {
+  if (!sessionId) {
+    throw new CheckoutActivationError(
+      "checkout_session_id_missing",
+      "checkout session id is required",
+    )
+  }
+
+  const stripeClient = stripe ?? (await import("./client")).getStripe()
+  const session = await stripeClient.checkout.sessions.retrieve(sessionId)
+  assertValidCheckoutSession(session)
+  return session
+}
+
+export async function ensureCheckoutAccount(
+  session: Stripe.Checkout.Session,
+  deps: CheckoutActivationDeps,
+): Promise<CheckoutAccountResult> {
+  const valid = assertValidCheckoutSession(session)
+  const existingProfile = await findExistingProfile(deps, valid.email, valid.customerId)
+
+  let userId: string
+  let canSetInitialPassword = false
+
+  if (existingProfile) {
+    userId = existingProfile.id
+    canSetInitialPassword = await canSetPasswordForCheckoutSession(deps, userId, valid.id)
+  } else {
+    const created = await createCheckoutUser(deps, valid.email, valid.id, valid.customerId)
+    if (created.created) {
+      userId = created.userId
+      canSetInitialPassword = true
+    } else {
+      userId = created.userId
+    }
+  }
+
+  const sub = (await deps.stripe.subscriptions.retrieve(valid.subscriptionId, {
+    expand: ["items.data.price"],
+  })) as unknown as RetrievedSub
+  const price = sub.items.data[0].price
+  const interval = intervalFromPrice({
+    interval: price.recurring?.interval ?? price.interval ?? "",
+    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
+  })
+
+  await upsertSubscriptionProfile(deps, userId, {
+    email: valid.email,
+    stripe_customer_id: valid.customerId,
+    stripe_subscription_id: sub.id,
+    subscription_status: "active",
+    subscription_interval: interval,
+    current_period_end: subPeriodEndIso(sub),
+    subscription_tier_id: deps.premiumTierId,
+  })
+
+  if (deps.linkQuizToProfile) {
+    const leadId = session.metadata?.lead_id || undefined
+    try {
+      await deps.linkQuizToProfile(userId, valid.email, leadId)
+    } catch (err) {
+      console.error("[stripe] linkQuizToProfile failed:", err)
+    }
+  }
+
+  return { userId, email: valid.email, canSetInitialPassword }
+}
+
+/**
+ * In Stripe API version 2025-08-27.basil, current_period_end moved from the
+ * Subscription root to each SubscriptionItem. Read item first, fall back to
+ * root for older API versions.
+ */
+export function subPeriodEndIso(sub: RetrievedSub): string {
+  const itemEnd = sub.items.data[0]?.current_period_end
+  const rootEnd = sub.current_period_end
+  const unix = itemEnd ?? rootEnd
+  if (typeof unix !== "number" || Number.isNaN(unix)) {
+    throw new Error("subscription has no current_period_end on item or root")
+  }
+  return new Date(unix * 1000).toISOString()
+}
+
+function assertValidCheckoutSession(session: Stripe.Checkout.Session): ValidCheckoutSession {
+  if (!session.id) {
+    throw new CheckoutActivationError("checkout_session_missing_id", "checkout session has no id")
+  }
+  if (session.status !== "complete") {
+    throw new CheckoutActivationError(
+      "checkout_session_incomplete",
+      "checkout session is not complete",
+    )
+  }
+  const email = session.customer_details?.email
+  if (!email) {
+    throw new CheckoutActivationError(
+      "checkout_session_email_missing",
+      "checkout session has no customer email",
+    )
+  }
+  if (typeof session.customer !== "string") {
+    throw new CheckoutActivationError(
+      "checkout_session_customer_missing",
+      "checkout session customer is missing",
+    )
+  }
+  if (typeof session.subscription !== "string") {
+    throw new CheckoutActivationError(
+      "checkout_session_subscription_missing",
+      "checkout session subscription is missing",
+    )
+  }
+  if (session.payment_status === "unpaid") {
+    throw new CheckoutActivationError(
+      "checkout_session_unpaid",
+      "checkout session payment is unpaid",
+    )
+  }
+
+  return {
+    id: session.id,
+    email,
+    customerId: session.customer,
+    subscriptionId: session.subscription,
+  }
+}
+
+async function findExistingProfile(
+  deps: CheckoutActivationDeps,
+  email: string,
+  customerId: string,
+): Promise<ProfileRow | null> {
+  const byEmail = await findProfileBy(deps, "email", email)
+  if (byEmail) return byEmail
+  return findProfileBy(deps, "stripe_customer_id", customerId)
+}
+
+async function findProfileBy(
+  deps: CheckoutActivationDeps,
+  column: "email" | "stripe_customer_id",
+  value: string,
+): Promise<ProfileRow | null> {
+  const { data, error } = await deps.supabase
+    .from("profiles")
+    .select("id, email, stripe_customer_id")
+    .eq(column, value)
+    .maybeSingle()
+  if (error) throw new Error(`profile lookup failed: ${error.message}`)
+  return data as ProfileRow | null
+}
+
+async function upsertSubscriptionProfile(
+  deps: CheckoutActivationDeps,
+  userId: string,
+  patch: SubscriptionProfilePatch,
+) {
+  const { error } = await deps.supabase.from("profiles").upsert(
+    {
+      id: userId,
+      ...patch,
+    },
+    { onConflict: "id" },
+  )
+
+  if (error) {
+    throw new Error(`profile upsert failed: ${error.message}`)
+  }
+}
+
+async function createCheckoutUser(
+  deps: CheckoutActivationDeps,
+  email: string,
+  sessionId: string,
+  customerId: string,
+): Promise<{ userId: string; created: boolean }> {
+  const { data, error } = await deps.supabase.auth.admin.createUser({
+    email,
+    email_confirm: true,
+    app_metadata: {
+      checkout_activation_session_hash: checkoutSessionHash(sessionId),
+    },
+  })
+
+  if (!error && data.user) return { userId: data.user.id, created: true }
+
+  if (isDuplicateUserError(error)) {
+    const existingProfile = await findExistingProfile(deps, email, customerId)
+    if (existingProfile) return { userId: existingProfile.id, created: false }
+
+    const existingAuthUserId = await findAuthUserIdByEmail(deps, email)
+    if (existingAuthUserId) return { userId: existingAuthUserId, created: false }
+
+    throw new CheckoutActivationError(
+      "checkout_user_race_unresolved",
+      "createUser reported a duplicate email but no existing user could be found",
+    )
+  }
+
+  throw new Error(`createUser failed: ${error?.message ?? "unknown"}`)
+}
+
+function checkoutSessionHash(sessionId: string): string {
+  return createHash("sha256").update(sessionId).digest("hex")
+}
+
+async function canSetPasswordForCheckoutSession(
+  deps: CheckoutActivationDeps,
+  userId: string,
+  sessionId: string,
+): Promise<boolean> {
+  const user = await getAuthUserById(deps, userId)
+  if (!user) return false
+
+  const appMetadata = isRecord(user.app_metadata) ? user.app_metadata : {}
+  if (Object.prototype.hasOwnProperty.call(appMetadata, "password_initialized_at")) return false
+
+  return appMetadata.checkout_activation_session_hash === checkoutSessionHash(sessionId)
+}
+
+async function getAuthUserById(
+  deps: CheckoutActivationDeps,
+  userId: string,
+): Promise<{ app_metadata?: unknown } | null> {
+  const admin = deps.supabase.auth.admin as unknown as {
+    getUserById?: (userId: string) => Promise<{
+      data?: { user?: { app_metadata?: unknown } | null }
+      error?: { message?: string } | null
+    }>
+  }
+
+  if (typeof admin.getUserById !== "function") return null
+  const { data, error } = await admin.getUserById(userId)
+  if (error) throw new Error(`getUserById failed: ${error.message ?? "unknown"}`)
+  return data?.user ?? null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isDuplicateUserError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const err = error as { message?: unknown; code?: unknown; status?: unknown }
+  const text = `${String(err.message ?? "")} ${String(err.code ?? "")}`.toLowerCase()
+  return (
+    text.includes("already registered") ||
+    text.includes("already exists") ||
+    text.includes("duplicate") ||
+    text.includes("email_exists") ||
+    text.includes("user_already_exists") ||
+    err.status === 422
+  )
+}
+
+async function findAuthUserIdByEmail(
+  deps: CheckoutActivationDeps,
+  email: string,
+): Promise<string | null> {
+  const admin = deps.supabase.auth.admin as unknown as {
+    listUsers?: (params?: { page?: number; perPage?: number }) => Promise<{
+      data?: { users?: Array<{ id: string; email?: string | null }> }
+      error?: { message?: string } | null
+    }>
+  }
+
+  if (typeof admin.listUsers !== "function") return null
+  const { data, error } = await admin.listUsers({ page: 1, perPage: 1000 })
+  if (error) throw new Error(`listUsers failed: ${error.message ?? "unknown"}`)
+
+  const normalized = email.toLowerCase()
+  return data?.users?.find((user) => user.email?.toLowerCase() === normalized)?.id ?? null
+}

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -1,93 +1,15 @@
 import type Stripe from "stripe"
-import type { SupabaseClient } from "@supabase/supabase-js"
+import type { CheckoutActivationDeps } from "./checkout-activation"
+import { ensureCheckoutAccount, subPeriodEndIso } from "./checkout-activation"
 import { intervalFromPrice } from "./intervals"
 
-export interface HandlerDeps {
-  supabase: SupabaseClient
-  stripe: Stripe
-  premiumTierId: string
-  linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
-}
-
-/** Shape we actually read from the retrieved subscription. */
-interface RetrievedSub {
-  id: string
-  current_period_end?: number
-  items: {
-    data: Array<{
-      current_period_end?: number
-      price: {
-        interval?: string
-        interval_count?: number
-        recurring?: { interval: string; interval_count: number }
-      }
-    }>
-  }
-}
+export type HandlerDeps = CheckoutActivationDeps
 
 export async function handleCheckoutSessionCompleted(
   session: Stripe.Checkout.Session,
   deps: HandlerDeps,
 ): Promise<void> {
-  const email = session.customer_details?.email
-  if (!email) throw new Error("session has no customer email")
-  if (typeof session.customer !== "string") throw new Error("session.customer missing")
-  if (typeof session.subscription !== "string") throw new Error("session.subscription missing")
-
-  // 1. Ensure a Supabase user exists for this email
-  const { data: existing } = await deps.supabase
-    .from("profiles")
-    .select("id, email")
-    .eq("email", email)
-    .maybeSingle()
-
-  let userId: string
-  if (existing) {
-    userId = existing.id
-  } else {
-    const { data, error } = await deps.supabase.auth.admin.createUser({
-      email,
-      email_confirm: true,
-    })
-    if (error || !data.user) {
-      throw new Error(`createUser failed: ${error?.message ?? "unknown"}`)
-    }
-    userId = data.user.id
-  }
-
-  // 2. Retrieve full subscription to get interval + period end
-  const sub = (await deps.stripe.subscriptions.retrieve(session.subscription, {
-    expand: ["items.data.price"],
-  })) as unknown as RetrievedSub
-  const price = sub.items.data[0].price
-  const interval = intervalFromPrice({
-    interval: price.recurring?.interval ?? price.interval ?? "",
-    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
-  })
-
-  // 3. Update profile
-  await deps.supabase
-    .from("profiles")
-    .update({
-      stripe_customer_id: session.customer,
-      stripe_subscription_id: sub.id,
-      subscription_status: "active",
-      subscription_interval: interval,
-      current_period_end: subPeriodEndIso(sub as unknown as RetrievedSub),
-      subscription_tier_id: deps.premiumTierId,
-    })
-    .eq("id", userId)
-
-  // 4. Carry quiz answers from leads into hair_profiles (fire-and-forget — a
-  //    linking failure must not fail fulfillment)
-  if (deps.linkQuizToProfile) {
-    const leadId = session.metadata?.lead_id || undefined
-    try {
-      await deps.linkQuizToProfile(userId, email, leadId)
-    } catch (err) {
-      console.error("[stripe] linkQuizToProfile failed:", err)
-    }
-  }
+  await ensureCheckoutAccount(session, deps)
 }
 
 /** Narrow shape we read from a subscription event. */
@@ -107,20 +29,6 @@ interface UpdatedSub {
       }
     }>
   }
-}
-
-/**
- * Recent Stripe API versions expose current_period_end on each
- * SubscriptionItem. Read item first, fall back to root for older API versions.
- */
-function subPeriodEndIso(sub: RetrievedSub | UpdatedSub): string {
-  const itemEnd = sub.items.data[0]?.current_period_end
-  const rootEnd = (sub as { current_period_end?: number }).current_period_end
-  const unix = itemEnd ?? rootEnd
-  if (typeof unix !== "number" || Number.isNaN(unix)) {
-    throw new Error("subscription has no current_period_end on item or root")
-  }
-  return new Date(unix * 1000).toISOString()
 }
 
 export async function handleSubscriptionUpdated(

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -59,6 +59,7 @@ export async function updateSession(request: NextRequest) {
     // session_id in the request body; the route itself verifies).
     "/api/auth/send-magic-link",
     "/api/auth/send-setup-link",
+    "/api/auth/set-checkout-password",
   ]
   const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -109,7 +109,7 @@ enabled = true
 # in emails.
 site_url = "https://hair-concierge.vercel.app"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://hair-concierge.vercel.app/api/auth/callback", "http://localhost:3000/api/auth/callback", "https://hair-concierge.vercel.app/auth/confirm", "http://localhost:3000/auth/confirm"]
+additional_redirect_urls = ["https://hair-concierge.vercel.app/api/auth/callback", "http://localhost:3000/api/auth/callback", "http://localhost:3449/api/auth/callback", "https://hair-concierge.vercel.app/auth/confirm", "http://localhost:3000/auth/confirm", "http://localhost:3449/auth/confirm"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.
@@ -185,6 +185,10 @@ content_path = "./supabase/templates/confirmation.html"
 [auth.email.template.recovery]
 subject = "Hair Concierge – Passwort zuruecksetzen"
 content_path = "./supabase/templates/recovery.html"
+
+[auth.email.template.magic_link]
+subject = "Hair Concierge – Login-Link"
+content_path = "./supabase/templates/magic-link.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/migrations/20260504120000_add_checkout_activation_claims.sql
+++ b/supabase/migrations/20260504120000_add_checkout_activation_claims.sql
@@ -1,0 +1,13 @@
+-- Atomic one-time claims for post-checkout account activation.
+CREATE TABLE IF NOT EXISTS public.checkout_activation_claims (
+  session_hash text PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  method text NOT NULL CHECK (method IN ('password', 'passwordless')),
+  claimed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_checkout_activation_claims_user_id
+  ON public.checkout_activation_claims (user_id);
+
+-- RLS enabled, no user-facing policies — only the service_role (admin client) accesses this table.
+ALTER TABLE public.checkout_activation_claims ENABLE ROW LEVEL SECURITY;

--- a/supabase/templates/magic-link.html
+++ b/supabase/templates/magic-link.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Login-Link</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body
+    style="
+      margin: 0;
+      padding: 0;
+      background-color: #231f20;
+      font-family:
+        &quot;Montserrat&quot;,
+        -apple-system,
+        BlinkMacSystemFont,
+        &quot;Segoe UI&quot;,
+        Roboto,
+        sans-serif;
+    "
+  >
+    <table
+      role="presentation"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      border="0"
+      style="background-color: #231f20"
+    >
+      <tr>
+        <td align="center" style="padding: 40px 16px">
+          <table
+            role="presentation"
+            width="520"
+            cellpadding="0"
+            cellspacing="0"
+            border="0"
+            style="
+              max-width: 520px;
+              width: 100%;
+              background-color: #2a2526;
+              border: 1px solid #3a3536;
+              border-radius: 16px;
+              overflow: hidden;
+            "
+          >
+            <tr>
+              <td style="padding: 40px 36px 0 36px; text-align: center">
+                <h1
+                  style="
+                    margin: 0 0 6px 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 28px;
+                    font-weight: 700;
+                    color: #f5c518;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                  "
+                >
+                  HAIR CONCIERGE
+                </h1>
+                <p
+                  style="
+                    margin: 0 0 24px 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 13px;
+                    color: #a09a8e;
+                  "
+                >
+                  Personalisierte Haarpflege-Beratung
+                </p>
+                <hr style="border: none; border-top: 1px solid #3a3536; margin: 0" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 28px 36px 0 36px">
+                <p
+                  style="
+                    margin: 0 0 20px 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 15px;
+                    line-height: 1.65;
+                    color: #e5dfd3;
+                  "
+                >
+                  Dein sicherer Login-Link ist bereit.
+                </p>
+                <p
+                  style="
+                    margin: 0 0 32px 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 15px;
+                    line-height: 1.65;
+                    color: #e5dfd3;
+                  "
+                >
+                  Klicke auf den Button und du bist direkt in deinem Hair Concierge Konto
+                  angemeldet.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td align="center" style="padding: 0 36px 28px 36px">
+                <a
+                  href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=magiclink&redirect_to={{ .RedirectTo }}"
+                  style="
+                    display: inline-block;
+                    background: linear-gradient(135deg, #f5c518, #d4a800);
+                    color: #231f20;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 15px;
+                    font-weight: 700;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                    text-decoration: none;
+                    padding: 14px 40px;
+                    border-radius: 8px;
+                  "
+                >
+                  Login-Link öffnen
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 0 36px 24px 36px">
+                <p
+                  style="
+                    margin: 0 0 20px 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 13px;
+                    line-height: 1.55;
+                    color: #8a847a;
+                  "
+                >
+                  Falls du diesen Login-Link nicht angefordert hast, kannst du diese E-Mail einfach
+                  ignorieren.
+                </p>
+                <p
+                  style="
+                    margin: 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 13px;
+                    line-height: 1.55;
+                    color: #8a847a;
+                  "
+                >
+                  Bis gleich!<br />
+                  Dein Hair Concierge Team
+                </p>
+              </td>
+            </tr>
+          </table>
+          <table
+            role="presentation"
+            width="520"
+            cellpadding="0"
+            cellspacing="0"
+            border="0"
+            style="max-width: 520px; width: 100%"
+          >
+            <tr>
+              <td style="padding: 20px 36px 0 36px; text-align: center">
+                <p
+                  style="
+                    margin: 0 0 4px 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 11px;
+                    color: #5a5550;
+                  "
+                >
+                  Hair Concierge
+                </p>
+                <p
+                  style="
+                    margin: 0;
+                    font-family: &quot;Montserrat&quot;, sans-serif;
+                    font-size: 11px;
+                    color: #5a5550;
+                  "
+                >
+                  Diese E-Mail wurde automatisch versendet.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/tests/auth-post-checkout-routes.spec.ts
+++ b/tests/auth-post-checkout-routes.spec.ts
@@ -1,0 +1,599 @@
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { expect, test } from "@playwright/test"
+import { resolveAuthRedirectPath, sanitizeAuthRedirectPath } from "../src/app/auth/confirm/route"
+import { handleSendMagicLink } from "../src/app/api/auth/send-magic-link/route"
+import { handleSendSetupLink } from "../src/app/api/auth/send-setup-link/route"
+import { handleSetCheckoutPassword } from "../src/app/api/auth/set-checkout-password/route"
+
+function sessionHash(sessionId: string) {
+  return createHash("sha256").update(sessionId).digest("hex")
+}
+
+function checkoutSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cs_test_password",
+    status: "complete",
+    payment_status: "paid",
+    customer: "cus_test_password",
+    customer_details: { email: "stripe@example.com" },
+    subscription: "sub_test_password",
+    ...overrides,
+  } as any
+}
+
+function stubSupabase(appMetadata: Record<string, unknown> = {}) {
+  const calls: any[] = []
+
+  return {
+    calls,
+    supabase: {
+      auth: {
+        admin: {
+          async getUserById(userId: string) {
+            calls.push(["getUserById", userId])
+            return {
+              data: {
+                user: {
+                  id: userId,
+                  app_metadata: appMetadata,
+                },
+              },
+              error: null,
+            }
+          },
+          async updateUserById(userId: string, patch: Record<string, unknown>) {
+            calls.push(["updateUserById", userId, patch])
+            return { data: { user: { id: userId } }, error: null }
+          },
+        },
+      },
+      from(table: string) {
+        return {
+          select() {
+            calls.push(["select", table])
+            return Promise.resolve({
+              data: [{ id: "tier-premium", slug: "premium" }],
+              error: null,
+            })
+          },
+        }
+      },
+    } as any,
+  }
+}
+
+function stubDeps(overrides: Partial<Parameters<typeof handleSetCheckoutPassword>[1]> = {}) {
+  const { calls, supabase } = stubSupabase({
+    checkout_activation_session_hash: sessionHash("cs_test_password"),
+    provider: "email",
+    roles: ["member"],
+  })
+
+  const deps: Parameters<typeof handleSetCheckoutPassword>[1] = {
+    stripe: {} as any,
+    supabase,
+    checkRateLimit: async () => ({ allowed: true }),
+    verifyCheckoutSessionForActivation: async () => checkoutSession(),
+    ensureCheckoutAccount: async () => ({
+      userId: "user-test",
+      email: "stripe@example.com",
+      canSetInitialPassword: true,
+    }),
+    claimCheckoutActivation: async () => true,
+    releaseCheckoutActivationClaim: async () => {},
+    ...overrides,
+  }
+
+  return { calls, deps }
+}
+
+test("auth confirm keeps only same-origin relative next paths", () => {
+  expect(sanitizeAuthRedirectPath("/onboarding")).toBe("/onboarding")
+  expect(sanitizeAuthRedirectPath("/chat?tab=routine")).toBe("/chat?tab=routine")
+  expect(sanitizeAuthRedirectPath("//evil.example/onboarding")).toBe("/chat")
+  expect(sanitizeAuthRedirectPath("/\\evil.example\\onboarding")).toBe("/chat")
+  expect(sanitizeAuthRedirectPath("https://evil.example/onboarding")).toBe("/chat")
+})
+
+test("auth confirm resolves Supabase redirect_to without overriding ordinary login links", () => {
+  const checkoutParams = new URLSearchParams({
+    redirect_to: "https://hair.example/auth/confirm?next=/onboarding",
+  })
+  expect(resolveAuthRedirectPath(checkoutParams, "https://hair.example")).toBe("/onboarding")
+
+  const regularLoginParams = new URLSearchParams({
+    redirect_to: "https://hair.example/auth/confirm",
+  })
+  expect(resolveAuthRedirectPath(regularLoginParams, "https://hair.example")).toBe("/chat")
+
+  const externalParams = new URLSearchParams({
+    redirect_to: "https://evil.example/auth/confirm?next=/onboarding",
+  })
+  expect(resolveAuthRedirectPath(externalParams, "https://hair.example")).toBe("/chat")
+})
+
+test("rejects missing request body before rate limiting or Stripe work", async () => {
+  const { calls, deps } = stubDeps()
+
+  const response = await handleSetCheckoutPassword({}, deps)
+
+  expect(response.status).toBe(400)
+  expect(response.body.error).toContain("Session")
+  expect(calls).toEqual([])
+})
+
+test("rejects weak passwords before changing anything", async () => {
+  const { calls, deps } = stubDeps()
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "short" },
+    deps,
+  )
+
+  expect(response.status).toBe(400)
+  expect(response.body.error).toContain("mindestens 8")
+  expect(calls).toEqual([])
+})
+
+test("returns 429 when the checkout session is rate limited", async () => {
+  let rateLimitIdentifier: string | undefined
+  const { calls, deps } = stubDeps({
+    checkRateLimit: async (identifier) => {
+      rateLimitIdentifier = identifier
+      return { allowed: false }
+    },
+  })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(429)
+  expect(response.body.error).toContain("Zu viele")
+  expect(rateLimitIdentifier).toBe("cs_test_password")
+  expect(calls).toEqual([])
+})
+
+test("returns 503 when the rate-limit service is unavailable", async () => {
+  const { deps } = stubDeps({
+    checkRateLimit: async () => ({ allowed: false, error: "service_unavailable" }),
+  })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(503)
+  expect(response.body.error).toContain("Bitte versuche es")
+})
+
+test("returns 409 when the checkout account cannot set an initial password", async () => {
+  const { deps } = stubDeps({
+    ensureCheckoutAccount: async () => ({
+      userId: "user-existing",
+      email: "stripe@example.com",
+      canSetInitialPassword: false,
+    }),
+  })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(409)
+  expect(response.body.error).toBe(
+    "Für diese E-Mail gibt es bereits ein Konto. Bitte melde dich an oder nutze den Login-Link.",
+  )
+})
+
+test("merges app metadata, clears activation hash, and confirms email on success", async () => {
+  const { calls, deps } = stubDeps()
+
+  const response = await handleSetCheckoutPassword(
+    {
+      session_id: "cs_test_password",
+      email: "attacker@example.com",
+      password: "long-enough",
+    },
+    deps,
+  )
+
+  expect(response).toMatchObject({
+    status: 200,
+    body: { ok: true, email: "stripe@example.com" },
+  })
+
+  const updateCall = calls.find(([op]) => op === "updateUserById")
+  expect(updateCall?.[1]).toBe("user-test")
+  expect(updateCall?.[2]).toMatchObject({
+    password: "long-enough",
+    email_confirm: true,
+    app_metadata: {
+      provider: "email",
+      roles: ["member"],
+    },
+  })
+  expect(updateCall?.[2].app_metadata).toHaveProperty("password_initialized_at")
+  expect(updateCall?.[2].app_metadata).not.toHaveProperty("checkout_activation_session_hash")
+})
+
+test("rejects password creation when the checkout activation was already claimed", async () => {
+  const { calls, deps } = stubDeps({
+    claimCheckoutActivation: async () => false,
+  })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(409)
+  expect(response.body.error).toContain("nicht mehr gültig")
+  expect(calls.some(([op]) => op === "updateUserById")).toBe(false)
+})
+
+test("releases the checkout activation claim if password creation fails", async () => {
+  let releasedSessionId: string | undefined
+  const { deps } = stubDeps({
+    releaseCheckoutActivationClaim: async (_supabase, sessionId) => {
+      releasedSessionId = sessionId
+    },
+  })
+  deps.supabase.auth.admin.updateUserById = async () => ({
+    data: { user: null },
+    error: { message: "update failed" } as any,
+  })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(500)
+  expect(releasedSessionId).toBe("cs_test_password")
+})
+
+test("rejects when the activation marker no longer matches immediately before update", async () => {
+  const { calls, supabase } = stubSupabase({
+    checkout_activation_session_hash: sessionHash("cs_other"),
+    provider: "email",
+  })
+  const { deps } = stubDeps({ supabase })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(409)
+  expect(response.body.error).toContain("nicht mehr gültig")
+  expect(calls.some(([op]) => op === "updateUserById")).toBe(false)
+})
+
+test("does not trust client email when verifying or updating checkout activation", async () => {
+  let verifiedSessionId: string | undefined
+  let ensuredEmail: string | undefined
+  const { deps } = stubDeps({
+    verifyCheckoutSessionForActivation: async (sessionId) => {
+      verifiedSessionId = sessionId
+      return checkoutSession({ customer_details: { email: "stripe-owned@example.com" } })
+    },
+    ensureCheckoutAccount: async (session) => {
+      ensuredEmail = session.customer_details?.email ?? undefined
+      return {
+        userId: "user-test",
+        email: "stripe-owned@example.com",
+        canSetInitialPassword: true,
+      }
+    },
+  })
+
+  const response = await handleSetCheckoutPassword(
+    {
+      session_id: "cs_test_password",
+      email: "client@example.com",
+      password: "long-enough",
+    },
+    deps,
+  )
+
+  expect(response.status).toBe(200)
+  expect(response.body.email).toBe("stripe-owned@example.com")
+  expect(verifiedSessionId).toBe("cs_test_password")
+  expect(ensuredEmail).toBe("stripe-owned@example.com")
+})
+
+test("password activation fallback links quiz metadata when fulfilling checkout", async () => {
+  let linked: { userId: string; email: string | undefined; leadId: string | undefined } | undefined
+  let forwardedLeadId: string | undefined
+  const { deps } = stubDeps({
+    verifyCheckoutSessionForActivation: async () =>
+      checkoutSession({
+        id: "cs_test_password",
+        customer_details: { email: "stripe@example.com" },
+        metadata: { lead_id: "lead-123" },
+      }),
+    ensureCheckoutAccount: async (session, options) => {
+      forwardedLeadId = session.metadata?.lead_id
+      await options.linkQuizToProfile?.(
+        "user-test",
+        "stripe@example.com",
+        session.metadata?.lead_id,
+      )
+      return {
+        userId: "user-test",
+        email: "stripe@example.com",
+        canSetInitialPassword: true,
+      }
+    },
+    linkQuizToProfile: async (userId, email, leadId) => {
+      linked = { userId, email, leadId }
+    },
+  })
+
+  const response = await handleSetCheckoutPassword(
+    { session_id: "cs_test_password", password: "long-enough" },
+    deps,
+  )
+
+  expect(response.status).toBe(200)
+  expect(forwardedLeadId).toBe("lead-123")
+  expect(linked).toEqual({
+    userId: "user-test",
+    email: "stripe@example.com",
+    leadId: "lead-123",
+  })
+})
+
+test("send magic link derives email from checkout activation and consumes matching password marker", async () => {
+  const calls: any[] = []
+  const supabase = {
+    auth: {
+      async signInWithOtp(args: Record<string, unknown>) {
+        calls.push(["signInWithOtp", args])
+        return { data: {}, error: null }
+      },
+      admin: {
+        async getUserById(userId: string) {
+          calls.push(["getUserById", userId])
+          return {
+            data: {
+              user: {
+                id: userId,
+                app_metadata: {
+                  checkout_activation_session_hash: sessionHash("cs_magic"),
+                  provider: "email",
+                },
+              },
+            },
+            error: null,
+          }
+        },
+        async updateUserById(userId: string, patch: Record<string, unknown>) {
+          calls.push(["updateUserById", userId, patch])
+          return { data: { user: { id: userId } }, error: null }
+        },
+      },
+    },
+    from(table: string) {
+      return {
+        select() {
+          calls.push(["select", table])
+          return Promise.resolve({
+            data: [{ id: "tier-premium", slug: "premium" }],
+            error: null,
+          })
+        },
+      }
+    },
+  } as any
+  let rateLimitIdentifier: string | undefined
+
+  const response = await handleSendMagicLink(
+    { session_id: "cs_magic", email: "attacker@example.com" },
+    {
+      stripe: {} as any,
+      supabase,
+      siteUrl: "https://hair.example",
+      now: () => new Date("2026-05-04T12:00:00.000Z"),
+      checkRateLimit: async (identifier) => {
+        rateLimitIdentifier = identifier
+        return { allowed: true }
+      },
+      verifyCheckoutSessionForActivation: async (sessionId) =>
+        checkoutSession({
+          id: sessionId,
+          customer_details: { email: "stripe-owned@example.com" },
+        }),
+      ensureCheckoutAccount: async () => ({
+        userId: "user-magic",
+        email: "stripe-owned@example.com",
+        canSetInitialPassword: true,
+      }),
+      claimCheckoutActivation: async () => true,
+      releaseCheckoutActivationClaim: async () => {},
+    },
+  )
+
+  expect(response).toMatchObject({
+    status: 200,
+    body: { ok: true, email: "stripe-owned@example.com" },
+  })
+  expect(rateLimitIdentifier).toBe("cs_magic")
+
+  const otpCall = calls.find(([op]) => op === "signInWithOtp")
+  expect(otpCall?.[1]).toMatchObject({
+    email: "stripe-owned@example.com",
+    options: {
+      emailRedirectTo: "https://hair.example/auth/confirm?next=/onboarding",
+      shouldCreateUser: false,
+    },
+  })
+
+  const updateCall = calls.find(([op]) => op === "updateUserById")
+  expect(updateCall?.[1]).toBe("user-magic")
+  expect(updateCall?.[2].app_metadata).toMatchObject({
+    provider: "email",
+    activation_method: "passwordless",
+    passwordless_login_sent_at: "2026-05-04T12:00:00.000Z",
+  })
+  expect(updateCall?.[2].app_metadata).not.toHaveProperty("checkout_activation_session_hash")
+})
+
+test("magic-link activation fallback links quiz metadata when fulfilling checkout", async () => {
+  const { deps } = stubDeps()
+  let linked: { userId: string; email: string | undefined; leadId: string | undefined } | undefined
+  const response = await handleSendMagicLink(
+    { session_id: "cs_magic" },
+    {
+      stripe: deps.stripe,
+      supabase: {
+        ...deps.supabase,
+        auth: {
+          ...deps.supabase.auth,
+          signInWithOtp: async () => ({ data: {}, error: null }),
+        },
+      } as any,
+      siteUrl: "https://hair.example",
+      checkRateLimit: deps.checkRateLimit,
+      verifyCheckoutSessionForActivation: async () =>
+        checkoutSession({
+          id: "cs_magic",
+          metadata: { lead_id: "lead-magic" },
+        }),
+      ensureCheckoutAccount: async (session, options) => {
+        await options.linkQuizToProfile?.(
+          "user-test",
+          "stripe@example.com",
+          session.metadata?.lead_id,
+        )
+        return {
+          userId: "user-test",
+          email: "stripe@example.com",
+          canSetInitialPassword: true,
+        }
+      },
+      linkQuizToProfile: async (userId, email, leadId) => {
+        linked = { userId, email, leadId }
+      },
+      claimCheckoutActivation: async () => true,
+      releaseCheckoutActivationClaim: async () => {},
+    },
+  )
+
+  expect(response.status).toBe(200)
+  expect(linked).toEqual({
+    userId: "user-test",
+    email: "stripe@example.com",
+    leadId: "lead-magic",
+  })
+})
+
+test("send magic link rejects when the checkout activation was already claimed", async () => {
+  const { deps } = stubDeps()
+  const response = await handleSendMagicLink(
+    { session_id: "cs_magic" },
+    {
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+      siteUrl: "https://hair.example",
+      checkRateLimit: deps.checkRateLimit,
+      verifyCheckoutSessionForActivation: deps.verifyCheckoutSessionForActivation,
+      ensureCheckoutAccount: deps.ensureCheckoutAccount,
+      claimCheckoutActivation: async () => false,
+      releaseCheckoutActivationClaim: async () => {},
+    },
+  )
+
+  expect(response.status).toBe(409)
+  expect(response.body.error).toContain("nicht mehr gültig")
+})
+
+test("send magic link releases the checkout activation claim if email sending fails", async () => {
+  const { deps } = stubDeps()
+  let releasedSessionId: string | undefined
+  deps.supabase.auth.signInWithOtp = async () => ({
+    data: { user: null, session: null },
+    error: { message: "email failed" } as any,
+  })
+
+  const response = await handleSendMagicLink(
+    { session_id: "cs_magic" },
+    {
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+      siteUrl: "https://hair.example",
+      checkRateLimit: deps.checkRateLimit,
+      verifyCheckoutSessionForActivation: deps.verifyCheckoutSessionForActivation,
+      ensureCheckoutAccount: deps.ensureCheckoutAccount,
+      claimCheckoutActivation: async () => true,
+      releaseCheckoutActivationClaim: async (_supabase, sessionId) => {
+        releasedSessionId = sessionId
+      },
+    },
+  )
+
+  expect(response.status).toBe(500)
+  expect(releasedSessionId).toBe("cs_magic")
+})
+
+test("send magic link requires only session_id and reports non-leaky German errors", async () => {
+  const { deps } = stubDeps()
+  const response = await handleSendMagicLink(
+    {},
+    {
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+      siteUrl: "https://hair.example",
+      checkRateLimit: deps.checkRateLimit,
+      verifyCheckoutSessionForActivation: deps.verifyCheckoutSessionForActivation,
+      ensureCheckoutAccount: deps.ensureCheckoutAccount,
+    },
+  )
+
+  expect(response.status).toBe(400)
+  expect(response.body.error).toBe("Bitte öffne den Aktivierungslink erneut.")
+})
+
+test("deprecated setup link route returns 410 without side effects", async () => {
+  const response = await handleSendSetupLink()
+
+  expect(response).toEqual({
+    status: 410,
+    body: {
+      error: "Dieser Link wird nicht mehr verwendet. Bitte kehre zur Kontoaktivierung zurück.",
+    },
+  })
+})
+
+test("welcome activation UI renders both equal checkout choices with a read-only email", async () => {
+  const source = readFileSync("src/app/welcome/welcome-client.tsx", "utf-8")
+
+  expect(source).toContain("Zahlung erfolgreich")
+  expect(source).toContain("Konto aktivieren")
+  expect(source).toContain("readOnly")
+  expect(source).toContain("Mit Passwort fortfahren")
+  expect(source).toContain(
+    "Erstelle ein Passwort und melde dich künftig direkt mit deiner E-Mail an.",
+  )
+  expect(source).toContain("Passwort wiederholen")
+  expect(source).toContain("Passwort erstellen")
+  expect(source).toContain("Ohne Passwort fortfahren")
+  expect(source).toContain(
+    "Wir senden dir einen sicheren Login-Link. Du klickst ihn im Postfach an und bist direkt angemeldet.",
+  )
+  expect(source).toContain("Login-Link senden")
+  expect(source).not.toContain("send-setup-link")
+  expect(source).not.toContain("zuruecksetzen")
+})
+
+test("magic link template keeps Supabase redirect target instead of hardcoding onboarding", async () => {
+  const source = readFileSync("supabase/templates/magic-link.html", "utf-8")
+
+  expect(source).toContain("redirect_to={{ .RedirectTo }}")
+  expect(source).not.toContain("next=/onboarding")
+})

--- a/tests/checkout-activation.spec.ts
+++ b/tests/checkout-activation.spec.ts
@@ -1,0 +1,487 @@
+import { createHash } from "node:crypto"
+import { expect, test } from "@playwright/test"
+import type { HandlerDeps } from "../src/lib/stripe/webhook-handlers"
+import {
+  ensureCheckoutAccount,
+  verifyCheckoutSessionForActivation,
+} from "../src/lib/stripe/checkout-activation"
+
+function checkoutSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cs_test_123",
+    status: "complete",
+    payment_status: "paid",
+    customer: "cus_test_123",
+    customer_details: { email: "new@example.com" },
+    subscription: "sub_test_123",
+    metadata: {},
+    ...overrides,
+  } as any
+}
+
+function sessionHash(sessionId: string) {
+  return createHash("sha256").update(sessionId).digest("hex")
+}
+
+function stubDeps() {
+  const calls: any[] = []
+  const users: Record<
+    string,
+    { id: string; email: string; app_metadata?: Record<string, unknown> }
+  > = {}
+  const profiles: Record<string, any> = {}
+  const duplicateEmails = new Set<string>()
+
+  const deps: HandlerDeps = {
+    supabase: {
+      auth: {
+        admin: {
+          async createUser(args: {
+            email: string
+            email_confirm: boolean
+            app_metadata?: Record<string, unknown>
+          }) {
+            calls.push(["createUser", args])
+            const emailKey = args.email.toLowerCase()
+            if (duplicateEmails.has(emailKey)) {
+              const existingUser = users[emailKey]
+              const id = existingUser?.id ?? "user-race"
+              profiles[id] = {
+                id,
+                email: args.email,
+                subscription_status: null,
+              }
+              return {
+                data: { user: null },
+                error: { message: "User already registered", status: 422, code: "email_exists" },
+              }
+            }
+
+            const id = `user-${Object.keys(users).length + 1}`
+            users[emailKey] = { id, email: args.email, app_metadata: args.app_metadata }
+            profiles[id] = { id, email: args.email, subscription_status: null }
+            return { data: { user: users[emailKey] }, error: null }
+          },
+          async getUserById(userId: string) {
+            calls.push(["getUserById", userId])
+            const user = Object.values(users).find((candidate) => candidate.id === userId)
+            return { data: { user: user ?? null }, error: null }
+          },
+        },
+      },
+      from(table: string) {
+        return {
+          select() {
+            return this
+          },
+          eq(col: string, val: string) {
+            calls.push([`select-${table}-${col}`, val])
+            const rows = table === "profiles" ? Object.values(profiles) : Object.values(users)
+            const row = rows.find((candidate: any) => candidate[col] === val)
+            return { maybeSingle: async () => ({ data: row ?? null, error: null }) }
+          },
+          update(patch: any) {
+            return {
+              eq(col: string, val: string) {
+                calls.push([`update-${table}`, val, patch])
+                const row = Object.values(profiles).find((candidate: any) => candidate[col] === val)
+                if (row) Object.assign(row, patch)
+                return Promise.resolve({ error: null })
+              },
+            }
+          },
+          upsert(row: any) {
+            calls.push([`upsert-${table}`, row])
+            if (table === "profiles") {
+              profiles[row.id] = {
+                ...(profiles[row.id] ?? {}),
+                ...row,
+              }
+            }
+            return Promise.resolve({ error: null })
+          },
+        }
+      },
+    } as any,
+    stripe: {
+      subscriptions: {
+        async retrieve(id: string) {
+          return {
+            id,
+            items: {
+              data: [
+                {
+                  price: { recurring: { interval: "month", interval_count: 1 } },
+                  current_period_end: 1_800_000_000,
+                },
+              ],
+            },
+          } as any
+        },
+      },
+    } as any,
+    premiumTierId: "tier-premium",
+  }
+
+  return { calls, users, profiles, duplicateEmails, deps }
+}
+
+test("ensureCheckoutAccount creates a fresh paid user with hashed checkout activation metadata", async () => {
+  const { deps, calls, profiles } = stubDeps()
+  const session = checkoutSession()
+
+  const result = await ensureCheckoutAccount(session, deps)
+
+  expect(result).toEqual({
+    userId: "user-1",
+    email: "new@example.com",
+    canSetInitialPassword: true,
+  })
+
+  const createUserCall = calls.find(([op]) => op === "createUser")
+  expect(createUserCall?.[1]).toMatchObject({
+    email: "new@example.com",
+    email_confirm: true,
+    app_metadata: {
+      checkout_activation_session_hash: sessionHash("cs_test_123"),
+    },
+  })
+  expect(JSON.stringify(createUserCall?.[1])).not.toContain("cs_test_123")
+  expect(createUserCall?.[1].app_metadata).not.toHaveProperty("password_initialized_at")
+
+  expect(profiles["user-1"]).toMatchObject({
+    email: "new@example.com",
+    stripe_customer_id: "cus_test_123",
+    stripe_subscription_id: "sub_test_123",
+    subscription_status: "active",
+    subscription_interval: "month",
+    subscription_tier_id: "tier-premium",
+  })
+})
+
+test("ensureCheckoutAccount reuses an existing email and denies initial password setup", async () => {
+  const { deps, calls, profiles, users } = stubDeps()
+  users["ret@example.com"] = {
+    id: "user-existing",
+    email: "ret@example.com",
+    app_metadata: { checkout_activation_session_hash: sessionHash("cs_other") },
+  }
+  profiles["user-existing"] = {
+    id: "user-existing",
+    email: "ret@example.com",
+    subscription_status: null,
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_existing",
+      customer: "cus_existing",
+      customer_details: { email: "ret@example.com" },
+      subscription: "sub_existing",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-existing",
+    email: "ret@example.com",
+    canSetInitialPassword: false,
+  })
+  expect(calls.some(([op]) => op === "createUser")).toBe(false)
+  expect(profiles["user-existing"]).toMatchObject({
+    stripe_customer_id: "cus_existing",
+    stripe_subscription_id: "sub_existing",
+    subscription_status: "active",
+  })
+})
+
+test("ensureCheckoutAccount allows password setup for an existing checkout-created user with matching activation metadata", async () => {
+  const { deps, calls, profiles, users } = stubDeps()
+  users["checkout@example.com"] = {
+    id: "user-checkout",
+    email: "checkout@example.com",
+    app_metadata: {
+      checkout_activation_session_hash: sessionHash("cs_checkout"),
+    },
+  }
+  profiles["user-checkout"] = {
+    id: "user-checkout",
+    email: "checkout@example.com",
+    subscription_status: null,
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_checkout",
+      customer: "cus_checkout",
+      customer_details: { email: "checkout@example.com" },
+      subscription: "sub_checkout",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-checkout",
+    email: "checkout@example.com",
+    canSetInitialPassword: true,
+  })
+  expect(calls.some(([op]) => op === "createUser")).toBe(false)
+  expect(JSON.stringify(users["checkout@example.com"].app_metadata)).not.toContain("cs_checkout")
+})
+
+test("ensureCheckoutAccount denies password setup when the matching activation marker is consumed", async () => {
+  const { deps, profiles, users } = stubDeps()
+  users["used@example.com"] = {
+    id: "user-used",
+    email: "used@example.com",
+    app_metadata: {
+      checkout_activation_session_hash: sessionHash("cs_used"),
+      password_initialized_at: "2026-05-04T10:00:00.000Z",
+    },
+  }
+  profiles["user-used"] = {
+    id: "user-used",
+    email: "used@example.com",
+    subscription_status: null,
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_used",
+      customer: "cus_used",
+      customer_details: { email: "used@example.com" },
+      subscription: "sub_used",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-used",
+    email: "used@example.com",
+    canSetInitialPassword: false,
+  })
+})
+
+test("ensureCheckoutAccount reuses an existing Stripe customer and does not create duplicates", async () => {
+  const { deps, calls, profiles, users } = stubDeps()
+  users["customer@example.com"] = {
+    id: "user-by-customer",
+    email: "customer@example.com",
+    app_metadata: {},
+  }
+  profiles["user-by-customer"] = {
+    id: "user-by-customer",
+    email: "customer@example.com",
+    stripe_customer_id: "cus_existing",
+    subscription_status: null,
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_customer",
+      customer: "cus_existing",
+      customer_details: { email: "newer@example.com" },
+      subscription: "sub_customer",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-by-customer",
+    email: "newer@example.com",
+    canSetInitialPassword: false,
+  })
+  expect(calls.some(([op]) => op === "createUser")).toBe(false)
+  expect(profiles["user-by-customer"].stripe_subscription_id).toBe("sub_customer")
+})
+
+test("ensureCheckoutAccount is idempotent on repeated fulfillment", async () => {
+  const { deps, calls, profiles } = stubDeps()
+  const session = checkoutSession()
+
+  const first = await ensureCheckoutAccount(session, deps)
+  const second = await ensureCheckoutAccount(session, deps)
+
+  expect(first.canSetInitialPassword).toBe(true)
+  expect(second.canSetInitialPassword).toBe(true)
+  expect(calls.filter(([op]) => op === "createUser")).toHaveLength(1)
+  expect(Object.values(profiles).filter((p: any) => p.email === "new@example.com")).toHaveLength(1)
+})
+
+test("ensureCheckoutAccount treats duplicate createUser races as an existing account", async () => {
+  const { deps, duplicateEmails, profiles } = stubDeps()
+  duplicateEmails.add("race@example.com")
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_race",
+      customer: "cus_race",
+      customer_details: { email: "race@example.com" },
+      subscription: "sub_race",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-race",
+    email: "race@example.com",
+    canSetInitialPassword: false,
+  })
+  expect(profiles["user-race"].subscription_status).toBe("active")
+})
+
+test("ensureCheckoutAccount creates a missing profile for duplicate auth users", async () => {
+  const { deps, duplicateEmails, profiles, users } = stubDeps()
+  duplicateEmails.add("auth-only@example.com")
+  users["auth-only@example.com"] = {
+    id: "user-auth-only",
+    email: "auth-only@example.com",
+    app_metadata: {},
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_auth_only",
+      customer: "cus_auth_only",
+      customer_details: { email: "auth-only@example.com" },
+      subscription: "sub_auth_only",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-auth-only",
+    email: "auth-only@example.com",
+    canSetInitialPassword: false,
+  })
+  expect(profiles["user-auth-only"]).toMatchObject({
+    id: "user-auth-only",
+    email: "auth-only@example.com",
+    stripe_customer_id: "cus_auth_only",
+    stripe_subscription_id: "sub_auth_only",
+    subscription_status: "active",
+  })
+})
+
+test("ensureCheckoutAccount denies password setup for duplicate createUser races even with matching activation metadata", async () => {
+  const { deps, duplicateEmails, profiles, users } = stubDeps()
+  duplicateEmails.add("race-match@example.com")
+  users["race-match@example.com"] = {
+    id: "user-race-match",
+    email: "race-match@example.com",
+    app_metadata: {
+      checkout_activation_session_hash: sessionHash("cs_race_match"),
+    },
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({
+      id: "cs_race_match",
+      customer: "cus_race_match",
+      customer_details: { email: "race-match@example.com" },
+      subscription: "sub_race_match",
+    }),
+    deps,
+  )
+
+  expect(result).toEqual({
+    userId: "user-race-match",
+    email: "race-match@example.com",
+    canSetInitialPassword: false,
+  })
+  expect(profiles["user-race-match"].subscription_status).toBe("active")
+})
+
+test("ensureCheckoutAccount still resolves when linkQuizToProfile rejects", async () => {
+  const { deps, profiles } = stubDeps()
+  deps.linkQuizToProfile = async () => {
+    throw new Error("lead lookup failed")
+  }
+
+  await expect(
+    ensureCheckoutAccount(checkoutSession({ metadata: { lead_id: "lead-1" } }), deps),
+  ).resolves.toMatchObject({ userId: "user-1", canSetInitialPassword: true })
+
+  expect(profiles["user-1"].subscription_status).toBe("active")
+})
+
+test("verifyCheckoutSessionForActivation returns complete paid sessions", async () => {
+  const stripe = {
+    checkout: {
+      sessions: {
+        async retrieve(id: string) {
+          return checkoutSession({ id })
+        },
+      },
+    },
+  } as any
+
+  await expect(verifyCheckoutSessionForActivation("cs_valid", stripe)).resolves.toMatchObject({
+    id: "cs_valid",
+    customer_details: { email: "new@example.com" },
+  })
+})
+
+test("verifyCheckoutSessionForActivation rejects incomplete and unpaid sessions", async () => {
+  const stripe = {
+    checkout: {
+      sessions: {
+        async retrieve(id: string) {
+          return id === "cs_unpaid"
+            ? checkoutSession({ id, payment_status: "unpaid" })
+            : checkoutSession({ id, status: "open" })
+        },
+      },
+    },
+  } as any
+
+  await expect(verifyCheckoutSessionForActivation("cs_open", stripe)).rejects.toMatchObject({
+    code: "checkout_session_incomplete",
+  })
+  await expect(verifyCheckoutSessionForActivation("cs_unpaid", stripe)).rejects.toMatchObject({
+    code: "checkout_session_unpaid",
+  })
+})
+
+test("verifyCheckoutSessionForActivation rejects missing session id input", async () => {
+  await expect(verifyCheckoutSessionForActivation("")).rejects.toMatchObject({
+    code: "checkout_session_id_missing",
+  })
+})
+
+test("verifyCheckoutSessionForActivation rejects returned sessions missing required fields", async () => {
+  const sessionsById: Record<string, any> = {
+    cs_missing_id: checkoutSession({ id: undefined }),
+    cs_missing_email: checkoutSession({ id: "cs_missing_email", customer_details: {} }),
+    cs_missing_customer: checkoutSession({ id: "cs_missing_customer", customer: null }),
+    cs_missing_subscription: checkoutSession({ id: "cs_missing_subscription", subscription: null }),
+  }
+  const stripe = {
+    checkout: {
+      sessions: {
+        async retrieve(id: string) {
+          return sessionsById[id]
+        },
+      },
+    },
+  } as any
+
+  await expect(verifyCheckoutSessionForActivation("cs_missing_id", stripe)).rejects.toMatchObject({
+    code: "checkout_session_missing_id",
+  })
+  await expect(
+    verifyCheckoutSessionForActivation("cs_missing_email", stripe),
+  ).rejects.toMatchObject({
+    code: "checkout_session_email_missing",
+  })
+  await expect(
+    verifyCheckoutSessionForActivation("cs_missing_customer", stripe),
+  ).rejects.toMatchObject({
+    code: "checkout_session_customer_missing",
+  })
+  await expect(
+    verifyCheckoutSessionForActivation("cs_missing_subscription", stripe),
+  ).rejects.toMatchObject({
+    code: "checkout_session_subscription_missing",
+  })
+})

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -48,6 +48,16 @@ function stubDeps() {
               },
             }
           },
+          upsert(row: any) {
+            calls.push([`upsert-${table}`, row])
+            if (table === "profiles") {
+              profiles[row.id] = {
+                ...(profiles[row.id] ?? {}),
+                ...row,
+              }
+            }
+            return Promise.resolve({ error: null })
+          },
         }
       },
     } as any,
@@ -78,6 +88,8 @@ test("checkout.session.completed creates a new Supabase user and activates the s
   const { deps, calls, profiles } = stubDeps()
   const session = {
     id: "cs_1",
+    status: "complete",
+    payment_status: "paid",
     customer: "cus_1",
     customer_details: { email: "new@example.com" },
     subscription: "sub_1",
@@ -107,6 +119,8 @@ test("checkout.session.completed on existing email reuses the user", async () =>
 
   const session = {
     id: "cs_2",
+    status: "complete",
+    payment_status: "paid",
     customer: "cus_2",
     customer_details: { email: "ret@example.com" },
     subscription: "sub_2",
@@ -174,6 +188,8 @@ test("checkout.session.completed with metadata.lead_id calls linkQuizToProfile w
 
   const session = {
     id: "cs_lead",
+    status: "complete",
+    payment_status: "paid",
     customer: "cus_lead",
     customer_details: { email: "lead@example.com" },
     subscription: "sub_lead",
@@ -199,6 +215,8 @@ test("checkout.session.completed without metadata calls linkQuizToProfile with u
 
   const session = {
     id: "cs_nolead",
+    status: "complete",
+    payment_status: "paid",
     customer: "cus_nolead",
     customer_details: { email: "nolead@example.com" },
     subscription: "sub_nolead",
@@ -221,6 +239,8 @@ test("checkout.session.completed does not throw when linkQuizToProfile rejects",
 
   const session = {
     id: "cs_err",
+    status: "complete",
+    payment_status: "paid",
     customer: "cus_err",
     customer_details: { email: "err@example.com" },
     subscription: "sub_err",
@@ -249,6 +269,8 @@ test("checkout.session.completed falls back to root current_period_end when item
   } as any
   const session = {
     id: "cs_root",
+    status: "complete",
+    payment_status: "paid",
     customer: "cus_root",
     customer_details: { email: "root@example.com" },
     subscription: "sub_root",


### PR DESCRIPTION
## Summary
- replaces the confusing post-checkout password reset flow with a two-path account activation page
- adds direct password creation for fresh paid checkout users and passwordless login-link activation
- verifies checkout sessions server-side, carries quiz metadata, and adds one-time activation claims
- adds Hair Concierge magic-link email copy and Supabase migration for activation claims
- aligns Stripe SDK type usage after the current main dependency bump

## Verification
- npx playwright test tests/auth-post-checkout-routes.spec.ts tests/checkout-activation.spec.ts tests/stripe-webhook-handlers.spec.ts — 44 passed
- npm run typecheck — passed
- npx eslint <touched source files> — passed
- npm run build — passed
- manual/local Stripe webhook checkout: direct password path returned 200; passwordless login-link endpoint returned 200

## Deployment notes
- Supabase migration 20260504120000_add_checkout_activation_claims.sql was already applied and marked applied on linked project pqdkhefxsxkyeqelqegq.
- Production path 2 still needs post-deploy smoke with a fresh email because magic links require the deployed origin.