### PR TITLE
feat(recommendations): add dry shampoo category

### DIFF
--- a/scripts/seed-dry-shampoo-products.ts
+++ b/scripts/seed-dry-shampoo-products.ts
@@ -1,7 +1,11 @@
 import { config as loadEnv } from "dotenv"
 import { createClient } from "@supabase/supabase-js"
 
-import type { ProductDryShampooSpecs } from "@/lib/dry-shampoo/constants"
+import {
+  DRY_SHAMPOO_DB_CATEGORIES,
+  isDryShampooCategory,
+  type ProductDryShampooSpecs,
+} from "@/lib/dry-shampoo/constants"
 
 loadEnv({ path: ".env.local" })
 
@@ -25,6 +29,12 @@ type DryShampooCatalogRow = {
 }
 
 const CATEGORY = "Trockenshampoo"
+const DRY_SHAMPOO_CATEGORY_ALIASES = [...DRY_SHAMPOO_DB_CATEGORIES]
+
+export const STALE_DRY_SHAMPOO_DEACTIVATION_PATCH = {
+  is_active: false,
+  lifecycle_status: "discontinued",
+} as const
 
 const DRY_SHAMPOO_SEED_PRODUCTS: DryShampooSeedProduct[] = [
   {
@@ -197,7 +207,7 @@ const PLANNED_PRODUCT_KEYS = new Set(DRY_SHAMPOO_SEED_PRODUCTS.map(productKey))
 
 export function findUnexpectedActiveDryShampooProducts(products: DryShampooCatalogRow[]): string[] {
   return products
-    .filter((product) => product.category === CATEGORY && product.is_active === true)
+    .filter((product) => isDryShampooCategory(product.category) && product.is_active === true)
     .filter((product) => !PLANNED_PRODUCT_KEYS.has(productKey(product)))
     .map((product) => product.id)
 }
@@ -288,7 +298,7 @@ async function main() {
   const { data: activeDryShampoos, error: activeLookupError } = await supabase
     .from("products")
     .select("id,brand,name,category,is_active")
-    .eq("category", CATEGORY)
+    .in("category", DRY_SHAMPOO_CATEGORY_ALIASES)
     .eq("is_active", true)
 
   if (activeLookupError) throw activeLookupError
@@ -300,10 +310,7 @@ async function main() {
   if (unexpectedActiveIds.length > 0) {
     const { error: deactivateError } = await supabase
       .from("products")
-      .update({
-        is_active: false,
-        lifecycle_status: "retired",
-      })
+      .update(STALE_DRY_SHAMPOO_DEACTIVATION_PATCH)
       .in("id", unexpectedActiveIds)
 
     if (deactivateError) throw deactivateError
@@ -313,7 +320,7 @@ async function main() {
   const { count: activeCount, error: countError } = await supabase
     .from("products")
     .select("id", { count: "exact", head: true })
-    .eq("category", CATEGORY)
+    .in("category", DRY_SHAMPOO_CATEGORY_ALIASES)
     .eq("is_active", true)
 
   if (countError) throw countError

--- a/scripts/seed-dry-shampoo-products.ts
+++ b/scripts/seed-dry-shampoo-products.ts
@@ -1,0 +1,270 @@
+import { config as loadEnv } from "dotenv"
+import { createClient } from "@supabase/supabase-js"
+
+import type { ProductDryShampooSpecs } from "@/lib/dry-shampoo/constants"
+
+loadEnv({ path: ".env.local" })
+
+type DryShampooSeedProduct = {
+  name: string
+  brand: string
+  description: string
+  affiliate_link: string
+  price_eur: number
+  currency: "EUR"
+  sort_order: number
+  specs: Omit<ProductDryShampooSpecs, "product_id">
+}
+
+const CATEGORY = "Trockenshampoo"
+
+const DRY_SHAMPOO_SEED_PRODUCTS: DryShampooSeedProduct[] = [
+  {
+    name: "Trockenshampoo Original",
+    brand: "Batiste",
+    description:
+      "Klassisches Trockenshampoo fuer einen kurzen Ansatz-Refresh zwischen zwei Haarwaeschen.",
+    affiliate_link: "https://www.dm.de/batiste-trockenshampoo-original-p5010724527481.html",
+    price_eur: 3.75,
+    currency: "EUR",
+    sort_order: 9201,
+    specs: {
+      primary_effect: "classic_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo Jedes Haar",
+    brand: "ISANA",
+    description:
+      "Universelles Trockenshampoo fuer gelegentliches Auffrischen am Ansatz, wenn Waschen gerade nicht moeglich ist.",
+    affiliate_link:
+      "https://www.rossmann.de/de/pflege-und-duft-isana-trockenshampoo-jedes-haar/p/4305615554532",
+    price_eur: 1.99,
+    currency: "EUR",
+    sort_order: 9202,
+    specs: {
+      primary_effect: "classic_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo Kopfhaut Sensitive",
+    brand: "Balea",
+    description:
+      "Sensitive Trockenshampoo-Option fuer eine kurze Between-Wash-Bruecke ohne aktive Kopfhautbeschwerden.",
+    affiliate_link: "https://www.dm.de/balea-trockenshampoo-kopfhaut-sensitive-p4066447438789.html",
+    price_eur: 1.95,
+    currency: "EUR",
+    sort_order: 9203,
+    specs: {
+      primary_effect: "sensitive_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "sensitive_ok",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo Sensible Kopfhaut",
+    brand: "Batiste",
+    description:
+      "Sensitive Refresh-Option fuer seltene Notfall- oder Tag-2-Situationen ohne Jucken, Schuppen oder Irritation.",
+    affiliate_link:
+      "https://www.dm.de/batiste-trockenshampoo-sensible-kopfhaut-leichter-duft-p5010724004777.html",
+    price_eur: 3.95,
+    currency: "EUR",
+    sort_order: 9204,
+    specs: {
+      primary_effect: "sensitive_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "sensitive_ok",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo Schaum Kopfhaut Sensitive",
+    brand: "Balea",
+    description:
+      "Schaum-/Liquid-Format fuer eine sensitive kurze Ansatz-Bruecke, nicht als Reinigungsschritt.",
+    affiliate_link:
+      "https://www.dm.de/balea-trockenshampoo-schaum-kopfhaut-sensitive-p4067796069556.html",
+    price_eur: 1.45,
+    currency: "EUR",
+    sort_order: 9205,
+    specs: {
+      primary_effect: "sensitive_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "sensitive_ok",
+      format: "foam_or_liquid",
+    },
+  },
+  {
+    name: "Trockenshampoo Liquid to Dry",
+    brand: "got2b",
+    description: "Liquid-to-dry Trockenshampoo fuer einen kurzen klassischen Refresh am Ansatz.",
+    affiliate_link: "https://www.dm.de/p/d/2476987/got2b-trockenshampoo-liquid-to-dry",
+    price_eur: 3.95,
+    currency: "EUR",
+    sort_order: 9206,
+    specs: {
+      primary_effect: "classic_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "normal_only",
+      format: "foam_or_liquid",
+    },
+  },
+  {
+    name: "Trockenshampoo Extra Volumen",
+    brand: "got2b",
+    description:
+      "Trockenshampoo fuer mehr Ansatzvolumen und Griff als gelegentliche Styling-Bruecke.",
+    affiliate_link:
+      "https://geizhals.de/got2b-trockenwaesche-extra-volumen-trockenshampoo-a2375994.html",
+    price_eur: 3.95,
+    currency: "EUR",
+    sort_order: 9207,
+    specs: {
+      primary_effect: "volume_texture",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo Blond",
+    brand: "Batiste",
+    description: "Farbfit-Option fuer blondes oder helles Haar bei einem kurzen Ansatz-Refresh.",
+    affiliate_link: "https://www.dm.de/p/d/1435894/batiste-trockenshampoo-blond",
+    price_eur: 3.95,
+    currency: "EUR",
+    sort_order: 9208,
+    specs: {
+      primary_effect: "classic_refresh",
+      hair_color_fit: "blonde_light",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo Bruenett",
+    brand: "Batiste",
+    description: "Farbfit-Option fuer braunes Haar bei einer gelegentlichen Between-Wash-Bruecke.",
+    affiliate_link: "https://www.dm.de/batiste-trockenshampoo-bruenett-p5010724527474.html",
+    price_eur: 3.95,
+    currency: "EUR",
+    sort_order: 9209,
+    specs: {
+      primary_effect: "classic_refresh",
+      hair_color_fit: "brown",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
+    },
+  },
+  {
+    name: "Trockenshampoo dunkel",
+    brand: "Batiste",
+    description: "Farbfit-Option fuer dunkles Haar bei einem kurzen kosmetischen Ansatz-Refresh.",
+    affiliate_link: "https://www.dm.de/batiste-trockenshampoo-dunkel-p5010724527443.html",
+    price_eur: 3.95,
+    currency: "EUR",
+    sort_order: 9210,
+    specs: {
+      primary_effect: "classic_refresh",
+      hair_color_fit: "dark",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
+    },
+  },
+]
+
+function printSeedMatrix() {
+  console.table(
+    DRY_SHAMPOO_SEED_PRODUCTS.map((product) => ({
+      product: product.name,
+      brand: product.brand,
+      price: `${product.price_eur} ${product.currency}`,
+      link: product.affiliate_link,
+      primary_effect: product.specs.primary_effect,
+      hair_color_fit: product.specs.hair_color_fit,
+      scalp_sensitivity_fit: product.specs.scalp_sensitivity_fit,
+      format: product.specs.format,
+    })),
+  )
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply")
+  printSeedMatrix()
+
+  if (!apply) {
+    console.log("\nDry run only. Re-run with --apply after Nick confirms the seed matrix.")
+    return
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+
+  for (const product of DRY_SHAMPOO_SEED_PRODUCTS) {
+    const { data: existing, error: lookupError } = await supabase
+      .from("products")
+      .select("id")
+      .eq("brand", product.brand)
+      .eq("name", product.name)
+      .maybeSingle()
+
+    if (lookupError) throw lookupError
+
+    const payload = {
+      name: product.name,
+      brand: product.brand,
+      description: product.description,
+      category: CATEGORY,
+      affiliate_link: product.affiliate_link,
+      price_eur: product.price_eur,
+      currency: product.currency,
+      tags: ["trockenshampoo", "between-wash", product.specs.format],
+      suitable_concerns: ["oily_scalp"],
+      is_active: true,
+      lifecycle_status: "active",
+      sort_order: product.sort_order,
+    }
+
+    const { data: saved, error: productError } = existing
+      ? await supabase.from("products").update(payload).eq("id", existing.id).select("id").single()
+      : await supabase.from("products").insert(payload).select("id").single()
+
+    if (productError) throw productError
+
+    const { error: specError } = await supabase.from("product_dry_shampoo_specs").upsert(
+      {
+        product_id: saved.id,
+        ...product.specs,
+      },
+      { onConflict: "product_id" },
+    )
+
+    if (specError) throw specError
+  }
+
+  console.log(`Seeded ${DRY_SHAMPOO_SEED_PRODUCTS.length} dry-shampoo products.`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/seed-dry-shampoo-products.ts
+++ b/scripts/seed-dry-shampoo-products.ts
@@ -16,6 +16,14 @@ type DryShampooSeedProduct = {
   specs: Omit<ProductDryShampooSpecs, "product_id">
 }
 
+type DryShampooCatalogRow = {
+  id: string
+  brand: string | null
+  name: string | null
+  category: string | null
+  is_active: boolean | null
+}
+
 const CATEGORY = "Trockenshampoo"
 
 const DRY_SHAMPOO_SEED_PRODUCTS: DryShampooSeedProduct[] = [
@@ -181,6 +189,19 @@ const DRY_SHAMPOO_SEED_PRODUCTS: DryShampooSeedProduct[] = [
   },
 ]
 
+function productKey(product: Pick<DryShampooCatalogRow, "brand" | "name">): string {
+  return `${product.brand ?? ""}\u0000${product.name ?? ""}`
+}
+
+const PLANNED_PRODUCT_KEYS = new Set(DRY_SHAMPOO_SEED_PRODUCTS.map(productKey))
+
+export function findUnexpectedActiveDryShampooProducts(products: DryShampooCatalogRow[]): string[] {
+  return products
+    .filter((product) => product.category === CATEGORY && product.is_active === true)
+    .filter((product) => !PLANNED_PRODUCT_KEYS.has(productKey(product)))
+    .map((product) => product.id)
+}
+
 function printSeedMatrix() {
   console.table(
     DRY_SHAMPOO_SEED_PRODUCTS.map((product) => ({
@@ -219,6 +240,8 @@ async function main() {
     },
   })
 
+  const seededProductIds: string[] = []
+
   for (const product of DRY_SHAMPOO_SEED_PRODUCTS) {
     const { data: existing, error: lookupError } = await supabase
       .from("products")
@@ -249,6 +272,7 @@ async function main() {
       : await supabase.from("products").insert(payload).select("id").single()
 
     if (productError) throw productError
+    seededProductIds.push(saved.id)
 
     const { error: specError } = await supabase.from("product_dry_shampoo_specs").upsert(
       {
@@ -261,10 +285,50 @@ async function main() {
     if (specError) throw specError
   }
 
+  const { data: activeDryShampoos, error: activeLookupError } = await supabase
+    .from("products")
+    .select("id,brand,name,category,is_active")
+    .eq("category", CATEGORY)
+    .eq("is_active", true)
+
+  if (activeLookupError) throw activeLookupError
+
+  const unexpectedActiveIds = findUnexpectedActiveDryShampooProducts(
+    (activeDryShampoos ?? []) as DryShampooCatalogRow[],
+  )
+
+  if (unexpectedActiveIds.length > 0) {
+    const { error: deactivateError } = await supabase
+      .from("products")
+      .update({
+        is_active: false,
+        lifecycle_status: "retired",
+      })
+      .in("id", unexpectedActiveIds)
+
+    if (deactivateError) throw deactivateError
+    console.log(`Deactivated ${unexpectedActiveIds.length} unexpected dry-shampoo products.`)
+  }
+
+  const { count: activeCount, error: countError } = await supabase
+    .from("products")
+    .select("id", { count: "exact", head: true })
+    .eq("category", CATEGORY)
+    .eq("is_active", true)
+
+  if (countError) throw countError
+  if (activeCount !== seededProductIds.length) {
+    throw new Error(
+      `Expected ${seededProductIds.length} active dry-shampoo products, found ${activeCount ?? 0}`,
+    )
+  }
+
   console.log(`Seeded ${DRY_SHAMPOO_SEED_PRODUCTS.length} dry-shampoo products.`)
 }
 
-main().catch((error) => {
-  console.error(error)
-  process.exit(1)
-})
+if (process.argv[1]?.endsWith("seed-dry-shampoo-products.ts")) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -28,6 +28,14 @@ import {
   PRODUCT_BOND_TREATMENT_MODE_LABELS,
   PRODUCT_BOND_USAGE_PROTOCOLS,
   PRODUCT_BOND_USAGE_PROTOCOL_LABELS,
+  DRY_SHAMPOO_FORMATS,
+  DRY_SHAMPOO_FORMAT_LABELS,
+  DRY_SHAMPOO_HAIR_COLOR_FITS,
+  DRY_SHAMPOO_HAIR_COLOR_FIT_LABELS,
+  DRY_SHAMPOO_PRIMARY_EFFECTS,
+  DRY_SHAMPOO_PRIMARY_EFFECT_LABELS,
+  DRY_SHAMPOO_SCALP_SENSITIVITY_FITS,
+  DRY_SHAMPOO_SCALP_SENSITIVITY_FIT_LABELS,
   PRODUCT_PEELING_TYPES,
   PRODUCT_PEELING_TYPE_LABELS,
   PRODUCT_SCALP_TYPE_FOCUSES,
@@ -83,7 +91,10 @@ interface DeepCleansingShampooSpecForm {
 }
 
 interface DryShampooSpecForm {
-  scalp_type_focus: string
+  primary_effect: string
+  hair_color_fit: string
+  scalp_sensitivity_fit: string
+  format: string
 }
 
 interface PeelingSpecForm {
@@ -147,7 +158,10 @@ const emptyDeepCleansingShampooSpecs: DeepCleansingShampooSpecForm = {
 }
 
 const emptyDryShampooSpecs: DryShampooSpecForm = {
-  scalp_type_focus: "balanced",
+  primary_effect: "classic_refresh",
+  hair_color_fit: "universal",
+  scalp_sensitivity_fit: "normal_only",
+  format: "aerosol_spray",
 }
 
 const emptyPeelingSpecs: PeelingSpecForm = {
@@ -284,7 +298,10 @@ export default function AdminProductsPage() {
 
     const dryShampooSpecs = product.dry_shampoo_specs
       ? {
-          scalp_type_focus: product.dry_shampoo_specs.scalp_type_focus,
+          primary_effect: product.dry_shampoo_specs.primary_effect,
+          hair_color_fit: product.dry_shampoo_specs.hair_color_fit,
+          scalp_sensitivity_fit: product.dry_shampoo_specs.scalp_sensitivity_fit,
+          format: product.dry_shampoo_specs.format,
         }
       : isDryShampooCategory(product.category || "")
         ? { ...emptyDryShampooSpecs }
@@ -534,7 +551,10 @@ export default function AdminProductsPage() {
         dry_shampoo_specs:
           dryShampooEnabled && form.dry_shampoo_specs
             ? {
-                scalp_type_focus: form.dry_shampoo_specs.scalp_type_focus,
+                primary_effect: form.dry_shampoo_specs.primary_effect,
+                hair_color_fit: form.dry_shampoo_specs.hair_color_fit,
+                scalp_sensitivity_fit: form.dry_shampoo_specs.scalp_sensitivity_fit,
+                format: form.dry_shampoo_specs.format,
               }
             : null,
         peeling_specs:
@@ -1324,36 +1344,63 @@ export default function AdminProductsPage() {
                     Trockenshampoo-Spezifikation
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    Der passende Kopfhaut-Fokus fuer Between-Wash-Bridge-Produkte.
+                    Schlanke Fit-Felder fuer Notfall-/Between-Wash-Bridge-Produkte.
                   </p>
                 </div>
 
-                <div>
-                  <label className="mb-1 block text-xs font-medium text-muted-foreground">
-                    Kopfhaut-Fokus
-                  </label>
-                  <select
-                    value={form.dry_shampoo_specs.scalp_type_focus}
-                    onChange={(e) =>
-                      setForm((prev) => ({
-                        ...prev,
-                        dry_shampoo_specs: prev.dry_shampoo_specs
-                          ? {
-                              ...prev.dry_shampoo_specs,
-                              scalp_type_focus: e.target.value,
-                            }
-                          : null,
-                      }))
-                    }
-                    className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-                  >
-                    {PRODUCT_SCALP_TYPE_FOCUSES.filter((value) => value !== "dry").map((value) => (
-                      <option key={value} value={value}>
-                        {PRODUCT_SCALP_TYPE_FOCUS_LABELS[value]}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+                {[
+                  {
+                    field: "primary_effect",
+                    label: "Primaere Wirkung",
+                    values: DRY_SHAMPOO_PRIMARY_EFFECTS,
+                    labels: DRY_SHAMPOO_PRIMARY_EFFECT_LABELS,
+                  },
+                  {
+                    field: "hair_color_fit",
+                    label: "Farbfit",
+                    values: DRY_SHAMPOO_HAIR_COLOR_FITS,
+                    labels: DRY_SHAMPOO_HAIR_COLOR_FIT_LABELS,
+                  },
+                  {
+                    field: "scalp_sensitivity_fit",
+                    label: "Sensitivitaetsfit",
+                    values: DRY_SHAMPOO_SCALP_SENSITIVITY_FITS,
+                    labels: DRY_SHAMPOO_SCALP_SENSITIVITY_FIT_LABELS,
+                  },
+                  {
+                    field: "format",
+                    label: "Format",
+                    values: DRY_SHAMPOO_FORMATS,
+                    labels: DRY_SHAMPOO_FORMAT_LABELS,
+                  },
+                ].map((config) => (
+                  <div key={config.field}>
+                    <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                      {config.label}
+                    </label>
+                    <select
+                      value={form.dry_shampoo_specs?.[config.field as keyof DryShampooSpecForm]}
+                      onChange={(e) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          dry_shampoo_specs: prev.dry_shampoo_specs
+                            ? {
+                                ...prev.dry_shampoo_specs,
+                                [config.field]: e.target.value,
+                              }
+                            : null,
+                        }))
+                      }
+                      className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      {config.values.map((value) => (
+                        <option key={value} value={value}>
+                          {(config.labels as Record<string, string>)[value]}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
               </div>
             )}
 

--- a/src/components/labs/agent-compare-lab.tsx
+++ b/src/components/labs/agent-compare-lab.tsx
@@ -133,12 +133,13 @@ function ProductTracePanel({ result }: { result: CompareRunResult }) {
                 ) : null}
                 {product.supported_claims.length > 0 ? (
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Belegt: {product.supported_claims.map((claim) => claim.label).join(" · ")}
+                    Sichere Angaben:{" "}
+                    {product.supported_claims.map((claim) => claim.label).join(" · ")}
                   </p>
                 ) : null}
                 {product.unsupported_requested_signals.length > 0 ? (
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Nicht belegt:{" "}
+                    Keine sichere Angabe:{" "}
                     {product.unsupported_requested_signals
                       .map((signal) => `${signal.field}=${signal.value}`)
                       .join(", ")}

--- a/src/lib/agent/orchestrator/prompt.ts
+++ b/src/lib/agent/orchestrator/prompt.ts
@@ -58,6 +58,7 @@ Regeln:
 - product_response_policy=no_catalog_match: keine Produkte erfinden.
 - Bei Trockenshampoo immer als kurze kosmetische Between-Wash-Bruecke framen, nicht als Pflege, Behandlung oder Reinigung.
 - Bei Trockenshampoo ist Pflicht: Trockenshampoo reinigt die Kopfhaut nicht und sollte spaeter ausgewaschen werden.
+- Das Trockenshampoo-Caveat nur einmal pro Antwort nennen und nicht unter jedem Produkt wiederholen; pro Produkt lieber den belegten Unterschied wie Format, Farbfit oder Sensitivitaetsfit nennen.
 - Auch ohne selected_products: Wenn route.product_category=dry_shampoo ist oder die Nutzerfrage Trockenshampoo nennt, muss diese Kopfhaut-nicht-gereinigt-/spaeter-auswaschen-Caveat in die Antwort.
 - Bei Trockenshampoo mit product_response_policy=caution_without_products oder redirect_to_better_lever: keine Produktliste und keine erfundenen Ersatzprodukte nennen; die bessere Kopfhaut-, Shampoo- oder Reset-Einordnung aus category_guidance nutzen.
 - Bei Trockenshampoo mit product_response_policy=no_catalog_match: keine Trockenshampoo-Produkte erfinden, keine Ersatzprodukte wie Babypuder nennen und die Kopfhaut-nicht-gereinigt-/spaeter-auswaschen-Caveat trotzdem nennen.

--- a/src/lib/agent/orchestrator/prompt.ts
+++ b/src/lib/agent/orchestrator/prompt.ts
@@ -56,6 +56,11 @@ Regeln:
 - product_response_policy=caution_without_products: normale Kosmetikprodukte nicht als medizinische Loesung darstellen; fuer Shampoo von Einordnung, Schuppen-Reduktion, beruhigender Kopfhautpflege oder passenden Optionen sprechen, nicht von Therapie. In einem Satz sagen, dass anhaltende/starke Reizung professionell oder dermatologisch abgeklaert werden sollte. Wenn es um Schuppen/Juckreiz geht, nicht als Sackgasse antworten: frage knapp, ob der Fokus eher Schuppen-Reduktion oder gereizte/empfindliche Kopfhaut ist, und sage, dass danach passende Shampoo-Optionen moeglich sind.
 - product_response_policy=needs_more_info: maximal eine gezielte Rueckfrage.
 - product_response_policy=no_catalog_match: keine Produkte erfinden.
+- Bei Trockenshampoo immer als kurze kosmetische Between-Wash-Bruecke framen, nicht als Pflege, Behandlung oder Reinigung.
+- Bei Trockenshampoo ist Pflicht: Trockenshampoo reinigt die Kopfhaut nicht und sollte spaeter ausgewaschen werden.
+- Auch ohne selected_products: Wenn route.product_category=dry_shampoo ist oder die Nutzerfrage Trockenshampoo nennt, muss diese Kopfhaut-nicht-gereinigt-/spaeter-auswaschen-Caveat in die Antwort.
+- Bei Trockenshampoo mit product_response_policy=caution_without_products oder redirect_to_better_lever: keine Produktliste und keine erfundenen Ersatzprodukte nennen; die bessere Kopfhaut-, Shampoo- oder Reset-Einordnung aus category_guidance nutzen.
+- Bei Trockenshampoo mit product_response_policy=no_catalog_match: keine Trockenshampoo-Produkte erfinden, keine Ersatzprodukte wie Babypuder nennen und die Kopfhaut-nicht-gereinigt-/spaeter-auswaschen-Caveat trotzdem nennen.
 - Caveats koennen intern mit "Fallback:" markiert sein. Den Marker und das Wort "Fallback" nie in der Nutzerantwort ausgeben.
 - Wenn intern schwaechere Optionen im Packet sind, erst Primaerempfehlungen nennen und die schwaecheren Optionen nur nachgeordnet natuerlich einordnen.
 - Bei product_response_policy=recommend musst du alle Produkte aus selected_products.products in der gegebenen Reihenfolge behandeln. Reduziere nicht eigenmaechtig von drei Tool-Produkten auf zwei; wenn ein Produkt intern als schwaechere Option markiert ist, nenne es als klar schwaechere oder caveated Option statt es wegzulassen.

--- a/src/lib/agent/orchestrator/route-packet.ts
+++ b/src/lib/agent/orchestrator/route-packet.ts
@@ -526,9 +526,24 @@ function inferDirectProductCategoryFromMessage(
     /\btag\s*2\b|\bday\s*2\b|\bzweiter\s+tag\b|\bbetween[-\s]?wash\b|\bzwischen\s+(?:den\s+)?(?:waeschen|waschen)\b/.test(
       normalized,
     )
+  const dryShampooCannotWashToday =
+    /\b(?:kann|schaffe|geht)\b.{0,50}\b(?:heute|jetzt|gerade)\b.{0,50}\b(?:nicht\s+)?wasch\w*\b|\bkeine\s+zeit\b.{0,50}\bwasch\w*\b/.test(
+      normalized,
+    )
+  const dryShampooEmergency =
+    /\bnotfall\w*\b|\bemergency\b|\blast[-\s]?minute\b|\bkurzfristig\w*\b|\breise\w*\b|\bunterwegs\b/.test(
+      normalized,
+    )
+  const dryShampooSameDay = /\b(?:heute|jetzt|gerade)\b/.test(normalized)
+  const hasDryShampooBridgeContext =
+    mentionsDryShampoo || dryShampooBetweenWash || dryShampooCannotWashToday || dryShampooEmergency
+  const dryShampooRootRefreshPhrase =
+    /\bauffrisch\w*\b.{0,50}\bansatz\b|\bansatz\b.{0,50}\bauffrisch\w*\b/.test(normalized) ||
+    /\brefresh\w*\b.{0,50}\bansatz\b|\bansatz\b.{0,50}\brefresh\w*\b/.test(normalized)
   const dryShampooRootRefresh =
-    /\bauffrisch\w*\b.{0,50}\bansatz\b|\bansatz\b.{0,50}\bauffrisch\w*\b/.test(normalized)
+    (hasDryShampooBridgeContext || dryShampooSameDay) && dryShampooRootRefreshPhrase
   const dryShampooGreasyRoot =
+    hasDryShampooBridgeContext &&
     /\bansatz\b.{0,50}\b(?:fett\w*|nachfett\w*)\b|\b(?:fett\w*|nachfett\w*)\b.{0,50}\bansatz\b/.test(
       normalized,
     )
@@ -537,17 +552,21 @@ function inferDirectProductCategoryFromMessage(
       normalized,
     )
   const dryShampooFormatRequest =
+    (hasDryShampooBridgeContext || (dryShampooSameDay && dryShampooRootRefreshPhrase)) &&
     /\bkein(?:e|en)?\s+(?:spray|aerosol)\b|\bohne\s+(?:spray|aerosol)\b|\bschaum\b|\bfoam\b|\bliquid\b|\bfluessig\w*\b|\bflussig\w*\b/.test(
       normalized,
-    ) && /\bansatz\b|\bauffrisch\w*\b/.test(normalized)
+    ) &&
+    /\bansatz\b|\bauffrisch\w*\b/.test(normalized)
   const dryShampooVolumeBridge =
     /\bvolumen\b|\bgrip\b|\bgriff\b|\btextur\w*\b|\bansatzvolumen\b/.test(normalized) &&
+    hasDryShampooBridgeContext &&
     (/\bansatz\b/.test(normalized) || dryShampooBetweenWash)
 
   if (
     !mentionsOtherCategory &&
     (mentionsDryShampoo ||
       dryShampooBetweenWash ||
+      dryShampooCannotWashToday ||
       dryShampooRootRefresh ||
       dryShampooGreasyRoot ||
       dryShampooColorCast ||

--- a/src/lib/agent/orchestrator/route-packet.ts
+++ b/src/lib/agent/orchestrator/route-packet.ts
@@ -520,6 +520,43 @@ function inferDirectProductCategoryFromMessage(
       normalized,
     )
 
+  const mentionsDryShampoo =
+    /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/.test(normalized)
+  const dryShampooBetweenWash =
+    /\btag\s*2\b|\bday\s*2\b|\bzweiter\s+tag\b|\bbetween[-\s]?wash\b|\bzwischen\s+(?:den\s+)?(?:waeschen|waschen)\b/.test(
+      normalized,
+    )
+  const dryShampooRootRefresh =
+    /\bauffrisch\w*\b.{0,50}\bansatz\b|\bansatz\b.{0,50}\bauffrisch\w*\b/.test(normalized)
+  const dryShampooGreasyRoot =
+    /\bansatz\b.{0,50}\b(?:fett\w*|nachfett\w*)\b|\b(?:fett\w*|nachfett\w*)\b.{0,50}\bansatz\b/.test(
+      normalized,
+    )
+  const dryShampooColorCast =
+    /\bweiss(?:er|e|en)?\s+schleier\b|\bwhite\s*cast\b|\bgrau(?:er|e|en)?\s+schleier\b/.test(
+      normalized,
+    )
+  const dryShampooFormatRequest =
+    /\bkein(?:e|en)?\s+(?:spray|aerosol)\b|\bohne\s+(?:spray|aerosol)\b|\bschaum\b|\bfoam\b|\bliquid\b|\bfluessig\w*\b|\bflussig\w*\b/.test(
+      normalized,
+    ) && /\bansatz\b|\bauffrisch\w*\b/.test(normalized)
+  const dryShampooVolumeBridge =
+    /\bvolumen\b|\bgrip\b|\bgriff\b|\btextur\w*\b|\bansatzvolumen\b/.test(normalized) &&
+    (/\bansatz\b/.test(normalized) || dryShampooBetweenWash)
+
+  if (
+    !mentionsOtherCategory &&
+    (mentionsDryShampoo ||
+      dryShampooBetweenWash ||
+      dryShampooRootRefresh ||
+      dryShampooGreasyRoot ||
+      dryShampooColorCast ||
+      dryShampooFormatRequest ||
+      dryShampooVolumeBridge)
+  ) {
+    return "dry_shampoo"
+  }
+
   if (mentionsMask && !mentionsOtherCategory) {
     return "mask"
   }
@@ -641,6 +678,26 @@ function isTroubleshootQuestionWithoutImmediateProductPick(
     /\b(?:macht|wirkt|fuhlt|fuehlt|ist|werden|wird)\b/.test(normalized)
 
   return describesTrouble && asksForReplacementAdvice && !explicitPick
+}
+
+function isDryShampooTroubleshootWithoutImmediateProductPick(
+  message: string,
+  userJob: AgentUserJob,
+  productCategory: SelectableProductCategory | null,
+): boolean {
+  if (userJob !== "troubleshoot" || productCategory !== "dry_shampoo") return false
+
+  const normalized = normalizeRouteMessage(message)
+  const explicitPick =
+    /\b(?:welch\w*|empfiehl\w*|empfehl\w*|nehmen|kaufen|passt|alternative)\b/.test(normalized)
+  if (explicitPick) return false
+
+  return (
+    /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/.test(normalized) &&
+    /\b(?:hat\s+nicht\s+geholfen|hilft\s+nicht|funktioniert\s+nicht|problem|trotzdem|macht|fuhlt|fuehlt|sieht|wirkt|belegt|klebrig|fettig)\b/.test(
+      normalized,
+    )
+  )
 }
 
 function isMaskTypeOrConceptQuestionWithoutImmediateProductPick(
@@ -772,6 +829,16 @@ function deriveToolPlan(params: {
 
       if (
         isTroubleshootQuestionWithoutImmediateProductPick(
+          params.message,
+          params.userJob,
+          params.productCategory,
+        )
+      ) {
+        return []
+      }
+
+      if (
+        isDryShampooTroubleshootWithoutImmediateProductPick(
           params.message,
           params.userJob,
           params.productCategory,

--- a/src/lib/agent/orchestrator/route-packet.ts
+++ b/src/lib/agent/orchestrator/route-packet.ts
@@ -514,14 +514,20 @@ function inferDirectProductCategoryFromMessage(
     /\b(?:haar)?kuren?\b/.test(normalized) ||
     /\b(?:protein|feuchtigkeits)masken?\b/.test(normalized)
   const mentionsOil = /\b(?:haar)?(?:oel\w*|ol(?:e|s|ig\w*)?)\b|\boils?\b/.test(normalized)
-  const mentionsOtherCategory =
-    mentionsOil ||
-    /\bleave[-\s]?in\b|\bleavein\b|\bconditioner\b|\bsp(?:u|ue)lung\w*\b|\bshampoos?\b|\bbond\s*builder\w*\b|\bbondbuilder\w*\b|\bbond\s*repair\b|\bk18\b|\bkr18\b|\bolaplex\b|\bepres\b/.test(
-      normalized,
-    )
-
   const mentionsDryShampoo =
     /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/.test(normalized)
+  const normalizedWithoutDryShampooTerms = normalized.replace(
+    /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/g,
+    " ",
+  )
+  const mentionsGenericShampoo = /\bshampoos?\b/.test(normalizedWithoutDryShampooTerms)
+  const mentionsOtherCategory =
+    mentionsOil ||
+    mentionsGenericShampoo ||
+    /\bleave[-\s]?in\b|\bleavein\b|\bconditioner\b|\bsp(?:u|ue)lung\w*\b|\bbond\s*builder\w*\b|\bbondbuilder\w*\b|\bbond\s*repair\b|\bk18\b|\bkr18\b|\bolaplex\b|\bepres\b/.test(
+      normalizedWithoutDryShampooTerms,
+    )
+
   const dryShampooBetweenWash =
     /\btag\s*2\b|\bday\s*2\b|\bzweiter\s+tag\b|\bbetween[-\s]?wash\b|\bzwischen\s+(?:den\s+)?(?:waeschen|waschen)\b/.test(
       normalized,

--- a/src/lib/agent/tools/select-products.ts
+++ b/src/lib/agent/tools/select-products.ts
@@ -1238,7 +1238,6 @@ function buildSupportedProductClaims(product: MatchedProduct): SupportedProductC
         "product_spec",
         meta.format ? `Format: ${meta.format}` : null,
       ),
-      buildClaim("usage_hint", meta.usage_hint, "category_decision", meta.usage_hint),
     ])
   }
 

--- a/src/lib/agent/tools/select-products.ts
+++ b/src/lib/agent/tools/select-products.ts
@@ -132,6 +132,10 @@ export const SUPPORTED_PRODUCT_CLAIM_FIELDS = [
   "reset_focus",
   "reset_intensity",
   "color_treated_suitability",
+  "primary_effect",
+  "hair_color_fit",
+  "scalp_sensitivity_fit",
+  "usage_hint",
   "bond_repair_axis",
   "treatment_mode",
   "usage_protocol",
@@ -1208,6 +1212,36 @@ function buildSupportedProductClaims(product: MatchedProduct): SupportedProductC
     ])
   }
 
+  if (meta?.category === "dry_shampoo") {
+    return uniqueClaims([
+      buildClaim(
+        "primary_effect",
+        meta.primary_effect,
+        "product_spec",
+        meta.primary_effect ? `Bridge-Wirkung: ${meta.primary_effect}` : null,
+      ),
+      buildClaim(
+        "hair_color_fit",
+        meta.hair_color_fit,
+        "product_spec",
+        meta.hair_color_fit ? `Farbfit: ${meta.hair_color_fit}` : null,
+      ),
+      buildClaim(
+        "scalp_sensitivity_fit",
+        meta.scalp_sensitivity_fit,
+        "product_spec",
+        meta.scalp_sensitivity_fit ? `Sensitivitaetsfit: ${meta.scalp_sensitivity_fit}` : null,
+      ),
+      buildClaim(
+        "format",
+        meta.format,
+        "product_spec",
+        meta.format ? `Format: ${meta.format}` : null,
+      ),
+      buildClaim("usage_hint", meta.usage_hint, "category_decision", meta.usage_hint),
+    ])
+  }
+
   if (meta?.category === "bondbuilder") {
     return uniqueClaims([
       buildClaim(
@@ -1526,18 +1560,18 @@ function signalHasSupportedClaim(
 
 function userMessageForUnsupportedSignal(signal: AgentActiveProfileSignal): string {
   if (signal.field === "chemical_treatment" && signal.value === "colored") {
-    return "Zum Farbschutz habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den belegten Fit-Daten."
+    return "Zum Farbschutz habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den sicheren Produktangaben."
   }
 
   if (signal.field === "chemical_treatment" && signal.value === "bleached") {
-    return "Zu blondiertem Haar habe ich bei diesen Produkten aktuell keine sichere Spezialangabe. Ich bewerte sie deshalb nach den belegten Fit-Daten."
+    return "Zu blondiertem Haar habe ich bei diesen Produkten aktuell keine sichere Spezialangabe. Ich bewerte sie deshalb nach den sicheren Produktangaben."
   }
 
   if (signal.field === "scalp_condition" && signal.value === "irritated") {
     return "Zur empfindlichen Kopfhaut habe ich bei diesen Produkten keine sichere Spezialangabe. Ich bewerte sie deshalb vor allem nach Kopfhaut-Fokus, Haardicke und Reinigungsintensitaet."
   }
 
-  return "Zu einem Teil deiner Anfrage habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den belegten Fit-Daten."
+  return "Zu einem Teil deiner Anfrage habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den sicheren Produktangaben."
 }
 
 function buildUnsupportedIngredientSignals(
@@ -1832,6 +1866,56 @@ function isDeepCleansingScalpTreatmentDecision(
     category === "deep_cleansing_shampoo" &&
     categoryDecision?.category === "deep_cleansing_shampoo" &&
     categoryDecision.notes.includes("scalp_treatment_needed")
+  )
+}
+
+const DRY_SHAMPOO_CAUTION_WITHOUT_PRODUCTS_REASONS = new Set([
+  "dry_shampoo_scalp_issue_hard_no",
+  "dry_shampoo_dry_breakage_hard_no",
+  "dry_shampoo_respiratory_aerosol_caution",
+  "dry_shampoo_child_context_hard_no",
+])
+
+const DRY_SHAMPOO_REDIRECT_REASONS = new Set([
+  "dry_shampoo_buildup_hard_no",
+  "dry_shampoo_frequent_use_reset_needed",
+])
+
+function dryShampooDecisionNotes(
+  category: SelectableProductCategory | null,
+  categoryDecision: CategoryDecision | null,
+): string[] {
+  if (category !== "dry_shampoo" || categoryDecision?.category !== "dry_shampoo") return []
+
+  return [...categoryDecision.notes, ...(categoryDecision.targetProfile?.cautionReasonCodes ?? [])]
+}
+
+function isDryShampooResetRedirectDecision(
+  category: SelectableProductCategory | null,
+  categoryDecision: CategoryDecision | null,
+): boolean {
+  return dryShampooDecisionNotes(category, categoryDecision).some((reason) =>
+    DRY_SHAMPOO_REDIRECT_REASONS.has(reason),
+  )
+}
+
+function isDryShampooCautionDecision(
+  category: SelectableProductCategory | null,
+  categoryDecision: CategoryDecision | null,
+): boolean {
+  return dryShampooDecisionNotes(category, categoryDecision).some((reason) =>
+    DRY_SHAMPOO_CAUTION_WITHOUT_PRODUCTS_REASONS.has(reason),
+  )
+}
+
+function isDryShampooNotRecommendedDecision(
+  category: SelectableProductCategory | null,
+  categoryDecision: CategoryDecision | null,
+): boolean {
+  return (
+    category === "dry_shampoo" &&
+    categoryDecision?.category === "dry_shampoo" &&
+    !categoryDecision.relevant
   )
 }
 
@@ -2216,6 +2300,10 @@ function deriveDecision(params: {
     return "not_recommended"
   }
 
+  if (isDryShampooNotRecommendedDecision(category, categoryDecision)) {
+    return "not_recommended"
+  }
+
   if (
     category === "shampoo" &&
     categoryDecision &&
@@ -2334,7 +2422,7 @@ function buildProductResponsePolicy(params: {
   categoryDecision: CategoryDecision | null
   routeContext?: SelectProductsRouteContext | null
 }): { product_response_policy: ProductResponsePolicy; policy_reason: string } {
-  const { category, decision, routeContext } = params
+  const { category, decision, categoryDecision, routeContext } = params
 
   if (decision === "needs_more_info") {
     return {
@@ -2348,6 +2436,22 @@ function buildProductResponsePolicy(params: {
       product_response_policy: "no_catalog_match",
       policy_reason:
         "Die Kategorie kann passen, aber der aktuelle Katalog liefert keinen sicheren Treffer.",
+    }
+  }
+
+  if (isDryShampooResetRedirectDecision(category, categoryDecision)) {
+    return {
+      product_response_policy: "redirect_to_better_lever",
+      policy_reason:
+        "Trockenshampoo-Nutzung oder Build-up spricht fuer Reduktion, Auswaschen und Reset-/Tiefenreinigungslogik statt fuer weiteres Trockenshampoo.",
+    }
+  }
+
+  if (isDryShampooCautionDecision(category, categoryDecision)) {
+    return {
+      product_response_policy: "caution_without_products",
+      policy_reason:
+        "Diese Trockenshampoo-Anfrage enthaelt Kopfhaut-, Haarbruch-, Aerosol-/Atemwegs- oder Kind-Kontext; deshalb keine Trockenshampoo-Produkte empfehlen.",
     }
   }
 
@@ -2452,6 +2556,30 @@ function buildCategoryGuidance(params: {
   routeContext?: SelectProductsRouteContext | null
 }): string {
   const { category, decision, categoryDecision, routeContext } = params
+
+  if (category === "dry_shampoo") {
+    if (isDryShampooResetRedirectDecision(category, categoryDecision)) {
+      return "Kein weiteres Trockenshampoo empfehlen: haeufige Nutzung oder belegte/coated Roots sollen in Reduktion, Auswaschen und Reset-/Tiefenreinigungslogik fuehren. Trockenshampoo reinigt die Kopfhaut nicht und sollte spaeter ausgewaschen werden."
+    }
+
+    if (isDryShampooCautionDecision(category, categoryDecision)) {
+      return "Trockenshampoo nicht als Produkt empfehlen: bei Juckreiz, Schuppen, gereizter oder schmerzender Kopfhaut, Haarverlust-/Bruchdominanz, Atem-/Aerosol-Caution oder Kind-Kontext guidance-only bleiben und zu Kopfhaut-, Shampoo- oder Reset-Einordnung umleiten. Trockenshampoo reinigt die Kopfhaut nicht und sollte spaeter ausgewaschen werden."
+    }
+
+    if (decision === "not_recommended") {
+      return "Trockenshampoo ist kein normaler Routinebaustein und hier kein guter Produkthebel. Es passt nur als konkrete kosmetische Between-Wash-Bruecke, nicht als Pflege, Behandlung oder Reinigung. Trockenshampoo reinigt die Kopfhaut nicht und sollte spaeter ausgewaschen werden."
+    }
+
+    if (decision === "needs_more_info") {
+      return "Fuer Trockenshampoo nur eine gezielte Rueckfrage stellen, wenn die kurze Between-Wash-Bruecke unklar ist. Nicht als Pflege, Behandlung oder Reinigung framen."
+    }
+
+    if (decision === "no_catalog_match") {
+      return "Trockenshampoo passt als kurze kosmetische Between-Wash-Bruecke, aber der aktuelle Katalog liefert keinen sicheren Treffer. Keine Produkte oder Ersatzprodukte wie Babypuder erfinden; trotzdem sagen, dass Trockenshampoo die Kopfhaut nicht reinigt und spaeter ausgewaschen werden sollte."
+    }
+
+    return "Trockenshampoo nur als kurze kosmetische Between-Wash-Bruecke am Ansatz framen, nicht als Pflege, Behandlung oder Reinigung. Immer sagen: Trockenshampoo reinigt die Kopfhaut nicht und sollte spaeter ausgewaschen werden."
+  }
 
   if (category === "shampoo") {
     if (isScalpSymptomShampooQuestion(category, routeContext)) {
@@ -2725,7 +2853,7 @@ async function runCategoryEngine(params: {
         runtime,
       })
     case "dry_shampoo":
-      return selectDryShampooProductsWithEngine({ message, hairProfile, routineItems })
+      return selectDryShampooProductsWithEngine({ message, hairProfile, routineItems, runtime })
     case "peeling":
       return selectPeelingProductsWithEngine({ message, hairProfile, routineItems })
     default:

--- a/src/lib/dry-shampoo/constants.ts
+++ b/src/lib/dry-shampoo/constants.ts
@@ -1,4 +1,9 @@
-import type { ProductScalpTypeFocus } from "@/lib/product-specs/constants"
+import type {
+  DryShampooFormat,
+  DryShampooHairColorFit,
+  DryShampooPrimaryEffect,
+  DryShampooScalpSensitivityFit,
+} from "@/lib/product-specs/constants"
 
 export const DRY_SHAMPOO_DB_CATEGORIES = [
   "Trockenshampoo",
@@ -7,11 +12,12 @@ export const DRY_SHAMPOO_DB_CATEGORIES = [
   "dry shampoo",
 ] as const
 
-export type DryShampooScalpTypeFocus = Exclude<ProductScalpTypeFocus, "dry">
-
 export interface ProductDryShampooSpecs {
   product_id: string
-  scalp_type_focus: DryShampooScalpTypeFocus
+  primary_effect: DryShampooPrimaryEffect
+  hair_color_fit: DryShampooHairColorFit
+  scalp_sensitivity_fit: DryShampooScalpSensitivityFit
+  format: DryShampooFormat
   created_at?: string
   updated_at?: string
 }

--- a/src/lib/product-specs/constants.ts
+++ b/src/lib/product-specs/constants.ts
@@ -96,3 +96,47 @@ export const PRODUCT_PEELING_TYPE_LABELS = {
   acid_serum: "Saeure-Serum",
   physical_scrub: "Physisches Scrub",
 } as const satisfies Record<ProductPeelingType, string>
+
+export const DRY_SHAMPOO_PRIMARY_EFFECTS = [
+  "classic_refresh",
+  "volume_texture",
+  "sensitive_refresh",
+] as const
+
+export type DryShampooPrimaryEffect = (typeof DRY_SHAMPOO_PRIMARY_EFFECTS)[number]
+
+export const DRY_SHAMPOO_PRIMARY_EFFECT_LABELS = {
+  classic_refresh: "Klassische Ansatz-Auffrischung",
+  volume_texture: "Volumen/Griff am Ansatz",
+  sensitive_refresh: "Sensitive Auffrischung",
+} as const satisfies Record<DryShampooPrimaryEffect, string>
+
+export const DRY_SHAMPOO_HAIR_COLOR_FITS = ["universal", "blonde_light", "brown", "dark"] as const
+
+export type DryShampooHairColorFit = (typeof DRY_SHAMPOO_HAIR_COLOR_FITS)[number]
+
+export const DRY_SHAMPOO_HAIR_COLOR_FIT_LABELS = {
+  universal: "Universell",
+  blonde_light: "Blond/hell",
+  brown: "Braun",
+  dark: "Dunkel",
+} as const satisfies Record<DryShampooHairColorFit, string>
+
+export const DRY_SHAMPOO_SCALP_SENSITIVITY_FITS = ["sensitive_ok", "normal_only"] as const
+
+export type DryShampooScalpSensitivityFit = (typeof DRY_SHAMPOO_SCALP_SENSITIVITY_FITS)[number]
+
+export const DRY_SHAMPOO_SCALP_SENSITIVITY_FIT_LABELS = {
+  sensitive_ok: "Auch fuer sensible Kopfhaut",
+  normal_only: "Nur normale Kopfhaut",
+} as const satisfies Record<DryShampooScalpSensitivityFit, string>
+
+export const DRY_SHAMPOO_FORMATS = ["aerosol_spray", "powder", "foam_or_liquid"] as const
+
+export type DryShampooFormat = (typeof DRY_SHAMPOO_FORMATS)[number]
+
+export const DRY_SHAMPOO_FORMAT_LABELS = {
+  aerosol_spray: "Aerosol-Spray",
+  powder: "Puder",
+  foam_or_liquid: "Schaum/Liquid",
+} as const satisfies Record<DryShampooFormat, string>

--- a/src/lib/rag/synthesizer.ts
+++ b/src/lib/rag/synthesizer.ts
@@ -586,8 +586,18 @@ function formatEngineCategoryDecision(
       parts.push(`- Reset-Bedarf: ${categoryDecision.targetProfile?.resetNeedLevel ?? "none"}`)
       break
     case "dry_shampoo":
-      if (categoryDecision.targetProfile?.scalpTypeFocus) {
-        parts.push(`- Kopfhaut-Fokus: ${categoryDecision.targetProfile.scalpTypeFocus}`)
+      if (categoryDecision.targetProfile) {
+        parts.push(
+          `- Rolle: Notfall-/Between-Wash-Bruecke, keine Kopfhautreinigung`,
+          `- Wirkung: ${categoryDecision.targetProfile.primaryEffectTarget}`,
+          `- Farbfit: ${categoryDecision.targetProfile.hairColorFitTarget}`,
+          `- Sensitivitaet erforderlich: ${
+            categoryDecision.targetProfile.requiresSensitiveFit ? "ja" : "nein"
+          }`,
+        )
+        if (categoryDecision.targetProfile.preferredFormat) {
+          parts.push(`- Formatpraeferenz: ${categoryDecision.targetProfile.preferredFormat}`)
+        }
       }
       break
     case "peeling":

--- a/src/lib/recommendation-engine/categories/dry-shampoo.ts
+++ b/src/lib/recommendation-engine/categories/dry-shampoo.ts
@@ -37,12 +37,8 @@ function profileHardNoReasons(profile: NormalizedProfile): string[] {
     reasons.push("dry_shampoo_scalp_issue_hard_no")
   }
 
-  if (profile.concerns.includes("hair_loss") || profile.concerns.includes("breakage")) {
-    reasons.push(
-      profile.concerns.includes("hair_loss")
-        ? "dry_shampoo_scalp_issue_hard_no"
-        : "dry_shampoo_dry_breakage_hard_no",
-    )
+  if (profile.concerns.includes("hair_loss")) {
+    reasons.push("dry_shampoo_scalp_issue_hard_no")
   }
 
   const currentUse = profile.routineInventory.dry_shampoo?.frequencyBand ?? null

--- a/src/lib/recommendation-engine/categories/dry-shampoo.ts
+++ b/src/lib/recommendation-engine/categories/dry-shampoo.ts
@@ -1,34 +1,115 @@
 import type {
   CategoryFitEvaluation,
   DryShampooCategoryDecision,
+  DryShampooTargetProfile,
   InterventionPlan,
   NormalizedProfile,
+  RecommendationRequestContext,
+  ResetAssessment,
 } from "@/lib/recommendation-engine/types"
-import { deriveScalpTypeFocus, getPlannedStep } from "@/lib/recommendation-engine/categories/shared"
+import { getPlannedStep, isFrequencyAtLeast } from "@/lib/recommendation-engine/categories/shared"
+import { emptyRecommendationRequestContext } from "@/lib/recommendation-engine/request-context"
 
 export interface DryShampooFitSpec {
-  scalp_type_focus: "oily" | "balanced" | null
+  primary_effect: DryShampooTargetProfile["primaryEffectTarget"] | null
+  hair_color_fit: DryShampooTargetProfile["hairColorFitTarget"] | null
+  scalp_sensitivity_fit: "sensitive_ok" | "normal_only" | null
+  format: NonNullable<DryShampooTargetProfile["preferredFormat"]> | null
+}
+
+const HARD_NO_REASONS = new Set([
+  "dry_shampoo_scalp_issue_hard_no",
+  "dry_shampoo_buildup_hard_no",
+  "dry_shampoo_frequent_use_reset_needed",
+  "dry_shampoo_dry_breakage_hard_no",
+  "dry_shampoo_respiratory_aerosol_caution",
+  "dry_shampoo_child_context_hard_no",
+])
+
+function profileHardNoReasons(profile: NormalizedProfile): string[] {
+  const reasons: string[] = []
+
+  if (
+    profile.scalpCondition === "irritated" ||
+    profile.scalpCondition === "dry_flakes" ||
+    profile.concerns.includes("dandruff")
+  ) {
+    reasons.push("dry_shampoo_scalp_issue_hard_no")
+  }
+
+  if (profile.concerns.includes("hair_loss") || profile.concerns.includes("breakage")) {
+    reasons.push(
+      profile.concerns.includes("hair_loss")
+        ? "dry_shampoo_scalp_issue_hard_no"
+        : "dry_shampoo_dry_breakage_hard_no",
+    )
+  }
+
+  const currentUse = profile.routineInventory.dry_shampoo?.frequencyBand ?? null
+  if (isFrequencyAtLeast(currentUse, "3_4x")) {
+    reasons.push("dry_shampoo_frequent_use_reset_needed")
+  }
+
+  return Array.from(new Set(reasons))
+}
+
+function hasResetHardNo(reset: ResetAssessment | null): boolean {
+  return (
+    reset?.triggers.includes("frequent_dry_shampoo_use") ||
+    reset?.triggers.includes("dry_shampoo_reset_pressure") ||
+    reset?.triggers.some(
+      (trigger) =>
+        trigger.includes("coated") ||
+        trigger.includes("buildup") ||
+        trigger.includes("waxy") ||
+        trigger.includes("product_buildup"),
+    ) === true
+  )
 }
 
 export function buildDryShampooCategoryDecision(
   profile: NormalizedProfile,
   plan: InterventionPlan,
+  requestContext: RecommendationRequestContext = emptyRecommendationRequestContext(),
+  reset: ResetAssessment | null = null,
 ): DryShampooCategoryDecision {
   const step = getPlannedStep(plan, "dry_shampoo")
+  const bridgeReasons = requestContext.dryShampooBridgeNeedReasonCodes ?? []
+  const requestCautions = requestContext.dryShampooCautionReasonCodes ?? []
+  const cautionReasons = Array.from(new Set([...requestCautions, ...profileHardNoReasons(profile)]))
+  const hardNo =
+    cautionReasons.some((reason) => HARD_NO_REASONS.has(reason)) || hasResetHardNo(reset)
+  const oilyScalpOnly =
+    bridgeReasons.length === 0 &&
+    (profile.scalpType === "oily" || profile.concerns.includes("oily_scalp"))
 
-  if (!step) {
+  if (!step || hardNo || bridgeReasons.length === 0) {
     return {
       category: "dry_shampoo",
       relevant: false,
-      action: null,
-      planReasonCodes: [],
+      action: step?.action ?? null,
+      planReasonCodes: step?.reasonCodes ?? [],
       currentInventory: profile.routineInventory.dry_shampoo,
       targetProfile: null,
-      notes: [],
+      notes: [
+        ...(oilyScalpOnly ? ["dry_shampoo_oily_scalp_alone_not_enough"] : []),
+        ...cautionReasons,
+        ...(hasResetHardNo(reset) ? ["dry_shampoo_frequent_use_reset_needed"] : []),
+      ],
     }
   }
 
-  const scalpTypeFocus = deriveScalpTypeFocus(profile)
+  const requiresSensitiveFit = requestContext.dryShampooRequiresSensitiveFit === true
+  const targetProfile: DryShampooTargetProfile = {
+    primaryEffectTarget:
+      requestContext.dryShampooPrimaryEffectRequest ??
+      (requiresSensitiveFit ? "sensitive_refresh" : "classic_refresh"),
+    hairColorFitTarget: requestContext.dryShampooHairColorFitRequest ?? "universal",
+    requiresSensitiveFit,
+    preferredFormat: requestContext.dryShampooPreferredFormat ?? null,
+    bridgeNeedReasonCodes: bridgeReasons,
+    cautionReasonCodes: cautionReasons,
+  }
 
   return {
     category: "dry_shampoo",
@@ -36,11 +117,18 @@ export function buildDryShampooCategoryDecision(
     action: step.action,
     planReasonCodes: step.reasonCodes,
     currentInventory: profile.routineInventory.dry_shampoo,
-    targetProfile: {
-      scalpTypeFocus: scalpTypeFocus === "dry" ? "balanced" : scalpTypeFocus,
-    },
-    notes: scalpTypeFocus === "dry" ? ["dry_shampoo_never_targets_dry_scalp"] : [],
+    targetProfile,
+    notes: cautionReasons,
   }
+}
+
+function isTintMismatch(
+  target: DryShampooTargetProfile["hairColorFitTarget"],
+  actual: DryShampooFitSpec["hair_color_fit"],
+): boolean {
+  if (!actual || actual === "universal" || target === "universal") return false
+  if (target === actual) return false
+  return true
 }
 
 export function evaluateDryShampooFit(
@@ -59,37 +147,66 @@ export function evaluateDryShampooFit(
     return {
       status: "unknown",
       reasonCodes: ["dry_shampoo_specs_missing"],
-      missingFields: ["scalp_type_focus"],
+      missingFields: ["primary_effect", "hair_color_fit", "scalp_sensitivity_fit", "format"],
     }
   }
 
-  if (!decision.targetProfile.scalpTypeFocus || !spec.scalp_type_focus) {
+  const target = decision.targetProfile
+  const missingFields = (
+    ["primary_effect", "hair_color_fit", "scalp_sensitivity_fit", "format"] as const
+  ).filter((field) => !spec[field])
+
+  if (missingFields.length > 0) {
     return {
       status: "unknown",
-      reasonCodes: ["dry_shampoo_fit_missing_scalp_focus"],
-      missingFields: ["scalp_type_focus"],
+      reasonCodes: ["dry_shampoo_specs_incomplete"],
+      missingFields,
     }
   }
 
-  if (decision.targetProfile.scalpTypeFocus === spec.scalp_type_focus) {
+  if (
+    isTintMismatch(target.hairColorFitTarget, spec.hair_color_fit) ||
+    (target.requiresSensitiveFit && spec.scalp_sensitivity_fit === "normal_only") ||
+    (target.cautionReasonCodes.includes("dry_shampoo_avoid_aerosol_format_request") &&
+      spec.format === "aerosol_spray")
+  ) {
     return {
-      status: "ideal",
-      reasonCodes: ["dry_shampoo_scalp_focus_exact_match"],
+      status: "mismatch",
+      reasonCodes: ["dry_shampoo_fit_hard_mismatch"],
       missingFields: [],
     }
   }
 
-  if (decision.targetProfile.scalpTypeFocus === "oily" && spec.scalp_type_focus === "balanced") {
+  const primaryExact = spec.primary_effect === target.primaryEffectTarget
+  const sensitiveBridge =
+    target.requiresSensitiveFit &&
+    target.primaryEffectTarget === "classic_refresh" &&
+    spec.primary_effect === "sensitive_refresh"
+  const colorFits =
+    spec.hair_color_fit === "universal" || spec.hair_color_fit === target.hairColorFitTarget
+  const sensitivityFits =
+    !target.requiresSensitiveFit || spec.scalp_sensitivity_fit === "sensitive_ok"
+  const formatFits = !target.preferredFormat || spec.format === target.preferredFormat
+
+  if ((primaryExact || sensitiveBridge) && colorFits && sensitivityFits && formatFits) {
+    return {
+      status: "ideal",
+      reasonCodes: ["dry_shampoo_fit_exact_match"],
+      missingFields: [],
+    }
+  }
+
+  if ((primaryExact || sensitiveBridge || spec.primary_effect === "classic_refresh") && colorFits) {
     return {
       status: "supportive",
-      reasonCodes: ["dry_shampoo_scalp_focus_close_match"],
+      reasonCodes: ["dry_shampoo_fit_supportive_match"],
       missingFields: [],
     }
   }
 
   return {
     status: "mismatch",
-    reasonCodes: ["dry_shampoo_scalp_focus_mismatch"],
+    reasonCodes: ["dry_shampoo_fit_mismatch"],
     missingFields: [],
   }
 }

--- a/src/lib/recommendation-engine/categories/index.ts
+++ b/src/lib/recommendation-engine/categories/index.ts
@@ -49,7 +49,7 @@ export function buildCategoryRecommendationSet(
       requestContext,
       resetAssessment,
     ),
-    dryShampoo: buildDryShampooCategoryDecision(profile, plan),
+    dryShampoo: buildDryShampooCategoryDecision(profile, plan, requestContext, resetAssessment),
     peeling: buildPeelingCategoryDecision(profile, damage, plan),
   }
 }

--- a/src/lib/recommendation-engine/planner/intervention.ts
+++ b/src/lib/recommendation-engine/planner/intervention.ts
@@ -5,16 +5,17 @@ import type {
   InterventionPlan,
   InterventionStep,
   NormalizedProfile,
+  RecommendationRequestContext,
   ResetAssessment,
 } from "@/lib/recommendation-engine/types"
 import { isExplicitNoneArray } from "@/lib/profile/signal-derivations"
 import {
   deriveBuildupResetNeed,
   getRoutineFrequencyBand,
-  hasBetweenWashBridgeNeed,
   hasScalpDrynessOrIrritationRisk,
   isFrequencyAtLeast,
 } from "@/lib/recommendation-engine/categories/shared"
+import { emptyRecommendationRequestContext } from "@/lib/recommendation-engine/request-context"
 
 function hasRoutineItem(
   profile: NormalizedProfile,
@@ -310,30 +311,47 @@ function buildDeepCleansingShampooSteps(
 function buildDryShampooSteps(
   profile: NormalizedProfile,
   damage: DamageAssessment,
+  requestContext: RecommendationRequestContext,
+  reset?: ResetAssessment,
 ): InterventionStep[] {
   const present = hasRoutineItem(profile, "dry_shampoo")
   const frequencyBand = getRoutineFrequencyBand(profile, "dry_shampoo")
-  const bridgeNeed = hasBetweenWashBridgeNeed(profile)
+  const bridgeReasonCodes = requestContext.dryShampooBridgeNeedReasonCodes ?? []
+  const cautionReasonCodes = requestContext.dryShampooCautionReasonCodes ?? []
+  const bridgeNeed = bridgeReasonCodes.length > 0
   const drynessRisk = hasScalpDrynessOrIrritationRisk(profile, damage)
+  const hardNoReasons = cautionReasonCodes.filter(
+    (reason) => reason !== "dry_shampoo_avoid_aerosol_format_request",
+  )
+  const resetPressure =
+    reset?.triggers.includes("frequent_dry_shampoo_use") ||
+    reset?.triggers.includes("dry_shampoo_reset_pressure") ||
+    cautionReasonCodes.includes("dry_shampoo_frequent_use_reset_needed")
+  const buildupPressure =
+    cautionReasonCodes.includes("dry_shampoo_buildup_hard_no") ||
+    reset?.triggers.some(
+      (trigger) =>
+        trigger.includes("coated") ||
+        trigger.includes("buildup") ||
+        trigger.includes("waxy") ||
+        trigger.includes("product_buildup"),
+    )
 
-  if (present && (drynessRisk || isFrequencyAtLeast(frequencyBand, "5_6x"))) {
+  if (present && (drynessRisk || resetPressure || isFrequencyAtLeast(frequencyBand, "5_6x"))) {
     return [
       {
         category: "dry_shampoo",
         action: "decrease_frequency",
-        reasonCodes: ["dry_shampoo_overuse_risk"],
+        reasonCodes: ["dry_shampoo_overuse_risk", ...cautionReasonCodes],
       },
     ]
   }
 
-  if (!bridgeNeed) {
+  if (!bridgeNeed || hardNoReasons.length > 0 || buildupPressure || resetPressure) {
     return []
   }
 
-  const reasonCodes = ["between_wash_bridge_needed"]
-  if (profile.scalpType === "oily" || profile.concerns.includes("oily_scalp")) {
-    reasonCodes.push("oily_scalp_between_wash_support")
-  }
+  const reasonCodes = bridgeReasonCodes
 
   if (!present) {
     return [
@@ -439,6 +457,7 @@ export function buildInterventionPlan(
   damage: DamageAssessment,
   careNeeds: CareNeedAssessment,
   reset?: ResetAssessment,
+  requestContext: RecommendationRequestContext = emptyRecommendationRequestContext(),
 ): InterventionPlan {
   const steps: InterventionStep[] = []
   const deferredSteps: InterventionStep[] = []
@@ -472,7 +491,7 @@ export function buildInterventionPlan(
   steps.push(...buildMaskSteps(profile, damage))
   steps.push(...buildLeaveInSteps(profile, damage, careNeeds))
   steps.push(...buildDeepCleansingShampooSteps(profile, damage, reset))
-  steps.push(...buildDryShampooSteps(profile, damage))
+  steps.push(...buildDryShampooSteps(profile, damage, requestContext, reset))
   steps.push(...buildPeelingSteps(profile, damage))
 
   const bondBuilderPlan = buildBondBuilderPlan(profile, damage)

--- a/src/lib/recommendation-engine/request-context.ts
+++ b/src/lib/recommendation-engine/request-context.ts
@@ -22,6 +22,13 @@ export function emptyRecommendationRequestContext(): RecommendationRequestContex
     leaveInRequestedFormats: [],
     oilPurpose: null,
     oilNoRecommendationReason: null,
+    dryShampooBridgeNeedReasonCodes: [],
+    dryShampooCautionReasonCodes: [],
+    dryShampooPrimaryEffectRequest: null,
+    dryShampooHairColorFitRequest: null,
+    dryShampooRequiresSensitiveFit: false,
+    dryShampooPreferredFormat: null,
+    dryShampooAvoidAerosol: false,
   }
 }
 
@@ -214,6 +221,154 @@ function inferLeaveInSeparateHeatProtectantMentionedFromMessage(message: string)
   )
 }
 
+function inferDryShampooSignalsFromMessage(message: string): {
+  bridgeNeedReasonCodes: string[]
+  cautionReasonCodes: string[]
+  primaryEffectRequest: RecommendationRequestContext["dryShampooPrimaryEffectRequest"]
+  hairColorFitRequest: RecommendationRequestContext["dryShampooHairColorFitRequest"]
+  requiresSensitiveFit: boolean
+  preferredFormat: RecommendationRequestContext["dryShampooPreferredFormat"]
+  avoidAerosol: boolean
+} {
+  const normalized = normalizeMessage(message)
+  const bridge = new Set<string>()
+  const caution = new Set<string>()
+
+  const mentionsDryShampoo =
+    /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/.test(normalized)
+  const cannotWashToday =
+    /\b(?:kann|schaffe|geht)\b.{0,50}\b(?:heute|jetzt|gerade)\b.{0,50}\b(?:nicht\s+)?wasch\w*\b|\bkeine\s+zeit\b.{0,50}\bwasch\w*\b/.test(
+      normalized,
+    )
+  const betweenWash =
+    /\bbetween[-\s]?wash\b|\bzwischen\s+(?:den\s+)?waeschen\b|\bzwischen\s+(?:den\s+)?waschen\b|\btag\s*2\b|\bday\s*2\b|\bzweiter\s+tag\b|\bauffrisch\w*\b|\brefresh\w*\b|\bansatz\b.{0,40}\bfettig\w*\b|\bfettig\w*\b.{0,40}\bansatz\b/.test(
+      normalized,
+    )
+  const emergency =
+    /\bnotfall\w*\b|\bemergency\b|\blast[-\s]?minute\b|\bkurzfristig\w*\b|\bschnell\w*\b|\breise\w*\b|\bunterwegs\b/.test(
+      normalized,
+    )
+  const postWorkout = /\bsport\b|\bworkout\b|\btraining\b|\bgeschwitzt\w*\b/.test(normalized)
+  const volumeTexture =
+    /\bvolumen\b|\bgrip\b|\bgriff\b|\btextur\w*\b|\bstand\b.{0,30}\bansatz\b|\bansatzvolumen\b/.test(
+      normalized,
+    )
+  const colorCast =
+    /\bweiss(?:er|e|en)?\s+schleier\b|\bwhite\s*cast\b|\bgrau(?:er|e|en)?\s+schleier\b|\brueckstaend\w*\b|\bruckstaend\w*\b/.test(
+      normalized,
+    )
+  const routineNeedQuestion =
+    /\b(?:routine|aufnehmen|einbauen|brauche\s+ich|sollte\s+ich|soll\s+ich)\b/.test(normalized)
+  const directDryShampooProductAsk =
+    mentionsDryShampoo &&
+    !routineNeedQuestion &&
+    /\b(?:welch\w*|empfiehl\w*|empfehl\w*|passt|nehmen|kaufen)\b/.test(normalized)
+
+  if (directDryShampooProductAsk) bridge.add("dry_shampoo_explicit_bridge_request")
+  if (betweenWash || cannotWashToday) bridge.add("dry_shampoo_between_wash_bridge_needed")
+  if (cannotWashToday || emergency) bridge.add("dry_shampoo_emergency_refresh")
+  if (postWorkout) bridge.add("dry_shampoo_post_workout_refresh")
+  if (volumeTexture) bridge.add("dry_shampoo_volume_texture_request")
+  if (colorCast) bridge.add("dry_shampoo_color_cast_concern")
+
+  if (
+    /\bjuck\w*\b|\bjuckreiz\b|\bschuppen\b|\bschupp\w*\b|\bgereizt\w*\b|\birrit\w*\b|\bbrenn\w*\b|\bschmerz\w*\b|\bwund\w*\b|\bpickel\w*\b|\bbeulen\w*\b|\bakne\b|\bhaarausfall\b|\bshedding\b/.test(
+      normalized,
+    )
+  ) {
+    caution.add("dry_shampoo_scalp_issue_hard_no")
+  }
+
+  if (
+    /\bbelegt\w*\b|\bwachsig\w*\b|\bklebrig\w*\b|\bproduktig\w*\b|\bbuildup\b|\bbuild[-\s]?up\b|\bablager\w*\b/.test(
+      normalized,
+    )
+  ) {
+    caution.add("dry_shampoo_buildup_hard_no")
+  }
+
+  const frequentDryShampooUse =
+    /\b(?:jeden|fast\s+jeden|taeglich|taglich)\s+tag\b.{0,60}\btrockenshampoo\b|\btrockenshampoo\b.{0,60}\b(?:jeden|fast\s+jeden|taeglich|taglich)\s+tag\b/.test(
+      normalized,
+    ) ||
+    (mentionsDryShampoo &&
+      (/\b(?:3|4|drei|vier)\s*(?:-|bis)?\s*(?:4|vier)?\s*x\b.{0,30}\b(?:pro\s+)?woche\b/.test(
+        normalized,
+      ) ||
+        /\bmehrmals\b.{0,20}\b(?:pro\s+)?woche\b/.test(normalized) ||
+        /\b(?:alle\s+paar|alle\s+2|alle\s+zwei)\s+tage\b/.test(normalized) ||
+        /\b(?:3|4|drei|vier)\s*mal\b.{0,30}\b(?:pro\s+)?woche\b/.test(normalized)))
+
+  if (frequentDryShampooUse) {
+    caution.add("dry_shampoo_frequent_use_reset_needed")
+  }
+
+  const normalizedWithoutDryShampooTerms = normalized.replace(
+    /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/g,
+    " ",
+  )
+
+  if (
+    /\bbruch\w*\b|\bbruechig\w*\b|\bbruchig\w*\b|\bsproede\w*\b|\btrocken(?:e|er|es|en|em)?\b/.test(
+      normalizedWithoutDryShampooTerms,
+    )
+  ) {
+    caution.add("dry_shampoo_dry_breakage_hard_no")
+  }
+
+  const avoidAerosol =
+    /\bkein(?:e|en)?\s+(?:spray|aerosol)\b|\bohne\s+(?:spray|aerosol)\b|\bnicht\s+sprueh\w*\b|\bnicht\s+spruh\w*\b|\baerosol\b.{0,30}\b(?:meiden|vermeiden)\b/.test(
+      normalized,
+    )
+
+  if (avoidAerosol) {
+    caution.add("dry_shampoo_avoid_aerosol_format_request")
+  }
+
+  if (
+    /\basthma\b|\batem\w*\b|\blunge\w*\b|\binhalier\w*\b|\bduftstoff\w*\b|\ballerg\w*\b/.test(
+      normalized,
+    )
+  ) {
+    caution.add("dry_shampoo_respiratory_aerosol_caution")
+  }
+
+  if (/\bkind\b|\bkleinkind\b|\bbaby\b/.test(normalized)) {
+    caution.add("dry_shampoo_child_context_hard_no")
+  }
+
+  let hairColorFitRequest: RecommendationRequestContext["dryShampooHairColorFitRequest"] = null
+  if (/\bblond\w*\b|\bhell\w*\b/.test(normalized)) hairColorFitRequest = "blonde_light"
+  if (/\bbraun\w*\b|\bbruenett\w*\b|\bbrunett\w*\b/.test(normalized)) hairColorFitRequest = "brown"
+  if (/\bdunkel\w*\b|\bschwarz\w*\b/.test(normalized)) hairColorFitRequest = "dark"
+  if (!hairColorFitRequest && colorCast) hairColorFitRequest = "universal"
+
+  const sensitive = /\bsensibel\w*\b|\bempfindlich\w*\b|\bsensitive\b/.test(normalized)
+  const preferredFormat = avoidAerosol
+    ? "foam_or_liquid"
+    : /\bpuder\b|\bpowder\b/.test(normalized)
+      ? "powder"
+      : /\bschaum\b|\bfoam\b|\bliquid\b|\bfluessig\w*\b|\bflussig\w*\b/.test(normalized)
+        ? "foam_or_liquid"
+        : null
+
+  return {
+    bridgeNeedReasonCodes: Array.from(bridge),
+    cautionReasonCodes: Array.from(caution),
+    primaryEffectRequest: volumeTexture
+      ? "volume_texture"
+      : sensitive
+        ? "sensitive_refresh"
+        : mentionsDryShampoo || betweenWash || cannotWashToday || emergency || postWorkout
+          ? "classic_refresh"
+          : null,
+    hairColorFitRequest,
+    requiresSensitiveFit: sensitive,
+    preferredFormat,
+    avoidAerosol,
+  }
+}
+
 export function buildRecommendationRequestContext(params: {
   requestedCategory: EngineCategoryId | null
   message: string
@@ -232,6 +387,7 @@ export function buildRecommendationRequestContext(params: {
     requestedCategory === "deep_cleansing_shampoo" || requestedCategory === "routine"
       ? inferResetSignalsFromMessage(message)
       : inferResetSignalsFromMessage(message)
+  const dryShampooSignals = inferDryShampooSignalsFromMessage(message)
 
   return {
     requestedCategory,
@@ -263,5 +419,12 @@ export function buildRecommendationRequestContext(params: {
       requestedCategory === "oil" || requestedCategory === "routine"
         ? inferOilNoRecommendationReason(oilPurpose, message)
         : null,
+    dryShampooBridgeNeedReasonCodes: dryShampooSignals.bridgeNeedReasonCodes,
+    dryShampooCautionReasonCodes: dryShampooSignals.cautionReasonCodes,
+    dryShampooPrimaryEffectRequest: dryShampooSignals.primaryEffectRequest,
+    dryShampooHairColorFitRequest: dryShampooSignals.hairColorFitRequest,
+    dryShampooRequiresSensitiveFit: dryShampooSignals.requiresSensitiveFit,
+    dryShampooPreferredFormat: dryShampooSignals.preferredFormat,
+    dryShampooAvoidAerosol: dryShampooSignals.avoidAerosol,
   }
 }

--- a/src/lib/recommendation-engine/request-context.ts
+++ b/src/lib/recommendation-engine/request-context.ts
@@ -320,12 +320,16 @@ function inferDryShampooSignalsFromMessage(message: string): {
     /\btrockenshampoo\w*\b|\btrocken[-\s]*shampoo\w*\b|\bdry[-\s]*shampoo\w*\b/g,
     " ",
   )
-
-  if (
-    /\bbruch\w*\b|\bbruechig\w*\b|\bbruchig\w*\b|\bsproede\w*\b|\btrocken(?:e|er|es|en|em)?\b/.test(
+  const breakageDominant =
+    /\bbruch\w*\b|\bbruechig\w*\b|\bbruchig\w*\b|\bsproede\w*\b|\bsprode\w*\b|\bbrech(?:e|en|t)?\w*\b|\bbricht\b/.test(
       normalizedWithoutDryShampooTerms,
     )
-  ) {
+  const dryBrittleCombo =
+    /\btrocken(?:e|er|es|en|em)?\b.{0,60}\b(?:bruch\w*|bruechig\w*|bruchig\w*|sproede\w*|sprode\w*|brech\w*|bricht)\b|\b(?:bruch\w*|bruechig\w*|bruchig\w*|sproede\w*|sprode\w*|brech\w*|bricht)\b.{0,60}\btrocken(?:e|er|es|en|em)?\b/.test(
+      normalizedWithoutDryShampooTerms,
+    )
+
+  if (breakageDominant || dryBrittleCombo) {
     caution.add("dry_shampoo_dry_breakage_hard_no")
   }
 

--- a/src/lib/recommendation-engine/request-context.ts
+++ b/src/lib/recommendation-engine/request-context.ts
@@ -240,15 +240,28 @@ function inferDryShampooSignalsFromMessage(message: string): {
     /\b(?:kann|schaffe|geht)\b.{0,50}\b(?:heute|jetzt|gerade)\b.{0,50}\b(?:nicht\s+)?wasch\w*\b|\bkeine\s+zeit\b.{0,50}\bwasch\w*\b/.test(
       normalized,
     )
-  const betweenWash =
-    /\bbetween[-\s]?wash\b|\bzwischen\s+(?:den\s+)?waeschen\b|\bzwischen\s+(?:den\s+)?waschen\b|\btag\s*2\b|\bday\s*2\b|\bzweiter\s+tag\b|\bauffrisch\w*\b|\brefresh\w*\b|\bansatz\b.{0,40}\bfettig\w*\b|\bfettig\w*\b.{0,40}\bansatz\b/.test(
+  const explicitBetweenWash =
+    /\bbetween[-\s]?wash\b|\bzwischen\s+(?:den\s+)?waeschen\b|\bzwischen\s+(?:den\s+)?waschen\b|\btag\s*2\b|\bday\s*2\b|\bzweiter\s+tag\b/.test(
       normalized,
     )
   const emergency =
-    /\bnotfall\w*\b|\bemergency\b|\blast[-\s]?minute\b|\bkurzfristig\w*\b|\bschnell\w*\b|\breise\w*\b|\bunterwegs\b/.test(
+    /\bnotfall\w*\b|\bemergency\b|\blast[-\s]?minute\b|\bkurzfristig\w*\b|\breise\w*\b|\bunterwegs\b/.test(
       normalized,
     )
+  const sameDay = /\b(?:heute|jetzt|gerade)\b/.test(normalized)
   const postWorkout = /\bsport\b|\bworkout\b|\btraining\b|\bgeschwitzt\w*\b/.test(normalized)
+  const rootRefresh =
+    /\bauffrisch\w*\b|\brefresh\w*\b/.test(normalized) && /\bansatz\b/.test(normalized)
+  const greasyRoot = /\bansatz\b.{0,40}\bfettig\w*\b|\bfettig\w*\b.{0,40}\bansatz\b/.test(
+    normalized,
+  )
+  const hasDryShampooBridgeContext =
+    mentionsDryShampoo || explicitBetweenWash || cannotWashToday || emergency || postWorkout
+  const betweenWash =
+    explicitBetweenWash ||
+    cannotWashToday ||
+    (rootRefresh && (hasDryShampooBridgeContext || sameDay)) ||
+    (greasyRoot && hasDryShampooBridgeContext)
   const volumeTexture =
     /\bvolumen\b|\bgrip\b|\bgriff\b|\btextur\w*\b|\bstand\b.{0,30}\bansatz\b|\bansatzvolumen\b/.test(
       normalized,

--- a/src/lib/recommendation-engine/runtime.ts
+++ b/src/lib/recommendation-engine/runtime.ts
@@ -43,7 +43,7 @@ export function buildRecommendationEngineRuntimeFromPersistence(
   const damage = buildDamageAssessment(normalized)
   const careNeeds = buildCareNeedAssessment(normalized, damage)
   const reset = buildResetAssessment(normalized, requestContext)
-  const plan = buildInterventionPlan(normalized, damage, careNeeds, reset)
+  const plan = buildInterventionPlan(normalized, damage, careNeeds, reset, requestContext)
   const categories = buildCategoryRecommendationSet(
     normalized,
     damage,

--- a/src/lib/recommendation-engine/selection.ts
+++ b/src/lib/recommendation-engine/selection.ts
@@ -66,6 +66,7 @@ import { buildRecommendationRequestContext } from "@/lib/recommendation-engine/r
 import type {
   BondbuilderCategoryDecision,
   CategoryFitEvaluation,
+  CategoryFitStatus,
   ConditionerCategoryDecision,
   DeepCleansingShampooCategoryDecision,
   DryShampooCategoryDecision,
@@ -82,6 +83,7 @@ const CANDIDATE_COUNT = 10
 
 type ScoredEngineProduct = MatchedProduct & {
   _engineScore: number
+  _fitStatus?: CategoryFitStatus
 }
 
 interface ProductRelationshipRow {
@@ -465,7 +467,7 @@ function markConditionerFallback(product: ScoredConditionerProduct): ScoredCondi
 
 function buildConditionerFallbackTradeoff(meta: ConditionerRecommendationMetadata): string {
   if (meta.fit_status === "unknown") {
-    return "Fallback: Dieser Conditioner hat noch unvollstaendige strukturierte Fit-Daten und erscheint nur, weil nicht genug sichere Treffer verfuegbar sind."
+    return "Hinweis: Zu diesem Conditioner fehlen noch einzelne sichere Produktangaben. Er erscheint nur, weil nicht genug sehr sichere Treffer verfuegbar sind."
   }
 
   return "Fallback: Dieser Conditioner weicht beim abgeleiteten Conditioner-Fit sichtbar ab und erscheint nur, weil nicht genug sichere Treffer verfuegbar sind."
@@ -1070,7 +1072,7 @@ export function rerankDeepCleansingShampooProductsWithEngine(params: {
 }
 
 function buildDryShampooUsageHint(): string {
-  return "Nur als Between-Wash-Bruecke sparsam am Ansatz einsetzen und nicht als Ersatz fuer regulaeres Waschen mit Wasser nutzen."
+  return "Nur als kurze Between-Wash-Bruecke am Ansatz verwenden, spaeter auswaschen und nicht als Ersatz fuer Shampoo/Wasser nutzen."
 }
 
 export function rerankDryShampooProductsWithEngine(params: {
@@ -1088,12 +1090,20 @@ export function rerankDryShampooProductsWithEngine(params: {
     const fit = evaluateDryShampooFit(decision, spec as DryShampooFitSpec | null)
     const { positives, tradeoffs } = buildFitSummary(
       fit,
-      "Passt sehr gut zum geplanten Between-Wash-Kopfhaut-Fokus.",
-      "Passt weitgehend zum Between-Wash-Bedarf.",
+      "Passt sehr gut zur Notfall-/Between-Wash-Bruecke.",
+      "Passt weitgehend zum kurzen Ansatz-Refresh.",
       "Die Trockenshampoo-Spezifikation ist noch nicht vollstaendig genug fuer eine sichere Idealeinstufung.",
-      "Weicht beim Kopfhaut-Fokus zu deutlich vom Between-Wash-Bedarf ab.",
+      "Weicht bei Effekt, Farbfit, Sensitivitaet oder Format zu deutlich vom Bedarf ab.",
     )
-    const score = toBaseScore(product) + fitStatusAdjustment(fit.status) + fitReasonAdjustment(fit)
+    const score =
+      toBaseScore(product) +
+      fitStatusAdjustment(fit.status) +
+      fitReasonAdjustment(fit) +
+      (spec?.primary_effect === target.primaryEffectTarget ? 16 : 0) +
+      (spec?.hair_color_fit === target.hairColorFitTarget ? 12 : 0) +
+      (spec?.hair_color_fit === "universal" ? 6 : 0) +
+      (target.requiresSensitiveFit && spec?.scalp_sensitivity_fit === "sensitive_ok" ? 14 : 0) +
+      (target.preferredFormat && spec?.format === target.preferredFormat ? 10 : 0)
 
     const recommendationMeta: DryShampooRecommendationMetadata = {
       category: "dry_shampoo",
@@ -1101,7 +1111,11 @@ export function rerankDryShampooProductsWithEngine(params: {
       top_reasons: positives.slice(0, 3),
       tradeoffs,
       usage_hint: buildDryShampooUsageHint(),
-      scalp_type_focus: target.scalpTypeFocus,
+      primary_effect: spec?.primary_effect ?? target.primaryEffectTarget,
+      hair_color_fit: spec?.hair_color_fit ?? target.hairColorFitTarget,
+      scalp_sensitivity_fit: spec?.scalp_sensitivity_fit ?? null,
+      format: spec?.format ?? target.preferredFormat,
+      fit_status: fit.status,
     }
 
     return {
@@ -1109,11 +1123,13 @@ export function rerankDryShampooProductsWithEngine(params: {
       dry_shampoo_specs: spec,
       recommendation_meta: recommendationMeta,
       _engineScore: score,
+      _fitStatus: fit.status,
     }
   })
 
   scored.sort(compareScoredProducts)
-  return stripScore(scored).slice(0, SELECTION_LIMIT)
+  const acceptable = scored.filter((product) => product._fitStatus !== "mismatch")
+  return stripScore(acceptable).slice(0, SELECTION_LIMIT)
 }
 
 function buildPeelingUsageHint(decision: PeelingCategoryDecision): string {
@@ -1670,7 +1686,14 @@ export async function selectConditionerProductsWithEngine(params: {
   routineItems: PersistenceRoutineItemRow[]
 }): Promise<MatchedProduct[]> {
   const { message, hairProfile, routineItems } = params
-  const runtime = buildRecommendationEngineRuntimeFromPersistence(hairProfile, routineItems)
+  const runtime = buildRecommendationEngineRuntimeFromPersistence(
+    hairProfile,
+    routineItems,
+    buildRecommendationRequestContext({
+      requestedCategory: "conditioner",
+      message,
+    }),
+  )
   const decision = runtime.categories.conditioner
   if (!decision.relevant || !decision.targetProfile) return []
 
@@ -1728,7 +1751,14 @@ export async function selectShampooProductsWithEngine(params: {
   routineItems: PersistenceRoutineItemRow[]
 }): Promise<MatchedProduct[]> {
   const { message, hairProfile, routineItems } = params
-  const runtime = buildRecommendationEngineRuntimeFromPersistence(hairProfile, routineItems)
+  const runtime = buildRecommendationEngineRuntimeFromPersistence(
+    hairProfile,
+    routineItems,
+    buildRecommendationRequestContext({
+      requestedCategory: "shampoo",
+      message,
+    }),
+  )
   const decision = runtime.categories.shampoo
   if (!decision.relevant || !decision.targetProfile?.shampooBucket || !hairProfile?.thickness) {
     return []
@@ -2227,9 +2257,19 @@ export async function selectDryShampooProductsWithEngine(params: {
   message: string
   hairProfile: HairProfile | null
   routineItems: PersistenceRoutineItemRow[]
+  runtime?: RecommendationEngineRuntime
 }): Promise<MatchedProduct[]> {
-  const { message, hairProfile, routineItems } = params
-  const runtime = buildRecommendationEngineRuntimeFromPersistence(hairProfile, routineItems)
+  const { message, hairProfile, routineItems, runtime: providedRuntime } = params
+  const runtime =
+    providedRuntime ??
+    buildRecommendationEngineRuntimeFromPersistence(
+      hairProfile,
+      routineItems,
+      buildRecommendationRequestContext({
+        requestedCategory: "dry_shampoo",
+        message,
+      }),
+    )
   const decision = runtime.categories.dryShampoo
   if (!decision.relevant || !decision.targetProfile) return []
 

--- a/src/lib/recommendation-engine/types.ts
+++ b/src/lib/recommendation-engine/types.ts
@@ -23,6 +23,11 @@ import type { ShampooBucket } from "@/lib/shampoo/constants"
 import type { OilNoRecommendationReason, OilPurpose, OilSubtype } from "@/lib/oil/constants"
 import type { LeaveInFormat } from "@/lib/leave-in/constants"
 import type {
+  DryShampooFormat,
+  DryShampooHairColorFit,
+  DryShampooPrimaryEffect,
+} from "@/lib/product-specs/constants"
+import type {
   BALANCE_DIRECTIONS,
   BOND_APPLICATION_MODES,
   BOND_BUILDER_PRIORITIES,
@@ -89,6 +94,13 @@ export interface RecommendationRequestContext {
   leaveInRequestedFormats: LeaveInFormat[]
   oilPurpose: OilPurpose | null
   oilNoRecommendationReason: OilNoRecommendationReason | null
+  dryShampooBridgeNeedReasonCodes?: string[]
+  dryShampooCautionReasonCodes?: string[]
+  dryShampooPrimaryEffectRequest?: DryShampooPrimaryEffect | null
+  dryShampooHairColorFitRequest?: DryShampooHairColorFit | null
+  dryShampooRequiresSensitiveFit?: boolean
+  dryShampooPreferredFormat?: DryShampooFormat | null
+  dryShampooAvoidAerosol?: boolean
 }
 
 export interface RawRoutineInventoryItem {
@@ -335,7 +347,12 @@ export type DeepCleansingShampooCategoryDecision = CategoryDecisionBase<
 >
 
 export interface DryShampooTargetProfile {
-  scalpTypeFocus: Exclude<ScalpTypeFocus, "dry"> | null
+  primaryEffectTarget: DryShampooPrimaryEffect
+  hairColorFitTarget: DryShampooHairColorFit
+  requiresSensitiveFit: boolean
+  preferredFormat: DryShampooFormat | null
+  bridgeNeedReasonCodes: string[]
+  cautionReasonCodes: string[]
 }
 
 export type DryShampooCategoryDecision = CategoryDecisionBase<

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,10 @@ import type {
   ProductBondRepairIntensity,
   ProductBondTreatmentMode,
   ProductBondUsageProtocol,
+  DryShampooFormat,
+  DryShampooHairColorFit,
+  DryShampooPrimaryEffect,
+  DryShampooScalpSensitivityFit,
   ProductPeelingType,
   ProductScalpTypeFocus,
 } from "@/lib/product-specs/constants"
@@ -451,7 +455,11 @@ export interface DeepCleansingShampooRecommendationMetadata extends BaseRecommen
 
 export interface DryShampooRecommendationMetadata extends BaseRecommendationMetadata {
   category: "dry_shampoo"
-  scalp_type_focus: Exclude<ProductScalpTypeFocus, "dry"> | null
+  primary_effect: DryShampooPrimaryEffect | null
+  hair_color_fit: DryShampooHairColorFit | null
+  scalp_sensitivity_fit: DryShampooScalpSensitivityFit | null
+  format: DryShampooFormat | null
+  fit_status?: "ideal" | "supportive" | "mismatch" | "unknown" | "not_applicable"
 }
 
 export interface PeelingRecommendationMetadata extends BaseRecommendationMetadata {

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -32,6 +32,10 @@ import { MASK_WEIGHTS, MASK_CONCENTRATIONS, isMaskCategory } from "@/lib/mask/co
 import { OIL_SUBTYPES, isOilCategory } from "@/lib/oil/constants"
 import { isPeelingCategory } from "@/lib/peeling/constants"
 import {
+  DRY_SHAMPOO_FORMATS,
+  DRY_SHAMPOO_HAIR_COLOR_FITS,
+  DRY_SHAMPOO_PRIMARY_EFFECTS,
+  DRY_SHAMPOO_SCALP_SENSITIVITY_FITS,
   PRODUCT_BALANCE_TARGETS,
   PRODUCT_BOND_APPLICATION_MODES,
   PRODUCT_BOND_PRODUCT_FORMATS,
@@ -104,7 +108,10 @@ const deepCleansingShampooSpecsSchema = z.object({
 })
 
 const dryShampooSpecsSchema = z.object({
-  scalp_type_focus: z.enum(["oily", "balanced"] as const),
+  primary_effect: z.enum(DRY_SHAMPOO_PRIMARY_EFFECTS),
+  hair_color_fit: z.enum(DRY_SHAMPOO_HAIR_COLOR_FITS),
+  scalp_sensitivity_fit: z.enum(DRY_SHAMPOO_SCALP_SENSITIVITY_FITS),
+  format: z.enum(DRY_SHAMPOO_FORMATS),
 })
 
 const peelingSpecsSchema = z.object({

--- a/supabase/migrations/20260504121000_expand_dry_shampoo_specs.sql
+++ b/supabase/migrations/20260504121000_expand_dry_shampoo_specs.sql
@@ -1,0 +1,55 @@
+ALTER TABLE public.product_dry_shampoo_specs
+  ADD COLUMN IF NOT EXISTS primary_effect text,
+  ADD COLUMN IF NOT EXISTS hair_color_fit text,
+  ADD COLUMN IF NOT EXISTS scalp_sensitivity_fit text,
+  ADD COLUMN IF NOT EXISTS format text;
+
+UPDATE public.product_dry_shampoo_specs
+SET
+  primary_effect = COALESCE(primary_effect, 'classic_refresh'),
+  hair_color_fit = COALESCE(hair_color_fit, 'universal'),
+  scalp_sensitivity_fit = COALESCE(scalp_sensitivity_fit, 'normal_only'),
+  format = COALESCE(format, 'aerosol_spray');
+
+ALTER TABLE public.product_dry_shampoo_specs
+  ALTER COLUMN primary_effect SET NOT NULL,
+  ALTER COLUMN hair_color_fit SET NOT NULL,
+  ALTER COLUMN scalp_sensitivity_fit SET NOT NULL,
+  ALTER COLUMN format SET NOT NULL;
+
+ALTER TABLE public.product_dry_shampoo_specs
+  DROP CONSTRAINT IF EXISTS product_dry_shampoo_specs_primary_effect_check,
+  DROP CONSTRAINT IF EXISTS product_dry_shampoo_specs_hair_color_fit_check,
+  DROP CONSTRAINT IF EXISTS product_dry_shampoo_specs_scalp_sensitivity_fit_check,
+  DROP CONSTRAINT IF EXISTS product_dry_shampoo_specs_format_check;
+
+ALTER TABLE public.product_dry_shampoo_specs
+  ADD CONSTRAINT product_dry_shampoo_specs_primary_effect_check CHECK (
+    primary_effect IN ('classic_refresh', 'volume_texture', 'sensitive_refresh')
+  ),
+  ADD CONSTRAINT product_dry_shampoo_specs_hair_color_fit_check CHECK (
+    hair_color_fit IN ('universal', 'blonde_light', 'brown', 'dark')
+  ),
+  ADD CONSTRAINT product_dry_shampoo_specs_scalp_sensitivity_fit_check CHECK (
+    scalp_sensitivity_fit IN ('sensitive_ok', 'normal_only')
+  ),
+  ADD CONSTRAINT product_dry_shampoo_specs_format_check CHECK (
+    format IN ('aerosol_spray', 'powder', 'foam_or_liquid')
+  );
+
+DROP INDEX IF EXISTS public.idx_product_dry_shampoo_specs_scalp_type_focus;
+
+ALTER TABLE public.product_dry_shampoo_specs
+  DROP COLUMN IF EXISTS scalp_type_focus;
+
+CREATE INDEX IF NOT EXISTS idx_product_dry_shampoo_specs_primary_effect
+  ON public.product_dry_shampoo_specs (primary_effect);
+
+CREATE INDEX IF NOT EXISTS idx_product_dry_shampoo_specs_hair_color_fit
+  ON public.product_dry_shampoo_specs (hair_color_fit);
+
+CREATE INDEX IF NOT EXISTS idx_product_dry_shampoo_specs_scalp_sensitivity_fit
+  ON public.product_dry_shampoo_specs (scalp_sensitivity_fit);
+
+CREATE INDEX IF NOT EXISTS idx_product_dry_shampoo_specs_format
+  ON public.product_dry_shampoo_specs (format);

--- a/tests/admin-product-support-specs.test.ts
+++ b/tests/admin-product-support-specs.test.ts
@@ -83,12 +83,15 @@ test("product schema requires deep-cleansing specs for deep-cleansing products",
   assert.ok(parsed.error.flatten().fieldErrors.deep_cleansing_shampoo_specs)
 })
 
-test("product schema restricts dry shampoo scalp focus to oily or balanced", () => {
+test("product schema restricts dry shampoo to supported bridge spec fields", () => {
   const parsed = productSchema.safeParse(
     buildBaseProduct({
       category: "Trockenshampoo",
       dry_shampoo_specs: {
-        scalp_type_focus: "dry",
+        primary_effect: "deep_cleanse",
+        hair_color_fit: "universal",
+        scalp_sensitivity_fit: "normal_only",
+        format: "aerosol_spray",
       },
     }),
   )

--- a/tests/agent-final-render-prompt.spec.ts
+++ b/tests/agent-final-render-prompt.spec.ts
@@ -55,3 +55,14 @@ test("final render prompt gives conceptual split-end mask answers enough substan
   assert.match(AGENT_FINAL_RENDER_PROMPT, /sichtbaren Spliss schneiden lassen/)
   assert.match(AGENT_FINAL_RENDER_PROMPT, /Keine Produktliste/)
 })
+
+test("final render prompt keeps dry shampoo as a narrow bridge with hard-no guardrails", () => {
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /Bei Trockenshampoo/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /Between-Wash-Bruecke/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /reinigt die Kopfhaut nicht/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /spaeter ausgewaschen/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /keine Trockenshampoo-Produkte erfinden/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /keine Ersatzprodukte wie Babypuder/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /Auch ohne selected_products/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /route\.product_category=dry_shampoo/)
+})

--- a/tests/agent-final-render-prompt.spec.ts
+++ b/tests/agent-final-render-prompt.spec.ts
@@ -66,3 +66,9 @@ test("final render prompt keeps dry shampoo as a narrow bridge with hard-no guar
   assert.match(AGENT_FINAL_RENDER_PROMPT, /Auch ohne selected_products/)
   assert.match(AGENT_FINAL_RENDER_PROMPT, /route\.product_category=dry_shampoo/)
 })
+
+test("final render prompt deduplicates the mandatory dry-shampoo caveat", () => {
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /Trockenshampoo-Caveat/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /nur einmal pro Antwort/)
+  assert.match(AGENT_FINAL_RENDER_PROMPT, /nicht unter jedem Produkt wiederholen/)
+})

--- a/tests/agent-route-packet.spec.ts
+++ b/tests/agent-route-packet.spec.ts
@@ -182,6 +182,8 @@ test("buildAgentRoutePacket infers shampoo for direct selection and comparison w
 test("buildAgentRoutePacket infers dry shampoo for explicit bridge product asks", () => {
   const prompts = [
     "Ich kann heute nicht waschen, mein Ansatz ist fettig. Welches Trockenshampoo?",
+    "Welches Trocken-Shampoo passt?",
+    "Which dry shampoo should I buy?",
     "Ich brauche Volumen am Ansatz fuer Tag 2.",
     "Ich will kein Aerosol-Spray, aber brauche heute eine kurze Auffrischung am Ansatz.",
     "Ich habe dunkle Haare und bekomme von Trockenshampoo immer weissen Schleier.",

--- a/tests/agent-route-packet.spec.ts
+++ b/tests/agent-route-packet.spec.ts
@@ -179,6 +179,72 @@ test("buildAgentRoutePacket infers shampoo for direct selection and comparison w
   assert.deepEqual(alternatePacket.validation_warnings, [])
 })
 
+test("buildAgentRoutePacket infers dry shampoo for explicit bridge product asks", () => {
+  const prompts = [
+    "Ich kann heute nicht waschen, mein Ansatz ist fettig. Welches Trockenshampoo?",
+    "Ich brauche Volumen am Ansatz fuer Tag 2.",
+    "Ich will kein Aerosol-Spray, aber brauche heute eine kurze Auffrischung am Ansatz.",
+    "Ich habe dunkle Haare und bekomme von Trockenshampoo immer weissen Schleier.",
+  ]
+
+  for (const message of prompts) {
+    const packet = buildAgentRoutePacket({
+      message,
+      userContext: createContext(),
+      classification: createClassification({
+        user_job: "product_pick",
+        product_category: null,
+      }),
+    })
+
+    assert.equal(packet.product_category, "dry_shampoo", message)
+    assert.deepEqual(packet.tool_plan, ["select_products"], message)
+    assert.deepEqual(packet.validation_warnings, [], message)
+  }
+})
+
+test("buildAgentRoutePacket does not infer dry shampoo from oily scalp alone", () => {
+  const packet = buildAgentRoutePacket({
+    message: "Ich habe fettige Kopfhaut, was soll ich tun?",
+    userContext: createContext(),
+    classification: createClassification({
+      user_job: "troubleshoot",
+      product_category: null,
+      concerns: ["oily_roots"],
+    }),
+  })
+
+  assert.equal(packet.product_category, null)
+  assert.deepEqual(packet.tool_plan, [])
+  assert.deepEqual(packet.validation_warnings, [])
+})
+
+test("buildAgentRoutePacket keeps dry-shampoo troubleshooting mentions guidance-only", () => {
+  const inferredPacket = buildAgentRoutePacket({
+    message: "Trockenshampoo hat nicht geholfen, mein Ansatz sieht trotzdem fettig aus.",
+    userContext: createContext(),
+    classification: createClassification({
+      user_job: "troubleshoot",
+      product_category: null,
+      concerns: ["oily_roots"],
+    }),
+  })
+  const classifiedPacket = buildAgentRoutePacket({
+    message: "Trockenshampoo hat nicht geholfen, mein Ansatz sieht trotzdem fettig aus.",
+    userContext: createContext(),
+    classification: createClassification({
+      user_job: "troubleshoot",
+      product_category: "dry_shampoo",
+      concerns: ["oily_roots"],
+    }),
+  })
+
+  assert.equal(inferredPacket.product_category, "dry_shampoo")
+  assert.deepEqual(inferredPacket.tool_plan, [])
+  assert.equal(classifiedPacket.product_category, "dry_shampoo")
+  assert.deepEqual(classifiedPacket.tool_plan, [])
+})
+
 test("buildAgentRoutePacket infers leave-in for replacement comparisons", () => {
   const packet = buildAgentRoutePacket({
     message:

--- a/tests/agent-route-packet.spec.ts
+++ b/tests/agent-route-packet.spec.ts
@@ -219,6 +219,24 @@ test("buildAgentRoutePacket does not infer dry shampoo from oily scalp alone", (
   assert.deepEqual(packet.validation_warnings, [])
 })
 
+test("buildAgentRoutePacket does not infer dry shampoo from oily-root product wording alone", () => {
+  const packet = buildAgentRoutePacket({
+    message: "Mein Ansatz ist schnell fettig, welches Produkt passt?",
+    userContext: createContext(),
+    classification: createClassification({
+      user_job: "product_pick",
+      product_category: null,
+      concerns: ["oily_roots"],
+    }),
+  })
+
+  assert.equal(packet.product_category, null)
+  assert.deepEqual(packet.tool_plan, [])
+  assert.deepEqual(packet.validation_warnings, [
+    "No product tool run for product_pick: product category missing.",
+  ])
+})
+
 test("buildAgentRoutePacket keeps dry-shampoo troubleshooting mentions guidance-only", () => {
   const inferredPacket = buildAgentRoutePacket({
     message: "Trockenshampoo hat nicht geholfen, mein Ansatz sieht trotzdem fettig aus.",

--- a/tests/agent-select-products-tool.spec.ts
+++ b/tests/agent-select-products-tool.spec.ts
@@ -11,6 +11,7 @@ import type { RecommendationEngineRuntime } from "../src/lib/recommendation-engi
 import type {
   BondbuilderCategoryDecision,
   DeepCleansingShampooCategoryDecision,
+  DryShampooCategoryDecision,
   MaskCategoryDecision,
   ShampooCategoryDecision,
 } from "../src/lib/recommendation-engine/types"
@@ -268,6 +269,36 @@ function createRelevantShampooDecision(
       shampooBucket: "dehydriert-fettig",
       secondaryBucket: null,
       cleansingIntensity: "regular",
+    },
+    notes: [],
+    ...overrides,
+  }
+}
+
+function createDryShampooRuntimeStub(
+  decision: DryShampooCategoryDecision,
+): RecommendationEngineRuntime {
+  const runtime = createRuntimeStub()
+  runtime.categories.dryShampoo = decision
+  return runtime
+}
+
+function createDryShampooDecision(
+  overrides: Partial<DryShampooCategoryDecision> = {},
+): DryShampooCategoryDecision {
+  return {
+    category: "dry_shampoo",
+    relevant: true,
+    action: "add",
+    planReasonCodes: ["dry_shampoo_bridge"],
+    currentInventory: null,
+    targetProfile: {
+      primaryEffectTarget: "classic_refresh",
+      hairColorFitTarget: "universal",
+      requiresSensitiveFit: false,
+      preferredFormat: null,
+      bridgeNeedReasonCodes: ["dry_shampoo_between_wash_bridge_needed"],
+      cautionReasonCodes: [],
     },
     notes: [],
     ...overrides,
@@ -1568,14 +1599,14 @@ test("projectSelectedProducts preserves unsupported active qualifiers for mask p
     value: "bleached",
     reason: "no_structured_product_data",
     user_message:
-      "Zu blondiertem Haar habe ich bei diesen Produkten aktuell keine sichere Spezialangabe. Ich bewerte sie deshalb nach den belegten Fit-Daten.",
+      "Zu blondiertem Haar habe ich bei diesen Produkten aktuell keine sichere Spezialangabe. Ich bewerte sie deshalb nach den sicheren Produktangaben.",
   })
   assert.deepEqual(result.unsupported_requested_signals[0], {
     field: "chemical_treatment",
     value: "bleached",
     reason: "no_structured_product_data",
     user_message:
-      "Zu blondiertem Haar habe ich bei diesen Produkten aktuell keine sichere Spezialangabe. Ich bewerte sie deshalb nach den belegten Fit-Daten.",
+      "Zu blondiertem Haar habe ich bei diesen Produkten aktuell keine sichere Spezialangabe. Ich bewerte sie deshalb nach den sicheren Produktangaben.",
   })
 })
 
@@ -1598,7 +1629,7 @@ test("projectSelectedProducts preserves unsupported active qualifiers without di
     value: "colored",
     reason: "no_structured_product_data",
     user_message:
-      "Zum Farbschutz habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den belegten Fit-Daten.",
+      "Zum Farbschutz habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den sicheren Produktangaben.",
   })
 })
 
@@ -2354,7 +2385,7 @@ test("projectSelectedProducts exposes per-product shampoo claims from structured
       [
         "chemical_treatment",
         "colored",
-        "Zum Farbschutz habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den belegten Fit-Daten.",
+        "Zum Farbschutz habe ich aktuell keine sichere Produktangabe. Ich bewerte die Optionen deshalb nach den sicheren Produktangaben.",
       ],
       [
         "scalp_condition",
@@ -2758,6 +2789,228 @@ test("projectSelectedProducts redirects deep-cleansing scalp treatment requests 
   assert.equal(result.product_response_policy, "caution_without_products")
   assert.deepEqual(result.products, [])
   assert.match(result.category_guidance, /Keine Produktkarten/)
+})
+
+test("projectSelectedProducts keeps dry-shampoo scalp symptoms guidance-only", () => {
+  const result = projectSelectedProducts(
+    [],
+    LOW_DAMAGE_PROFILE,
+    "dry_shampoo",
+    createDryShampooRuntimeStub(
+      createDryShampooDecision({
+        relevant: false,
+        action: null,
+        targetProfile: null,
+        notes: ["dry_shampoo_scalp_issue_hard_no"],
+      }),
+    ),
+  )
+
+  assert.equal(result.decision, "not_recommended")
+  assert.equal(result.product_response_policy, "caution_without_products")
+  assert.deepEqual(result.products, [])
+  assert.match(result.category_guidance, /Trockenshampoo nicht als Produkt empfehlen/)
+  assert.match(result.category_guidance, /reinigt die Kopfhaut nicht/)
+})
+
+test("projectSelectedProducts redirects frequent dry-shampoo use to reset logic", () => {
+  const result = projectSelectedProducts(
+    [],
+    LOW_DAMAGE_PROFILE,
+    "dry_shampoo",
+    createDryShampooRuntimeStub(
+      createDryShampooDecision({
+        relevant: false,
+        action: null,
+        targetProfile: null,
+        notes: ["dry_shampoo_frequent_use_reset_needed"],
+      }),
+    ),
+  )
+
+  assert.equal(result.decision, "not_recommended")
+  assert.equal(result.product_response_policy, "redirect_to_better_lever")
+  assert.deepEqual(result.products, [])
+  assert.match(result.category_guidance, /Kein weiteres Trockenshampoo/)
+  assert.match(result.category_guidance, /Reset/)
+})
+
+test("projectSelectedProducts preserves no_catalog_match for relevant dry-shampoo requests", () => {
+  const result = projectSelectedProducts(
+    [],
+    LOW_DAMAGE_PROFILE,
+    "dry_shampoo",
+    createDryShampooRuntimeStub(createDryShampooDecision()),
+  )
+
+  assert.equal(result.decision, "no_catalog_match")
+  assert.equal(result.product_response_policy, "no_catalog_match")
+  assert.deepEqual(result.products, [])
+  assert.match(result.category_guidance, /Katalog/)
+  assert.match(result.category_guidance, /spaeter ausgewaschen/)
+})
+
+test("selectProducts passes explicit dry-shampoo bridge context into category engine", async () => {
+  const tool = createSelectProductsTool({
+    runCategoryEngine: async ({ category, runtime }) => {
+      assert.equal(category, "dry_shampoo")
+      assert.equal(runtime.categories.dryShampoo.relevant, true)
+      assert.ok(
+        runtime.categories.dryShampoo.targetProfile?.bridgeNeedReasonCodes.includes(
+          "dry_shampoo_emergency_refresh",
+        ),
+      )
+
+      return [
+        createMatchedProduct("dry-bridge", 0.91, {
+          category: "Trockenshampoo",
+          recommendation_meta: {
+            category: "dry_shampoo",
+            score: 91,
+            top_reasons: ["Passt als kurze Notfall-/Between-Wash-Bruecke."],
+            tradeoffs: [],
+            usage_hint:
+              "Nur als kurze Between-Wash-Bruecke am Ansatz verwenden, spaeter auswaschen und nicht als Ersatz fuer Shampoo/Wasser nutzen.",
+            primary_effect: "classic_refresh",
+            hair_color_fit: "universal",
+            scalp_sensitivity_fit: "normal_only",
+            format: "aerosol_spray",
+            fit_status: "ideal",
+          },
+        }),
+      ]
+    },
+  })
+
+  const result = await tool({
+    category: "dry_shampoo",
+    message: "Ich kann heute nicht waschen, mein Ansatz ist fettig. Welches Trockenshampoo?",
+    hairProfile: {
+      ...LOW_DAMAGE_PROFILE,
+      scalp_type: "oily",
+      concerns: ["oily_scalp"],
+      wash_frequency: "every_2_3_days",
+    } as HairProfile,
+    memoryContext: {
+      enabled: false,
+      entries: [],
+      promptContext: null,
+      dislikedProductNames: [],
+    },
+    routineItems: [],
+  })
+
+  assert.equal(result.decision, "recommended")
+  assert.equal(
+    result.products[0]?.supported_claims.some((claim) => claim.field === "usage_hint"),
+    true,
+  )
+})
+
+test("selectProducts redirects message-stated frequent dry-shampoo use instead of recommending more", async () => {
+  const tool = createSelectProductsTool({
+    runCategoryEngine: async ({ category, runtime }) => {
+      assert.equal(category, "dry_shampoo")
+      assert.equal(runtime.categories.dryShampoo.relevant, false)
+      assert.ok(
+        runtime.categories.dryShampoo.notes.includes("dry_shampoo_frequent_use_reset_needed"),
+      )
+
+      return [
+        createMatchedProduct("dry-frequent", 0.91, {
+          category: "Trockenshampoo",
+          recommendation_meta: {
+            category: "dry_shampoo",
+            score: 91,
+            top_reasons: ["Passt als kurze Notfall-/Between-Wash-Bruecke."],
+            tradeoffs: [],
+            usage_hint:
+              "Nur als kurze Between-Wash-Bruecke am Ansatz verwenden, spaeter auswaschen und nicht als Ersatz fuer Shampoo/Wasser nutzen.",
+            primary_effect: "classic_refresh",
+            hair_color_fit: "universal",
+            scalp_sensitivity_fit: "normal_only",
+            format: "aerosol_spray",
+            fit_status: "ideal",
+          },
+        }),
+      ]
+    },
+  })
+
+  const result = await tool({
+    category: "dry_shampoo",
+    message: "Ich nutze Trockenshampoo 3-4x pro Woche, welches passt?",
+    hairProfile: {
+      ...LOW_DAMAGE_PROFILE,
+      scalp_type: "oily",
+      wash_frequency: "every_2_3_days",
+    } as HairProfile,
+    memoryContext: {
+      enabled: false,
+      entries: [],
+      promptContext: null,
+      dislikedProductNames: [],
+    },
+    routineItems: [],
+  })
+
+  assert.equal(result.decision, "not_recommended")
+  assert.equal(result.product_response_policy, "redirect_to_better_lever")
+  assert.deepEqual(result.products, [])
+})
+
+test("selectProducts treats dry-shampoo routine need questions as guidance-only, not dry-hair hard-nos", async () => {
+  const tool = createSelectProductsTool({
+    runCategoryEngine: async ({ category, runtime }) => {
+      assert.equal(category, "dry_shampoo")
+      assert.equal(runtime.categories.dryShampoo.relevant, false)
+      assert.ok(!runtime.categories.dryShampoo.notes.includes("dry_shampoo_dry_breakage_hard_no"))
+
+      return [
+        createMatchedProduct("dry-routine", 0.91, {
+          category: "Trockenshampoo",
+          recommendation_meta: {
+            category: "dry_shampoo",
+            score: 91,
+            top_reasons: ["Passt als kurze Notfall-/Between-Wash-Bruecke."],
+            tradeoffs: [],
+            usage_hint:
+              "Nur als kurze Between-Wash-Bruecke am Ansatz verwenden, spaeter auswaschen und nicht als Ersatz fuer Shampoo/Wasser nutzen.",
+            primary_effect: "classic_refresh",
+            hair_color_fit: "universal",
+            scalp_sensitivity_fit: "normal_only",
+            format: "aerosol_spray",
+            fit_status: "ideal",
+          },
+        }),
+      ]
+    },
+  })
+
+  const result = await tool({
+    category: "dry_shampoo",
+    message: "Sollte ich Trocken-Shampoo in meiner Routine aufnehmen?",
+    hairProfile: {
+      ...LOW_DAMAGE_PROFILE,
+      scalp_type: "balanced",
+      scalp_condition: null,
+      wash_frequency: "daily",
+    } as HairProfile,
+    memoryContext: {
+      enabled: false,
+      entries: [],
+      promptContext: null,
+      dislikedProductNames: [],
+    },
+    routineItems: [],
+    userJob: "compare_or_decide",
+    concerns: [],
+  })
+
+  assert.equal(result.decision, "not_recommended")
+  assert.equal(result.product_response_policy, "redirect_to_better_lever")
+  assert.deepEqual(result.products, [])
+  assert.match(result.category_guidance, /Routinebaustein/)
 })
 
 test("selectProducts tool only accepts engine-backed categories", () => {

--- a/tests/agent-select-products-tool.spec.ts
+++ b/tests/agent-select-products-tool.spec.ts
@@ -3013,6 +3013,61 @@ test("selectProducts treats dry-shampoo routine need questions as guidance-only,
   assert.match(result.category_guidance, /Routinebaustein/)
 })
 
+test("selectProducts does not treat oily-root product wording as a dry-shampoo bridge", async () => {
+  const tool = createSelectProductsTool({
+    runCategoryEngine: async ({ category, runtime }) => {
+      assert.equal(category, "dry_shampoo")
+      assert.equal(runtime.categories.dryShampoo.relevant, false)
+      assert.ok(
+        runtime.categories.dryShampoo.notes.includes("dry_shampoo_oily_scalp_alone_not_enough"),
+      )
+
+      return [
+        createMatchedProduct("dry-oily-root", 0.91, {
+          category: "Trockenshampoo",
+          recommendation_meta: {
+            category: "dry_shampoo",
+            score: 91,
+            top_reasons: ["Passt als kurze Notfall-/Between-Wash-Bruecke."],
+            tradeoffs: [],
+            usage_hint:
+              "Nur als kurze Between-Wash-Bruecke am Ansatz verwenden, spaeter auswaschen und nicht als Ersatz fuer Shampoo/Wasser nutzen.",
+            primary_effect: "classic_refresh",
+            hair_color_fit: "universal",
+            scalp_sensitivity_fit: "normal_only",
+            format: "aerosol_spray",
+            fit_status: "ideal",
+          },
+        }),
+      ]
+    },
+  })
+
+  const result = await tool({
+    category: "dry_shampoo",
+    message: "Mein Ansatz ist schnell fettig, welches Produkt passt?",
+    hairProfile: {
+      ...LOW_DAMAGE_PROFILE,
+      scalp_type: "oily",
+      concerns: ["oily_scalp"],
+      wash_frequency: "every_2_3_days",
+    } as HairProfile,
+    memoryContext: {
+      enabled: false,
+      entries: [],
+      promptContext: null,
+      dislikedProductNames: [],
+    },
+    routineItems: [],
+    userJob: "product_pick",
+    concerns: ["oily_roots"],
+  })
+
+  assert.equal(result.decision, "not_recommended")
+  assert.equal(result.product_response_policy, "redirect_to_better_lever")
+  assert.deepEqual(result.products, [])
+})
+
 test("selectProducts tool only accepts engine-backed categories", () => {
   type ToolParams = Parameters<ReturnType<typeof createSelectProductsTool>>[0]
 

--- a/tests/agent-select-products-tool.spec.ts
+++ b/tests/agent-select-products-tool.spec.ts
@@ -2903,8 +2903,10 @@ test("selectProducts passes explicit dry-shampoo bridge context into category en
   assert.equal(result.decision, "recommended")
   assert.equal(
     result.products[0]?.supported_claims.some((claim) => claim.field === "usage_hint"),
-    true,
+    false,
   )
+  assert.match(result.category_guidance, /reinigt die Kopfhaut nicht/)
+  assert.match(result.category_guidance, /spaeter ausgewaschen/)
 })
 
 test("selectProducts redirects message-stated frequent dry-shampoo use instead of recommending more", async () => {

--- a/tests/recommendation-engine-categories.test.ts
+++ b/tests/recommendation-engine-categories.test.ts
@@ -1011,11 +1011,10 @@ test("category set activates support/reset categories for oily buildup-heavy rou
     cautionFlags: [],
   })
 
-  assert.equal(categories.dryShampoo.relevant, true)
-  assert.equal(categories.dryShampoo.action, "add")
-  assert.deepEqual(categories.dryShampoo.targetProfile, {
-    scalpTypeFocus: "oily",
-  })
+  assert.equal(categories.dryShampoo.relevant, false)
+  assert.equal(categories.dryShampoo.action, null)
+  assert.deepEqual(categories.dryShampoo.targetProfile, null)
+  assert.ok(categories.dryShampoo.notes.includes("dry_shampoo_oily_scalp_alone_not_enough"))
 
   assert.equal(categories.peeling.relevant, true)
   assert.equal(categories.peeling.action, "add")

--- a/tests/recommendation-engine-categories.test.ts
+++ b/tests/recommendation-engine-categories.test.ts
@@ -1024,6 +1024,55 @@ test("category set activates support/reset categories for oily buildup-heavy rou
   })
 })
 
+test("dry shampoo allows explicit bridge requests despite stored breakage or ordinary dry lengths", () => {
+  const requestContext = buildRecommendationRequestContext({
+    requestedCategory: "dry_shampoo",
+    message:
+      "Ich kann heute nicht waschen, mein Ansatz ist fettig und meine Laengen sind trocken. Welches Trockenshampoo?",
+  })
+  const { normalized, damage, careNeeds } = buildEngineState(
+    {
+      ...LOW_DAMAGE_PROFILE,
+      concerns: ["breakage"],
+    },
+    [],
+  )
+  const reset = buildResetAssessment(normalized, requestContext)
+  const plan = buildInterventionPlan(normalized, damage, careNeeds, reset, requestContext)
+  const categories = buildCategoryRecommendationSet(
+    normalized,
+    damage,
+    careNeeds,
+    plan,
+    requestContext,
+    reset,
+  )
+
+  assert.equal(categories.dryShampoo.relevant, true)
+  assert.ok(!categories.dryShampoo.notes.includes("dry_shampoo_dry_breakage_hard_no"))
+})
+
+test("dry shampoo blocks current-message breakage-dominant requests", () => {
+  const requestContext = buildRecommendationRequestContext({
+    requestedCategory: "dry_shampoo",
+    message: "Meine Haare sind trocken, sproede und brechen ab. Welches Trockenshampoo hilft?",
+  })
+  const { normalized, damage, careNeeds } = buildEngineState(LOW_DAMAGE_PROFILE, [])
+  const reset = buildResetAssessment(normalized, requestContext)
+  const plan = buildInterventionPlan(normalized, damage, careNeeds, reset, requestContext)
+  const categories = buildCategoryRecommendationSet(
+    normalized,
+    damage,
+    careNeeds,
+    plan,
+    requestContext,
+    reset,
+  )
+
+  assert.equal(categories.dryShampoo.relevant, false)
+  assert.ok(categories.dryShampoo.notes.includes("dry_shampoo_dry_breakage_hard_no"))
+})
+
 test("bondbuilder fit uses intensity and does not rank by treatment mode", () => {
   const { normalized, damage, plan } = buildEngineState(SEVERE_DAMAGE_PROFILE, [
     {

--- a/tests/recommendation-engine-planner.test.ts
+++ b/tests/recommendation-engine-planner.test.ts
@@ -6,6 +6,7 @@ import { buildDamageAssessment } from "../src/lib/recommendation-engine/assessme
 import { adaptRecommendationInputFromPersistence } from "../src/lib/recommendation-engine/adapters/from-persistence"
 import { normalizeRecommendationInput } from "../src/lib/recommendation-engine/normalize"
 import { buildInterventionPlan } from "../src/lib/recommendation-engine/planner/intervention"
+import { buildRecommendationRequestContext } from "../src/lib/recommendation-engine/request-context"
 import {
   LOW_DAMAGE_PROFILE,
   SEVERE_DAMAGE_PROFILE,
@@ -133,13 +134,9 @@ test("planner activates reset-family categories for oily buildup-prone routines"
         step.reasonCodes.includes("buildup_reset_need_present"),
     ),
   )
-  assert.ok(
-    plan.steps.some(
-      (step) =>
-        step.category === "dry_shampoo" &&
-        step.action === "add" &&
-        step.reasonCodes.includes("between_wash_bridge_needed"),
-    ),
+  assert.equal(
+    plan.steps.some((step) => step.category === "dry_shampoo"),
+    false,
   )
   assert.ok(
     plan.steps.some(
@@ -147,6 +144,35 @@ test("planner activates reset-family categories for oily buildup-prone routines"
         step.category === "peeling" &&
         step.action === "add" &&
         step.reasonCodes.includes("buildup_reset_need_present"),
+    ),
+  )
+})
+
+test("planner adds dry shampoo only for explicit between-wash bridge requests", () => {
+  const adapted = adaptRecommendationInputFromPersistence(
+    {
+      ...LOW_DAMAGE_PROFILE,
+      scalp_type: "oily",
+      concerns: ["oily_scalp"],
+      wash_frequency: "every_2_3_days",
+    },
+    [],
+  )
+  const normalized = normalizeRecommendationInput(adapted.input)
+  const damage = buildDamageAssessment(normalized)
+  const careNeeds = buildCareNeedAssessment(normalized, damage)
+  const context = buildRecommendationRequestContext({
+    requestedCategory: "dry_shampoo",
+    message: "Ich kann heute nicht waschen, mein Ansatz ist fettig. Welches Trockenshampoo?",
+  })
+  const plan = buildInterventionPlan(normalized, damage, careNeeds, undefined, context)
+
+  assert.ok(
+    plan.steps.some(
+      (step) =>
+        step.category === "dry_shampoo" &&
+        step.action === "add" &&
+        step.reasonCodes.includes("dry_shampoo_emergency_refresh"),
     ),
   )
 })

--- a/tests/recommendation-engine-selection.test.ts
+++ b/tests/recommendation-engine-selection.test.ts
@@ -1803,7 +1803,7 @@ test("engine deep-cleansing shampoo reranking suppresses unsupported mineral and
   assert.deepEqual(reranked, [])
 })
 
-test("engine dry shampoo reranking keeps the oily-focus candidate ahead of a broader balanced option", () => {
+test("engine dry shampoo reranking prefers exact bridge effect and color fit", () => {
   const decision: DryShampooCategoryDecision = {
     category: "dry_shampoo",
     relevant: true,
@@ -1811,7 +1811,12 @@ test("engine dry shampoo reranking keeps the oily-focus candidate ahead of a bro
     planReasonCodes: [],
     currentInventory: null,
     targetProfile: {
-      scalpTypeFocus: "oily",
+      primaryEffectTarget: "volume_texture",
+      hairColorFitTarget: "dark",
+      requiresSensitiveFit: false,
+      preferredFormat: null,
+      bridgeNeedReasonCodes: ["dry_shampoo_volume_texture_request"],
+      cautionReasonCodes: [],
     },
     notes: [],
   }
@@ -1824,11 +1829,17 @@ test("engine dry shampoo reranking keeps the oily-focus candidate ahead of a bro
   const specs: ProductDryShampooSpecs[] = [
     {
       product_id: "balanced",
-      scalp_type_focus: "balanced",
+      primary_effect: "classic_refresh",
+      hair_color_fit: "universal",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
     },
     {
       product_id: "ideal",
-      scalp_type_focus: "oily",
+      primary_effect: "volume_texture",
+      hair_color_fit: "dark",
+      scalp_sensitivity_fit: "normal_only",
+      format: "aerosol_spray",
     },
   ]
 
@@ -1842,8 +1853,56 @@ test("engine dry shampoo reranking keeps the oily-focus candidate ahead of a bro
   assert.equal(reranked[0]?.recommendation_meta?.category, "dry_shampoo")
   assert.equal(
     (reranked[0]?.recommendation_meta as DryShampooRecommendationMetadata | undefined)
-      ?.scalp_type_focus,
-    "oily",
+      ?.primary_effect,
+    "volume_texture",
+  )
+})
+
+test("engine dry shampoo reranking filters aerosol when non-spray format is requested", () => {
+  const decision: DryShampooCategoryDecision = {
+    category: "dry_shampoo",
+    relevant: true,
+    action: "add",
+    planReasonCodes: [],
+    currentInventory: null,
+    targetProfile: {
+      primaryEffectTarget: "classic_refresh",
+      hairColorFitTarget: "universal",
+      requiresSensitiveFit: false,
+      preferredFormat: "foam_or_liquid",
+      bridgeNeedReasonCodes: ["dry_shampoo_between_wash_bridge_needed"],
+      cautionReasonCodes: ["dry_shampoo_avoid_aerosol_format_request"],
+    },
+    notes: [],
+  }
+
+  const reranked = rerankDryShampooProductsWithEngine({
+    candidates: [
+      createMatchedProduct("spray", "Dry Shampoo", { combined_score: 0.95 }),
+      createMatchedProduct("foam", "Dry Shampoo", { combined_score: 0.7 }),
+    ],
+    specs: [
+      {
+        product_id: "spray",
+        primary_effect: "classic_refresh",
+        hair_color_fit: "universal",
+        scalp_sensitivity_fit: "normal_only",
+        format: "aerosol_spray",
+      },
+      {
+        product_id: "foam",
+        primary_effect: "classic_refresh",
+        hair_color_fit: "universal",
+        scalp_sensitivity_fit: "normal_only",
+        format: "foam_or_liquid",
+      },
+    ],
+    decision,
+  })
+
+  assert.deepEqual(
+    reranked.map((product) => product.id),
+    ["foam"],
   )
 })
 

--- a/tests/seed-dry-shampoo-products.test.ts
+++ b/tests/seed-dry-shampoo-products.test.ts
@@ -5,6 +5,10 @@ test("dry-shampoo seed helper identifies active rows outside the planned catalog
   const module = await import("../scripts/seed-dry-shampoo-products")
 
   assert.equal(typeof module.findUnexpectedActiveDryShampooProducts, "function")
+  assert.deepEqual(module.STALE_DRY_SHAMPOO_DEACTIVATION_PATCH, {
+    is_active: false,
+    lifecycle_status: "discontinued",
+  })
   assert.deepEqual(
     module.findUnexpectedActiveDryShampooProducts([
       {
@@ -15,10 +19,24 @@ test("dry-shampoo seed helper identifies active rows outside the planned catalog
         is_active: true,
       },
       {
+        id: "planned-alias",
+        brand: "Batiste",
+        name: "Trockenshampoo Original",
+        category: "Dry Shampoo",
+        is_active: true,
+      },
+      {
         id: "stale",
         brand: "Legacy",
         name: "Old Dry Shampoo",
         category: "Trockenshampoo",
+        is_active: true,
+      },
+      {
+        id: "stale-alias",
+        brand: "Legacy",
+        name: "Old Dry Shampoo Alias",
+        category: "dry_shampoo",
         is_active: true,
       },
       {
@@ -28,7 +46,14 @@ test("dry-shampoo seed helper identifies active rows outside the planned catalog
         category: "Trockenshampoo",
         is_active: false,
       },
+      {
+        id: "other-category",
+        brand: "Legacy",
+        name: "Old Shampoo",
+        category: "Shampoo",
+        is_active: true,
+      },
     ]),
-    ["stale"],
+    ["stale", "stale-alias"],
   )
 })

--- a/tests/seed-dry-shampoo-products.test.ts
+++ b/tests/seed-dry-shampoo-products.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+test("dry-shampoo seed helper identifies active rows outside the planned catalog", async () => {
+  const module = await import("../scripts/seed-dry-shampoo-products")
+
+  assert.equal(typeof module.findUnexpectedActiveDryShampooProducts, "function")
+  assert.deepEqual(
+    module.findUnexpectedActiveDryShampooProducts([
+      {
+        id: "planned",
+        brand: "Batiste",
+        name: "Trockenshampoo Original",
+        category: "Trockenshampoo",
+        is_active: true,
+      },
+      {
+        id: "stale",
+        brand: "Legacy",
+        name: "Old Dry Shampoo",
+        category: "Trockenshampoo",
+        is_active: true,
+      },
+      {
+        id: "inactive",
+        brand: "Legacy",
+        name: "Inactive Dry Shampoo",
+        category: "Trockenshampoo",
+        is_active: false,
+      },
+    ]),
+    ["stale"],
+  )
+})


### PR DESCRIPTION
## Summary
- adds dry-shampoo structured specs, schema migration, seed script, and admin support for the planned 10 products
- wires dry-shampoo routing, request context, category decisions, reranking, and Agent v1 product response handling
- keeps dry shampoo as a narrow between-wash bridge with hard-no guidance for scalp symptoms, frequent use, buildup/reset pressure, respiratory/child context, and current-message breakage-dominant asks
- dedupes the mandatory scalp-cleaning caveat so it appears once per answer instead of under every product

## Verification
- npx tsx --test tests/agent-route-packet.spec.ts tests/agent-select-products-tool.spec.ts tests/recommendation-engine-planner.test.ts tests/recommendation-engine-categories.test.ts tests/recommendation-engine-selection.test.ts tests/agent-final-render-prompt.spec.ts tests/seed-dry-shampoo-products.test.ts: 209/209 pass
- npm run typecheck: pass
- npm run lint: 0 errors, 4 pre-existing warnings
- git diff --check: pass
- npx tsx scripts/seed-dry-shampoo-products.ts: dry-run prints planned 10 products only
- local compare lab smoke: explicit dry shampoo prompt routes to dry_shampoo and shows products; oily-root-only prompt stays guidance-only

## Notes
- migration has already been applied/repaired on the linked Supabase project during local verification
- untracked local tmp/ compare-lab log is intentionally not included