### PR TITLE
Revamp quiz landing screen

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const securityHeaders = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu.i.posthog.com",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://*.supabase.co",
+      "img-src 'self' data: blob: https://*.supabase.co https://www.tophair.de",
       "font-src 'self' data:",
       "connect-src 'self' https://eu.i.posthog.com https://eu.posthog.com https://*.supabase.co https://*.sentry.io",
       "frame-ancestors 'none'",
@@ -27,6 +27,15 @@ const nextConfig: NextConfig = {
   // Keep Turbopack scoped to this repo even when a parent folder has another lockfile.
   turbopack: {
     root: process.cwd(),
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "www.tophair.de",
+        pathname: "/app/uploads/**",
+      },
+    ],
   },
   outputFileTracingIncludes: {
     "/api/chat": ["./data/agent-guidance/**/*"],

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,7 +81,11 @@
   --brand-plum-light: #C8B8E0;
   --brand-plum-ice: #F2EEFA;
   --brand-plum-rgb: 107, 80, 160;
+  --brand-plum-light-rgb: 200, 184, 224;
   --brand-coral: #D4616A;
+  --brand-coral-dark: #C0555D;
+  --brand-coral-deep: #AA464E;
+  --brand-coral-deeper: #9F3D45;
   --brand-coral-light: #FDEEF0;
   --brand-coral-rgb: 212, 97, 106;
 
@@ -140,14 +144,17 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-body), Arial, Helvetica, sans-serif;
+    --font-display: var(--font-playfair-display), Georgia, "Times New Roman", serif;
+    --font-body: var(--font-plus-jakarta-sans), Arial, Helvetica, sans-serif;
+    --font-mono: var(--font-ibm-plex-mono), ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-family: var(--font-body);
   }
 }
 
 /* Header font utility */
 @layer components {
   .font-header {
-    font-family: var(--font-display), Georgia, serif;
+    font-family: var(--font-display);
     font-weight: 500;
     letter-spacing: normal;
   }

--- a/src/app/quiz/layout.tsx
+++ b/src/app/quiz/layout.tsx
@@ -8,6 +8,7 @@ export default function QuizLayout({ children }: { children: React.ReactNode }) 
   const step = useQuizStore((s) => s.step)
   const standardScrollRef = useRef<HTMLDivElement>(null)
   const resultScrollRef = useRef<HTMLDivElement>(null)
+  const landingScrollRef = useRef<HTMLDivElement>(null)
   const previousStepRef = useRef(step)
 
   useEffect(() => {
@@ -15,7 +16,12 @@ export default function QuizLayout({ children }: { children: React.ReactNode }) 
     previousStepRef.current = step
 
     const frame = window.requestAnimationFrame(() => {
-      const container = step === 11 ? resultScrollRef.current : standardScrollRef.current
+      const container =
+        step === 11
+          ? resultScrollRef.current
+          : step === 1
+            ? landingScrollRef.current
+            : standardScrollRef.current
       container?.scrollTo({ top: 0 })
       window.scrollTo({ top: 0 })
 
@@ -36,6 +42,16 @@ export default function QuizLayout({ children }: { children: React.ReactNode }) 
     return (
       <div ref={resultScrollRef} className="min-h-[100dvh] overflow-y-auto bg-background">
         <div className="mx-auto max-w-[960px] px-5 py-8 md:px-10 md:py-12">{children}</div>
+      </div>
+    )
+  }
+
+  if (step === 1) {
+    return (
+      <div ref={landingScrollRef} className="min-h-[100dvh] overflow-y-auto bg-background">
+        <div className="mx-auto flex min-h-[100dvh] w-full max-w-[440px] flex-col justify-center px-6 py-10 sm:px-8 lg:max-w-[520px]">
+          {children}
+        </div>
       </div>
     )
   }

--- a/src/components/quiz/quiz-landing.tsx
+++ b/src/components/quiz/quiz-landing.tsx
@@ -1,67 +1,129 @@
 "use client"
 
+import Link from "next/link"
+import Image from "next/image"
+import { Droplet, Star } from "lucide-react"
 import { useQuizStore } from "@/lib/quiz/store"
 import { Button } from "@/components/ui/button"
 
-const bullets = [
-  "Individuelle Analyse statt pauschaler Tipps",
-  "Ordnet Frizz, Trockenheit und Kopfhautstress besser ein",
-  "Zeigt dir den nächsten sinnvollen Schritt für dein Haar",
-]
+const tomHannemannImageUrl =
+  "https://www.tophair.de/app/uploads/2025/03/SA-WS-NewFlag-TomHannemann-MS-7-683x1024.jpg"
 
 export function QuizLanding() {
   const goNext = useQuizStore((s) => s.goNext)
 
   return (
-    <div className="flex flex-col animate-fade-in-up">
-      <div className="flex-1 flex flex-col justify-center">
-        <h1 className="font-header text-4xl leading-tight text-foreground mb-4">
-          Finde in 2 Minuten heraus, was deine Haare wirklich brauchen
-        </h1>
-        <p className="text-base text-muted-foreground mb-6 leading-relaxed">
-          Hair Concierge analysiert Struktur, Kopfhaut und Pflegebedarf und zeigt dir, womit du bei
-          deiner Pflege wirklich anfangen solltest.
-        </p>
-        <ul className="space-y-3 mb-8">
-          {bullets.map((text) => (
-            <li key={text} className="flex items-start gap-2.5">
-              <span
-                className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
-                style={{ background: "rgba(var(--brand-plum-rgb), 0.15)" }}
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path
-                    d="M2.5 6L5 8.5L9.5 4"
-                    stroke="var(--brand-plum)"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </span>
-              <span className="text-base text-foreground">{text}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
+    <main className="relative isolate flex w-full animate-fade-in-up flex-col items-center text-center">
+      <div
+        className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
+        style={{
+          background:
+            "radial-gradient(ellipse 75% 52% at 12% 8%, rgba(var(--brand-plum-rgb), 0.105), transparent 62%), radial-gradient(ellipse 52% 62% at 88% 82%, rgba(var(--brand-coral-rgb), 0.085), transparent 58%), radial-gradient(ellipse 42% 42% at 55% 52%, rgba(var(--brand-plum-light-rgb), 0.08), transparent 64%), hsl(var(--background))",
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none fixed inset-0 -z-10 bg-[repeating-linear-gradient(0deg,transparent,transparent_39px,rgba(var(--brand-plum-rgb),0.045)_39px,rgba(var(--brand-plum-rgb),0.045)_40px)]"
+        aria-hidden="true"
+      />
 
-      <div className="space-y-2">
+      <header className="mb-8 flex items-center justify-center gap-2.5 sm:mb-9">
+        <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)] text-white shadow-[0_10px_24px_rgba(42,24,69,0.16)]">
+          <Droplet aria-hidden="true" className="h-[19px] w-[19px] stroke-[1.65]" />
+        </span>
+        <p className="font-header text-[21px] font-semibold leading-none text-[var(--brand-plum-darkest)]">
+          Hair Concierge
+        </p>
+      </header>
+
+      <section aria-labelledby="quiz-landing-title" className="space-y-4">
+        <h1
+          id="quiz-landing-title"
+          className="text-balance font-header text-[30px] leading-[1.14] text-[var(--text-heading)] min-[380px]:text-[37px] sm:text-[40px]"
+        >
+          Weißt du, was deine Haare <em className="text-[var(--brand-plum)]">wirklich</em> brauchen?
+        </h1>
+        <p className="mx-auto max-w-[350px] text-[15px] leading-[1.62] text-[var(--text-sub)]">
+          Hair Concierge analysiert dein Haar und zeigt dir, was deine Haare tatsächlich brauchen -
+          individuell, nicht pauschal.
+        </p>
+      </section>
+
+      <section aria-label="Quiz starten" className="mt-6 w-full sm:mt-7">
         <Button
           onClick={goNext}
-          variant="unstyled"
-          className="quiz-btn-primary w-full h-14 text-base font-bold tracking-wide rounded-xl"
+          variant="landingCta"
+          aria-label="Quiz starten"
+          aria-describedby="quiz-landing-cta-detail"
         >
-          Quiz starten
+          <span className="flex flex-col items-center leading-tight">
+            <span className="text-[17px] font-extrabold tracking-[-0.01em]">Quiz starten</span>
+            <span aria-hidden="true" className="mt-1 text-xs font-medium opacity-[0.96]">
+              In ca. 2 Minuten · Kostenlos
+            </span>
+          </span>
+          <span id="quiz-landing-cta-detail" className="sr-only">
+            In ca. 2 Minuten, kostenlos
+          </span>
         </Button>
-        <p className="text-center text-sm text-[var(--text-caption)]">
-          Dauert ca. 2 Minuten. Wir führen dich Schritt für Schritt durch.
-        </p>
-        <p className="text-center text-sm text-muted-foreground pt-2">
-          <a href="/auth?force=login" className="underline hover:text-foreground transition-colors">
-            Du hast bereits ein Konto? Hier anmelden
-          </a>
+      </section>
+
+      <figure className="mt-[18px] w-full rounded-[14px] border border-border bg-white/70 p-4 shadow-[0_14px_38px_rgba(42,24,69,0.045)] backdrop-blur-[10px]">
+        <div className="flex items-center gap-3 text-left">
+          <Image
+            src={tomHannemannImageUrl}
+            alt="Tom Hannemann"
+            width={104}
+            height={104}
+            className="h-[52px] w-[52px] shrink-0 rounded-full border-2 border-[var(--brand-plum-light)] bg-[var(--brand-plum-ice)] object-cover object-[52%_18%]"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+          />
+          <div>
+            <blockquote className="font-header text-[13.5px] italic leading-[1.36] text-[var(--brand-plum-darkest)]">
+              „Ich sage es immer: Ohne Analyse ist jede Produktempfehlung Glücksspiel. Deswegen
+              empfehle ich genau das hier.&quot;
+            </blockquote>
+            <figcaption className="mt-2 font-mono text-[10px] font-medium uppercase leading-[1.35] tracking-[0.075em] text-[var(--text-caption)]">
+              <strong className="text-[var(--brand-plum)]">Tom Hannemann</strong> · Friseurmeister,
+              18 Jahre Erfahrung
+            </figcaption>
+          </div>
+        </div>
+      </figure>
+
+      <div
+        className="mt-[18px] flex max-w-full flex-wrap items-center justify-center gap-x-2.5 gap-y-1 text-[var(--brand-plum)]"
+        aria-label="4,9 von 5 aus ersten Nutzerinnen-Feedbacks"
+      >
+        <div className="flex justify-center gap-0.5" aria-hidden="true">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Star key={index} aria-hidden="true" className="h-[13px] w-[13px] fill-current" />
+          ))}
+        </div>
+        <p className="font-mono text-[9.5px] font-medium uppercase leading-tight tracking-[0.055em] text-[var(--text-sub)]">
+          <strong className="font-semibold text-[var(--text-body)]">4,9/5</strong> aus ersten
+          Nutzerinnen-Feedbacks
         </p>
       </div>
-    </div>
+
+      <p className="mt-4 flex items-center justify-center gap-2 font-mono text-[10.5px] font-medium uppercase leading-tight tracking-[0.11em] text-[var(--brand-coral)]">
+        <span
+          className="h-1.5 w-1.5 rounded-full bg-[var(--brand-coral)] shadow-[0_0_0_5px_rgba(var(--brand-coral-rgb),0.11)] motion-safe:animate-pulse"
+          aria-hidden="true"
+        />
+        Starte heute damit
+      </p>
+
+      <p className="mt-[15px] text-[13px] text-[var(--text-caption)]">
+        Du hast bereits ein Konto?{" "}
+        <Link
+          href="/auth?force=login"
+          className="font-semibold text-[var(--brand-plum)] underline-offset-4 transition-colors hover:text-[var(--brand-plum-dark)] hover:underline"
+        >
+          Anmelden
+        </Link>
+      </p>
+    </main>
   )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
         default:
           "bg-primary text-primary-foreground shadow hover:bg-primary/90 text-[13px] font-semibold rounded-[11px] w-full",
         cta: "bg-secondary text-secondary-foreground shadow hover:bg-secondary/90 text-[14px] font-semibold rounded-[12px]",
+        landingCta:
+          "relative h-auto w-full overflow-hidden rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-6 py-4 text-base font-bold text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-colors after:pointer-events-none after:absolute after:inset-0 after:bg-[linear-gradient(135deg,rgba(255,255,255,0.18),transparent_45%)] motion-safe:transition-transform motion-safe:hover:-translate-y-0.5 hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] hover:shadow-[0_12px_36px_rgba(var(--brand-coral-rgb),0.36),inset_0_1px_0_rgba(255,255,255,0.22)]",
         outline:
           "border-[1.5px] border-primary bg-transparent text-primary text-[13px] font-semibold rounded-[12px] hover:bg-muted",
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
@@ -41,8 +43,14 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, ...props }, ref) => {
+    const resolvedSize = variant === "landingCta" && size === undefined ? null : size
+
     return (
-      <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <button
+        className={cn(buttonVariants({ variant, size: resolvedSize, className }))}
+        ref={ref}
+        {...props}
+      />
     )
   },
 )

--- a/tests/e2e-deployed.spec.ts
+++ b/tests/e2e-deployed.spec.ts
@@ -22,20 +22,33 @@ test.describe("Deployed App E2E Tests", () => {
     await expect(page).toHaveURL(/\/quiz/)
 
     // Should show the quiz landing content
-    await expect(page.getByText("FINDE IN 2 MINUTEN HERAUS", { exact: false })).toBeVisible({
+    await expect(page.getByText("Weißt du, was deine", { exact: false })).toBeVisible({
       timeout: 15000,
     })
 
     // "QUIZ STARTEN" button should exist
     await expect(page.getByRole("button", { name: /QUIZ STARTEN/i })).toBeVisible()
 
-    // Key bullet points should be present
-    await expect(page.getByText("Individuelle Analyse", { exact: false })).toBeVisible()
+    // Key landing signals should be present
+    await expect(page.getByText("Hair Concierge", { exact: true })).toBeVisible()
+    await expect(page.getByText("Tom Hannemann", { exact: false })).toBeVisible()
+    await expect(page.getByRole("img", { name: "Tom Hannemann" })).toBeVisible()
+    await expect(page.getByText("4,9/5", { exact: false })).toBeVisible()
+    await expect(page.getByText("Starte heute damit", { exact: false })).toBeVisible()
+    await expect(page.getByRole("link", { name: /Anmelden/i })).toHaveAttribute(
+      "href",
+      "/auth?force=login",
+    )
+
+    const headingFontFamily = await page.locator("#quiz-landing-title").evaluate((element) => {
+      return getComputedStyle(element).fontFamily
+    })
+    expect(headingFontFamily).toContain("Playfair")
   })
 
   test("quiz flow: start quiz and navigate through first 4 questions", async ({ page }) => {
     await page.goto("/quiz", { waitUntil: "networkidle" })
-    await expect(page.getByText("FINDE IN 2 MINUTEN HERAUS", { exact: false })).toBeVisible({
+    await expect(page.getByText("Weißt du, was deine", { exact: false })).toBeVisible({
       timeout: 15000,
     })
 
@@ -146,7 +159,7 @@ test.describe("Deployed App E2E Tests", () => {
       .click()
 
     // Should go back to landing
-    await expect(page.getByText("FINDE IN 2 MINUTEN HERAUS", { exact: false })).toBeVisible({
+    await expect(page.getByText("Weißt du, was deine", { exact: false })).toBeVisible({
       timeout: 10000,
     })
   })
@@ -169,7 +182,7 @@ test.describe("Deployed App E2E Tests", () => {
     expect(redirectedToQuiz || redirectedToAuth).toBe(true)
 
     if (redirectedToQuiz) {
-      await expect(page.getByText("FINDE IN 2 MINUTEN HERAUS", { exact: false })).toBeVisible({
+      await expect(page.getByText("Weißt du, was deine", { exact: false })).toBeVisible({
         timeout: 15000,
       })
     } else {


### PR DESCRIPTION
## Summary
- Replaces the unauthenticated quiz landing placeholder with the approved Hair Concierge hero treatment.
- Adds the richer background, brand mark, landing CTA variant, Tom Hannemann testimonial image, inline proof row, urgency line, and login link.
- Fixes font token resolution so Playfair/Jakarta render correctly and allows the TOP HAIR image source through Next/Image and CSP report-only config.

## Verification
- npm run typecheck
- npm run lint (passes with existing unrelated warnings)
- npm run build
- PLAYWRIGHT_BASE_URL=http://localhost:3767 npx playwright test tests/e2e-deployed.spec.ts --grep "quiz page loads with landing screen"
- Visual checks at 320, 390, and desktop widths

## Risk
- Tom image currently depends on the remote TOP HAIR asset remaining available; replace with an owned asset before final production marketing use if needed.