### PR TITLE
Fix password setup guidance

### DIFF
--- a/src/app/api/auth/set-checkout-password/route.ts
+++ b/src/app/api/auth/set-checkout-password/route.ts
@@ -8,6 +8,7 @@ import {
   releaseCheckoutActivationClaim,
 } from "@/lib/auth/checkout-activation-claim"
 import { checkRateLimit, SET_CHECKOUT_PASSWORD_RATE_LIMIT } from "@/lib/rate-limit"
+import { validatePasswordDraft } from "@/lib/auth/password-policy"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import {
   CheckoutActivationError,
@@ -79,7 +80,8 @@ export async function handleSetCheckoutPassword(
   if (!parsed.ok) return { status: 400, body: { error: INVALID_REQUEST_ERROR } }
 
   const { sessionId, password } = parsed
-  if (password.length < 8) return { status: 400, body: { error: WEAK_PASSWORD_ERROR } }
+  const passwordValidation = validatePasswordDraft(password, password)
+  if (!passwordValidation.ok) return { status: 400, body: { error: WEAK_PASSWORD_ERROR } }
 
   const rateCheck = await deps.checkRateLimit(sessionId, SET_CHECKOUT_PASSWORD_RATE_LIMIT)
   if (!rateCheck.allowed) {

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/client"
 import { useState, useEffect, useMemo } from "react"
+import { PasswordPolicyChecklist } from "@/components/auth/password-policy-checklist"
 import { Input } from "@/components/ui/input"
 import {
   extractSupabaseHashSession,
@@ -9,6 +10,7 @@ import {
   PASSWORD_RESET_LINK_ERROR,
   type PasswordResetMessage,
 } from "@/lib/auth/password-reset"
+import { validatePasswordDraft } from "@/lib/auth/password-policy"
 
 const UPDATE_TIMEOUT_MS = 15_000
 const UPDATE_TIMEOUT_ERROR: PasswordResetMessage = {
@@ -93,12 +95,9 @@ export default function UpdatePasswordPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
 
-    if (password.length < 8) {
-      setError({ message: "Passwort muss mindestens 8 Zeichen lang sein." })
-      return
-    }
-    if (password !== confirmPassword) {
-      setError({ message: "Passwörter stimmen nicht überein." })
+    const validation = validatePasswordDraft(password, confirmPassword)
+    if (!validation.ok) {
+      setError({ message: validation.message })
       return
     }
 
@@ -209,6 +208,11 @@ export default function UpdatePasswordPage() {
                     required
                     minLength={8}
                     className="h-11"
+                  />
+                  <PasswordPolicyChecklist
+                    password={password}
+                    confirmPassword={confirmPassword}
+                    context="reset"
                   />
                   <button
                     type="submit"

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -3,7 +3,9 @@
 import { CheckCircle, Mail } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useState, type FormEvent } from "react"
+import { PasswordPolicyChecklist } from "@/components/auth/password-policy-checklist"
 import { Input } from "@/components/ui/input"
+import { validatePasswordDraft } from "@/lib/auth/password-policy"
 import { createClient } from "@/lib/supabase/client"
 
 interface WelcomeClientProps {
@@ -38,13 +40,9 @@ export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
     setMessage(null)
     setHighlightMagicLink(false)
 
-    if (password.length < 8) {
-      setMessage("Passwort muss mindestens 8 Zeichen lang sein.")
-      return
-    }
-
-    if (password !== confirmPassword) {
-      setMessage("Passwörter stimmen nicht überein.")
+    const validation = validatePasswordDraft(password, confirmPassword)
+    if (!validation.ok) {
+      setMessage(validation.message)
       return
     }
 
@@ -204,6 +202,11 @@ export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
                     className="h-11"
                   />
                 </div>
+                <PasswordPolicyChecklist
+                  password={password}
+                  confirmPassword={confirmPassword}
+                  context="create"
+                />
               </div>
 
               <button

--- a/src/components/auth/password-policy-checklist.tsx
+++ b/src/components/auth/password-policy-checklist.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { CheckCircle2, Circle, Info } from "lucide-react"
+import {
+  getPasswordPolicyItems,
+  MIN_PASSWORD_LENGTH,
+  type PasswordPolicyContext,
+  type PasswordPolicyItemId,
+} from "@/lib/auth/password-policy"
+
+interface PasswordPolicyChecklistProps {
+  password: string
+  confirmPassword: string
+  context: PasswordPolicyContext
+}
+
+export function PasswordPolicyChecklist({
+  password,
+  confirmPassword,
+  context,
+}: PasswordPolicyChecklistProps) {
+  const items = getPasswordPolicyItems(context)
+
+  return (
+    <ul className="space-y-2 rounded-lg bg-muted/40 px-3 py-3 text-left text-xs text-muted-foreground">
+      {items.map((item) => {
+        if (item.id === "different") {
+          return (
+            <li key={item.id} className="flex items-center gap-2">
+              <Info className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span>{item.label}</span>
+            </li>
+          )
+        }
+
+        const met = isPolicyItemMet(item.id, password, confirmPassword)
+        const Icon = met ? CheckCircle2 : Circle
+
+        return (
+          <li
+            key={item.id}
+            className={met ? "flex items-center gap-2 text-primary" : "flex items-center gap-2"}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span>{item.label}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function isPolicyItemMet(
+  id: PasswordPolicyItemId,
+  password: string,
+  confirmPassword: string,
+): boolean {
+  if (id === "length") return password.length >= MIN_PASSWORD_LENGTH
+  if (id === "match") return password.length > 0 && password === confirmPassword
+  return false
+}

--- a/src/lib/auth/password-policy.ts
+++ b/src/lib/auth/password-policy.ts
@@ -1,0 +1,38 @@
+export type PasswordPolicyContext = "create" | "reset"
+export type PasswordPolicyItemId = "length" | "match" | "different"
+
+export type PasswordPolicyItem = {
+  id: PasswordPolicyItemId
+  label: string
+}
+
+export const MIN_PASSWORD_LENGTH = 8
+
+const BASE_POLICY_ITEMS: PasswordPolicyItem[] = [
+  { id: "length", label: "Mindestens 8 Zeichen" },
+  { id: "match", label: "Beide Passwörter stimmen überein" },
+]
+
+const RESET_ONLY_POLICY_ITEM: PasswordPolicyItem = {
+  id: "different",
+  label: "Nicht dasselbe Passwort erneut verwenden",
+}
+
+export function getPasswordPolicyItems(context: PasswordPolicyContext): PasswordPolicyItem[] {
+  return context === "reset" ? [...BASE_POLICY_ITEMS, RESET_ONLY_POLICY_ITEM] : BASE_POLICY_ITEMS
+}
+
+export function validatePasswordDraft(
+  password: string,
+  confirmPassword: string,
+): { ok: true } | { ok: false; message: string } {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return { ok: false, message: "Passwort muss mindestens 8 Zeichen lang sein." }
+  }
+
+  if (password !== confirmPassword) {
+    return { ok: false, message: "Passwörter stimmen nicht überein." }
+  }
+
+  return { ok: true }
+}

--- a/src/lib/auth/password-reset.ts
+++ b/src/lib/auth/password-reset.ts
@@ -52,6 +52,21 @@ export function mapPasswordUpdateError(error: unknown): PasswordResetMessage {
   }
 
   if (
+    combined.includes("same_password") ||
+    combined.includes("same") ||
+    combined.includes("different from") ||
+    combined.includes("different password")
+  ) {
+    return {
+      message: "Dieses Passwort ist bereits für dein Konto gesetzt.",
+      guidance: "Melde dich mit diesem Passwort an oder wähle ein anderes Passwort.",
+      actionHref: "/auth",
+      actionLabel: "Zur Anmeldung",
+    }
+  }
+
+  if (
+    combined.includes("weak_password") ||
     combined.includes("weak") ||
     combined.includes("password_strength") ||
     combined.includes("password should be") ||
@@ -59,22 +74,7 @@ export function mapPasswordUpdateError(error: unknown): PasswordResetMessage {
   ) {
     return {
       message: "Dieses Passwort ist zu schwach.",
-      guidance:
-        "Wähle mindestens 8 Zeichen und kombiniere am besten Buchstaben, Zahlen und ein Sonderzeichen.",
-    }
-  }
-
-  if (
-    combined.includes("same") ||
-    combined.includes("different from") ||
-    combined.includes("different password")
-  ) {
-    return {
-      message: "Dieses Passwort ist bereits für dein Konto gesetzt.",
-      guidance:
-        "Wähle ein anderes Passwort oder melde dich direkt mit deinem bestehenden Passwort an.",
-      actionHref: "/auth",
-      actionLabel: "Zur Anmeldung",
+      guidance: "Wähle ein Passwort mit mindestens 8 Zeichen.",
     }
   }
 
@@ -96,15 +96,23 @@ function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (typeof error === "object" && error && "message" in error) {
     const message = (error as { message?: unknown }).message
+    if (typeof message === "string") return message
+  }
+  if (typeof error === "object" && error && "msg" in error) {
+    const message = (error as { msg?: unknown }).msg
     return typeof message === "string" ? message : ""
   }
   return ""
 }
 
 function getErrorCode(error: unknown): string {
+  if (typeof error === "object" && error && "error_code" in error) {
+    const code = (error as { error_code?: unknown }).error_code
+    if (typeof code === "string") return code
+  }
   if (typeof error === "object" && error && "code" in error) {
     const code = (error as { code?: unknown }).code
-    return typeof code === "string" ? code : ""
+    return typeof code === "string" || typeof code === "number" ? String(code) : ""
   }
   return ""
 }

--- a/tests/password-reset-helpers.test.ts
+++ b/tests/password-reset-helpers.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test"
 import assert from "node:assert/strict"
+import { getPasswordPolicyItems, validatePasswordDraft } from "@/lib/auth/password-policy"
 import { extractSupabaseHashSession, mapPasswordUpdateError } from "@/lib/auth/password-reset"
 
 test("extracts Supabase recovery session tokens from URL hash", () => {
@@ -34,4 +35,47 @@ test("maps weak password errors to password guidance", () => {
 
   assert.equal(mapped.message, "Dieses Passwort ist zu schwach.")
   assert.match(mapped.guidance ?? "", /8 Zeichen/)
+})
+
+test("maps same-password errors before generic weak-password wording", () => {
+  const mapped = mapPasswordUpdateError({
+    code: 422,
+    error_code: "same_password",
+    message: null,
+    msg: "New password should be different from the old password.",
+  })
+
+  assert.equal(mapped.message, "Dieses Passwort ist bereits für dein Konto gesetzt.")
+  assert.match(mapped.guidance ?? "", /anderes Passwort/)
+  assert.equal(mapped.actionHref, "/auth")
+})
+
+test("password policy exposes visible checklist items for creation and reset", () => {
+  assert.deepEqual(getPasswordPolicyItems("create"), [
+    { id: "length", label: "Mindestens 8 Zeichen" },
+    { id: "match", label: "Beide Passwörter stimmen überein" },
+  ])
+
+  assert.deepEqual(getPasswordPolicyItems("reset"), [
+    { id: "length", label: "Mindestens 8 Zeichen" },
+    { id: "match", label: "Beide Passwörter stimmen überein" },
+    {
+      id: "different",
+      label: "Nicht dasselbe Passwort erneut verwenden",
+    },
+  ])
+})
+
+test("password draft validation only enforces visible local rules", () => {
+  assert.deepEqual(validatePasswordDraft("1234567", "1234567"), {
+    ok: false,
+    message: "Passwort muss mindestens 8 Zeichen lang sein.",
+  })
+
+  assert.deepEqual(validatePasswordDraft("12345678", "87654321"), {
+    ok: false,
+    message: "Passwörter stimmen nicht überein.",
+  })
+
+  assert.deepEqual(validatePasswordDraft("12345678", "12345678"), { ok: true })
 })


### PR DESCRIPTION
## Summary
- Fixes password reset error mapping so Supabase `same_password` responses no longer show misleading weak-password copy.
- Adds a shared visible password checklist for password creation and reset pages.
- Reuses the same local password validation on checkout activation, reset, and tests.

## Verification
- `npm run test:node -- tests/password-reset-helpers.test.ts` — 219 passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors, 4 existing warnings
- `npx playwright test tests/auth-post-checkout-routes.spec.ts --project=chromium` — 22 passed
- `npm run build` — passed

## Notes
- Production behavior still depends on Vercel finishing the deployment after merge.
