### PR TITLE
Fix nested product mention buttons

### DIFF
--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -183,10 +183,11 @@ function renderWithProductMentions(
 }
 
 /**
- * Recursively processes React children, replacing string segments that contain
- * [N] citation markers with CitationBadge components, then product mentions.
- * Also recurses into React elements (e.g. <strong>, <em>) so product names
- * inside bold/italic markdown formatting are still matched.
+ * Processes React children, replacing string segments that contain [N] citation
+ * markers with CitationBadge components, then product mentions.
+ * Custom markdown components call this at their own boundary, so React elements
+ * are left alone to avoid re-processing product mention buttons inside bold or
+ * italic text.
  */
 function processChildren(
   children: ReactNode,
@@ -208,21 +209,6 @@ function processChildren(
       }
       return processed
     })
-  }
-  // Recurse into React elements (e.g. <strong>, <em>, <a>)
-  if (children !== null && typeof children === "object" && "props" in children) {
-    const element = children as React.ReactElement<{ children?: ReactNode }>
-    if (element.props.children) {
-      const processed = processChildren(
-        element.props.children,
-        sourceMap,
-        productMap,
-        hairProfile,
-        onProductClick,
-      )
-      // Clone the element with processed children
-      return { ...element, props: { ...element.props, children: processed } }
-    }
   }
   return children
 }

--- a/tests/chat-product-mentions.test.tsx
+++ b/tests/chat-product-mentions.test.tsx
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { ChatMessage } from "@/components/chat/chat-message"
+import type { Message, Product } from "@/lib/types"
+
+function createProduct(name: string): Product {
+  return {
+    id: "product-1",
+    name,
+    brand: "Test Brand",
+    description: null,
+    short_description: null,
+    category: "Leave-in",
+    affiliate_link: null,
+    image_url: null,
+    price_eur: 18,
+    currency: "EUR",
+    tags: [],
+    suitable_thicknesses: [],
+    suitable_concerns: [],
+    is_active: true,
+    lifecycle_status: "active",
+    sort_order: 0,
+    recommendation_meta: null,
+    created_at: "2026-05-06T00:00:00.000Z",
+    updated_at: "2026-05-06T00:00:00.000Z",
+  }
+}
+
+function createAssistantMessage(content: string, products: Product[]): Message {
+  return {
+    id: "message-1",
+    conversation_id: "conversation-1",
+    role: "assistant",
+    content,
+    product_recommendations: products,
+    rag_context: null,
+    token_usage: null,
+    langfuse_trace_id: null,
+    langfuse_trace_url: null,
+    user_feedback_score: null,
+    user_feedback_at: null,
+    created_at: "2026-05-06T00:00:00.000Z",
+  }
+}
+
+function hasNestedButton(html: string) {
+  let depth = 0
+  const buttonTagPattern = /<\/?button\b[^>]*>/g
+  let match: RegExpExecArray | null
+
+  while ((match = buttonTagPattern.exec(html)) !== null) {
+    const tag = match[0]
+
+    if (tag.startsWith("</")) {
+      depth = Math.max(0, depth - 1)
+      continue
+    }
+
+    if (depth > 0) {
+      return true
+    }
+    depth += 1
+  }
+
+  return false
+}
+
+test("bold inline product mentions render one clickable trigger without nested buttons", () => {
+  const product = createProduct("Silky Leave-in")
+  const html = renderToStaticMarkup(
+    <ChatMessage
+      message={createAssistantMessage("Nimm **Silky Leave-in** nur in den Längen.", [product])}
+      hairProfile={null}
+      onProductClick={() => {}}
+    />,
+  )
+
+  const buttonCount = (html.match(/<button\b/g) ?? []).length
+
+  assert.equal(buttonCount, 2)
+  assert.equal(hasNestedButton(html), false)
+  assert.match(html, /<strong>[\s\S]*Silky Leave-in[\s\S]*<\/strong>/)
+})


### PR DESCRIPTION
## Summary
- stop recursively re-processing already-rendered markdown elements for inline product mentions
- keep product mentions inside bold/italic text working through the component-specific markdown renderers
- add a regression test that renders a bold inline product mention without nested button markup

## Verification
- npx tsx --test tests/chat-product-mentions.test.tsx
- npm run typecheck
- npm run lint (passes with 4 existing unrelated warnings)
- git diff --check