### PR TITLE
feat(langfuse): observe agentic tool loop prompts

### DIFF
--- a/docs/langfuse-quality-loop.md
+++ b/docs/langfuse-quality-loop.md
@@ -1,25 +1,35 @@
 # Langfuse Quality Loop
 
-This repo now has a phase-1 Langfuse integration for the production chat path.
+This repo has a Langfuse integration for the production chat path and the
+agentic tool-loop recommendation engine.
 
 ## What is live in the app
 
 - One Langfuse trace per chat turn, grouped by conversation ID as the session ID.
-- Child observations for the major pipeline stages:
-  - context loading
-  - intent classification
-  - routing
-  - retrieval
-  - product selection
-  - synthesis
-  - memory extraction
+- The production chat route runs `runProductionAgentPipeline`, which uses the
+  `tool_loop` engine.
+- Observed OpenAI generations for current agent prompts:
+  - `agentic-tool-loop-step`
+  - `agentic-tool-loop-contextual-composer` when composer mode is used
+  - legacy bounded-agent route/render generations when Compare Lab or older
+    helper paths use them
+- The root chat observation output includes compact review fields:
+  - `response_composition`
+  - `engine_summary`
+  - `selected_products`
+  - `agentic_tool_loop_summary`
+- The full sanitized turn trace is persisted in Supabase
+  `conversation_turn_traces`.
 - Prompt linkage for the production chat prompts:
   - chat system prompt
   - intent classifier prompt
   - conversation title prompt
   - memory extraction prompt
+  - agent route classifier prompt
+  - agentic tool-loop prompt
+  - agentic contextual composer prompt
+  - agent final render prompt
 - Prompt fallback behavior if Langfuse is unavailable or a label is missing.
-- Dual-write trace persistence in Supabase via `conversation_turn_traces`.
 - Assistant-message thumbs up/down feedback stored locally and sent to Langfuse scores.
 - Eval harness publishing into Langfuse experiments.
 
@@ -40,7 +50,8 @@ Use your Langfuse EU cloud base URL for `LANGFUSE_BASE_URL`.
 
 ## Prompt workflow
 
-The repo keeps prompt fallbacks in code and treats Langfuse as the runtime source of truth.
+The repo keeps prompt fallbacks in code and treats Langfuse as the runtime
+source of truth for managed prompts that are fetched by the current runtime.
 
 1. Sync the repo prompts into Langfuse:
 
@@ -50,7 +61,9 @@ npm run langfuse:sync-prompts
 
 2. Review or relabel the synced versions in Langfuse.
 
-3. Production chat reads by label. If that fetch fails, the app falls back to the in-repo prompt text and marks the trace as fallback-backed.
+3. Production chat reads managed prompts by label for the agentic model calls.
+   If that fetch fails, the app falls back to the in-repo prompt text and marks
+   the generation metadata as fallback-backed.
 
 Use `--dry-run` to preview prompt changes:
 
@@ -117,30 +130,29 @@ The PR chat smoke suite intentionally stays small to control external API cost a
 
 The retrieval metric gate requires an annotated gold set. The current placeholder value `__ANNOTATE__` is intentionally treated as not enforceable so CI does not report meaningless zero-quality scores as product regressions.
 
-## Agentic Tool Loop Rollout Gate
+## Agentic Tool Loop Production Status
 
-The `tool_loop` engine starts in Compare Lab only. Do not wire it as the default production chat engine until blinded Compare Lab review shows it is materially better than `classic`.
+The `tool_loop` engine is the production chat path. Compare Lab still exists for
+side-by-side review, but `/api/chat` now routes through the agentic tool loop and
+deterministic recommendation tools.
 
-Each Compare Lab judgment for `classic` vs `tool_loop` should record:
+For production review, inspect:
 
-- blinded winner: `classic`, `tool_loop`, or `tie`
-- failure bucket, including `semantic_state_conflict` and `tool_not_called`
-- critical product-claim failure: yes/no
-- latency for both variants
-- model step count for `tool_loop`
-- tool-call count for `tool_loop`
+- `response_composition.path = agentic_tool_loop`
+- `engine_variant = tool_loop`
+- `router_decision.retrieval_mode = agentic_tool_loop`
+- `agentic_tool_loop.model_steps`
+- `agentic_tool_loop.tool_calls`
+- `agentic_tool_loop.loaded_guidance_ids`
+- `agentic_tool_loop.answer_context_capsule_ids`
+- `agentic_tool_loop.guardrails`
+- `agentic_tool_loop.visible_failure`
+- `decision_context.engine_trace`
+- `decision_context.matched_products`
 
-Minimum rollout gate:
-
-- at least 50 blinded judgments
-- at least 25 held-out real historical turns, not only crafted prompts
-- two reviewers, or an explicit single-reviewer caveat in the PR
-- `semantic_state_conflict` plus `tool_not_called` failures reduced by at least 50% versus `classic`
-- wins exceed losses by at least 15 percentage points, excluding ties
-- zero critical invented-product or unsupported product-claim failures
-- p50 latency within +25% of `classic` and p95 within +35%
-
-Rollback stays simple: set `CHAT_AGENT_ENGINE=classic`. Tool-loop traces and conversation-state transitions should preserve `updated_by_engine`, and classic readers must ignore unknown tool-loop metadata.
+The main risk buckets are now tool-choice misses, missing or over-broad guidance,
+deterministic engine/category fit regressions, unsupported product-claim wording,
+and visible tool-loop failure handling.
 
 ## GitHub repository settings to confirm
 
@@ -181,6 +193,8 @@ Production dataset items include review metadata for slicing:
 - `trace_version`
 - `response_composition_path`
 - `prompt_kind`
+- `retrieval_mode`
+- `response_mode`
 - `engine_damage_level`
 - `engine_repair_priority`
 - `engine_actions`
@@ -195,10 +209,17 @@ Trace Schema V2 keeps the review-critical decision path in structured fields:
 - `decision_context.engine_trace.damage`: engine damage assessment, including overall level and repair priority.
 - `decision_context.engine_trace.categories`: category-level engine actions. For review, inspect each category's `relevant`, `action`, reason codes, and target profile.
 - `decision_context.matched_products`: selected product traces, including `recommendation_meta` for score, top reasons, tradeoffs, usage hint, and category-specific fit metadata.
+- `agentic_tool_loop`: compact model-step, tool-call, loaded-guidance,
+  answer-context, guardrail, and visible-failure metadata. Raw prompt context and
+  raw guidance bodies are intentionally not persisted here.
 - `response_composition`: composer path, migration mode, fallback reason, rendering path, plan type, and attachment mode.
 - `user_feedback`: thumbs feedback and review annotations when present, including `failure_bucket`.
 
