### PR TITLE
Reduce checkout activation latency

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server"
+import { after, NextResponse, type NextRequest } from "next/server"
 import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 import { getStripe } from "@/lib/stripe/client"
 import {
@@ -7,24 +7,22 @@ import {
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
 } from "@/lib/stripe/webhook-handlers"
+import { getStripeTierIds } from "@/lib/stripe/tier-ids"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import type Stripe from "stripe"
 
 export const runtime = "nodejs" // raw body required; edge runtime buffers differently
 
-async function getTierIds(supabase: SupabaseClient): Promise<{
-  freeTierId: string
-  premiumTierId: string
-}> {
-  const { data, error } = await supabase.from("subscription_tiers").select("id, slug")
-  if (error) throw new Error(`failed to load subscription_tiers: ${error.message}`)
-  const free = data?.find((r: { id: string; slug: string }) => r.slug === "free")?.id
-  const premium = data?.find((r: { id: string; slug: string }) => r.slug === "premium")?.id
-  if (!free || !premium) throw new Error("subscription_tiers seed rows missing")
-  return { freeTierId: free, premiumTierId: premium }
+async function getPremiumTierId(supabase: SupabaseClient) {
+  return (await getStripeTierIds(supabase)).premiumTierId
+}
+
+async function getFreeTierId(supabase: SupabaseClient) {
+  return (await getStripeTierIds(supabase)).freeTierId
 }
 
 export async function POST(req: NextRequest) {
+  const startedAt = Date.now()
   const sig = req.headers.get("stripe-signature")
   const body = await req.text()
   if (!sig) return new NextResponse("missing signature", { status: 400 })
@@ -46,26 +44,32 @@ export async function POST(req: NextRequest) {
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
     { auth: { persistSession: false } },
   )
-  const { freeTierId, premiumTierId } = await getTierIds(supabase)
-  const deps = { supabase, stripe, premiumTierId, linkQuizToProfile }
-  const deleteDeps = { ...deps, freeTierId }
 
   try {
     switch (event.type) {
       case "checkout.session.completed":
         await handleCheckoutSessionCompleted(
           event.data.object as unknown as Stripe.Checkout.Session,
-          deps,
+          {
+            supabase,
+            stripe,
+            premiumTierId: await getPremiumTierId(supabase),
+            linkQuizToProfile,
+            profileLinkMode: "defer",
+            defer: (work) => after(work),
+          },
         )
         break
       case "customer.subscription.updated":
-        await handleSubscriptionUpdated(event.data.object as unknown as Stripe.Subscription, deps)
+        await handleSubscriptionUpdated(event.data.object as unknown as Stripe.Subscription, {
+          supabase,
+        })
         break
       case "customer.subscription.deleted":
-        await handleSubscriptionDeleted(
-          event.data.object as unknown as Stripe.Subscription,
-          deleteDeps,
-        )
+        await handleSubscriptionDeleted(event.data.object as unknown as Stripe.Subscription, {
+          supabase,
+          freeTierId: await getFreeTierId(supabase),
+        })
         break
       case "invoice.payment_failed":
         await handleInvoicePaymentFailed(event.data.object as unknown as Stripe.Invoice)
@@ -78,6 +82,12 @@ export async function POST(req: NextRequest) {
     console.error("[stripe] handler error:", err)
     return new NextResponse(`handler error: ${message}`, { status: 500 })
   }
+
+  console.info("[stripe:webhook] handled", {
+    eventId: event.id,
+    type: event.type,
+    durationMs: Date.now() - startedAt,
+  })
 
   return NextResponse.json({ received: true })
 }

--- a/src/lib/stripe/checkout-activation.ts
+++ b/src/lib/stripe/checkout-activation.ts
@@ -8,6 +8,8 @@ export interface CheckoutActivationDeps {
   stripe: Stripe
   premiumTierId: string
   linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
+  profileLinkMode?: "await" | "defer" | "skip"
+  defer?: (work: () => void | Promise<void>) => void
   now?: () => Date
 }
 
@@ -91,7 +93,9 @@ export async function verifyCheckoutSessionForActivation(
   }
 
   const stripeClient = stripe ?? (await import("./client")).getStripe()
-  const session = await stripeClient.checkout.sessions.retrieve(sessionId)
+  const session = await measureCheckoutStep("stripe.checkout.sessions.retrieve", () =>
+    stripeClient.checkout.sessions.retrieve(sessionId),
+  )
   assertValidCheckoutSession(session)
   return session
 }
@@ -100,13 +104,19 @@ export async function ensureCheckoutAccount(
   session: Stripe.Checkout.Session,
   deps: CheckoutActivationDeps,
 ): Promise<CheckoutAccountResult> {
+  const startedAt = Date.now()
   const valid = assertValidCheckoutSession(session)
-  const sub = (await deps.stripe.subscriptions.retrieve(valid.subscriptionId, {
-    expand: ["items.data.price"],
-  })) as unknown as RetrievedSub
+  const sessionHash = checkoutSessionHash(valid.id).slice(0, 12)
+  const sub = (await measureCheckoutStep("stripe.subscriptions.retrieve", () =>
+    deps.stripe.subscriptions.retrieve(valid.subscriptionId, {
+      expand: ["items.data.price"],
+    }),
+  )) as unknown as RetrievedSub
   assertCurrentCheckoutSubscription(sub, deps.now?.() ?? new Date())
 
-  const existingProfile = await findExistingProfile(deps, valid.email, valid.customerId)
+  const existingProfile = await measureCheckoutStep("profiles.findExisting", () =>
+    findExistingProfile(deps, valid.email, valid.customerId),
+  )
 
   let userId: string
   let canSetInitialPassword = false
@@ -115,7 +125,9 @@ export async function ensureCheckoutAccount(
     userId = existingProfile.id
     canSetInitialPassword = await canSetPasswordForCheckoutSession(deps, userId, valid.id)
   } else {
-    const created = await createCheckoutUser(deps, valid.email, valid.id, valid.customerId)
+    const created = await measureCheckoutStep("auth.createCheckoutUser", () =>
+      createCheckoutUser(deps, valid.email, valid.id, valid.customerId),
+    )
     if (created.created) {
       userId = created.userId
       canSetInitialPassword = true
@@ -130,26 +142,71 @@ export async function ensureCheckoutAccount(
     interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
   })
 
-  await upsertSubscriptionProfile(deps, userId, {
-    email: valid.email,
-    stripe_customer_id: valid.customerId,
-    stripe_subscription_id: sub.id,
-    subscription_status: "active",
-    subscription_interval: interval,
-    current_period_end: subPeriodEndIso(sub),
-    subscription_tier_id: deps.premiumTierId,
+  await measureCheckoutStep("profiles.upsertSubscription", () =>
+    upsertSubscriptionProfile(deps, userId, {
+      email: valid.email,
+      stripe_customer_id: valid.customerId,
+      stripe_subscription_id: sub.id,
+      subscription_status: "active",
+      subscription_interval: interval,
+      current_period_end: subPeriodEndIso(sub),
+      subscription_tier_id: deps.premiumTierId,
+    }),
+  )
+
+  await linkCheckoutQuizProfile(session, deps, userId, valid.email)
+
+  console.info("[checkout-activation] account ensured", {
+    sessionHash,
+    userId,
+    profileLinkMode: deps.profileLinkMode ?? "await",
+    durationMs: Date.now() - startedAt,
   })
 
-  if (deps.linkQuizToProfile) {
-    const leadId = session.metadata?.lead_id || undefined
+  return { userId, email: valid.email, canSetInitialPassword }
+}
+
+async function measureCheckoutStep<T>(label: string, work: () => Promise<T>): Promise<T> {
+  const startedAt = Date.now()
+  try {
+    return await work()
+  } finally {
+    console.info("[checkout-activation] step", {
+      label,
+      durationMs: Date.now() - startedAt,
+    })
+  }
+}
+
+async function linkCheckoutQuizProfile(
+  session: Stripe.Checkout.Session,
+  deps: CheckoutActivationDeps,
+  userId: string,
+  email: string,
+) {
+  if (!deps.linkQuizToProfile || deps.profileLinkMode === "skip") return
+
+  const leadId = session.metadata?.lead_id || undefined
+  const work = async () => {
+    const startedAt = Date.now()
     try {
-      await deps.linkQuizToProfile(userId, valid.email, leadId)
+      await deps.linkQuizToProfile?.(userId, email, leadId)
+      console.info("[checkout-activation] quiz profile linked", {
+        userId,
+        hasLeadId: Boolean(leadId),
+        durationMs: Date.now() - startedAt,
+      })
     } catch (err) {
       console.error("[stripe] linkQuizToProfile failed:", err)
     }
   }
 
-  return { userId, email: valid.email, canSetInitialPassword }
+  if (deps.profileLinkMode === "defer" && deps.defer) {
+    deps.defer(work)
+    return
+  }
+
+  await work()
 }
 
 function assertCurrentCheckoutSubscription(sub: RetrievedSub, now: Date) {
@@ -233,9 +290,12 @@ async function findExistingProfile(
   email: string,
   customerId: string,
 ): Promise<ProfileRow | null> {
-  const byEmail = await findProfileBy(deps, "email", email)
+  const [byEmail, byCustomer] = await Promise.all([
+    findProfileBy(deps, "email", email),
+    findProfileBy(deps, "stripe_customer_id", customerId),
+  ])
   if (byEmail) return byEmail
-  return findProfileBy(deps, "stripe_customer_id", customerId)
+  return byCustomer
 }
 
 async function findProfileBy(

--- a/src/lib/stripe/tier-ids.ts
+++ b/src/lib/stripe/tier-ids.ts
@@ -1,0 +1,40 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export interface StripeTierIds {
+  freeTierId: string
+  premiumTierId: string
+}
+
+let tierIds: StripeTierIds | null = null
+let tierIdsPromise: Promise<StripeTierIds> | null = null
+
+export async function getStripeTierIds(supabase: SupabaseClient): Promise<StripeTierIds> {
+  if (tierIds) return tierIds
+  if (tierIdsPromise) return tierIdsPromise
+
+  tierIdsPromise = loadStripeTierIds(supabase)
+    .then((ids) => {
+      tierIds = ids
+      return ids
+    })
+    .catch((err) => {
+      tierIdsPromise = null
+      throw err
+    })
+
+  return tierIdsPromise
+}
+
+export function resetStripeTierIdsCacheForTests() {
+  tierIds = null
+  tierIdsPromise = null
+}
+
+async function loadStripeTierIds(supabase: SupabaseClient): Promise<StripeTierIds> {
+  const { data, error } = await supabase.from("subscription_tiers").select("id, slug")
+  if (error) throw new Error(`failed to load subscription_tiers: ${error.message}`)
+  const free = data?.find((r: { id: string; slug: string }) => r.slug === "free")?.id
+  const premium = data?.find((r: { id: string; slug: string }) => r.slug === "premium")?.id
+  if (!free || !premium) throw new Error("subscription_tiers seed rows missing")
+  return { freeTierId: free, premiumTierId: premium }
+}

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -4,6 +4,7 @@ import { ensureCheckoutAccount, subPeriodEndIso } from "./checkout-activation"
 import { intervalFromPrice } from "./intervals"
 
 export type HandlerDeps = CheckoutActivationDeps
+type SubscriptionUpdateDeps = Pick<HandlerDeps, "supabase">
 
 export async function handleCheckoutSessionCompleted(
   session: Stripe.Checkout.Session,
@@ -33,7 +34,7 @@ interface UpdatedSub {
 
 export async function handleSubscriptionUpdated(
   sub: Stripe.Subscription,
-  deps: HandlerDeps,
+  deps: SubscriptionUpdateDeps,
 ): Promise<void> {
   const s = sub as unknown as UpdatedSub
   if (typeof s.customer !== "string") throw new Error("sub.customer not a string")
@@ -52,7 +53,8 @@ export async function handleSubscriptionUpdated(
     .eq("stripe_customer_id", s.customer)
 }
 
-export interface DeleteDeps extends HandlerDeps {
+export interface DeleteDeps {
+  supabase: HandlerDeps["supabase"]
   freeTierId: string
 }
 

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -7,6 +7,18 @@ export async function updateSession(request: NextRequest) {
     request,
   })
 
+  const { pathname } = request.nextUrl
+  const fastPublicRoutes = [
+    "/api/stripe",
+    "/api/auth/send-magic-link",
+    "/api/auth/send-setup-link",
+    "/api/auth/set-checkout-password",
+    "/welcome",
+  ]
+  if (fastPublicRoutes.some((route) => pathname.startsWith(route))) {
+    return supabaseResponse
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -32,7 +44,6 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const { pathname } = request.nextUrl
   const isQuizRetake = pathname === "/quiz" && request.nextUrl.searchParams.get("mode") === "retake"
   const isForcedAuthLogin =
     pathname === "/auth" && request.nextUrl.searchParams.get("force") === "login"

--- a/tests/checkout-activation.spec.ts
+++ b/tests/checkout-activation.spec.ts
@@ -406,6 +406,33 @@ test("ensureCheckoutAccount still resolves when linkQuizToProfile rejects", asyn
   expect(profiles["user-1"].subscription_status).toBe("active")
 })
 
+test("ensureCheckoutAccount can defer quiz profile linking until after the account is active", async () => {
+  const { deps, profiles } = stubDeps()
+  const linkCalls: Array<[string, string | undefined, string | undefined]> = []
+  const deferred: { work?: () => void | Promise<void> } = {}
+
+  deps.linkQuizToProfile = async (userId, email, leadId) => {
+    linkCalls.push([userId, email, leadId])
+  }
+  deps.profileLinkMode = "defer"
+  deps.defer = (work) => {
+    deferred.work = work
+  }
+
+  const result = await ensureCheckoutAccount(
+    checkoutSession({ metadata: { lead_id: "lead-deferred" } }),
+    deps,
+  )
+
+  expect(result).toMatchObject({ userId: "user-1", canSetInitialPassword: true })
+  expect(profiles["user-1"].subscription_status).toBe("active")
+  expect(linkCalls).toHaveLength(0)
+
+  expect(deferred.work).toBeDefined()
+  await deferred.work?.()
+  expect(linkCalls).toEqual([["user-1", "new@example.com", "lead-deferred"]])
+})
+
 test("ensureCheckoutAccount rejects inactive checkout subscriptions", async () => {
   const { deps, profiles } = stubDeps()
   deps.stripe.subscriptions.retrieve = async (id: string) =>

--- a/tests/stripe-tier-ids.spec.ts
+++ b/tests/stripe-tier-ids.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test"
+import { getStripeTierIds, resetStripeTierIdsCacheForTests } from "../src/lib/stripe/tier-ids"
+
+function supabaseWithResponses(responses: Array<{ data?: unknown; error?: { message: string } }>) {
+  let calls = 0
+
+  return {
+    get calls() {
+      return calls
+    },
+    client: {
+      from(table: string) {
+        expect(table).toBe("subscription_tiers")
+        return {
+          async select(columns: string) {
+            expect(columns).toBe("id, slug")
+            const response = responses[calls]
+            calls += 1
+            return response ?? responses.at(-1)
+          },
+        }
+      },
+    } as any,
+  }
+}
+
+test.beforeEach(() => {
+  resetStripeTierIdsCacheForTests()
+})
+
+test("getStripeTierIds retries after a transient subscription tier lookup failure", async () => {
+  const supabase = supabaseWithResponses([
+    { error: { message: "temporary timeout" } },
+    {
+      data: [
+        { id: "tier-free", slug: "free" },
+        { id: "tier-premium", slug: "premium" },
+      ],
+    },
+  ])
+
+  await expect(getStripeTierIds(supabase.client)).rejects.toThrow(
+    "failed to load subscription_tiers: temporary timeout",
+  )
+  await expect(getStripeTierIds(supabase.client)).resolves.toEqual({
+    freeTierId: "tier-free",
+    premiumTierId: "tier-premium",
+  })
+  expect(supabase.calls).toBe(2)
+})
+
+test("getStripeTierIds caches successful subscription tier lookup", async () => {
+  const supabase = supabaseWithResponses([
+    {
+      data: [
+        { id: "tier-free", slug: "free" },
+        { id: "tier-premium", slug: "premium" },
+      ],
+    },
+  ])
+
+  await expect(getStripeTierIds(supabase.client)).resolves.toEqual({
+    freeTierId: "tier-free",
+    premiumTierId: "tier-premium",
+  })
+  await expect(getStripeTierIds(supabase.client)).resolves.toEqual({
+    freeTierId: "tier-free",
+    premiumTierId: "tier-premium",
+  })
+  expect(supabase.calls).toBe(1)
+})

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -231,6 +231,40 @@ test("checkout.session.completed without metadata calls linkQuizToProfile with u
   expect(calledLeadId).toBeUndefined()
 })
 
+test("checkout.session.completed can defer quiz profile linking", async () => {
+  const { deps, profiles } = stubDeps()
+  const calls: Array<[string, string | undefined, string | undefined]> = []
+  const deferred: { work?: () => void | Promise<void> } = {}
+
+  deps.linkQuizToProfile = async (userId, email, leadId) => {
+    calls.push([userId, email, leadId])
+  }
+  deps.profileLinkMode = "defer"
+  deps.defer = (work) => {
+    deferred.work = work
+  }
+
+  const session = {
+    id: "cs_defer",
+    status: "complete",
+    payment_status: "paid",
+    customer: "cus_defer",
+    customer_details: { email: "defer@example.com" },
+    subscription: "sub_defer",
+    metadata: { lead_id: "lead-defer" },
+  } as any
+
+  await handleCheckoutSessionCompleted(session, deps)
+
+  const p = Object.values(profiles).find((x: any) => x.email === "defer@example.com") as any
+  expect(p?.subscription_status).toBe("active")
+  expect(calls).toHaveLength(0)
+
+  expect(deferred.work).toBeDefined()
+  await deferred.work?.()
+  expect(calls).toEqual([[p.id, "defer@example.com", "lead-defer"]])
+})
+
 test("checkout.session.completed does not throw when linkQuizToProfile rejects", async () => {
   const { deps, profiles } = stubDeps()
   deps.linkQuizToProfile = async () => {


### PR DESCRIPTION
## Why

Post-payment activation felt slow after successful Stripe checkout. We want the paid account/subscription activation to stay reliable and synchronous, while moving non-critical enrichment work off the critical webhook path.

## What changed

- Keeps Stripe checkout account activation synchronous through subscription retrieval, user/profile resolution, and subscription upsert.
- Defers quiz/profile linking from the Stripe webhook with Next after().
- Adds step timing logs for checkout activation and webhook handling.
- Lazily loads and caches Stripe tier IDs, with retry after transient lookup failures.
- Skips middleware auth refresh for public checkout/welcome activation endpoints whose routes verify their own inputs.
- Adds focused tests for deferred quiz linking and tier ID cache retry behavior.

## Verification

- npm run typecheck
- npx playwright test tests/stripe-tier-ids.spec.ts tests/checkout-activation.spec.ts tests/stripe-webhook-handlers.spec.ts tests/stripe-gating.spec.ts tests/stripe-intervals.spec.ts tests/auth-post-checkout-routes.spec.ts --project=chromium
- npm run lint (passed with 4 unrelated existing warnings)
- npm run build
- Code review requested; one cache-poisoning issue fixed and re-reviewed as resolved.

## Notes

This PR re-applies the latency change after #96 restored main to the pre-direct-push state.