### PR TITLE
Fix password recovery token flow

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -19,6 +19,10 @@ const REASON_COPY: Record<string, { heading: string; subtext: string }> = {
     heading: "Bis bald!",
     subtext: "Du wurdest erfolgreich abgemeldet.",
   },
+  password_updated: {
+    heading: "Passwort gespeichert",
+    subtext: "Dein Passwort wurde gespeichert. Bitte melde dich jetzt an.",
+  },
 }
 
 export default function AuthPage() {

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -2,37 +2,66 @@
 
 import { createClient } from "@/lib/supabase/client"
 import { useState, useEffect, useMemo } from "react"
-import { useRouter } from "next/navigation"
 import { Input } from "@/components/ui/input"
+import {
+  extractSupabaseHashSession,
+  mapPasswordUpdateError,
+  PASSWORD_RESET_LINK_ERROR,
+  type PasswordResetMessage,
+} from "@/lib/auth/password-reset"
 
 const UPDATE_TIMEOUT_MS = 15_000
-const UPDATE_TIMEOUT_MESSAGE =
-  "Speichern dauert zu lange. Bitte prüfe deine Verbindung und versuche es erneut."
-const UPDATE_ERROR_MESSAGE = "Passwort konnte nicht gespeichert werden. Bitte versuche es erneut."
+const UPDATE_TIMEOUT_ERROR: PasswordResetMessage = {
+  message: "Speichern dauert zu lange.",
+  guidance: "Bitte prüfe deine Verbindung und versuche es erneut.",
+}
 
 export default function UpdatePasswordPage() {
-  const supabase = useMemo(() => createClient(), [])
-  const router = useRouter()
+  const supabase = useMemo(() => createClient({ detectSessionInUrl: false }), [])
 
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<PasswordResetMessage | null>(null)
   const [success, setSuccess] = useState(false)
   const [checking, setChecking] = useState(true)
+  const [canUpdatePassword, setCanUpdatePassword] = useState(false)
+  const [recoveryAccessToken, setRecoveryAccessToken] = useState<string | null>(null)
+  const [recoveryEmail, setRecoveryEmail] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
 
     async function preparePasswordSession() {
       const code = new URLSearchParams(window.location.search).get("code")
+      const hashSession = extractSupabaseHashSession(window.location.hash)
+
+      if (hashSession) {
+        window.history.replaceState({}, "", "/auth/update-password")
+        const { email, error } = await getRecoveryUser(hashSession.access_token)
+        if (!active) return
+
+        if (error) {
+          console.error("Password recovery token validation failed:", error)
+          setError(PASSWORD_RESET_LINK_ERROR)
+          setChecking(false)
+          return
+        }
+
+        setRecoveryAccessToken(hashSession.access_token)
+        setRecoveryEmail(email)
+        setCanUpdatePassword(true)
+        setChecking(false)
+        return
+      }
+
       if (code) {
         const { error } = await supabase.auth.exchangeCodeForSession(code)
         if (!active) return
 
         if (error) {
           console.error("Password recovery session exchange failed:", error)
-          setError("Der Link ist abgelaufen oder ungültig. Bitte fordere einen neuen Link an.")
+          setError(PASSWORD_RESET_LINK_ERROR)
           setChecking(false)
           return
         }
@@ -46,8 +75,10 @@ export default function UpdatePasswordPage() {
       if (!active) return
 
       if (!user) {
-        router.replace("/auth?error=link_expired")
+        setError(PASSWORD_RESET_LINK_ERROR)
+        setChecking(false)
       } else {
+        setCanUpdatePassword(true)
         setChecking(false)
       }
     }
@@ -57,17 +88,17 @@ export default function UpdatePasswordPage() {
     return () => {
       active = false
     }
-  }, [supabase, router])
+  }, [supabase])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
 
     if (password.length < 8) {
-      setError("Passwort muss mindestens 8 Zeichen lang sein.")
+      setError({ message: "Passwort muss mindestens 8 Zeichen lang sein." })
       return
     }
     if (password !== confirmPassword) {
-      setError("Passwörter stimmen nicht überein.")
+      setError({ message: "Passwörter stimmen nicht überein." })
       return
     }
 
@@ -75,21 +106,42 @@ export default function UpdatePasswordPage() {
     setError(null)
 
     try {
-      const { error } = await withUpdateTimeout(supabase.auth.updateUser({ password }))
+      const { error } = await withUpdateTimeout(
+        recoveryAccessToken
+          ? updatePasswordWithRecoveryToken(recoveryAccessToken, password)
+          : supabase.auth.updateUser({ password }),
+      )
 
       if (error) {
         console.error("Update password error:", error)
-        setError(UPDATE_ERROR_MESSAGE)
+        setError(mapPasswordUpdateError(error))
         setLoading(false)
       } else {
+        if (recoveryEmail) {
+          const { error: signInError } = await supabase.auth.signInWithPassword({
+            email: recoveryEmail,
+            password,
+          })
+
+          if (signInError) {
+            console.error("Password recovery sign-in failed:", signInError)
+            setSuccess(true)
+            setLoading(false)
+            setTimeout(() => window.location.assign("/auth?reason=password_updated"), 1200)
+            return
+          }
+        }
+
         setSuccess(true)
         setLoading(false)
-        setTimeout(() => router.replace("/chat"), 1200)
+        setTimeout(() => window.location.assign("/chat"), 1200)
       }
     } catch (err) {
       console.error("Update password failed:", err)
       setError(
-        err instanceof PasswordUpdateTimeoutError ? UPDATE_TIMEOUT_MESSAGE : UPDATE_ERROR_MESSAGE,
+        err instanceof PasswordUpdateTimeoutError
+          ? UPDATE_TIMEOUT_ERROR
+          : mapPasswordUpdateError(err),
       )
       setLoading(false)
     }
@@ -134,41 +186,39 @@ export default function UpdatePasswordPage() {
             </div>
           ) : (
             <div className="space-y-4">
-              {error && (
-                <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                  {error}
-                </div>
-              )}
+              {error && <PasswordResetErrorBanner error={error} />}
 
-              <form onSubmit={handleSubmit} className="space-y-3">
-                <Input
-                  type="password"
-                  placeholder="Neues Passwort (min. 8 Zeichen)"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  disabled={loading}
-                  required
-                  minLength={8}
-                  className="h-11"
-                />
-                <Input
-                  type="password"
-                  placeholder="Passwort wiederholen"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  disabled={loading}
-                  required
-                  minLength={8}
-                  className="h-11"
-                />
-                <button
-                  type="submit"
-                  disabled={loading || !password || !confirmPassword}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
-                >
-                  {loading ? "Wird gespeichert..." : "Passwort speichern"}
-                </button>
-              </form>
+              {canUpdatePassword && (
+                <form onSubmit={handleSubmit} className="space-y-3">
+                  <Input
+                    type="password"
+                    placeholder="Neues Passwort (min. 8 Zeichen)"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    disabled={loading}
+                    required
+                    minLength={8}
+                    className="h-11"
+                  />
+                  <Input
+                    type="password"
+                    placeholder="Passwort wiederholen"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    disabled={loading}
+                    required
+                    minLength={8}
+                    className="h-11"
+                  />
+                  <button
+                    type="submit"
+                    disabled={loading || !password || !confirmPassword}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
+                  >
+                    {loading ? "Wird gespeichert..." : "Passwort speichern"}
+                  </button>
+                </form>
+              )}
             </div>
           )}
         </div>
@@ -188,7 +238,7 @@ export default function UpdatePasswordPage() {
 
 class PasswordUpdateTimeoutError extends Error {
   constructor() {
-    super(UPDATE_TIMEOUT_MESSAGE)
+    super(UPDATE_TIMEOUT_ERROR.message)
     this.name = "PasswordUpdateTimeoutError"
   }
 }
@@ -204,4 +254,63 @@ function withUpdateTimeout<T>(promise: Promise<T>): Promise<T> {
   ]).finally(() => {
     if (timeout) clearTimeout(timeout)
   })
+}
+
+async function getRecoveryUser(
+  accessToken: string,
+): Promise<{ email: string | null; error: unknown | null }> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+
+  const body = await parseSupabaseBody(response)
+  if (!response.ok) return { email: null, error: body }
+
+  return {
+    email: typeof body.email === "string" ? body.email : null,
+    error: null,
+  }
+}
+
+async function updatePasswordWithRecoveryToken(accessToken: string, password: string) {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/user`, {
+    method: "PUT",
+    headers: {
+      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ password }),
+  })
+
+  if (response.ok) return { error: null }
+  return { error: await parseSupabaseBody(response) }
+}
+
+async function parseSupabaseBody(response: Response) {
+  try {
+    return await response.json()
+  } catch {
+    return { message: response.statusText, code: String(response.status) }
+  }
+}
+
+function PasswordResetErrorBanner({ error }: { error: PasswordResetMessage }) {
+  return (
+    <div className="space-y-3 rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      <div className="font-medium">{error.message}</div>
+      {error.guidance && <div className="leading-5 text-destructive/90">{error.guidance}</div>}
+      {error.actionHref && error.actionLabel && (
+        <a
+          href={error.actionHref}
+          className="inline-flex w-full items-center justify-center rounded-md border border-destructive/20 bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          {error.actionLabel}
+        </a>
+      )}
+    </div>
+  )
 }

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -174,7 +174,7 @@ export function AuthForm({
     setLoginErrorIsCredentials(false)
 
     const { error } = await supabase.auth.resetPasswordForEmail(trimmedEmail, {
-      redirectTo: `${window.location.origin}/auth/confirm?next=/auth/update-password`,
+      redirectTo: `${window.location.origin}/auth/update-password`,
     })
 
     if (error) {

--- a/src/lib/auth/password-reset.ts
+++ b/src/lib/auth/password-reset.ts
@@ -1,0 +1,110 @@
+export type PasswordResetMessage = {
+  message: string
+  guidance?: string
+  actionHref?: string
+  actionLabel?: string
+}
+
+export type PasswordResetSession = {
+  access_token: string
+  refresh_token: string
+}
+
+export const PASSWORD_RESET_LINK_ERROR: PasswordResetMessage = {
+  message: "Der Passwort-Link ist abgelaufen oder wurde schon verwendet.",
+  guidance: "Fordere einen neuen Link an und öffne danach den neuesten Link aus deinem Postfach.",
+  actionHref: "/auth",
+  actionLabel: "Neuen Link anfordern",
+}
+
+export const PASSWORD_RESET_GENERIC_ERROR: PasswordResetMessage = {
+  message: "Passwort konnte nicht gespeichert werden.",
+  guidance: "Bitte versuche es erneut. Wenn es weiter nicht klappt, fordere einen neuen Link an.",
+}
+
+export function extractSupabaseHashSession(hash: string): PasswordResetSession | null {
+  const rawHash = hash.startsWith("#") ? hash.slice(1) : hash
+  if (!rawHash) return null
+
+  const params = new URLSearchParams(rawHash)
+  const accessToken = params.get("access_token")
+  const refreshToken = params.get("refresh_token")
+  if (!accessToken || !refreshToken) return null
+
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+  }
+}
+
+export function mapPasswordUpdateError(error: unknown): PasswordResetMessage {
+  const message = getErrorMessage(error).toLowerCase()
+  const code = getErrorCode(error).toLowerCase()
+  const combined = `${code} ${message}`
+
+  if (
+    combined.includes("session") ||
+    combined.includes("jwt") ||
+    combined.includes("expired") ||
+    combined.includes("invalid token")
+  ) {
+    return PASSWORD_RESET_LINK_ERROR
+  }
+
+  if (
+    combined.includes("weak") ||
+    combined.includes("password_strength") ||
+    combined.includes("password should be") ||
+    combined.includes("password must")
+  ) {
+    return {
+      message: "Dieses Passwort ist zu schwach.",
+      guidance:
+        "Wähle mindestens 8 Zeichen und kombiniere am besten Buchstaben, Zahlen und ein Sonderzeichen.",
+    }
+  }
+
+  if (
+    combined.includes("same") ||
+    combined.includes("different from") ||
+    combined.includes("different password")
+  ) {
+    return {
+      message: "Dieses Passwort ist bereits für dein Konto gesetzt.",
+      guidance:
+        "Wähle ein anderes Passwort oder melde dich direkt mit deinem bestehenden Passwort an.",
+      actionHref: "/auth",
+      actionLabel: "Zur Anmeldung",
+    }
+  }
+
+  if (
+    combined.includes("rate") ||
+    combined.includes("too many") ||
+    combined.includes("over_email_send_rate_limit")
+  ) {
+    return {
+      message: "Zu viele Versuche in kurzer Zeit.",
+      guidance: "Warte kurz und versuche es dann noch einmal.",
+    }
+  }
+
+  return PASSWORD_RESET_GENERIC_ERROR
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === "object" && error && "message" in error) {
+    const message = (error as { message?: unknown }).message
+    return typeof message === "string" ? message : ""
+  }
+  return ""
+}
+
+function getErrorCode(error: unknown): string {
+  if (typeof error === "object" && error && "code" in error) {
+    const code = (error as { code?: unknown }).code
+    return typeof code === "string" ? code : ""
+  }
+  return ""
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -2,19 +2,24 @@
 
 import { createBrowserClient } from "@supabase/ssr"
 
-export function createClient() {
+export function createClient(options?: { detectSessionInUrl?: boolean }) {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       auth: {
+        detectSessionInUrl: options?.detectSessionInUrl,
         // Bypass Navigator Locks API to prevent AbortError when lock
         // acquisition times out (causes infinite loading spinner).
         // Safe because createBrowserClient returns a singleton per tab.
-        lock: async <R>(_name: string, _acquireTimeout: number, fn: () => Promise<R>): Promise<R> => {
+        lock: async <R>(
+          _name: string,
+          _acquireTimeout: number,
+          fn: () => Promise<R>,
+        ): Promise<R> => {
           return await fn()
         },
       },
-    }
+    },
   )
 }

--- a/tests/password-reset-helpers.test.ts
+++ b/tests/password-reset-helpers.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { extractSupabaseHashSession, mapPasswordUpdateError } from "@/lib/auth/password-reset"
+
+test("extracts Supabase recovery session tokens from URL hash", () => {
+  assert.deepEqual(
+    extractSupabaseHashSession(
+      "#access_token=access-123&expires_in=3600&refresh_token=refresh-456&type=recovery",
+    ),
+    {
+      access_token: "access-123",
+      refresh_token: "refresh-456",
+    },
+  )
+})
+
+test("ignores incomplete URL hash sessions", () => {
+  assert.equal(extractSupabaseHashSession("#access_token=access-123&type=recovery"), null)
+  assert.equal(extractSupabaseHashSession(""), null)
+})
+
+test("maps expired or missing sessions to recovery-link guidance", () => {
+  const mapped = mapPasswordUpdateError({
+    message: "Auth session missing!",
+    code: "session_not_found",
+  })
+
+  assert.match(mapped.message, /Passwort-Link/)
+  assert.equal(mapped.actionHref, "/auth")
+})
+
+test("maps weak password errors to password guidance", () => {
+  const mapped = mapPasswordUpdateError({ message: "Password should be stronger" })
+
+  assert.equal(mapped.message, "Dieses Passwort ist zu schwach.")
+  assert.match(mapped.guidance ?? "", /8 Zeichen/)
+})


### PR DESCRIPTION
## Summary
- route password reset emails directly to the password page so Supabase recovery fragments are available client-side
- validate recovery tokens explicitly, save the new password through Supabase Auth, then sign the user in with the new password
- replace the generic save failure with guidance for expired links, weak/reused passwords, rate limits, and fallback sign-in

## Verification
- npm run typecheck
- npm run lint (existing unrelated warnings only)
- npm run test:node -- tests/password-reset-helpers.test.ts
- npx playwright test tests/auth-post-checkout-routes.spec.ts --project=chromium
- npm run build
- generated a real Supabase recovery link for a disposable user and completed the password-set browser flow locally; unpaid test user correctly routed to pricing after sign-in