-In Langfuse, start from the production dataset item metadata for slicing, then open the source trace to inspect the full `router_decision`, engine categories, matched product `recommendation_meta`, `response_composition`, and `user_feedback` details.
+In Langfuse, start from the production dataset item metadata for slicing, then
+open the source trace to inspect the root observation output. Use the linked
+Supabase `conversation_turn_traces` row or admin conversation trace view for the
+full `agentic_tool_loop`, `router_decision`, engine categories, matched product
+`recommendation_meta`, `response_composition`, and `user_feedback` details.
 
 ## Review queue setup
 
@@ -227,14 +248,15 @@ Use the shared review rubric in [docs/chat-quality-review-rubric.md](docs/chat-q
 
 ## Tester Cohort Review
 
-Run tester cohort review weekly while the C-lite rollout is active, and additionally after prompt, router, recommendation-engine, or response-composition changes.
+Run tester cohort review weekly, and additionally after prompt, tool-routing,
+recommendation-engine, answer-context, or response-composition changes.
 
 Suggested cadence:
 
 - `2x` per week: review new thumbs-down traces from the tester cohort.
 - weekly: sample zero-feedback traces across the most active categories.
 - weekly: sample thumbs-up traces as positive references.
-- before a C-lite rule or prompt change: seed the production dataset and tag the review batch.
+- before a tool-loop rule or prompt change: seed the production dataset and tag the review batch.
 - after the change: compare the same slicing dimensions against the next tester cohort sample.
 
 Primary slicing dimensions:
@@ -247,6 +269,11 @@ Primary slicing dimensions:
 - `retrieval_mode`
 - `response_mode`
 - `needs_clarification`
+- `agentic_tool_loop.tool_calls[].name`
+- `agentic_tool_loop.loaded_guidance_ids`
+- `agentic_tool_loop.answer_context_capsule_ids`
+- `agentic_tool_loop.guardrails`
+- `agentic_tool_loop.visible_failure`
 - `engine_damage_level`
 - `engine_repair_priority`
 - `engine_actions.<category>.relevant`

--- a/docs/mockups/langfuse-message-journey.html
+++ b/docs/mockups/langfuse-message-journey.html
@@ -1,0 +1,963 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Langfuse Message Journey</title>
+    <style>
+      :root {
+        --paper: #f7f4ef;
+        --ink: #1c2321;
+        --muted: #65716c;
+        --line: #d6d1c8;
+        --soft: #fffaf2;
+        --server: #e8f1ec;
+        --agent: #eef0fb;
+        --data: #f6eadc;
+        --lf: #161b22;
+        --lf2: #2f6f68;
+        --accent: #b85f49;
+        --blue: #355f89;
+        --green: #48785f;
+        --shadow: 0 18px 50px rgba(42, 35, 24, 0.12);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--paper);
+        color: var(--ink);
+        font-family:
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        line-height: 1.45;
+      }
+
+      main {
+        width: min(1480px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 28px 0 48px;
+      }
+
+      .hero {
+        min-height: 58vh;
+        display: grid;
+        grid-template-columns: minmax(0, 1.04fr) minmax(340px, 0.96fr);
+        gap: 24px;
+        align-items: stretch;
+        padding: 32px 0 26px;
+      }
+
+      .hero-copy {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-right: 18px;
+      }
+
+      .eyebrow {
+        color: var(--lf2);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 10px 0 14px;
+        max-width: 760px;
+        font-size: clamp(44px, 6vw, 92px);
+        line-height: 0.96;
+        letter-spacing: 0;
+      }
+
+      .lead {
+        max-width: 720px;
+        color: #414b47;
+        font-size: clamp(18px, 2vw, 24px);
+      }
+
+      .hero-panel {
+        position: relative;
+        min-height: 460px;
+        border: 1px solid var(--line);
+        background:
+          linear-gradient(135deg, rgba(255, 250, 242, 0.96), rgba(232, 241, 236, 0.92)),
+          repeating-linear-gradient(90deg, transparent 0 52px, rgba(28, 35, 33, 0.04) 52px 53px);
+        box-shadow: var(--shadow);
+        overflow: hidden;
+      }
+
+      .hero-panel::before {
+        content: "";
+        position: absolute;
+        inset: 24px;
+        border: 1px solid rgba(28, 35, 33, 0.12);
+        pointer-events: none;
+      }
+
+      .mini-flow {
+        position: absolute;
+        inset: 50px 42px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: repeat(4, 1fr);
+        gap: 14px;
+      }
+
+      .mini-node {
+        position: relative;
+        min-height: 72px;
+        padding: 16px 16px 14px;
+        border: 1px solid rgba(28, 35, 33, 0.13);
+        background: rgba(255, 255, 255, 0.72);
+      }
+
+      .mini-node strong {
+        display: block;
+        font-size: 14px;
+        line-height: 1.2;
+      }
+
+      .mini-node span {
+        display: block;
+        margin-top: 4px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .mini-node.langfuse {
+        background: var(--lf);
+        color: #fffdf8;
+        border-color: var(--lf);
+      }
+
+      .mini-node.langfuse span {
+        color: #b9c8c4;
+      }
+
+      .pin {
+        position: absolute;
+        top: -12px;
+        right: -10px;
+        width: 28px;
+        height: 28px;
+        display: grid;
+        place-items: center;
+        border: 2px solid var(--paper);
+        border-radius: 50%;
+        background: var(--accent);
+        color: #fff;
+        font-weight: 800;
+        font-size: 12px;
+        box-shadow: 0 8px 18px rgba(184, 95, 73, 0.25);
+      }
+
+      .section-title {
+        margin: 38px 0 16px;
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 18px;
+      }
+
+      h2 {
+        margin: 0;
+        font-size: clamp(28px, 4vw, 46px);
+        letter-spacing: 0;
+      }
+
+      .section-title p {
+        margin: 0;
+        max-width: 620px;
+        color: var(--muted);
+        font-size: 15px;
+      }
+
+      .legend {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(170px, 1fr));
+        gap: 12px;
+        margin: 10px 0 22px;
+      }
+
+      .legend-item {
+        border: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.52);
+        padding: 12px 14px;
+        font-size: 13px;
+      }
+
+      .swatch {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        margin-right: 8px;
+        vertical-align: -1px;
+        background: var(--lf);
+      }
+
+      .swatch.server {
+        background: var(--green);
+      }
+      .swatch.agent {
+        background: var(--blue);
+      }
+      .swatch.data {
+        background: var(--accent);
+      }
+
+      .journey {
+        position: relative;
+        display: grid;
+        grid-template-columns: 150px repeat(9, minmax(130px, 1fr));
+        border: 1px solid var(--line);
+        background: var(--soft);
+        box-shadow: var(--shadow);
+        overflow-x: auto;
+      }
+
+      .lane-label,
+      .step-head,
+      .lane-cell {
+        min-width: 130px;
+        border-right: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+      }
+
+      .lane-label {
+        min-width: 150px;
+      }
+
+      .step-head {
+        padding: 14px 12px;
+        background: #efe7dc;
+        color: #3a403d;
+        font-size: 12px;
+        font-weight: 800;
+        text-transform: uppercase;
+      }
+
+      .lane-label {
+        position: sticky;
+        left: 0;
+        z-index: 2;
+        padding: 18px 14px;
+        background: #efe7dc;
+        color: #222b27;
+        font-weight: 800;
+      }
+
+      .lane-label small {
+        display: block;
+        margin-top: 4px;
+        color: var(--muted);
+        font-weight: 500;
+      }
+
+      .lane-cell {
+        position: relative;
+        min-height: 170px;
+        padding: 14px;
+        background: rgba(255, 255, 255, 0.38);
+      }
+
+      .lane-cell.server {
+        background: var(--server);
+      }
+      .lane-cell.agent {
+        background: var(--agent);
+      }
+      .lane-cell.data {
+        background: var(--data);
+      }
+      .lane-cell.langfuse {
+        background: #f1f4f2;
+      }
+
+      .event {
+        height: 100%;
+        border: 1px solid rgba(28, 35, 33, 0.15);
+        background: rgba(255, 255, 255, 0.78);
+        padding: 12px 12px 11px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .event.dark {
+        background: var(--lf);
+        color: #fff;
+        border-color: var(--lf);
+      }
+
+      .event.empty {
+        opacity: 0.34;
+        border-style: dashed;
+        background: transparent;
+      }
+
+      .event h3 {
+        margin: 0 0 4px;
+        font-size: 15px;
+        line-height: 1.18;
+        letter-spacing: 0;
+        overflow-wrap: anywhere;
+      }
+
+      .event p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 12px;
+        overflow-wrap: anywhere;
+      }
+
+      .event.dark p {
+        color: #c8d5d1;
+      }
+
+      code {
+        color: inherit;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.94em;
+        overflow-wrap: anywhere;
+      }
+
+      .dock {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        display: grid;
+        place-items: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: var(--accent);
+        color: #fff;
+        font-size: 12px;
+        font-weight: 900;
+        box-shadow: 0 8px 18px rgba(184, 95, 73, 0.25);
+      }
+
+      .arrow {
+        position: absolute;
+        top: 50%;
+        right: -15px;
+        z-index: 3;
+        color: #79857f;
+        font-size: 24px;
+        transform: translateY(-50%);
+      }
+
+      .dock-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 14px;
+        margin-top: 18px;
+      }
+
+      .dock-card {
+        position: relative;
+        border: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.7);
+        padding: 18px 18px 16px;
+        min-height: 190px;
+      }
+
+      .dock-card::before {
+        content: attr(data-number);
+        position: absolute;
+        top: 14px;
+        right: 14px;
+        width: 34px;
+        height: 34px;
+        display: grid;
+        place-items: center;
+        border-radius: 50%;
+        background: var(--lf);
+        color: #fff;
+        font-weight: 900;
+        font-size: 13px;
+      }
+
+      .dock-card h3 {
+        margin: 0 42px 8px 0;
+        font-size: 18px;
+        line-height: 1.2;
+      }
+
+      .dock-card p {
+        margin: 0 0 12px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      .file-ref {
+        display: block;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid rgba(28, 35, 33, 0.12);
+        color: #33443f;
+        font-size: 12px;
+        word-break: break-word;
+      }
+
+      .trace-map {
+        display: grid;
+        grid-template-columns: 1.05fr 0.95fr;
+        gap: 18px;
+        margin-top: 20px;
+      }
+
+      .trace-box {
+        border: 1px solid var(--line);
+        background: rgba(255, 255, 255, 0.7);
+        padding: 20px;
+      }
+
+      .trace-list {
+        display: grid;
+        gap: 10px;
+        margin: 16px 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .trace-list li {
+        display: grid;
+        grid-template-columns: 136px 1fr;
+        gap: 12px;
+        padding: 10px 0;
+        border-top: 1px solid rgba(28, 35, 33, 0.11);
+        font-size: 13px;
+      }
+
+      .trace-list b {
+        color: var(--lf2);
+      }
+
+      .footer-note {
+        margin-top: 26px;
+        padding: 18px 20px;
+        border: 1px solid var(--line);
+        background: #eee5d8;
+        color: #38423e;
+        font-size: 14px;
+      }
+
+      @media (max-width: 980px) {
+        main {
+          width: min(100vw - 20px, 760px);
+        }
+
+        .hero,
+        .trace-map,
+        .dock-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .legend {
+          grid-template-columns: 1fr 1fr;
+        }
+
+        .hero-panel {
+          min-height: 560px;
+        }
+
+        .mini-flow {
+          grid-template-columns: 1fr;
+          grid-template-rows: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <div class="hero-copy">
+          <div class="eyebrow">Hair Concierge Observability</div>
+          <h1>Eine Chat-Nachricht auf dem Weg durch Langfuse</h1>
+          <p class="lead">
+            Diese Ansicht zeigt, wo Langfuse wirklich andockt: am Request-Trace, an den
+            OpenAI-Generations, an Prompt-Versionen, am kompakten Turn-Output, an Feedback-Scores
+            und an Eval-/Dataset-Laeufen.
+          </p>
+        </div>
+
+        <div class="hero-panel" aria-label="Kurzer Langfuse Ueberblick">
+          <div class="mini-flow">
+            <div class="mini-node">
+              <strong>1. Nutzerin fragt</strong>
+              <span>Browser sendet POST /api/chat</span>
+            </div>
+            <div class="mini-node langfuse">
+              <span class="pin">1</span>
+              <strong>Root Trace startet</strong>
+              <span>production-chat-turn</span>
+            </div>
+            <div class="mini-node">
+              <strong>2. Tool Loop entscheidet</strong>
+              <span>Guidance, Produkt-Tool, Routine-Tool</span>
+            </div>
+            <div class="mini-node langfuse">
+              <span class="pin">3</span>
+              <strong>OpenAI wird beobachtet</strong>
+              <span>agentic-tool-loop-step</span>
+            </div>
+            <div class="mini-node">
+              <strong>3. Antwort streamt</strong>
+              <span>SSE, Produktkarten, done-event</span>
+            </div>
+            <div class="mini-node langfuse">
+              <span class="pin">5</span>
+              <strong>Trace-Output</strong>
+              <span>engine_summary, selected_products</span>
+            </div>
+            <div class="mini-node">
+              <strong>4. Feedback/Evals</strong>
+              <span>Daumen, Datasets, Runs</span>
+            </div>
+            <div class="mini-node langfuse">
+              <span class="pin">7</span>
+              <strong>Scores & Experimente</strong>
+              <span>Review und Regressionen</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-title">
+          <h2>Die Reise</h2>
+          <p>
+            Jede Spalte ist ein Moment im Turn. Schwarze Elemente sind direkte Langfuse-Docks,
+            orange Pins markieren die Stellen, an denen Langfuse Daten bekommt oder IDs liefert.
+          </p>
+        </div>
+
+        <div class="legend">
+          <div class="legend-item"><span class="swatch server"></span>Next.js / API Route</div>
+          <div class="legend-item"><span class="swatch agent"></span>Agentic Tool Loop</div>
+          <div class="legend-item">
+            <span class="swatch data"></span>Supabase / lokale Trace-Daten
+          </div>
+          <div class="legend-item"><span class="swatch"></span>Langfuse Dock</div>
+        </div>
+
+        <div
+          class="journey"
+          role="img"
+          aria-label="Journey einer Chat-Nachricht mit Langfuse Andockpunkten"
+        >
+          <div class="step-head"></div>
+          <div class="step-head">01 Eingang</div>
+          <div class="step-head">02 Trace Start</div>
+          <div class="step-head">03 Attribute</div>
+          <div class="step-head">04 Pipeline</div>
+          <div class="step-head">05 LLM Call</div>
+          <div class="step-head">06 Tools</div>
+          <div class="step-head">07 Antwort</div>
+          <div class="step-head">08 Speichern</div>
+          <div class="step-head">09 Review</div>
+
+          <div class="lane-label">Nutzeroberflaeche<small>Browser / Chat UI</small></div>
+          <div class="lane-cell">
+            <div class="event">
+              <div>
+                <h3>Nachricht geht los</h3>
+                <p><code>POST /api/chat</code> mit Text und optionaler conversation_id.</p>
+              </div>
+              <span class="arrow">-></span>
+            </div>
+          </div>
+          <div class="lane-cell"><div class="event empty"></div></div>
+          <div class="lane-cell"><div class="event empty"></div></div>
+          <div class="lane-cell"><div class="event empty"></div></div>
+          <div class="lane-cell"><div class="event empty"></div></div>
+          <div class="lane-cell"><div class="event empty"></div></div>
+          <div class="lane-cell">
+            <div class="event">
+              <div>
+                <h3>Stream zurueck</h3>
+                <p>SSE sendet Text, Produktkarten, Quellen und <code>done</code>.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell"><div class="event empty"></div></div>
+          <div class="lane-cell">
+            <div class="event">
+              <div>
+                <h3>Daumen Feedback</h3>
+                <p>Assistant Message bekommt +1 oder -1.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="lane-label">API Route<small>src/app/api/chat/route.ts</small></div>
+          <div class="lane-cell server">
+            <div class="event">
+              <div>
+                <h3>Auth + Rate Limit</h3>
+                <p>User wird geladen, Conversation wird validiert oder erstellt.</p>
+              </div>
+              <span class="arrow">-></span>
+            </div>
+          </div>
+          <div class="lane-cell server">
+            <div class="event dark">
+              <span class="dock">1</span>
+              <div>
+                <h3><code>startObservation</code></h3>
+                <p>Langfuse Root Chain <code>production-chat-turn</code> startet.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell server">
+            <div class="event dark">
+              <span class="dock">2</span>
+              <div>
+                <h3><code>propagateAttributes</code></h3>
+                <p>userId, sessionId, release, tags und route-Metadaten werden angehaengt.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell server">
+            <div class="event">
+              <div>
+                <h3><code>runProductionAgentPipeline</code></h3>
+                <p>Der aktuelle Produktionspfad ist <code>tool_loop</code>.</p>
+              </div>
+              <span class="arrow">-></span>
+            </div>
+          </div>
+          <div class="lane-cell server"><div class="event empty"></div></div>
+          <div class="lane-cell server"><div class="event empty"></div></div>
+          <div class="lane-cell server">
+            <div class="event dark">
+              <span class="dock">4</span>
+              <div>
+                <h3>Trace-ID im SSE</h3>
+                <p>Frontend sieht <code>langfuse_trace</code> und spaeter die Trace URL.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell server">
+            <div class="event dark">
+              <span class="dock">5</span>
+              <div>
+                <h3><code>observation.update</code></h3>
+                <p>Kompakte Zusammenfassung geht an Langfuse.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell server"><div class="event empty"></div></div>
+
+          <div class="lane-label">Agent<small>Tool Loop Runtime</small></div>
+          <div class="lane-cell agent"><div class="event empty"></div></div>
+          <div class="lane-cell agent"><div class="event empty"></div></div>
+          <div class="lane-cell agent"><div class="event empty"></div></div>
+          <div class="lane-cell agent">
+            <div class="event">
+              <div>
+                <h3>Kontext laden</h3>
+                <p>Conversation History, Profil, Memory und Conversation State.</p>
+              </div>
+              <span class="arrow">-></span>
+            </div>
+          </div>
+          <div class="lane-cell agent">
+            <div class="event dark">
+              <span class="dock">3</span>
+              <div>
+                <h3><code>getObservedOpenAI</code></h3>
+                <p>Langfuse beobachtet <code>agentic-tool-loop-step</code> und Prompt-Version.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell agent">
+            <div class="event">
+              <div>
+                <h3>Deterministische Tools</h3>
+                <p>
+                  <code>select_products</code>, <code>load_advisor_guidance</code>,
+                  <code>build_or_fix_routine</code>.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell agent">
+            <div class="event">
+              <div>
+                <h3>Finale Antwort</h3>
+                <p>Tool-Fakten und Answer Context werden in natuerliche Antwort gebracht.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell agent"><div class="event empty"></div></div>
+          <div class="lane-cell agent"><div class="event empty"></div></div>
+
+          <div class="lane-label">Datenlage<small>Supabase + Trace Draft</small></div>
+          <div class="lane-cell data"><div class="event empty"></div></div>
+          <div class="lane-cell data"><div class="event empty"></div></div>
+          <div class="lane-cell data"><div class="event empty"></div></div>
+          <div class="lane-cell data">
+            <div class="event">
+              <div>
+                <h3>Prompt Snapshot</h3>
+                <p><code>prompt_ref</code>, Modell, Temperatur und gekuerzte Input-Metadaten.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell data">
+            <div class="event">
+              <div>
+                <h3>Prompt Registry</h3>
+                <p>Langfuse Prompt wird nach Label geladen, sonst Code-Fallback.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell data">
+            <div class="event">
+              <div>
+                <h3>Engine Trace</h3>
+                <p>Category decisions, Produkt-Metadaten, Guidance IDs, Guardrails.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell data"><div class="event empty"></div></div>
+          <div class="lane-cell data">
+            <div class="event">
+              <div>
+                <h3>Full Trace lokal</h3>
+                <p>
+                  <code>conversation_turn_traces.trace</code> speichert den vollen Review-Kontext.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell data">
+            <div class="event">
+              <div>
+                <h3>Datasets</h3>
+                <p>Sampling-Skripte verlinken spaeter per <code>sourceTraceId</code>.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="lane-label">Langfuse<small>Cloud / SDK</small></div>
+          <div class="lane-cell langfuse"><div class="event empty"></div></div>
+          <div class="lane-cell langfuse">
+            <div class="event dark">
+              <span class="dock">1</span>
+              <div>
+                <h3>Trace Container</h3>
+                <p>Eine Trace pro Chat Turn, Session = conversation_id.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell langfuse">
+            <div class="event dark">
+              <span class="dock">2</span>
+              <div>
+                <h3>Trace Attribute</h3>
+                <p>Release, User, Session, Route und Tags werden suchbar.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell langfuse">
+            <div class="event dark">
+              <span class="dock">2</span>
+              <div>
+                <h3>Parent Context</h3>
+                <p>Alle beobachteten OpenAI Calls haengen unter demselben Turn.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell langfuse">
+            <div class="event dark">
+              <span class="dock">3</span>
+              <div>
+                <h3>Generation + Prompt</h3>
+                <p>Promptname, Version, Label, Fallback-Status und Modellaufruf.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell langfuse"><div class="event empty"></div></div>
+          <div class="lane-cell langfuse"><div class="event empty"></div></div>
+          <div class="lane-cell langfuse">
+            <div class="event dark">
+              <span class="dock">6</span>
+              <div>
+                <h3>Root Output</h3>
+                <p>Antwort-Vorschau, Produkte, Engine Summary, Tool-Loop Summary.</p>
+              </div>
+            </div>
+          </div>
+          <div class="lane-cell langfuse">
+            <div class="event dark">
+              <span class="dock">7</span>
+              <div>
+                <h3>Scores & Runs</h3>
+                <p>Feedback-Scores, Review Queues, Eval Experiments.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-title">
+          <h2>Docking Points</h2>
+          <p>
+            Das sind die konkreten Stellen, an denen Langfuse aktiv wird oder spaeter Daten
+            verknuepft.
+          </p>
+        </div>
+
+        <div class="dock-grid">
+          <article class="dock-card" data-number="1">
+            <h3>SDK und Root Observation</h3>
+            <p>
+              Beim Request wird Langfuse Tracing sichergestellt und eine Chain namens
+              <code>production-chat-turn</code> gestartet.
+            </p>
+            <span class="file-ref">instrumentation.ts:4-7</span>
+            <span class="file-ref">src/app/api/chat/route.ts:247-268</span>
+          </article>
+
+          <article class="dock-card" data-number="2">
+            <h3>Trace-Metadaten</h3>
+            <p>
+              <code>propagateAttributes</code> setzt User, Session, Release, Tags und
+              Request-Metadaten, bevor die Pipeline laeuft.
+            </p>
+            <span class="file-ref">src/app/api/chat/route.ts:304-325</span>
+          </article>
+
+          <article class="dock-card" data-number="3">
+            <h3>Prompt- und LLM-Beobachtung</h3>
+            <p>
+              Der Model Client laedt verwaltete Agent-Prompts aus Langfuse und umhuellt OpenAI mit
+              <code>getObservedOpenAI</code>.
+            </p>
+            <span class="file-ref">src/lib/agent/orchestrator/model-client.ts:206-235</span>
+            <span class="file-ref">src/lib/agent/orchestrator/model-client.ts:312-330</span>
+          </article>
+
+          <article class="dock-card" data-number="4">
+            <h3>Trace-ID zur UI</h3>
+            <p>
+              Die API streamt die <code>langfuse_trace</code> ID sofort als SSE Event, damit der
+              Turn spaeter in Admin/Evals verlinkt bleibt.
+            </p>
+            <span class="file-ref">src/app/api/chat/route.ts:364-370</span>
+          </article>
+
+          <article class="dock-card" data-number="5">
+            <h3>Lokaler Full Trace</h3>
+            <p>
+              Der vollere Review-Kontext bleibt in Supabase. Langfuse bekommt die Trace-ID und
+              spaeter die kompakte Root-Observation.
+            </p>
+            <span class="file-ref">src/app/api/chat/route.ts:538-568</span>
+          </article>
+
+          <article class="dock-card" data-number="6">
+            <h3>Langfuse Root Output</h3>
+            <p>
+              Am Ende werden Produktanzahl, Antwort-Vorschau, Engine Summary, selected products und
+              Tool-Loop Summary an Langfuse geschrieben.
+            </p>
+            <span class="file-ref">src/app/api/chat/route.ts:571-585</span>
+          </article>
+
+          <article class="dock-card" data-number="7">
+            <h3>Feedback und Evals</h3>
+            <p>
+              Daumen-Feedback wird als Score an Langfuse geschickt. Eval- und Dataset-Skripte
+              verlinken Runs mit Live Trace IDs.
+            </p>
+            <span class="file-ref">src/app/api/chat/feedback/route.ts:72-86</span>
+            <span class="file-ref">scripts/eval-chat/langfuse.ts</span>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-title">
+          <h2>Was sieht Langfuse direkt?</h2>
+          <p>
+            Die wichtigste Unterscheidung: Langfuse bekommt kompakte, suchbare Zusammenfassungen
+            direkt. Der sehr detaillierte Debug-Trace bleibt lokal in Supabase und ist ueber die
+            Trace-ID verknuepfbar.
+          </p>
+        </div>
+
+        <div class="trace-map">
+          <div class="trace-box">
+            <h3>Direkt in Langfuse</h3>
+            <ul class="trace-list">
+              <li><b>Input</b><span>sanitisierte User Message + conversation_id</span></li>
+              <li>
+                <b>Attribute</b><span>userId, sessionId, release, environment, route, tags</span>
+              </li>
+              <li>
+                <b>Generations</b
+                ><span>generationName, Modellaufruf, Promptname, Version, Label, Fallback</span>
+              </li>
+              <li>
+                <b>Output</b
+                ><span>Status, Produktanzahl, Assistant Preview, Response Composition</span>
+              </li>
+              <li>
+                <b>Summary</b
+                ><span>Engine Summary, selected_products, agentic_tool_loop_summary</span>
+              </li>
+              <li><b>Scores</b><span>Daumen-Feedback und Eval Scores</span></li>
+            </ul>
+          </div>
+
+          <div class="trace-box">
+            <h3>Lokal in Supabase, per Trace-ID verknuepft</h3>
+            <ul class="trace-list">
+              <li>
+                <b>Full Turn</b><span><code>conversation_turn_traces.trace</code></span>
+              </li>
+              <li>
+                <b>Tool Loop</b><span>model_steps, tool_calls, guardrails, visible_failure</span>
+              </li>
+              <li>
+                <b>Engine</b
+                ><span>category decisions, damage, intervention plan, reason codes</span>
+              </li>
+              <li>
+                <b>Produkte</b><span>recommendation_meta, top_reasons, tradeoffs, usage_hint</span>
+              </li>
+              <li><b>State</b><span>conversation_state transition und persistence status</span></li>
+              <li>
+                <b>Review</b><span>Admin Trace UI und Dataset-Seeding nutzen diese Details</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="footer-note">
+          Kurz gesagt: Langfuse sitzt nicht nur "am Ende" der Antwort. Es startet den Turn, traegt
+          die Request-Attribute, beobachtet die OpenAI-Generations mit Prompt-Versionen, bekommt die
+          kompakte Ergebnis-Zusammenfassung und nimmt spaeter Feedback/Eval-Scores auf. Die tiefen
+          Recommendation-Debugdaten bleiben bewusst im lokalen Supabase-Trace und werden ueber
+          dieselbe Trace-ID auffindbar.
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/scripts/langfuse/sync-prompts.ts
+++ b/scripts/langfuse/sync-prompts.ts
@@ -1,37 +1,11 @@
-import {
-  INTENT_CLASSIFICATION_PROMPT,
-  MEMORY_EXTRACTION_JSON_PROMPT,
-  SYSTEM_PROMPT,
-  TITLE_GENERATION_PROMPT,
-} from "../../src/lib/rag/prompts"
-import {
-  loadLocalEnv,
-  getLangfuseClientOrThrow,
-  getPromptLabel,
-  parseArgs,
-  hasFlag,
-} from "./shared"
-
-const LANGFUSE_PROMPTS = [
-  {
-    name: "hair-concierge-chat-system",
-    fallback: SYSTEM_PROMPT,
-  },
-  {
-    name: "hair-concierge-intent-classifier",
-    fallback: INTENT_CLASSIFICATION_PROMPT,
-  },
-  {
-    name: "hair-concierge-title-generator",
-    fallback: TITLE_GENERATION_PROMPT,
-  },
-  {
-    name: "hair-concierge-memory-extraction",
-    fallback: MEMORY_EXTRACTION_JSON_PROMPT,
-  },
-] as const
+process.env.LANGFUSE_LOG_LEVEL ??= "NONE"
 
 async function main() {
+  const [
+    { LANGFUSE_PROMPTS },
+    { loadLocalEnv, getLangfuseClientOrThrow, getPromptLabel, parseArgs, hasFlag },
+  ] = await Promise.all([import("../../src/lib/langfuse/prompts"), import("./shared")])
+
   loadLocalEnv()
 
   const args = parseArgs(process.argv.slice(2))
@@ -40,7 +14,7 @@ async function main() {
   const langfuse = getLangfuseClientOrThrow()
   const commitMessage = `sync from repo (${process.env.LANGFUSE_RELEASE ?? new Date().toISOString()})`
 
-  for (const prompt of LANGFUSE_PROMPTS) {
+  for (const prompt of Object.values(LANGFUSE_PROMPTS)) {
     try {
       const existing = await langfuse.prompt.get(prompt.name, {
         type: "text",

--- a/src/lib/agent/orchestrator/model-client.ts
+++ b/src/lib/agent/orchestrator/model-client.ts
@@ -2,14 +2,22 @@ import type OpenAI from "openai"
 
 import { DEFAULT_CHAT_COMPLETION_MODEL } from "@/lib/openai/chat"
 import { getObservedOpenAI } from "@/lib/openai/client"
+import {
+  buildLangfusePromptConfig,
+  getManagedTextPromptTemplate,
+  LANGFUSE_PROMPTS,
+  type PromptDefinition,
+} from "@/lib/langfuse/prompts"
 import type {
   AgenticToolLoopModelClient,
   AgenticToolLoopModelStep,
 } from "@/lib/agent/orchestrator/agentic-tool-loop-types"
 import type { AgentToolName } from "@/lib/agent/orchestrator/tool-definitions"
+import type { LangfusePromptReference } from "@/lib/types"
 import {
   AGENT_ROUTE_CLASSIFIER_PROMPT,
   AGENTIC_CONTEXTUAL_COMPOSER_PROMPT,
+  AGENTIC_TOOL_LOOP_PROMPT,
   AGENT_FINAL_RENDER_PROMPT,
 } from "@/lib/agent/orchestrator/prompt"
 import {
@@ -199,16 +207,93 @@ const ROUTE_CLASSIFICATION_RESPONSE_FORMAT = {
   },
 } satisfies OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming["response_format"]
 
-export function createOpenAIToolModelClient(params: { model?: string } = {}): AgentModelClient {
+async function resolveManagedAgentPrompt(params: {
+  systemPrompt: string
+  prompt: PromptDefinition
+}): Promise<{
+  systemPrompt: string
+  langfuseConfig: Parameters<typeof getObservedOpenAI>[0]
+  ref: LangfusePromptReference | null
+}> {
+  if (params.systemPrompt !== params.prompt.fallback) {
+    return {
+      systemPrompt: params.systemPrompt,
+      langfuseConfig: undefined,
+      ref: null,
+    }
+  }
+
+  const managedPrompt = await getManagedTextPromptTemplate(params.prompt)
+
+  return {
+    systemPrompt: managedPrompt.template,
+    langfuseConfig: {
+      generationMetadata: {
+        prompt_label: managedPrompt.ref.label,
+        prompt_is_fallback: String(managedPrompt.ref.is_fallback),
+      },
+      langfusePrompt: buildLangfusePromptConfig(managedPrompt.ref),
+    },
+    ref: managedPrompt.ref,
+  }
+}
+
+type ManagedAgentPromptObserver = (event: {
+  prompt: PromptDefinition
+  ref: LangfusePromptReference
+}) => void
+
+function createManagedAgentPromptResolver(
+  params: {
+    onManagedPrompt?: ManagedAgentPromptObserver
+  } = {},
+) {
+  const cache = new Map<string, Promise<Awaited<ReturnType<typeof resolveManagedAgentPrompt>>>>()
+
+  return async (input: {
+    systemPrompt: string
+    prompt: PromptDefinition
+  }): ReturnType<typeof resolveManagedAgentPrompt> => {
+    if (input.systemPrompt !== input.prompt.fallback) {
+      return resolveManagedAgentPrompt(input)
+    }
+
+    let resolved = cache.get(input.prompt.name)
+    if (!resolved) {
+      resolved = resolveManagedAgentPrompt(input)
+      cache.set(input.prompt.name, resolved)
+    }
+
+    const managedPrompt = await resolved
+    if (managedPrompt.ref) {
+      params.onManagedPrompt?.({ prompt: input.prompt, ref: managedPrompt.ref })
+    }
+
+    return managedPrompt
+  }
+}
+
+export function createOpenAIToolModelClient(
+  params: { model?: string; onManagedPrompt?: ManagedAgentPromptObserver } = {},
+): AgentModelClient {
+  const resolvePrompt = createManagedAgentPromptResolver({
+    onManagedPrompt: params.onManagedPrompt,
+  })
+
   return {
     async classifyRoute({ systemPrompt = AGENT_ROUTE_CLASSIFIER_PROMPT, message, userContext }) {
+      const managedPrompt = await resolvePrompt({
+        systemPrompt,
+        prompt: LANGFUSE_PROMPTS.agentRouteClassifier,
+      })
       const response = await getObservedOpenAI({
         generationName: "bounded-agent-route-classification",
+        ...managedPrompt.langfuseConfig,
       }).chat.completions.create({
         model: params.model ?? DEFAULT_CHAT_COMPLETION_MODEL,
         temperature: 0,
         messages: [
-          { role: "system", content: systemPrompt },
+          { role: "system", content: managedPrompt.systemPrompt },
           {
             role: "user",
             content: JSON.stringify({
@@ -225,13 +310,18 @@ export function createOpenAIToolModelClient(params: { model?: string } = {}): Ag
       return parseRouteClassification(raw)
     },
     async renderFinalAnswer({ systemPrompt = AGENT_FINAL_RENDER_PROMPT, message, packet }) {
+      const managedPrompt = await resolvePrompt({
+        systemPrompt,
+        prompt: LANGFUSE_PROMPTS.agentFinalRender,
+      })
       const response = await getObservedOpenAI({
         generationName: "bounded-agent-final-render",
+        ...managedPrompt.langfuseConfig,
       }).chat.completions.create({
         model: params.model ?? DEFAULT_CHAT_COMPLETION_MODEL,
         temperature: 0,
         messages: [
-          { role: "system", content: systemPrompt },
+          { role: "system", content: managedPrompt.systemPrompt },
           {
             role: "user",
             content: JSON.stringify({
@@ -263,16 +353,25 @@ function parseToolCallInput(raw: string | undefined): Record<string, unknown> {
 }
 
 export function createOpenAIAgenticToolLoopModelClient(
-  params: { model?: string } = {},
+  params: { model?: string; onManagedPrompt?: ManagedAgentPromptObserver } = {},
 ): AgenticToolLoopModelClient {
+  const resolvePrompt = createManagedAgentPromptResolver({
+    onManagedPrompt: params.onManagedPrompt,
+  })
+
   return {
     async runStep({ systemPrompt, messages, tools }) {
+      const managedPrompt = await resolvePrompt({
+        systemPrompt,
+        prompt: LANGFUSE_PROMPTS.agenticToolLoop,
+      })
       const response = await getObservedOpenAI({
         generationName: "agentic-tool-loop-step",
+        ...managedPrompt.langfuseConfig,
       }).chat.completions.create({
         model: params.model ?? DEFAULT_CHAT_COMPLETION_MODEL,
         temperature: 0,
-        messages: [{ role: "system", content: systemPrompt }, ...messages],
+        messages: [{ role: "system", content: managedPrompt.systemPrompt }, ...messages],
         tools,
       })
 
@@ -304,13 +403,18 @@ export function createOpenAIAgenticToolLoopModelClient(
       }
     },
     async composeFinalAnswer({ systemPrompt = AGENTIC_CONTEXTUAL_COMPOSER_PROMPT, ...input }) {
+      const managedPrompt = await resolvePrompt({
+        systemPrompt,
+        prompt: LANGFUSE_PROMPTS.agenticContextualComposer,
+      })
       const response = await getObservedOpenAI({
         generationName: "agentic-tool-loop-contextual-composer",
+        ...managedPrompt.langfuseConfig,
       }).chat.completions.create({
         model: params.model ?? DEFAULT_CHAT_COMPLETION_MODEL,
         temperature: 0,
         messages: [
-          { role: "system", content: systemPrompt },
+          { role: "system", content: managedPrompt.systemPrompt },
           {
             role: "user",
             content: JSON.stringify(input),

--- a/src/lib/agent/production/chat-pipeline.ts
+++ b/src/lib/agent/production/chat-pipeline.ts
@@ -29,6 +29,7 @@ import {
   buildRecommendationEngineTrace,
   getRuntimeCategoryDecision,
 } from "@/lib/recommendation-engine"
+import { LANGFUSE_PROMPTS } from "@/lib/langfuse/prompts"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { DEFAULT_CHAT_COMPLETION_MODEL } from "@/lib/openai/chat"
 import { loadConversationState as loadPersistedConversationState } from "@/lib/rag/conversation-state-store"
@@ -124,6 +125,7 @@ function promptRef(name: string): LangfusePromptReference {
 function buildToolLoopPromptSnapshot(params: {
   message: string
   recentMessages: RecentConversationMessage[]
+  promptRef: LangfusePromptReference
 }): ChatPromptSnapshot {
   const recentMessageRoles = params.recentMessages.slice(-4).map((message) => message.role)
 
@@ -131,7 +133,7 @@ function buildToolLoopPromptSnapshot(params: {
     kind: "agentic_tool_loop",
     model: DEFAULT_CHAT_COMPLETION_MODEL,
     temperature: 0,
-    prompt_ref: promptRef("agentic-tool-loop"),
+    prompt_ref: params.promptRef,
     system_prompt: "agentic_tool_loop",
     messages: [
       {
@@ -421,12 +423,24 @@ export async function runProductionAgentPipeline(
 
   const recentMessages = projectRecentMessages(conversationHistory)
   const selectedProductsHolder: { current: SelectProductsToolResult | null } = { current: null }
+  const promptRefs: { agenticToolLoop: LangfusePromptReference } = {
+    agenticToolLoop: promptRef(LANGFUSE_PROMPTS.agenticToolLoop.name),
+  }
+  const modelClient =
+    deps.modelClient ??
+    createOpenAIAgenticToolLoopModelClient({
+      onManagedPrompt: ({ prompt, ref }) => {
+        if (prompt.name === LANGFUSE_PROMPTS.agenticToolLoop.name) {
+          promptRefs.agenticToolLoop = ref
+        }
+      },
+    })
 
   const agentStart = performance.now()
   const toolLoopResult = await runAgenticToolTurn({
     message,
     recentMessages,
-    modelClient: deps.modelClient ?? createOpenAIAgenticToolLoopModelClient(),
+    modelClient,
     tools: makeAgenticTools({
       onSelectProducts: (selection) => {
         selectedProductsHolder.current = selection
@@ -479,6 +493,7 @@ export async function runProductionAgentPipeline(
   const prompt = buildToolLoopPromptSnapshot({
     message,
     recentMessages,
+    promptRef: promptRefs.agenticToolLoop,
   })
   const debugTrace = buildPipelineTraceDraft({
     request_id: requestId,
@@ -511,7 +526,7 @@ export async function runProductionAgentPipeline(
     category_decision: exposedCategoryDecision,
     engine_trace: exposedEngineTrace,
     matched_products: exposedMatchedProducts,
-    classification_prompt_ref: promptRef("agentic-tool-loop"),
+    classification_prompt_ref: promptRefs.agenticToolLoop,
     prompt,
     response_composition: {
       path: "agentic_tool_loop",

--- a/src/lib/langfuse/prompts.ts
+++ b/src/lib/langfuse/prompts.ts
@@ -1,6 +1,12 @@
 import type { LangfusePromptReference } from "@/lib/types"
 import type { LangfuseConfig as LangfuseOpenAIConfig } from "@langfuse/openai"
 import {
+  AGENT_FINAL_RENDER_PROMPT,
+  AGENT_ROUTE_CLASSIFIER_PROMPT,
+  AGENTIC_CONTEXTUAL_COMPOSER_PROMPT,
+  AGENTIC_TOOL_LOOP_PROMPT,
+} from "@/lib/agent/orchestrator/prompt"
+import {
   INTENT_CLASSIFICATION_PROMPT,
   MEMORY_EXTRACTION_JSON_PROMPT,
   SYSTEM_PROMPT,
@@ -28,9 +34,25 @@ export const LANGFUSE_PROMPTS = {
     name: "hair-concierge-memory-extraction",
     fallback: MEMORY_EXTRACTION_JSON_PROMPT,
   },
+  agentRouteClassifier: {
+    name: "hair-concierge-agent-route-classifier",
+    fallback: AGENT_ROUTE_CLASSIFIER_PROMPT,
+  },
+  agenticToolLoop: {
+    name: "hair-concierge-agentic-tool-loop",
+    fallback: AGENTIC_TOOL_LOOP_PROMPT,
+  },
+  agenticContextualComposer: {
+    name: "hair-concierge-agentic-contextual-composer",
+    fallback: AGENTIC_CONTEXTUAL_COMPOSER_PROMPT,
+  },
+  agentFinalRender: {
+    name: "hair-concierge-agent-final-render",
+    fallback: AGENT_FINAL_RENDER_PROMPT,
+  },
 } as const
 
-type PromptDefinition = (typeof LANGFUSE_PROMPTS)[keyof typeof LANGFUSE_PROMPTS]
+export type PromptDefinition = (typeof LANGFUSE_PROMPTS)[keyof typeof LANGFUSE_PROMPTS]
 
 export interface ManagedTextPrompt {
   text: string

--- a/tests/langfuse-prompts.test.ts
+++ b/tests/langfuse-prompts.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { LANGFUSE_PROMPTS } from "../src/lib/langfuse/prompts"
+import {
+  AGENT_FINAL_RENDER_PROMPT,
+  AGENT_ROUTE_CLASSIFIER_PROMPT,
+  AGENTIC_CONTEXTUAL_COMPOSER_PROMPT,
+  AGENTIC_TOOL_LOOP_PROMPT,
+} from "../src/lib/agent/orchestrator/prompt"
+
+test("Langfuse prompt registry includes current agentic chat prompts", () => {
+  assert.equal(LANGFUSE_PROMPTS.agentRouteClassifier.fallback, AGENT_ROUTE_CLASSIFIER_PROMPT)
+  assert.equal(LANGFUSE_PROMPTS.agenticToolLoop.fallback, AGENTIC_TOOL_LOOP_PROMPT)
+  assert.equal(
+    LANGFUSE_PROMPTS.agenticContextualComposer.fallback,
+    AGENTIC_CONTEXTUAL_COMPOSER_PROMPT,
+  )
+  assert.equal(LANGFUSE_PROMPTS.agentFinalRender.fallback, AGENT_FINAL_RENDER_PROMPT)
+})
+
+test("Langfuse prompt names are unique", () => {
+  const names = Object.values(LANGFUSE_PROMPTS).map((prompt) => prompt.name)
+
+  assert.equal(new Set(names).size, names.length)
+})


### PR DESCRIPTION
## Why

Langfuse was still centered on the old classic/RAG prompt set while production chat now runs through the agentic tool-loop path. That made prompt syncing and quality review easy to drift away from the real recommendation flow.

## What changed

- Added the current agentic route classifier, tool-loop, contextual composer, and final render prompts to the shared Langfuse registry.
- Updated prompt sync to use that registry as the source of truth.
- Wired the agentic OpenAI calls to managed Langfuse prompts when the default prompt is used, while preserving custom prompt overrides and code fallbacks.
- Recorded the actual managed tool-loop prompt ref in the production trace.
- Updated the Langfuse quality-loop docs and added a visual HTML message-journey mockup.
- Added prompt-registry coverage to the normal node test suite.

## Verification

- npx tsx --test tests/langfuse-prompts.test.ts tests/agent-production-chat-pipeline.spec.ts
- npm run typecheck
- npm run langfuse:sync-prompts -- --dry-run
- npm run test:node
- npx playwright test tests/chat-debug-trace.spec.ts --project=chromium
- git diff --check

## Notes

Opened as draft so CI can run before review/merge decisions.