### PR TITLE
Fix auth recovery and onboarding completion

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -134,6 +134,7 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
       initialDrilldownCategory={
         forcedStep === "product_drilldown" ? initialDrilldownCategory : null
       }
+      allowCompletionFallback={!forcedStep && profileRow?.onboarding_step === "celebration"}
     />
   )
 }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,8 +1,12 @@
 import { redirect } from "next/navigation"
+import type { SupabaseClient } from "@supabase/supabase-js"
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import { getStripe } from "@/lib/stripe/client"
 import {
   CheckoutActivationError,
+  ensureCheckoutAccount,
   verifyCheckoutSessionForActivation,
 } from "@/lib/stripe/checkout-activation"
 import { WelcomeClient } from "./welcome-client"
@@ -34,8 +38,24 @@ export default async function WelcomePage({
     data: { user },
   } = await supabase.auth.getUser()
   if (user?.email?.toLowerCase() === email.toLowerCase()) {
+    const admin = createAdminClient()
+    await ensureCheckoutAccount(session, {
+      supabase: admin,
+      stripe,
+      premiumTierId: await getPremiumTierId(admin),
+      linkQuizToProfile,
+    })
     redirect("/onboarding")
   }
 
   return <WelcomeClient email={email} sessionId={session_id} />
+}
+
+async function getPremiumTierId(supabase: SupabaseClient): Promise<string> {
+  const { data, error } = await supabase.from("subscription_tiers").select("id, slug")
+  if (error) throw new Error(`failed to load subscription_tiers: ${error.message}`)
+
+  const premium = data?.find((row: { id: string; slug: string }) => row.slug === "premium")?.id
+  if (!premium) throw new Error("subscription_tiers premium seed row missing")
+  return premium
 }

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -86,15 +86,11 @@ export function AuthForm({
     <div className="space-y-2">
       <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
       {loginErrorIsCredentials && (
-        <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={handleMagicLink}
-            disabled={loading !== null || !email.trim()}
-            className="flex-1 rounded-md border border-border bg-transparent px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
-          >
-            {loading === "magic_link" ? "Wird gesendet..." : "Login-Link senden"}
-          </button>
+        <div className="space-y-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-3 text-left">
+          <p className="text-xs leading-5 text-destructive/90">
+            Du kannst unten einen Login-Link per E-Mail anfordern. Das funktioniert auch, wenn du
+            noch kein Passwort festgelegt hast.
+          </p>
           <button
             type="button"
             onClick={() => {
@@ -104,9 +100,9 @@ export function AuthForm({
               setMagicLinkError(null)
               setPassword("")
             }}
-            className="flex-1 rounded-md border border-border bg-transparent px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+            className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-xs font-medium text-foreground transition-colors hover:bg-accent"
           >
-            Passwort zuruecksetzen
+            Passwort zuruecksetzen oder erstmals festlegen
           </button>
         </div>
       )}
@@ -148,7 +144,7 @@ export function AuthForm({
       const credentialsError = isInvalidCredentials(error.message)
       setError(
         credentialsError
-          ? "Login nicht moeglich. Falls du noch kein Passwort festgelegt hast, kannst du auch einen Login-Link anfordern oder dein Passwort zuruecksetzen."
+          ? "Anmeldung mit Passwort nicht moeglich. Das Passwort ist falsch oder fuer dieses Konto wurde noch kein Passwort festgelegt."
           : mapSupabaseError(error.message),
       )
       setLoginErrorIsCredentials(credentialsError)

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useRef, useState, useCallback } from "react"
-import { useRouter } from "next/navigation"
 import posthog from "posthog-js"
 import { useToast } from "@/providers/toast-provider"
 import { createClient } from "@/lib/supabase/client"
@@ -94,6 +93,18 @@ const CATEGORY_SUBTITLES: Record<string, string> = {
   peeling: "Nutzt du ein Serum oder Scrub für deine Kopfhaut? Welches Produkt und wie oft?",
 }
 
+const SAVE_TIMEOUT_MS = 15_000
+const SAVE_TIMEOUT_MESSAGE =
+  "Speichern dauert zu lange. Bitte pruefe deine Verbindung und versuche es erneut."
+const SAVE_ERROR_MESSAGE = "Fehler beim Speichern. Bitte versuche es erneut."
+
+class SaveTimeoutError extends Error {
+  constructor() {
+    super(SAVE_TIMEOUT_MESSAGE)
+    this.name = "SaveTimeoutError"
+  }
+}
+
 /* ── Props ── */
 
 interface OnboardingFlowProps {
@@ -105,6 +116,7 @@ interface OnboardingFlowProps {
   editScope?: OnboardingEditScope | null
   singleStepEdit?: boolean
   initialDrilldownCategory?: string | null
+  allowCompletionFallback?: boolean
 }
 
 type OnboardingStateSnapshot = ReturnType<typeof useOnboardingStore.getState>
@@ -178,8 +190,8 @@ export function OnboardingFlow({
   editScope = null,
   singleStepEdit = false,
   initialDrilldownCategory = null,
+  allowCompletionFallback = false,
 }: OnboardingFlowProps) {
-  const router = useRouter()
   const { toast } = useToast()
   const store = useOnboardingStore()
   const [hydrated, setHydrated] = useState(false)
@@ -291,15 +303,16 @@ export function OnboardingFlow({
   // ── Per-step save helpers ──
 
   const saveProductUsage = useCallback(
-    async (categories: string[]) => {
+    async (categories: string[], signal?: AbortSignal) => {
       const supabase = createClient()
       const drilldowns = useOnboardingStore.getState().productDrilldowns
 
       // Get existing rows
-      const { data: existing, error: existingError } = await supabase
+      const existingQuery = supabase
         .from("user_product_usage")
         .select("id, category")
         .eq("user_id", userId)
+      const { data: existing, error: existingError } = await withAbortSignal(existingQuery, signal)
 
       if (existingError) throw existingError
 
@@ -321,13 +334,15 @@ export function OnboardingFlow({
         }
 
         if (existingMap.has(cat)) {
-          const { error: updateError } = await supabase
+          const updateQuery = supabase
             .from("user_product_usage")
             .update(payload)
             .eq("id", existingMap.get(cat))
+          const { error: updateError } = await withAbortSignal(updateQuery, signal)
           if (updateError) throw updateError
         } else {
-          const { error: insertError } = await supabase.from("user_product_usage").insert(payload)
+          const insertQuery = supabase.from("user_product_usage").insert(payload)
+          const { error: insertError } = await withAbortSignal(insertQuery, signal)
           if (insertError) throw insertError
         }
       }
@@ -338,10 +353,8 @@ export function OnboardingFlow({
         .map((r: Record<string, unknown>) => r.id as string)
 
       if (toDelete.length > 0) {
-        const { error: deleteError } = await supabase
-          .from("user_product_usage")
-          .delete()
-          .in("id", toDelete)
+        const deleteQuery = supabase.from("user_product_usage").delete().in("id", toDelete)
+        const { error: deleteError } = await withAbortSignal(deleteQuery, signal)
         if (deleteError) throw deleteError
       }
     },
@@ -349,17 +362,17 @@ export function OnboardingFlow({
   )
 
   const saveHairProfile = useCallback(
-    async (fields: Record<string, unknown>) => {
+    async (fields: Record<string, unknown>, signal?: AbortSignal) => {
       const supabase = createClient()
       const payload = { user_id: userId, ...fields }
-      const { error } = await supabase
-        .from("hair_profiles")
-        .upsert(payload, { onConflict: "user_id" })
+      const upsertQuery = supabase.from("hair_profiles").upsert(payload, { onConflict: "user_id" })
+      const { error } = await withAbortSignal(upsertQuery, signal)
 
       if (error && error.code === "22P02" && typeof fields.drying_method === "string") {
-        const { error: retryError } = await supabase
+        const retryQuery = supabase
           .from("hair_profiles")
           .upsert({ ...payload, drying_method: [fields.drying_method] }, { onConflict: "user_id" })
+        const { error: retryError } = await withAbortSignal(retryQuery, signal)
 
         if (!retryError) return
         throw retryError
@@ -390,7 +403,7 @@ export function OnboardingFlow({
           case "products_basics":
           case "products_extras": {
             const allProducts = [...state.selectedBasicProducts, ...state.selectedExtraProducts]
-            await saveProductUsage(allProducts)
+            await withSaveTimeout((signal) => saveProductUsage(allProducts, signal))
             break
           }
 
@@ -486,15 +499,25 @@ export function OnboardingFlow({
           }
 
           case "night_protection": {
-            await saveHairProfile({
-              night_protection: state.nightProtection,
-            })
-            const { error: onboardingCompletedError } = await supabase
-              .from("profiles")
-              .update({ onboarding_completed: true })
-              .eq("id", userId)
+            await withSaveTimeout(async (signal) => {
+              await saveHairProfile(
+                {
+                  night_protection: state.nightProtection,
+                },
+                signal,
+              )
 
-            if (onboardingCompletedError) throw onboardingCompletedError
+              const completionQuery = supabase
+                .from("profiles")
+                .update({ onboarding_completed: true, onboarding_step: "celebration" })
+                .eq("id", userId)
+              const { error: onboardingCompletedError } = await withAbortSignal(
+                completionQuery,
+                signal,
+              )
+
+              if (onboardingCompletedError) throw onboardingCompletedError
+            })
 
             if (!returnTo) {
               posthog.capture("onboarding_completed", { userId })
@@ -505,7 +528,15 @@ export function OnboardingFlow({
           case "celebration": {
             const { error: completionPopupError } = await supabase
               .from("profiles")
-              .update({ has_seen_completion_popup: true })
+              .update({
+                has_seen_completion_popup: true,
+                ...(allowCompletionFallback
+                  ? {
+                      onboarding_completed: true,
+                      onboarding_step: "celebration",
+                    }
+                  : {}),
+              })
               .eq("id", userId)
 
             if (completionPopupError) throw completionPopupError
@@ -513,7 +544,7 @@ export function OnboardingFlow({
               window.location.assign(returnTo)
               return
             }
-            router.push("/chat")
+            window.location.assign("/chat")
             return // Don't advance step
           }
         }
@@ -543,7 +574,7 @@ export function OnboardingFlow({
         }, 50)
       } catch (err) {
         console.error("Failed to save onboarding step:", err)
-        toast({ title: "Fehler beim Speichern. Bitte versuche es erneut.", variant: "destructive" })
+        toast({ title: userFacingSaveError(err), variant: "destructive" })
       } finally {
         savingStepsRef.current.delete(completedStep)
         setSavingStep(null)
@@ -551,7 +582,6 @@ export function OnboardingFlow({
     },
     [
       userId,
-      router,
       toast,
       saveProductUsage,
       saveHairProfile,
@@ -559,6 +589,7 @@ export function OnboardingFlow({
       returnTo,
       editScope,
       singleStepEdit,
+      allowCompletionFallback,
     ],
   )
 
@@ -898,4 +929,30 @@ export function OnboardingFlow({
       {renderScreen()}
     </div>
   )
+}
+
+function withAbortSignal<T>(query: T, signal?: AbortSignal): T {
+  if (!signal) return query
+  return (query as { abortSignal: (signal: AbortSignal) => T }).abortSignal(signal)
+}
+
+function withSaveTimeout<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  return Promise.race([
+    operation(controller.signal),
+    new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort()
+        reject(new SaveTimeoutError())
+      }, SAVE_TIMEOUT_MS)
+    }),
+  ]).finally(() => {
+    if (timeout) clearTimeout(timeout)
+  })
+}
+
+function userFacingSaveError(err: unknown): string {
+  return err instanceof SaveTimeoutError ? SAVE_TIMEOUT_MESSAGE : SAVE_ERROR_MESSAGE
 }

--- a/src/lib/stripe/checkout-activation.ts
+++ b/src/lib/stripe/checkout-activation.ts
@@ -8,6 +8,7 @@ export interface CheckoutActivationDeps {
   stripe: Stripe
   premiumTierId: string
   linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
+  now?: () => Date
 }
 
 export type CheckoutActivationErrorCode =
@@ -18,6 +19,8 @@ export type CheckoutActivationErrorCode =
   | "checkout_session_customer_missing"
   | "checkout_session_subscription_missing"
   | "checkout_session_unpaid"
+  | "checkout_subscription_inactive"
+  | "checkout_subscription_expired"
   | "checkout_user_race_unresolved"
 
 export class CheckoutActivationError extends Error {
@@ -55,6 +58,7 @@ interface SubscriptionProfilePatch {
 /** Shape we actually read from the retrieved subscription. */
 export interface RetrievedSub {
   id: string
+  status?: string
   current_period_end?: number
   items: {
     data: Array<{
@@ -97,6 +101,11 @@ export async function ensureCheckoutAccount(
   deps: CheckoutActivationDeps,
 ): Promise<CheckoutAccountResult> {
   const valid = assertValidCheckoutSession(session)
+  const sub = (await deps.stripe.subscriptions.retrieve(valid.subscriptionId, {
+    expand: ["items.data.price"],
+  })) as unknown as RetrievedSub
+  assertCurrentCheckoutSubscription(sub, deps.now?.() ?? new Date())
+
   const existingProfile = await findExistingProfile(deps, valid.email, valid.customerId)
 
   let userId: string
@@ -115,9 +124,6 @@ export async function ensureCheckoutAccount(
     }
   }
 
-  const sub = (await deps.stripe.subscriptions.retrieve(valid.subscriptionId, {
-    expand: ["items.data.price"],
-  })) as unknown as RetrievedSub
   const price = sub.items.data[0].price
   const interval = intervalFromPrice({
     interval: price.recurring?.interval ?? price.interval ?? "",
@@ -144,6 +150,23 @@ export async function ensureCheckoutAccount(
   }
 
   return { userId, email: valid.email, canSetInitialPassword }
+}
+
+function assertCurrentCheckoutSubscription(sub: RetrievedSub, now: Date) {
+  if (sub.status && sub.status !== "active") {
+    throw new CheckoutActivationError(
+      "checkout_subscription_inactive",
+      "checkout subscription is not active",
+    )
+  }
+
+  const periodEnd = subPeriodEndIso(sub)
+  if (new Date(periodEnd).getTime() <= now.getTime()) {
+    throw new CheckoutActivationError(
+      "checkout_subscription_expired",
+      "checkout subscription period has expired",
+    )
+  }
 }
 
 /**

--- a/tests/checkout-activation.spec.ts
+++ b/tests/checkout-activation.spec.ts
@@ -108,6 +108,7 @@ function stubDeps() {
         async retrieve(id: string) {
           return {
             id,
+            status: "active",
             items: {
               data: [
                 {
@@ -403,6 +404,51 @@ test("ensureCheckoutAccount still resolves when linkQuizToProfile rejects", asyn
   ).resolves.toMatchObject({ userId: "user-1", canSetInitialPassword: true })
 
   expect(profiles["user-1"].subscription_status).toBe("active")
+})
+
+test("ensureCheckoutAccount rejects inactive checkout subscriptions", async () => {
+  const { deps, profiles } = stubDeps()
+  deps.stripe.subscriptions.retrieve = async (id: string) =>
+    ({
+      id,
+      status: "canceled",
+      items: {
+        data: [
+          {
+            price: { recurring: { interval: "month", interval_count: 1 } },
+            current_period_end: 1_800_000_000,
+          },
+        ],
+      },
+    }) as any
+
+  await expect(ensureCheckoutAccount(checkoutSession(), deps)).rejects.toMatchObject({
+    code: "checkout_subscription_inactive",
+  })
+  expect(Object.values(profiles)).toHaveLength(0)
+})
+
+test("ensureCheckoutAccount rejects expired checkout subscriptions", async () => {
+  const { deps, profiles } = stubDeps()
+  deps.now = () => new Date("2026-05-05T10:00:00.000Z")
+  deps.stripe.subscriptions.retrieve = async (id: string) =>
+    ({
+      id,
+      status: "active",
+      items: {
+        data: [
+          {
+            price: { recurring: { interval: "month", interval_count: 1 } },
+            current_period_end: 1_700_000_000,
+          },
+        ],
+      },
+    }) as any
+
+  await expect(ensureCheckoutAccount(checkoutSession(), deps)).rejects.toMatchObject({
+    code: "checkout_subscription_expired",
+  })
+  expect(Object.values(profiles)).toHaveLength(0)
 })
 
 test("verifyCheckoutSessionForActivation returns complete paid sessions", async () => {


### PR DESCRIPTION
## Why

Testing exposed brittle edges in the paid account activation flow:

- logged-in resubscribe checkouts could return to pricing on the first successful payment while waiting for the Stripe webhook to update the profile
- password-login failures showed duplicate login-link CTAs and did not clearly explain the no-password case
- some onboarding users could land on the completion popup with onboarding_step=celebration but onboarding_completed=false, making "Zum Chat" appear to do nothing
- product onboarding saves could appear to spin forever without a user-facing recovery path

## What changed

- The welcome page now synchronously fulfills the verified Stripe checkout for an already signed-in matching user before redirecting into onboarding.
- Checkout activation now revalidates the retrieved Stripe subscription and rejects inactive or expired subscriptions before creating/updating app accounts.
- The auth form now has one normal login-link CTA and a clearer password-error explanation with a reset/first-password path.
- Onboarding now persists onboarding_step=celebration together with completion and adds a guarded completion fallback only for the real stuck celebration state.
- Product/final onboarding saves now use an aborting timeout, so the UI cannot spin forever and stale Supabase requests cannot keep mutating rows after retry.
- Unknown onboarding save errors stay generic and German; technical details remain in console logs.

## Verification

- npm run typecheck
- npm run lint (passes with existing warnings only)
- npx playwright test tests/checkout-activation.spec.ts tests/auth-post-checkout-routes.spec.ts tests/stripe-webhook-handlers.spec.ts --project=chromium
- NODE_OPTIONS='--require dotenv/config' DOTENV_CONFIG_PATH=/Users/nick/AI_work/hair_conscierge/.env.local npx playwright test tests/quiz-onboarding-e2e.spec.ts --project=chromium --grep "quiz hands off"

## Review

Requested superpowers code review. It found three issues: stale Stripe subscriptions could reactivate access, the save timeout could race the original Supabase request, and raw backend errors could leak into UI. All three were addressed in this branch.

## Notes

The production test account nickrupprechter+39@gmail.com is currently in the stuck state this patch repairs: onboarding_step=celebration, has_seen_completion_popup=true, onboarding_completed=false. After this deploy, clicking the popup CTA should repair it; alternatively that one row can be manually corrected if needed before deploy.
