### PR TITLE
Make product cards user-ready

### DIFF
--- a/docs/mockups/product-card-drawer-revised-mockup.html
+++ b/docs/mockups/product-card-drawer-revised-mockup.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Compact Card + Intelligent Drawer</title>
+    <style>
+      :root {
+        --ink: #2f243d;
+        --muted: #756e7d;
+        --line: #e5e0e8;
+        --soft: #f4f0fa;
+        --purple: #7658b4;
+        --purple-dark: #33204f;
+        --shadow: 0 14px 34px rgba(49, 38, 63, 0.12);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: #fbfaf8;
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.45;
+      }
+      main { width: min(1180px, calc(100vw - 40px)); margin: 34px auto 56px; }
+      h1, h2, h3, h4, p { margin: 0; }
+      .eyebrow { color: var(--purple); font-size: 13px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; }
+      h1 { margin-top: 8px; font-size: clamp(32px, 4vw, 54px); line-height: 1.04; }
+      .lead { max-width: 900px; margin-top: 10px; color: var(--muted); font-size: 18px; }
+      .context { margin-top: 26px; display: grid; gap: 14px; }
+      .question, .answer {
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        background: #fff;
+        padding: 18px 20px;
+        box-shadow: 0 8px 24px rgba(49, 38, 63, .05);
+      }
+      .question { justify-self: end; max-width: 760px; }
+      .answer { max-width: 990px; background: #f1edf8; }
+      .label { margin-bottom: 8px; color: var(--muted); font-size: 13px; font-weight: 780; letter-spacing: .03em; text-transform: uppercase; }
+      .answer-text { display: grid; gap: 9px; color: #403946; font-size: 16px; }
+      .answer-text strong { color: var(--purple); }
+      .section-title { margin: 38px 0 16px; display: flex; align-items: end; justify-content: space-between; gap: 20px; }
+      h2 { font-size: 25px; }
+      .section-title p { max-width: 700px; color: var(--muted); }
+      .mock-grid { display: grid; grid-template-columns: minmax(320px, .88fr) minmax(460px, 1.12fr); gap: 18px; align-items: start; }
+      .panel { border: 1px solid var(--line); border-radius: 24px; background: #fff; overflow: hidden; box-shadow: 0 8px 24px rgba(49,38,63,.05); }
+      .panel-head { padding: 18px; border-bottom: 1px solid var(--line); }
+      .panel-head h3 { margin-top: 6px; font-size: 19px; }
+      .panel-head p:last-child { margin-top: 8px; color: var(--muted); font-size: 14px; }
+      .kicker { color: var(--purple); font-size: 12px; font-weight: 820; letter-spacing: .05em; text-transform: uppercase; }
+      .panel-body, .drawer-body { display: grid; gap: 16px; padding: 16px; }
+      .product-card {
+        display: grid;
+        grid-template-columns: 58px minmax(0, 1fr) auto;
+        gap: 14px;
+        align-items: center;
+        border: 1px solid var(--line);
+        border-radius: 20px;
+        background: #fff;
+        padding: 14px;
+        box-shadow: 0 8px 22px rgba(49,38,63,.05);
+      }
+      .product-card::after { content: "›"; color: var(--muted); font-size: 28px; line-height: 1; }
+      .icon { width: 58px; height: 58px; border-radius: 16px; display: grid; place-items: center; color: var(--purple); background: var(--soft); }
+      .icon svg { width: 28px; height: 28px; }
+      .name, .drawer-title { color: #26163f; font-weight: 840; line-height: 1.18; }
+      .brand, .drawer-brand { margin-top: 2px; color: var(--muted); font-size: 14px; }
+      .pills { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 9px; }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        min-height: 25px;
+        border: 1px solid #ded5e8;
+        border-radius: 999px;
+        background: #f8f5fb;
+        color: #3b285e;
+        padding: 4px 10px;
+        font-size: 12px;
+        font-weight: 760;
+      }
+      .drawer { border: 1px solid var(--line); border-radius: 28px; background: #fff; overflow: hidden; box-shadow: var(--shadow); }
+      .drawer-header { display: grid; grid-template-columns: 68px minmax(0, 1fr); gap: 16px; align-items: center; padding: 20px; border-bottom: 1px solid var(--line); }
+      .drawer-title { margin-top: 2px; font-size: 22px; }
+      .drawer-section h4 { margin-bottom: 10px; color: #554c60; font-size: 13px; font-weight: 820; letter-spacing: .04em; text-transform: uppercase; }
+      .why-box { display: grid; gap: 12px; border-radius: 16px; background: #f2edf9; padding: 15px; }
+      .why-box p { color: #443653; font-size: 15px; }
+      .fact-row {
+        display: grid;
+        grid-template-columns: minmax(122px, .38fr) minmax(0, 1fr);
+        gap: 10px;
+        border-radius: 12px;
+        background: #f8f6fa;
+        padding: 10px 11px;
+      }
+      .fact-row span:first-child { color: var(--muted); font-weight: 760; }
+      .fact-row span:last-child { color: #382b49; font-weight: 720; }
+      .copy { color: var(--muted); font-size: 15px; }
+      .facts { display: grid; gap: 8px; }
+      .drawer-footer { display: grid; gap: 8px; border-top: 1px solid var(--line); padding-top: 16px; }
+      .buy-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+      .drawer-price { color: var(--purple); font-size: 23px; font-weight: 840; }
+      .buy { border: 0; border-radius: 12px; background: var(--purple); color: #fff; padding: 11px 16px; font: inherit; font-weight: 780; }
+      .disclosure { color: var(--muted); font-size: 12px; }
+      @media (max-width: 860px) {
+        main { width: min(100vw - 24px, 620px); margin-top: 18px; }
+        .mock-grid, .section-title { display: grid; }
+        .product-card { grid-template-columns: 52px minmax(0, 1fr) auto; }
+        .fact-row { grid-template-columns: 1fr; gap: 2px; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="eyebrow">Revised Direction</p>
+      <h1>Quiet Compact Card, Intelligent Drawer</h1>
+      <p class="lead">
+        Compact card stays clean: no price, no sentence. The drawer carries the high-context recommendation logic and explains how product facts transfer to the user profile.
+      </p>
+
+      <section class="context" aria-label="Chat Kontext">
+        <div class="question">
+          <p class="label">Nutzerfrage</p>
+          <p>Welches Leave-in passt, wenn ich mein feines Haar regelmäßig mit Hitze style und mehr Glanz möchte?</p>
+        </div>
+        <div class="answer">
+          <p class="label">Antwort-Kontext</p>
+          <div class="answer-text">
+            <p>Für dein Haarprofil mit feinem Haar, regelmäßigem Hitzestyling und dem Ziel von mehr Glanz würde ich ein leichtes Leave-in mit Hitzeschutz wählen.</p>
+            <p><strong>Wella Ultimate Repair Leave-In:</strong> eine Lotion mit mittlerem Gewicht, ausgewogener Pflege und Hitzeschutz.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="section-title">
+        <h2>Zielzustand</h2>
+        <p>Die Karte ist nur ein ruhiger Produktsprung. Die eigentliche Concierge-Erklärung sitzt im Drawer.</p>
+      </div>
+
+      <section class="mock-grid" aria-label="Compact Card und Drawer">
+        <article class="panel">
+          <div class="panel-head">
+            <p class="kicker">Compact Card</p>
+            <h3>Nur Identität + Produktfacts</h3>
+            <p>Kein Preis, kein Satz. Nur scannbare Fakten und ein klares Tap-Affordance.</p>
+          </div>
+          <div class="panel-body">
+            <div class="product-card">
+              <div class="icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M4 12c4-7 12-7 16 0" />
+                  <path d="M6 14c3-4 9-4 12 0" />
+                  <path d="M9 17c1.5-1.5 4.5-1.5 6 0" />
+                </svg>
+              </div>
+              <div>
+                <p class="name">Wella Ultimate Repair Leave-In</p>
+                <p class="brand">Wella</p>
+                <div class="pills">
+                  <span class="pill">Lotion</span>
+                  <span class="pill">Hitzeschutz</span>
+                  <span class="pill">Pflege: ausgewogen</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="panel">
+          <div class="panel-head">
+            <p class="kicker">Drawer</p>
+            <h3>Intelligente Passung</h3>
+            <p>Der Drawer erklärt die Verbindung zwischen deinem Profil, deinem Ziel und dem Produkt.</p>
+          </div>
+          <div class="panel-body">
+            <div class="drawer">
+              <div class="drawer-header">
+                <div class="icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                    <path d="M4 12c4-7 12-7 16 0" />
+                    <path d="M6 14c3-4 9-4 12 0" />
+                    <path d="M9 17c1.5-1.5 4.5-1.5 6 0" />
+                  </svg>
+                </div>
+                <div>
+                  <p class="drawer-brand">Wella</p>
+                  <p class="drawer-title">Wella Ultimate Repair Leave-In</p>
+                  <div class="pills"><span class="pill">Leave-in</span></div>
+                </div>
+              </div>
+
+              <div class="drawer-body">
+                <section class="drawer-section">
+                  <h4>Warum es passt</h4>
+                  <div class="why-box">
+                    <p>
+                      Du stylst regelmäßig mit Hitze und möchtest mehr Glanz, hast aber feines Haar,
+                      das schnell beschwert wirken kann. Diese Leave-in-Lotion passt als Booster
+                      nach dem Conditioner, weil sie Hitzeschutz mit ausgewogener Pflege verbindet,
+                      ohne in eine sehr reichhaltige Richtung zu gehen.
+                    </p>
+                  </div>
+                </section>
+
+                <section class="drawer-section">
+                  <h4>Anwendung</h4>
+                  <p class="copy">Sehr sparsam ins handtuchtrockene Haar geben und vor dem Föhnen oder Hitzestyling gleichmäßig in Längen und Spitzen verteilen. Bei feinem Haar lieber mit wenig Produkt starten und nur bei Bedarf nachlegen.</p>
+                </section>
+
+                <section class="drawer-section">
+                  <h4>Produktprofil</h4>
+                  <div class="facts">
+                    <div class="fact-row"><span>Textur/Form</span><span>Lotion</span></div>
+                    <div class="fact-row"><span>Gefühl</span><span>Mittel</span></div>
+                    <div class="fact-row"><span>Wirkung</span><span>Ausgewogene Pflege</span></div>
+                    <div class="fact-row"><span>Hitzeschutz</span><span>Ja</span></div>
+                    <div class="fact-row"><span>Rolle</span><span>Booster nach dem Conditioner</span></div>
+                  </div>
+                </section>
+
+                <div class="drawer-footer">
+                  <div class="buy-row">
+                    <p class="drawer-price">18,51 €</p>
+                    <button class="buy" type="button">Bei dm kaufen ↗</button>
+                  </div>
+                  <p class="disclosure">Anzeige: Der Kauflink kann ein Affiliate-Link sein.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/plans/2026-05-13-product-card-drawer-user-ready.md
+++ b/plans/2026-05-13-product-card-drawer-user-ready.md
@@ -1,0 +1,399 @@
+# Product Card + Drawer User-Ready Plan
+
+> **For implementation:** use `superpowers:subagent-driven-development` or `superpowers:executing-plans` in a fresh repo-local worktree. This plan is scoped to chat product cards and the chat product detail drawer.
+
+## Goal
+
+Make chat product recommendations feel user-ready by removing internal recommendation/debug metadata from the compact card and drawer while preserving useful product context.
+
+The finalized UX is:
+
+- **Compact card:** quiet product jump with identity + whitelisted product facts only.
+- **Drawer:** richer recommendation surface with a concise, intelligent `Warum es passt` explanation that synthesizes user profile, user goal, routine role, and product properties.
+
+Reference mockup:
+
+- `docs/mockups/product-card-drawer-revised-mockup.html`
+
+## Final UX Contract
+
+### Compact Product Card
+
+Show:
+
+- Product icon or image
+- Product name
+- Brand
+- Max 1-3 product fact pills
+- Tap affordance, e.g. chevron
+
+Do not show:
+
+- Price
+- Generated reason sentence
+- `Score`
+- `Tags`
+- `Profil-Match`
+- Raw category/debug metadata
+- Generic copy like `Passt in grossen Teilen zu deinem Leave-in-Zielprofil`
+
+Example:
+
+```text
+Wella Ultimate Repair Leave-In
+Wella
+[Lotion] [Hitzeschutz] [Pflege: ausgewogen]  ›
+```
+
+### Product Detail Drawer
+
+Use the finalized Drawer D structure:
+
+1. Header
+   - Brand
+   - Product name
+   - Product category pill, e.g. `Leave-in`
+
+2. `Warum es passt`
+   - One concise paragraph.
+   - It should sound intelligent and personalized.
+   - It should synthesize the user’s relevant profile and goal into the conclusion.
+   - Do not show separate profile-transfer cards such as `Dein Styling`, `Deine Haardicke`, `Dein Ziel`, `Routine-Rolle`.
+
+3. `Anwendung`
+   - Full sentence.
+   - Include dosing caveats when relevant, e.g. fine hair should start with little product.
+
+4. `Produktprofil`
+   - Labeled rows, not loose pills.
+   - For leave-ins:
+     - `Textur/Form`
+     - `Gefühl`
+     - `Wirkung`
+     - `Hitzeschutz`
+     - `Rolle`
+
+5. Footer
+   - Price
+   - Shop-aware buy button when possible, e.g. `Bei dm kaufen`
+   - Affiliate disclosure when links are monetized
+
+Example `Warum es passt`:
+
+```text
+Du stylst regelmäßig mit Hitze und möchtest mehr Glanz, hast aber feines Haar, das schnell beschwert wirken kann. Diese Leave-in-Lotion passt als Booster nach dem Conditioner, weil sie Hitzeschutz mit ausgewogener Pflege verbindet, ohne in eine sehr reichhaltige Richtung zu gehen.
+```
+
+Example drawer:
+
+```text
+Wella
+Wella Ultimate Repair Leave-In
+[Leave-in]
+
+Warum es passt
+Du stylst regelmäßig mit Hitze und möchtest mehr Glanz, hast aber feines Haar, das schnell beschwert wirken kann. Diese Leave-in-Lotion passt als Booster nach dem Conditioner, weil sie Hitzeschutz mit ausgewogener Pflege verbindet, ohne in eine sehr reichhaltige Richtung zu gehen.
+
+Anwendung
+Sehr sparsam ins handtuchtrockene Haar geben und vor dem Föhnen oder Hitzestyling gleichmäßig in Längen und Spitzen verteilen. Bei feinem Haar lieber mit wenig Produkt starten und nur bei Bedarf nachlegen.
+
+Produktprofil
+Textur/Form    Lotion
+Gefühl         Mittel
+Wirkung        Ausgewogene Pflege
+Hitzeschutz    Ja
+Rolle          Booster nach dem Conditioner
+
+18,51 €        Bei dm kaufen
+Anzeige: Der Kauflink kann ein Affiliate-Link sein.
+```
+
+## Data Source Rules
+
+Use existing structured product/recommendation fields. Do not add a new LLM hop for card or drawer copy.
+
+Primary source fields for leave-ins:
+
+- `recommendation_meta.product_format`
+- `recommendation_meta.product_weight`
+- `recommendation_meta.product_balance_direction`
+- `recommendation_meta.product_care_benefits`
+- `recommendation_meta.provides_heat_protection`
+- `recommendation_meta.conditioner_relationship`
+- `recommendation_meta.usage_hint`
+- profile fields available in the message/product context, such as:
+  - heat styling / styling tools
+  - hair thickness
+  - density if available
+  - goals such as shine
+  - current routine / conditioner relationship
+- `recommendation_meta.top_reasons`, only after filtering generic/internal phrases
+
+Fallback behavior:
+
+- Omit missing compact card facts.
+- Use category pill as a last-resort compact fact only if no better product fact exists.
+- Omit negative booleans on compact cards.
+- In the drawer, boolean facts may be explicit, e.g. `Hitzeschutz: Ja`.
+- Never show raw `tags`.
+- Never show `score`.
+- Never show `matched_profile` or profile-match chips directly.
+- Do not surface the profile-transfer inputs as separate UI rows; fold them into the `Warum es passt` paragraph.
+
+## Target Files
+
+Create:
+
+- `src/components/chat/product-display-model.ts`
+  - Shared helper for compact facts, drawer rows, price formatting, category labels, application sentence, shop labels, affiliate disclosure, and match summary.
+
+Modify:
+
+- `src/components/chat/product-card.tsx`
+  - Remove top reason and price.
+  - Render product fact pills.
+  - Add clear tap affordance.
+
+- `src/components/chat/product-detail-drawer.tsx`
+  - Replace internal recommendation context with finalized Drawer D.
+
+Inspect:
+
+- `src/components/chat/product-popover.tsx`
+  - Confirm hover/inline mention UI does not reintroduce old internal language.
+
+Tests:
+
+- `tests/product-display-model.test.ts`
+- `tests/product-card-rendering.test.tsx`
+- Existing `tests/chat-product-mentions.test.tsx`
+
+## Implementation Tasks
+
+### Task 1: Add Product Display Model
+
+Create `src/components/chat/product-display-model.ts`.
+
+Responsibilities:
+
+- `buildCompactProductFacts(product)`
+- `buildDrawerProductProfileRows(product)`
+- `buildProductMatchSummary(product, hairProfile?)`
+- `buildProductApplicationSentence(product, hairProfile?)`
+- `formatProductPrice(price, currency)`
+- `getProductCategoryLabel(category)`
+- `getShopLabel(affiliateLink)`
+- `shouldShowAffiliateDisclosure(product)`
+
+Rules:
+
+- Return only user-facing German labels.
+- Use whitelisted structured fields.
+- Filter generic/internal `top_reasons`.
+- Keep missing data empty instead of inventing filler.
+- Build `Warum es passt` with deterministic templates from available profile/product facts, not a new LLM call.
+
+Leave-in compact fact priority:
+
+1. Format: `Lotion`, `Spray`, `Creme`
+2. Heat protection: `Hitzeschutz`
+3. Care focus: `Pflege: ausgewogen`, `Pflege: Feuchtigkeit`, `Pflege: Protein`
+4. Weight only if needed: `Leicht`, `Mittel`, `Reichhaltig`
+
+Leave-in drawer row mapping:
+
+- `product_format` -> `Textur/Form`
+- `product_weight` -> `Gefühl`
+- `product_balance_direction` or primary care benefit -> `Wirkung`
+- `provides_heat_protection` -> `Hitzeschutz`
+- `conditioner_relationship` or primary role -> `Rolle`
+
+### Task 2: Test the Display Model
+
+Create `tests/product-display-model.test.ts`.
+
+Must verify:
+
+- Compact facts for the Wella leave-in become:
+
+```ts
+[
+  { label: "Lotion", source: "format" },
+  { label: "Hitzeschutz", source: "heat_protection" },
+  { label: "Pflege: ausgewogen", source: "care_focus" },
+]
+```
+
+- Drawer rows become:
+
+```ts
+[
+  { label: "Textur/Form", value: "Lotion" },
+  { label: "Gefühl", value: "Mittel" },
+  { label: "Wirkung", value: "Ausgewogene Pflege" },
+  { label: "Hitzeschutz", value: "Ja" },
+  { label: "Rolle", value: "Booster nach dem Conditioner" },
+]
+```
+
+- `buildProductMatchSummary` returns one concise paragraph that integrates:
+  - regular heat styling
+  - fine hair / weight sensitivity
+  - shine goal
+  - lotion format
+  - heat protection
+  - booster role
+
+- The match summary does not include separate labels such as `Dein Styling`, `Deine Haardicke`, `Dein Ziel`, or `Routine-Rolle`.
+- Generic/internal match reasons are not reused.
+- Price formats as `18,51 €`.
+- Usage hint is returned as a full application sentence.
+- Shop label is derived from affiliate host where possible.
+
+Run:
+
+```bash
+npm run test:node -- tests/product-display-model.test.ts
+```
+
+### Task 3: Rework Compact Product Card
+
+Modify `src/components/chat/product-card.tsx`.
+
+Change:
+
+- Remove `topReason`.
+- Remove compact-card price.
+- Import `buildCompactProductFacts`.
+- Render fact pills under brand.
+- Add visual tap affordance, e.g. chevron.
+
+Expected compact card:
+
+- Shows `Wella Ultimate Repair Leave-In`
+- Shows `Wella`
+- Shows `Lotion`, `Hitzeschutz`, `Pflege: ausgewogen`
+- Does not show `18,51 €`
+- Does not show a reason sentence
+- Does not show `Zielprofil`
+- Does not show internal tags
+
+Add `tests/product-card-rendering.test.tsx` with `renderToStaticMarkup`.
+
+Run:
+
+```bash
+npm run test:node -- tests/product-card-rendering.test.tsx
+```
+
+### Task 4: Rework Product Detail Drawer
+
+Modify `src/components/chat/product-detail-drawer.tsx`.
+
+Remove:
+
+- Personalization box
+- `Empfehlungskontext`
+- `Score`
+- `Warum passend` from raw `top_reasons`
+- `Trade-offs`
+- Internal category fields like `Shampoo-Bucket`
+- `Profil-Match`
+- `Geeignete Haardicke`
+- `Hilft bei`
+- Raw `Tags`
+- Separate profile-transfer UI cards
+
+Render:
+
+- Header with brand, name, category pill
+- `Warum es passt` paragraph from `buildProductMatchSummary`
+- `Anwendung` sentence from `buildProductApplicationSentence`
+- `Produktprofil` rows from `buildDrawerProductProfileRows`
+- Price from `formatProductPrice`
+- Shop-aware buy button if `affiliate_link` exists
+- Affiliate disclosure if applicable
+
+Order:
+
+1. Header
+2. `Warum es passt`
+3. `Anwendung`
+4. `Produktprofil`
+5. Price / buy / disclosure
+
+Note: `BottomSheetContent` mounts via client effects, so drawer rendering should be verified in browser rather than relying only on static markup.
+
+### Task 5: Verify Product Payloads
+
+Inspect:
+
+- `src/app/api/chat/route.ts`
+- `src/lib/recommendation-engine/selection.ts`
+
+Confirm chat products sent to the UI preserve:
+
+- `recommendation_meta.product_format`
+- `recommendation_meta.product_weight`
+- `recommendation_meta.product_balance_direction`
+- `recommendation_meta.provides_heat_protection`
+- `recommendation_meta.conditioner_relationship`
+- `recommendation_meta.usage_hint`
+- profile context needed for match-summary templates
+
+If serialization drops these fields, add a focused regression assertion to the closest existing chat pipeline test.
+
+### Task 6: Browser Verification
+
+Use this prompt:
+
+```text
+Welches Leave-in passt, wenn ich mein feines Haar regelmäßig mit Hitze style und mehr Glanz möchte?
+```
+
+Compact card must:
+
+- show product name and brand
+- show fact pills
+- not show price
+- not show a reason sentence
+- not show score, tags, profile match, or generic top reason
+
+Drawer must:
+
+- show one concise `Warum es passt` paragraph
+- fold styling, hair thickness, goal, routine role, and product facts into that paragraph
+- not show separate `Dein Styling` / `Deine Haardicke` / `Dein Ziel` / `Routine-Rolle` cards
+- show `Anwendung` before `Produktprofil`
+- show labeled product profile rows
+- show price + shop-aware buy button + affiliate disclosure
+- not show internal metadata
+
+Check desktop and mobile widths.
+
+### Task 7: Final Checks
+
+Run:
+
+```bash
+npm run test:node -- tests/product-display-model.test.ts tests/product-card-rendering.test.tsx tests/chat-product-mentions.test.tsx
+npm run typecheck
+npm run lint
+```
+
+Because this touches chat UI, recommendation presentation, copy, and trust, run `ready-check` before shipping.
+
+## Non-Goals
+
+- No recommendation ranking changes.
+- No new DB fields.
+- No new LLM card/drawer copy generation step.
+- No prompt rewrite.
+- No admin product editor redesign.
+- No catalog page redesign.
+
+## Open Risks
+
+- Some categories may have weaker structured fields than leave-ins. The helper should omit missing facts rather than inventing labels.
+- Some usage strings are ASCII-transliterated in existing code. Keep project consistency unless a separate copy pass is requested.
+- Product popovers may still contain older personalization language; inspect and treat as follow-up unless it visibly conflicts with the compact card/drawer end-state.

--- a/src/components/chat/product-card.tsx
+++ b/src/components/chat/product-card.tsx
@@ -1,3 +1,9 @@
+import { ChevronRight } from "lucide-react"
+
+import {
+  buildCompactProductFacts,
+  formatProductPrice,
+} from "@/components/chat/product-display-model"
 import type { Product } from "@/lib/types"
 import { Icon, type IconName } from "@/components/ui/icon"
 
@@ -9,30 +15,41 @@ interface ProductCardProps {
 /** Maps product.category to the icon name in our icon system. */
 function categoryIconName(category: string | null): IconName {
   if (!category) return "product-shampoo"
-  const mapped = `product-${category.replaceAll("_", "-")}` as IconName
-  // Check if the mapped name is a valid icon; fall back otherwise.
-  const validIcons: IconName[] = [
-    "product-shampoo",
-    "product-conditioner",
-    "product-oil",
-    "product-mask",
-    "product-leave-in",
-    "product-peeling",
-    "product-dry-shampoo",
-    "product-bond-builder",
-    "product-deep-cleansing",
-  ]
-  return validIcons.includes(mapped) ? mapped : "product-shampoo"
-}
+  const normalizedCategory = category
+    .trim()
+    .toLowerCase()
+    .replace(/[()]/g, "")
+    .replace(/[\s_-]+/g, "-")
 
-/** Formats a number as German-style price: `12,99 €` */
-function formatPrice(price: number): string {
-  return `${price.toFixed(2).replace(".", ",")} €`
+  const categoryIcons: Record<string, IconName> = {
+    shampoo: "product-shampoo",
+    conditioner: "product-conditioner",
+    "conditioner-drogerie": "product-conditioner",
+    oil: "product-oil",
+    oel: "product-oil",
+    öl: "product-oil",
+    öle: "product-oil",
+    oele: "product-oil",
+    mask: "product-mask",
+    maske: "product-mask",
+    "leave-in": "product-leave-in",
+    leavein: "product-leave-in",
+    peeling: "product-peeling",
+    "dry-shampoo": "product-dry-shampoo",
+    trockenshampoo: "product-dry-shampoo",
+    bondbuilder: "product-bond-builder",
+    "bond-builder": "product-bond-builder",
+    "deep-cleansing-shampoo": "product-deep-cleansing",
+    "deep-cleansing": "product-deep-cleansing",
+  }
+
+  return categoryIcons[normalizedCategory] ?? "product-shampoo"
 }
 
 export function ProductCard({ product, onClick }: ProductCardProps) {
   const iconName = categoryIconName(product.category)
-  const topReason = product.recommendation_meta?.top_reasons?.[0]
+  const facts = buildCompactProductFacts(product)
+  const price = formatProductPrice(product.price_eur, product.currency)
 
   return (
     <button
@@ -53,19 +70,32 @@ export function ProductCard({ product, onClick }: ProductCardProps) {
         {product.brand && (
           <p className="truncate text-[11px] text-[var(--text-caption)]">{product.brand}</p>
         )}
-        {topReason && (
-          <p className="mt-0.5 whitespace-normal break-words text-[11px] leading-snug text-primary">
-            {topReason}
-          </p>
+        {facts.length > 0 && (
+          <div className="mt-1 flex min-w-0 flex-wrap gap-1">
+            {facts.map((fact) => (
+              <span
+                key={`${fact.source}:${fact.label}`}
+                className="max-w-full truncate rounded-full bg-[var(--brand-plum-ice)] px-2 py-0.5 text-[10px] font-medium leading-4 text-primary"
+              >
+                {fact.label}
+              </span>
+            ))}
+          </div>
         )}
       </div>
 
-      {/* Price */}
-      {product.price_eur != null && (
-        <span className="shrink-0 font-mono text-[12px] font-medium text-[var(--text-heading)]">
-          {formatPrice(product.price_eur)}
+      {price && (
+        <span className="shrink-0 whitespace-nowrap text-[12px] font-semibold text-[var(--text-heading)]">
+          {price}
         </span>
       )}
+
+      <span className="sr-only">Produktdetails öffnen</span>
+      <ChevronRight
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0 text-[var(--text-caption)]"
+        strokeWidth={1.8}
+      />
     </button>
   )
 }

--- a/src/components/chat/product-detail-drawer.tsx
+++ b/src/components/chat/product-detail-drawer.tsx
@@ -1,31 +1,6 @@
 "use client"
 
 import type { Product, HairProfile } from "@/lib/types"
-import { getPersonalizationSentence } from "@/lib/product-utils"
-import { getCatalogConcernLabel } from "@/lib/product-specs/concern-taxonomy"
-import { SHAMPOO_BUCKET_LABELS } from "@/lib/shampoo/constants"
-import {
-  HAIR_TEXTURE_LABELS,
-  HAIR_THICKNESS_LABELS,
-  HAIR_DENSITY_LABELS,
-  PROTEIN_MOISTURE_LABELS,
-  CUTICLE_CONDITION_LABELS,
-  SCALP_CONDITION_LABELS,
-  SCALP_TYPE_LABELS,
-  CHEMICAL_TREATMENT_LABELS,
-} from "@/lib/vocabulary"
-import {
-  CONDITIONER_WEIGHT_LABELS,
-  CONDITIONER_REPAIR_LEVEL_LABELS,
-} from "@/lib/conditioner/constants"
-import {
-  LEAVE_IN_CONDITIONER_RELATIONSHIP_LABELS,
-  LEAVE_IN_NEED_BUCKET_LABELS,
-  LEAVE_IN_STYLING_CONTEXT_LABELS,
-  LEAVE_IN_WEIGHT_LABELS,
-} from "@/lib/leave-in/constants"
-import { OIL_SUBTYPE_LABELS, OIL_USE_MODE_LABELS } from "@/lib/oil/constants"
-import { ProductImage } from "./product-image"
 import { Badge } from "@/components/ui/badge"
 import {
   BottomSheet,
@@ -34,6 +9,17 @@ import {
   BottomSheetTitle,
 } from "@/components/ui/bottom-sheet"
 import { ExternalLink } from "lucide-react"
+import {
+  buildDrawerProductProfileRows,
+  buildProductApplicationSentence,
+  buildProductMatchSummary,
+  formatProductPrice,
+  getProductCategoryLabel,
+  getShopLabel,
+  getValidAffiliateLink,
+  shouldShowAffiliateDisclosure,
+} from "./product-display-model"
+import { ProductImage } from "./product-image"
 
 interface ProductDetailDrawerProps {
   product: Product | null
@@ -50,8 +36,16 @@ export function ProductDetailDrawer({
 }: ProductDetailDrawerProps) {
   if (!product) return null
 
-  const personalization = getPersonalizationSentence(product, hairProfile)
-  const description = product.short_description || product.description
+  const categoryLabel = getProductCategoryLabel(
+    product.recommendation_meta?.category ?? product.category,
+  )
+  const matchSummary = buildProductMatchSummary(product, hairProfile)
+  const applicationSentence = buildProductApplicationSentence(product, hairProfile)
+  const profileRows = buildDrawerProductProfileRows(product)
+  const price = formatProductPrice(product.price_eur, product.currency)
+  const affiliateHref = getValidAffiliateLink(product.affiliate_link)
+  const shopLabel = getShopLabel(affiliateHref)
+  const showAffiliateDisclosure = shouldShowAffiliateDisclosure(product)
 
   return (
     <BottomSheet open={open} onOpenChange={onOpenChange}>
@@ -63,410 +57,78 @@ export function ProductDetailDrawer({
               <p className="text-sm font-medium text-muted-foreground">{product.brand}</p>
             )}
             <BottomSheetTitle className="text-lg">{product.name}</BottomSheetTitle>
-            {product.category && (
+            {categoryLabel && (
               <Badge variant="default" className="mt-2">
-                {product.category}
+                {categoryLabel}
               </Badge>
             )}
           </div>
         </BottomSheetHeader>
 
-        <div className="space-y-4 pt-2">
-          {/* Personalization */}
-          {personalization && (
-            <div className="rounded-lg bg-primary/10 px-4 py-3">
-              <p className="text-sm font-medium text-primary">{personalization}</p>
-            </div>
+        <div className="space-y-5 pt-2">
+          {matchSummary && (
+            <section className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Warum es passt
+              </h3>
+              <div className="rounded-lg bg-primary/10 px-4 py-3">
+                <p className="text-sm leading-6 text-foreground">{matchSummary}</p>
+              </div>
+            </section>
           )}
 
-          {product.recommendation_meta && (
-            <div className="space-y-2 rounded-lg border border-border/60 bg-muted/40 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Empfehlungskontext
-              </p>
-              <p className="text-sm font-medium text-foreground">
-                Score: {product.recommendation_meta.score.toFixed(1)}
-              </p>
-              {product.recommendation_meta.top_reasons.length > 0 && (
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground">Warum passend</p>
-                  <ul className="mt-1 space-y-1">
-                    {product.recommendation_meta.top_reasons.map((reason) => (
-                      <li key={reason} className="text-sm text-foreground">
-                        - {reason}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {product.recommendation_meta.tradeoffs.length > 0 && (
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground">Trade-offs</p>
-                  <ul className="mt-1 space-y-1">
-                    {product.recommendation_meta.tradeoffs.map((tradeoff) => (
-                      <li key={tradeoff} className="text-sm text-foreground">
-                        - {tradeoff}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {product.recommendation_meta.usage_hint && (
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground">Anwendung</p>
-                  <p className="text-sm text-foreground">
-                    {product.recommendation_meta.usage_hint}
-                  </p>
-                </div>
-              )}
-              {product.recommendation_meta.category === "shampoo" && (
-                <>
-                  {product.recommendation_meta.matched_bucket && (
-                    <div>
-                      <p className="text-xs font-medium text-muted-foreground">Shampoo-Bucket</p>
-                      <p className="text-sm text-foreground">
-                        {SHAMPOO_BUCKET_LABELS[product.recommendation_meta.matched_bucket]}
-                      </p>
-                    </div>
+          {applicationSentence && (
+            <section className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Anwendung
+              </h3>
+              <p className="text-sm leading-6 text-foreground">{applicationSentence}</p>
+            </section>
+          )}
+
+          {profileRows.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Produktprofil
+              </h3>
+              <div className="divide-y divide-border/70 rounded-lg border border-border/70">
+                {profileRows.map((row) => (
+                  <div
+                    key={`${row.label}-${row.value}`}
+                    className="grid grid-cols-1 gap-1 px-4 py-3 text-sm sm:grid-cols-[minmax(8rem,0.8fr)_minmax(0,1.2fr)] sm:gap-4"
+                  >
+                    <span className="font-medium text-muted-foreground">{row.label}</span>
+                    <span className="min-w-0 break-words text-foreground">{row.value}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {(price || affiliateHref || showAffiliateDisclosure) && (
+            <footer className="space-y-2 border-t border-border pt-4">
+              {(price || affiliateHref) && (
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  {price && <p className="text-lg font-bold text-primary">{price}</p>}
+                  {affiliateHref && (
+                    <a
+                      href={affiliateHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex min-h-10 w-full items-center justify-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 sm:w-auto"
+                    >
+                      <span>{shopLabel}</span>
+                      <ExternalLink className="h-4 w-4 shrink-0" aria-hidden="true" />
+                    </a>
                   )}
-
-                  <div>
-                    <p className="text-xs font-medium text-muted-foreground">Profil-Match</p>
-                    <div className="mt-1 flex flex-wrap gap-1.5">
-                      {product.recommendation_meta.matched_profile.thickness && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            HAIR_THICKNESS_LABELS[
-                              product.recommendation_meta.matched_profile.thickness
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.scalp_type && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            SCALP_TYPE_LABELS[
-                              product.recommendation_meta.matched_profile.scalp_type
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.scalp_condition && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            SCALP_CONDITION_LABELS[
-                              product.recommendation_meta.matched_profile.scalp_condition
-                            ]
-                          }
-                        </Badge>
-                      )}
-                    </div>
-                  </div>
-                </>
+                </div>
               )}
-              {product.recommendation_meta.category === "conditioner" && (
-                <>
-                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                    {product.recommendation_meta.matched_balance_need && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Pflegefokus</p>
-                        <p className="text-sm text-foreground">
-                          {product.recommendation_meta.matched_balance_need === "moisture" &&
-                            "Feuchtigkeit"}
-                          {product.recommendation_meta.matched_balance_need === "balanced" &&
-                            "Ausgewogene Pflege"}
-                          {product.recommendation_meta.matched_balance_need === "protein" &&
-                            "Protein"}
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.matched_weight && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Gewicht</p>
-                        <p className="text-sm text-foreground">
-                          {CONDITIONER_WEIGHT_LABELS[product.recommendation_meta.matched_weight]}
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.matched_repair_level && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Repair-Level</p>
-                        <p className="text-sm text-foreground">
-                          {
-                            CONDITIONER_REPAIR_LEVEL_LABELS[
-                              product.recommendation_meta.matched_repair_level
-                            ]
-                          }
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.matched_profile.protein_moisture_balance && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Zugtest</p>
-                        <p className="text-sm text-foreground">
-                          {
-                            PROTEIN_MOISTURE_LABELS[
-                              product.recommendation_meta.matched_profile.protein_moisture_balance
-                            ]
-                          }
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  <div>
-                    <p className="text-xs font-medium text-muted-foreground">Profil-Match</p>
-                    <div className="mt-1 flex flex-wrap gap-1.5">
-                      {product.recommendation_meta.matched_profile.thickness && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            HAIR_THICKNESS_LABELS[
-                              product.recommendation_meta.matched_profile.thickness
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.density && (
-                        <Badge variant="outline" className="text-xs">
-                          {HAIR_DENSITY_LABELS[product.recommendation_meta.matched_profile.density]}
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.cuticle_condition && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            CUTICLE_CONDITION_LABELS[
-                              product.recommendation_meta.matched_profile.cuticle_condition
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.chemical_treatment.map(
-                        (treatment) => (
-                          <Badge key={treatment} variant="outline" className="text-xs">
-                            {CHEMICAL_TREATMENT_LABELS[treatment] ?? treatment}
-                          </Badge>
-                        ),
-                      )}
-                    </div>
-                  </div>
-                </>
+              {showAffiliateDisclosure && (
+                <p className="text-xs leading-5 text-muted-foreground">
+                  Anzeige: Der Kauflink kann ein Affiliate-Link sein.
+                </p>
               )}
-              {product.recommendation_meta.category === "leave_in" && (
-                <>
-                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                    {product.recommendation_meta.need_bucket && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Pflegefokus</p>
-                        <p className="text-sm text-foreground">
-                          {LEAVE_IN_NEED_BUCKET_LABELS[product.recommendation_meta.need_bucket]}
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.styling_context && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Styling-Kontext</p>
-                        <p className="text-sm text-foreground">
-                          {
-                            LEAVE_IN_STYLING_CONTEXT_LABELS[
-                              product.recommendation_meta.styling_context
-                            ]
-                          }
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.conditioner_relationship && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">
-                          Conditioner-Rolle
-                        </p>
-                        <p className="text-sm text-foreground">
-                          {
-                            LEAVE_IN_CONDITIONER_RELATIONSHIP_LABELS[
-                              product.recommendation_meta.conditioner_relationship
-                            ]
-                          }
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.matched_weight && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Gewicht</p>
-                        <p className="text-sm text-foreground">
-                          {LEAVE_IN_WEIGHT_LABELS[product.recommendation_meta.matched_weight]}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  <div>
-                    <p className="text-xs font-medium text-muted-foreground">Profil-Match</p>
-                    <div className="mt-1 flex flex-wrap gap-1.5">
-                      {product.recommendation_meta.matched_profile.hair_texture && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            HAIR_TEXTURE_LABELS[
-                              product.recommendation_meta.matched_profile.hair_texture
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.thickness && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            HAIR_THICKNESS_LABELS[
-                              product.recommendation_meta.matched_profile.thickness
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.density && (
-                        <Badge variant="outline" className="text-xs">
-                          {HAIR_DENSITY_LABELS[product.recommendation_meta.matched_profile.density]}
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.cuticle_condition && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            CUTICLE_CONDITION_LABELS[
-                              product.recommendation_meta.matched_profile.cuticle_condition
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.matched_profile.chemical_treatment.map(
-                        (treatment) => (
-                          <Badge key={treatment} variant="outline" className="text-xs">
-                            {CHEMICAL_TREATMENT_LABELS[treatment] ?? treatment}
-                          </Badge>
-                        ),
-                      )}
-                    </div>
-                  </div>
-                </>
-              )}
-              {product.recommendation_meta.category === "oil" && (
-                <>
-                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                    {product.recommendation_meta.matched_subtype && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Oel-Typ</p>
-                        <p className="text-sm text-foreground">
-                          {OIL_SUBTYPE_LABELS[product.recommendation_meta.matched_subtype]}
-                        </p>
-                      </div>
-                    )}
-                    {product.recommendation_meta.use_mode && (
-                      <div>
-                        <p className="text-xs font-medium text-muted-foreground">Anwendung</p>
-                        <p className="text-sm text-foreground">
-                          {OIL_USE_MODE_LABELS[product.recommendation_meta.use_mode]}
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  <div>
-                    <p className="text-xs font-medium text-muted-foreground">Profil-Match</p>
-                    <div className="mt-1 flex flex-wrap gap-1.5">
-                      {product.recommendation_meta.matched_profile.thickness && (
-                        <Badge variant="outline" className="text-xs">
-                          {
-                            HAIR_THICKNESS_LABELS[
-                              product.recommendation_meta.matched_profile.thickness
-                            ]
-                          }
-                        </Badge>
-                      )}
-                      {product.recommendation_meta.adjunct_scalp_support && (
-                        <Badge variant="outline" className="text-xs">
-                          Kopfhaut-supportiv
-                        </Badge>
-                      )}
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-          )}
-
-          {/* Description */}
-          {description && (
-            <div>
-              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Beschreibung
-              </p>
-              <p className="text-sm text-muted-foreground">{description}</p>
-            </div>
-          )}
-
-          {/* Hair types */}
-          {product.suitable_thicknesses?.length > 0 && (
-            <div>
-              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Geeignete Haardicke
-              </p>
-              <div className="flex flex-wrap gap-1.5">
-                {product.suitable_thicknesses.map((ht) => (
-                  <Badge key={ht} variant="outline" className="text-xs">
-                    {HAIR_THICKNESS_LABELS[ht as keyof typeof HAIR_THICKNESS_LABELS] ?? ht}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Concerns */}
-          {product.suitable_concerns?.length > 0 && (
-            <div>
-              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Hilft bei
-              </p>
-              <div className="flex flex-wrap gap-1.5">
-                {product.suitable_concerns.map((c) => (
-                  <Badge key={c} variant="outline" className="text-xs">
-                    {getCatalogConcernLabel(c)}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Tags */}
-          {product.tags?.length > 0 && (
-            <div>
-              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Tags
-              </p>
-              <div className="flex flex-wrap gap-1.5">
-                {product.tags.map((t) => (
-                  <Badge key={t} variant="default" className="text-xs">
-                    {t}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Price + affiliate link */}
-          {(product.price_eur || product.affiliate_link) && (
-            <div className="flex items-center justify-between border-t border-border pt-4">
-              {product.price_eur && (
-                <span className="text-lg font-bold text-primary">
-                  {product.price_eur.toFixed(2)} \u20AC
-                </span>
-              )}
-              {product.affiliate_link && (
-                <a
-                  href={product.affiliate_link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-                >
-                  Kaufen
-                  <ExternalLink className="h-4 w-4" />
-                </a>
-              )}
-            </div>
+            </footer>
           )}
         </div>
       </BottomSheetContent>

--- a/src/components/chat/product-display-model.ts
+++ b/src/components/chat/product-display-model.ts
@@ -1,0 +1,544 @@
+import {
+  LEAVE_IN_FORMAT_LABELS,
+  LEAVE_IN_WEIGHT_LABELS,
+  isLeaveInCategory,
+} from "@/lib/leave-in/constants"
+import type { HairProfile, LeaveInRecommendationMetadata, Product } from "@/lib/types"
+
+export type CompactProductFactSource =
+  | "format"
+  | "heat_protection"
+  | "care_focus"
+  | "weight"
+  | "category"
+
+export interface CompactProductFact {
+  label: string
+  source: CompactProductFactSource
+}
+
+export interface DrawerProductProfileRow {
+  label: string
+  value: string
+}
+
+const BALANCE_LABELS = {
+  moisture: "Feuchtigkeit",
+  balanced: "ausgewogen",
+  protein: "Protein",
+} as const
+
+const BALANCE_ROW_LABELS = {
+  moisture: "Feuchtigkeit",
+  balanced: "Ausgewogene Pflege",
+  protein: "Proteinpflege",
+} as const
+
+const CARE_BENEFIT_LABELS = {
+  moisture: "Feuchtigkeit",
+  protein: "Protein",
+  repair: "Repair",
+  detangling: "Entwirren",
+  anti_frizz: "Anti-Frizz",
+  shine: "Glanz",
+  curl_definition: "Definition",
+  volume: "Volumen",
+} as const
+
+const CATEGORY_LABELS: Record<string, string> = {
+  shampoo: "Shampoo",
+  conditioner: "Conditioner",
+  "conditioner-drogerie": "Conditioner",
+  leave_in: "Leave-in",
+  "leave-in": "Leave-in",
+  "leave in": "Leave-in",
+  leavein: "Leave-in",
+  mask: "Maske",
+  maske: "Maske",
+  oil: "Öl",
+  oel: "Öl",
+  öle: "Öl",
+  oele: "Öl",
+  bondbuilder: "Bondbuilder",
+  "bond-builder": "Bondbuilder",
+  deep_cleansing_shampoo: "Tiefenreinigung",
+  "deep-cleansing-shampoo": "Tiefenreinigung",
+  "deep-cleansing": "Tiefenreinigung",
+  dry_shampoo: "Trockenshampoo",
+  "dry-shampoo": "Trockenshampoo",
+  trockenshampoo: "Trockenshampoo",
+  peeling: "Peeling",
+}
+
+const THICKNESS_PROFILE_LABELS: Record<string, string> = {
+  fine: "Feines Haar",
+  normal: "Mittelstarkes Haar",
+  coarse: "Dickes Haar",
+}
+
+const THICKNESS_SUMMARY_LABELS: Record<string, string> = {
+  fine: "feines Haar",
+  normal: "mittelstarkes Haar",
+  coarse: "dickes Haar",
+}
+
+const CONCERN_LABELS: Record<string, string> = {
+  dandruff: "Schuppen",
+  schuppen: "Schuppen",
+  oily_scalp: "Fettige Kopfhaut",
+  dryness: "Trockenheit",
+  trocken: "Trockenheit",
+  frizz: "Frizz",
+  hair_damage: "Haarschäden",
+  split_ends: "Spliss",
+  breakage: "Haarbruch",
+  tangling: "Verknotungen",
+  protein: "Protein",
+  feuchtigkeit: "Feuchtigkeit",
+  performance: "Performance",
+  repair: "Reparatur",
+  moisture_anti_frizz: "Feuchtigkeit & Anti-Frizz",
+  healthy_scalp: "Gesunde Kopfhaut",
+  normal: "Normale Kopfhaut",
+  "dehydriert-fettig": "Dehydriert-fettige Kopfhaut",
+  irritationen: "Empfindliche Kopfhaut",
+}
+
+const SHOP_HOST_LABELS: Record<string, string> = {
+  "dm.de": "dm",
+  "rossmann.de": "Rossmann",
+  "mueller.de": "Müller",
+  "douglas.de": "Douglas",
+  "flaconi.de": "Flaconi",
+  "amazon.de": "Amazon",
+  "notino.de": "Notino",
+  "hagel-shop.de": "Hagel-Shop",
+}
+
+export function buildCompactProductFacts(product: Product): CompactProductFact[] {
+  if (isLeaveInProduct(product)) {
+    const facts: CompactProductFact[] = []
+    const meta = getLeaveInMeta(product)
+    const format = meta?.product_format ?? product.leave_in_specs?.format ?? null
+    const weight = meta?.product_weight ?? product.leave_in_specs?.weight ?? null
+    const balance = meta?.product_balance_direction ?? null
+
+    if (format) {
+      facts.push({ label: LEAVE_IN_FORMAT_LABELS[format], source: "format" })
+    }
+
+    if (meta?.provides_heat_protection ?? product.leave_in_specs?.provides_heat_protection) {
+      facts.push({ label: "Hitzeschutz", source: "heat_protection" })
+    }
+
+    if (balance) {
+      facts.push({ label: `Pflege: ${BALANCE_LABELS[balance]}`, source: "care_focus" })
+    } else {
+      const benefit = firstLeaveInCareBenefit(
+        meta?.product_care_benefits ?? product.leave_in_specs?.care_benefits,
+      )
+      if (benefit) {
+        facts.push({ label: `Pflege: ${benefit}`, source: "care_focus" })
+      }
+    }
+
+    if (facts.length < 3 && weight) {
+      facts.push({ label: LEAVE_IN_WEIGHT_LABELS[weight], source: "weight" })
+    }
+
+    return facts.slice(0, 3)
+  }
+
+  const categoryLabel = getProductCategoryLabel(
+    product.recommendation_meta?.category ?? product.category,
+  )
+  return categoryLabel ? [{ label: categoryLabel, source: "category" }] : []
+}
+
+export function buildDrawerProductProfileRows(product: Product): DrawerProductProfileRow[] {
+  if (!isLeaveInProduct(product)) return buildFallbackProductProfileRows(product)
+
+  const meta = getLeaveInMeta(product)
+  const rows: DrawerProductProfileRow[] = []
+  const format = meta?.product_format ?? product.leave_in_specs?.format ?? null
+  const weight = meta?.product_weight ?? product.leave_in_specs?.weight ?? null
+  const balance = meta?.product_balance_direction ?? null
+  const providesHeatProtection =
+    meta?.provides_heat_protection ?? product.leave_in_specs?.provides_heat_protection ?? null
+  const role = getLeaveInRoleLabel(meta, product)
+
+  if (format) rows.push({ label: "Textur/Form", value: LEAVE_IN_FORMAT_LABELS[format] })
+  if (weight) rows.push({ label: "Gefühl", value: LEAVE_IN_WEIGHT_LABELS[weight] })
+  if (balance) rows.push({ label: "Wirkung", value: BALANCE_ROW_LABELS[balance] })
+  if (!balance) {
+    const benefit = firstLeaveInCareBenefit(
+      meta?.product_care_benefits ?? product.leave_in_specs?.care_benefits,
+    )
+    if (benefit) rows.push({ label: "Wirkung", value: benefit })
+  }
+  if (providesHeatProtection !== null) {
+    rows.push({ label: "Hitzeschutz", value: providesHeatProtection ? "Ja" : "Nein" })
+  }
+  if (role) rows.push({ label: "Rolle", value: role })
+
+  return rows
+}
+
+export function buildProductMatchSummary(
+  product: Product,
+  hairProfile?: HairProfile | null,
+): string {
+  if (!isLeaveInProduct(product)) {
+    return buildFallbackProductMatchSummary(product, hairProfile)
+  }
+
+  const meta = getLeaveInMeta(product)
+  const goals = hairProfile?.goals ?? []
+  const heatStyling = hairProfile?.heat_styling ?? null
+  const hasRegularHeatStyling =
+    meta?.styling_context === "heat_style" ||
+    heatStyling === "daily" ||
+    heatStyling === "several_weekly" ||
+    heatStyling === "once_weekly"
+  const wantsShine = goals.includes("shine") || meta?.need_bucket === "shine_protect"
+  const hasFineHair =
+    hairProfile?.thickness === "fine" || meta?.matched_profile.thickness === "fine"
+
+  const format = meta?.product_format ?? product.leave_in_specs?.format ?? null
+  const role = getLeaveInRoleLabel(meta, product)
+  const balance = meta?.product_balance_direction ?? null
+  const categoryLabel =
+    getProductCategoryLabel(product.recommendation_meta?.category ?? product.category) || "Leave-in"
+  const productSubject = getLeaveInProductSubject(categoryLabel, format)
+  const providesHeatProtection =
+    meta?.provides_heat_protection ?? product.leave_in_specs?.provides_heat_protection ?? false
+
+  const profileSentence = buildLeaveInProfileSentence(
+    hasRegularHeatStyling,
+    wantsShine,
+    hasFineHair,
+  )
+  const rolePhrase = role ? ` als ${role}` : ""
+  const factPhrase = buildLeaveInFactPhrase(providesHeatProtection, balance, productSubject.article)
+  const weightCaution =
+    hairProfile?.thickness === "fine" &&
+    (meta?.product_weight ?? product.leave_in_specs?.weight) !== "rich"
+      ? ", ohne in eine sehr reichhaltige Richtung zu gehen"
+      : ""
+
+  return `${profileSentence}${productSubject.label} passt${rolePhrase}${factPhrase}${weightCaution}.`
+}
+
+export function buildProductApplicationSentence(
+  product: Product,
+  hairProfile?: HairProfile | null,
+): string {
+  const usageHint = product.recommendation_meta?.usage_hint?.trim()
+  if (!usageHint) return ""
+
+  const sentences = [ensureSentenceEnding(usageHint)]
+  if (hairProfile?.thickness === "fine" && !hasFineHairOrSparseUseGuidance(usageHint)) {
+    sentences.push("Bei feinem Haar lieber mit wenig Produkt starten und nur bei Bedarf nachlegen.")
+  }
+
+  return sentences.join(" ")
+}
+
+export function formatProductPrice(
+  price: number | null | undefined,
+  currency: string | null | undefined,
+): string {
+  if (price === null || price === undefined || !Number.isFinite(price)) return ""
+
+  const formatCurrency = (currencyCode: string) =>
+    new Intl.NumberFormat("de-DE", {
+      style: "currency",
+      currency: currencyCode,
+    })
+      .format(price)
+      .replace(/\u00a0/g, " ")
+
+  try {
+    return formatCurrency(currency || "EUR")
+  } catch {
+    return formatCurrency("EUR")
+  }
+}
+
+export function getProductCategoryLabel(category: string | null | undefined): string {
+  if (!category) return ""
+  return CATEGORY_LABELS[normalizeCategoryKey(category)] ?? ""
+}
+
+export function getValidAffiliateLink(affiliateLink: string | null | undefined): string {
+  const trimmed = affiliateLink?.trim()
+  if (!trimmed) return ""
+
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== "https:" && url.protocol !== "http:") return ""
+    return url.toString()
+  } catch {
+    return ""
+  }
+}
+
+export function getShopLabel(affiliateLink: string | null | undefined): string {
+  const validLink = getValidAffiliateLink(affiliateLink)
+  if (!validLink) return "Kaufen"
+
+  try {
+    const host = new URL(validLink).hostname.replace(/^www\./, "").toLowerCase()
+    const knownLabel = SHOP_HOST_LABELS[host]
+    if (knownLabel) return `Bei ${knownLabel} kaufen`
+
+    const baseLabel = host.split(".")[0]
+    if (!baseLabel) return "Kaufen"
+    return `Bei ${capitalize(baseLabel)} kaufen`
+  } catch {
+    return "Kaufen"
+  }
+}
+
+export function shouldShowAffiliateDisclosure(product: Product): boolean {
+  return Boolean(getValidAffiliateLink(product.affiliate_link))
+}
+
+function isLeaveInProduct(product: Product): boolean {
+  return (
+    product.recommendation_meta?.category === "leave_in" ||
+    isLeaveInCategory(product.category) ||
+    Boolean(product.leave_in_specs)
+  )
+}
+
+function getLeaveInMeta(product: Product): LeaveInRecommendationMetadata | null {
+  return product.recommendation_meta?.category === "leave_in" ? product.recommendation_meta : null
+}
+
+function buildLeaveInProfileSentence(
+  hasRegularHeatStyling: boolean,
+  wantsShine: boolean,
+  hasFineHair: boolean,
+): string {
+  const firstParts: string[] = []
+  if (hasRegularHeatStyling) firstParts.push("Du stylst regelmäßig mit Hitze")
+  if (wantsShine)
+    firstParts.push(firstParts.length > 0 ? "möchtest mehr Glanz" : "Du möchtest mehr Glanz")
+
+  if (hasFineHair) {
+    if (firstParts.length > 0) {
+      return `${joinGermanList(firstParts)}, während dein feines Haar schnell beschwert wirken kann. `
+    }
+    return "Dein feines Haar kann schnell beschwert wirken. "
+  }
+
+  return firstParts.length > 0 ? `${joinGermanList(firstParts)}. ` : ""
+}
+
+function getLeaveInProductSubject(
+  categoryLabel: string,
+  format: LeaveInRecommendationMetadata["product_format"] | null | undefined,
+): { label: string; article: "Diese" | "Dieses" } {
+  const noun = `${categoryLabel}${format ? `-${LEAVE_IN_FORMAT_LABELS[format]}` : ""}`
+  const article =
+    format === "lotion" || format === "cream" || format === "milk" ? "Diese" : "Dieses"
+  return { label: `${article} ${noun}`, article }
+}
+
+function buildLeaveInFactPhrase(
+  providesHeatProtection: boolean,
+  balance: LeaveInRecommendationMetadata["product_balance_direction"] | null | undefined,
+  article: "Diese" | "Dieses",
+): string {
+  const pronoun = article === "Diese" ? "sie" : "es"
+  const carePhrase = balance ? getCarePhrase(balance) : ""
+
+  if (providesHeatProtection && carePhrase) {
+    return `, weil ${pronoun} Hitzeschutz mit ${carePhrase} verbindet`
+  }
+  if (providesHeatProtection) {
+    return `, weil ${pronoun} Hitzeschutz bietet`
+  }
+  if (carePhrase) {
+    return `, weil ${pronoun} ${carePhrase} mitbringt`
+  }
+
+  return ""
+}
+
+function getCarePhrase(
+  balance: NonNullable<LeaveInRecommendationMetadata["product_balance_direction"]>,
+): string {
+  if (balance === "moisture") return "Feuchtigkeitspflege"
+  if (balance === "protein") return "Proteinpflege"
+  return "ausgewogener Pflege"
+}
+
+function buildFallbackProductProfileRows(product: Product): DrawerProductProfileRow[] {
+  const rows: DrawerProductProfileRow[] = []
+  const categoryLabel = getSafeProductCategoryLabel(product)
+  const thicknessLabels = getWhitelistedLabels(
+    product.suitable_thicknesses,
+    THICKNESS_PROFILE_LABELS,
+  )
+  const concernLabels = getWhitelistedLabels(product.suitable_concerns, CONCERN_LABELS)
+
+  if (categoryLabel) rows.push({ label: "Kategorie", value: categoryLabel })
+  if (thicknessLabels.length > 0) {
+    rows.push({ label: "Geeignet für", value: joinGermanList(thicknessLabels) })
+  }
+  if (concernLabels.length > 0) {
+    rows.push({ label: "Fokus", value: concernLabels.slice(0, 3).join(", ") })
+  }
+
+  return rows
+}
+
+function buildFallbackProductMatchSummary(
+  product: Product,
+  hairProfile?: HairProfile | null,
+): string {
+  const categoryLabel = getSafeProductCategoryLabel(product)
+  const subject = getProductSubject(categoryLabel)
+  const description = getProductDescriptionSummary(product)
+  const reasonClauses: string[] = []
+  const thicknessPhrase = getThicknessSummaryPhrase(product, hairProfile)
+  const concernLabels = getWhitelistedLabels(product.suitable_concerns, CONCERN_LABELS).slice(0, 2)
+
+  if (thicknessPhrase) {
+    reasonClauses.push(`es für ${thicknessPhrase} eingeordnet ist`)
+  }
+  if (concernLabels.length > 0) {
+    reasonClauses.push(`der Fokus auf ${joinGermanList(concernLabels)} liegt`)
+  }
+
+  if (reasonClauses.length > 0) {
+    const descriptionSentence = description ? ` ${ensureSentenceEnding(description)}` : ""
+    return `${subject} passt, weil ${joinGermanList(reasonClauses)}.${descriptionSentence}`
+  }
+
+  if (description) {
+    return `${subject} passt zu diesem Pflegeschritt. ${ensureSentenceEnding(description)}`
+  }
+
+  return categoryLabel ? `${subject} passt als ${categoryLabel} in diesen Pflegeschritt.` : ""
+}
+
+function getSafeProductCategoryLabel(product: Product): string {
+  const label = getProductCategoryLabel(product.recommendation_meta?.category ?? product.category)
+  if (!label || !isSafePublicText(label)) return "Produkt"
+  return label
+}
+
+function getWhitelistedLabels(
+  values: readonly string[] | null | undefined,
+  labels: Record<string, string>,
+): string[] {
+  const result: string[] = []
+
+  for (const value of values ?? []) {
+    const label = labels[value]
+    if (label && !result.includes(label)) result.push(label)
+  }
+
+  return result
+}
+
+function getThicknessSummaryPhrase(product: Product, hairProfile?: HairProfile | null): string {
+  const suitableThicknesses = product.suitable_thicknesses ?? []
+  const profileThickness = hairProfile?.thickness ?? null
+
+  if (profileThickness && suitableThicknesses.includes(profileThickness)) {
+    return THICKNESS_SUMMARY_LABELS[profileThickness] ?? ""
+  }
+
+  return getWhitelistedLabels(suitableThicknesses, THICKNESS_SUMMARY_LABELS)
+    .slice(0, 2)
+    .join(" oder ")
+}
+
+function getProductSubject(categoryLabel: string): string {
+  if (!categoryLabel || categoryLabel === "Produkt") return "Dieses Produkt"
+
+  const normalized = categoryLabel.toLowerCase()
+  if (normalized === "conditioner" || normalized === "bondbuilder") return `Dieser ${categoryLabel}`
+  if (normalized === "maske" || normalized === "tiefenreinigung") return `Diese ${categoryLabel}`
+  return `Dieses ${categoryLabel}`
+}
+
+function getProductDescriptionSummary(product: Product): string {
+  const rawDescription = product.short_description?.trim() || product.description?.trim() || ""
+  if (!rawDescription) return ""
+
+  const normalized = rawDescription.replace(/\s+/g, " ")
+  if (!isSafePublicText(normalized)) return ""
+
+  const firstSentence = normalized.match(/^(.+?[.!?])(?:\s|$)/)?.[1] ?? normalized
+  return firstSentence.length > 180 ? `${firstSentence.slice(0, 177).trim()}...` : firstSentence
+}
+
+function isSafePublicText(value: string): boolean {
+  return !(
+    /Score|Profil-Match|Empfehlungskontext|Shampoo-Bucket|Trade-offs|recommendation_meta|matched_profile|matched-profile|top_reasons|top-reasons|tradeoffs|trade-offs/i.test(
+      value,
+    ) ||
+    /\b[a-z][a-z0-9_-]*:[a-z0-9_-]+\b/i.test(value) ||
+    /\b[a-z]+_[a-z0-9_]*[a-z0-9]\b/i.test(value)
+  )
+}
+
+function normalizeCategoryKey(category: string): string {
+  return category
+    .trim()
+    .toLowerCase()
+    .replace(/ä/g, "ae")
+    .replace(/ö/g, "ö")
+    .replace(/ü/g, "ue")
+    .replace(/ß/g, "ss")
+    .replace(/[()]/g, "")
+    .replace(/[\s_-]+/g, "-")
+}
+
+function firstLeaveInCareBenefit(
+  benefits: readonly (keyof typeof CARE_BENEFIT_LABELS)[] | null | undefined,
+): string | null {
+  const benefit = benefits?.[0]
+  return benefit ? CARE_BENEFIT_LABELS[benefit] : null
+}
+
+function getLeaveInRoleLabel(
+  meta: LeaveInRecommendationMetadata | null,
+  product: Product,
+): string | null {
+  const relationship =
+    meta?.conditioner_relationship ?? product.leave_in_specs?.conditioner_relationship ?? null
+  if (relationship === "booster_only") return "Booster nach dem Conditioner"
+  if (relationship === "replacement_capable") return "Kann Conditioner ersetzen"
+
+  const roles = meta?.product_roles ?? product.leave_in_specs?.roles ?? []
+  if (roles.includes("extension_conditioner")) return "Booster nach dem Conditioner"
+  if (roles.includes("replacement_conditioner")) return "Kann Conditioner ersetzen"
+  if (roles.includes("styling_prep")) return "Styling-Vorbereitung"
+  if (roles.includes("oil_replacement")) return "Öl-Ersatz"
+
+  return null
+}
+
+function ensureSentenceEnding(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`
+}
+
+function hasFineHairOrSparseUseGuidance(value: string): boolean {
+  return /feinem Haar|feines Haar|sparsam|wenig Produkt/i.test(value)
+}
+
+function joinGermanList(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? ""
+  if (parts.length === 2) return `${parts[0]} und ${parts[1]}`
+  return `${parts.slice(0, -1).join(", ")} und ${parts[parts.length - 1]}`
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}

--- a/tests/product-card-rendering.test.tsx
+++ b/tests/product-card-rendering.test.tsx
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { ProductCard } from "@/components/chat/product-card"
+import type { Product } from "@/lib/types"
+
+function createWellaLikeLeaveIn(): Product {
+  return {
+    id: "product-wella-leave-in",
+    name: "Wella Ultimate Repair Leave-In",
+    brand: "Wella",
+    description: null,
+    short_description: null,
+    category: "Leave-in",
+    affiliate_link: "https://www.dm.de/wella-ultimate-repair-leave-in-p4064666338183.html",
+    image_url: null,
+    price_eur: 18.51,
+    currency: "EUR",
+    tags: ["internal:leave-in", "heat_style"],
+    suitable_thicknesses: [],
+    suitable_concerns: [],
+    is_active: true,
+    lifecycle_status: "active",
+    sort_order: 0,
+    recommendation_meta: {
+      category: "leave_in",
+      score: 0.91,
+      top_reasons: [
+        "Passt in grossen Teilen zu deinem Leave-in-Zielprofil",
+        "Routine-Rolle: Booster nach dem Conditioner",
+      ],
+      tradeoffs: [],
+      usage_hint:
+        "Sehr sparsam ins handtuchtrockene Haar geben und vor dem Föhnen oder Hitzestyling gleichmäßig in Längen und Spitzen verteilen.",
+      matched_profile: {
+        hair_texture: "wavy",
+        thickness: "fine",
+        density: "medium",
+        cuticle_condition: null,
+        chemical_treatment: [],
+      },
+      need_bucket: "shine_protect",
+      styling_context: "heat_style",
+      conditioner_relationship: "booster_only",
+      matched_weight: "medium",
+      fit_status: "ideal",
+      product_format: "lotion",
+      product_weight: "medium",
+      product_roles: ["extension_conditioner"],
+      product_care_benefits: ["shine", "repair"],
+      provides_heat_protection: true,
+      product_application_stage: ["towel_dry", "pre_heat"],
+      heat_protection_need: "high",
+      styling_prep_need: "heat_style",
+      product_balance_direction: "balanced",
+    },
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  }
+}
+
+test("compact product card renders identity, price, whitelisted facts, and a quiet tap affordance", () => {
+  const html = renderToStaticMarkup(
+    <ProductCard product={createWellaLikeLeaveIn()} onClick={() => {}} />,
+  )
+
+  assert.match(html, /Wella Ultimate Repair Leave-In/)
+  assert.match(html, /Wella/)
+  assert.match(html, /Lotion/)
+  assert.match(html, /Hitzeschutz/)
+  assert.match(html, /Pflege: ausgewogen/)
+  assert.match(html, /lucide-sparkles/)
+  assert.doesNotMatch(html, /lucide-shower-head/)
+
+  assert.match(html, /18,51\s*€/)
+  assert.doesNotMatch(html, /Zielprofil|grossen Teilen|Routine-Rolle/)
+  assert.doesNotMatch(html, /score|0\.91/i)
+  assert.doesNotMatch(html, /Tags|Profil-Match|Zielprofil/i)
+  assert.doesNotMatch(html, /internal:leave-in|heat_style|booster_only|matched_profile|leave_in/)
+
+  assert.match(html, /Produktdetails öffnen/)
+  assert.match(html, /lucide-chevron-right[\s\S]*aria-hidden="true"/)
+})
+
+test("compact product card does not surface unmapped raw category values", () => {
+  const product = createWellaLikeLeaveIn()
+  product.category = "internal_shampoo_bucket"
+  product.recommendation_meta = null
+  product.leave_in_specs = null
+
+  const html = renderToStaticMarkup(<ProductCard product={product} onClick={() => {}} />)
+
+  assert.doesNotMatch(html, /internal_shampoo_bucket|shampoo_bucket/)
+})
+
+test("compact product card maps known category variants to their icons", () => {
+  const product = createWellaLikeLeaveIn()
+  product.category = "Bondbuilder"
+  product.recommendation_meta = null
+  product.leave_in_specs = null
+
+  const html = renderToStaticMarkup(<ProductCard product={product} onClick={() => {}} />)
+
+  assert.match(html, /lucide-atom/)
+  assert.doesNotMatch(html, /lucide-shower-head/)
+})

--- a/tests/product-display-model.test.ts
+++ b/tests/product-display-model.test.ts
@@ -1,0 +1,329 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildCompactProductFacts,
+  buildDrawerProductProfileRows,
+  buildProductApplicationSentence,
+  buildProductMatchSummary,
+  formatProductPrice,
+  getProductCategoryLabel,
+  getShopLabel,
+  getValidAffiliateLink,
+  shouldShowAffiliateDisclosure,
+} from "@/components/chat/product-display-model"
+import type { HairProfile, Product } from "@/lib/types"
+
+function createWellaLikeLeaveIn(): Product {
+  return {
+    id: "product-wella-leave-in",
+    name: "Wella Ultimate Repair Leave-In",
+    brand: "Wella",
+    description: null,
+    short_description: null,
+    category: "Leave-in",
+    affiliate_link: "https://www.dm.de/wella-ultimate-repair-leave-in-p4064666338183.html",
+    image_url: null,
+    price_eur: 18.51,
+    currency: "EUR",
+    tags: ["internal:leave-in"],
+    suitable_thicknesses: [],
+    suitable_concerns: [],
+    is_active: true,
+    lifecycle_status: "active",
+    sort_order: 0,
+    recommendation_meta: {
+      category: "leave_in",
+      score: 0.91,
+      top_reasons: [
+        "Passt in grossen Teilen zu deinem Leave-in-Zielprofil",
+        "Routine-Rolle: Booster nach dem Conditioner",
+      ],
+      tradeoffs: [],
+      usage_hint:
+        "Sehr sparsam ins handtuchtrockene Haar geben und vor dem Föhnen oder Hitzestyling gleichmäßig in Längen und Spitzen verteilen.",
+      matched_profile: {
+        hair_texture: "wavy",
+        thickness: "fine",
+        density: "medium",
+        cuticle_condition: null,
+        chemical_treatment: [],
+      },
+      need_bucket: "shine_protect",
+      styling_context: "heat_style",
+      conditioner_relationship: "booster_only",
+      matched_weight: "medium",
+      fit_status: "ideal",
+      product_format: "lotion",
+      product_weight: "medium",
+      product_roles: ["extension_conditioner"],
+      product_care_benefits: ["shine", "repair"],
+      provides_heat_protection: true,
+      product_application_stage: ["towel_dry", "pre_heat"],
+      heat_protection_need: "high",
+      styling_prep_need: "heat_style",
+      product_balance_direction: "balanced",
+    },
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  }
+}
+
+function createNonLeaveInShampoo(): Product {
+  return {
+    id: "product-shampoo-1",
+    name: "Sensitive Balance Shampoo",
+    brand: "Beispiel",
+    description:
+      "Mildes Shampoo fuer eine ruhige Kopfhaut und Laengen, die nicht zusaetzlich beschwert werden sollen.",
+    short_description: "Mildes Shampoo fuer feines Haar und schuppige Kopfhaut.",
+    category: "Shampoo",
+    affiliate_link: null,
+    image_url: null,
+    price_eur: 8.95,
+    currency: "EUR",
+    tags: ["internal:shampoo_bucket", "matched_profile:fine"],
+    suitable_thicknesses: ["fine"],
+    suitable_concerns: ["schuppen", "dryness", "raw_unknown_code"],
+    is_active: true,
+    lifecycle_status: "active",
+    sort_order: 1,
+    recommendation_meta: {
+      category: "shampoo",
+      score: 0.87,
+      top_reasons: ["Profil-Match: fine", "Shampoo-Bucket: schuppen"],
+      tradeoffs: ["Trade-offs: raw fallback"],
+      usage_hint: "In die nasse Kopfhaut einmassieren und gruendlich ausspuelen.",
+      matched_profile: {
+        thickness: "fine",
+        scalp_type: "dry",
+        scalp_condition: "dandruff",
+      },
+      matched_bucket: "schuppen",
+      matched_concern_code: "schuppen",
+    },
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  }
+}
+
+function createFineHairProfile(): HairProfile {
+  return {
+    id: "hair-profile-1",
+    user_id: "user-1",
+    hair_texture: "wavy",
+    thickness: "fine",
+    density: "medium",
+    concerns: [],
+    products_used: null,
+    wash_frequency: null,
+    heat_styling: "several_weekly",
+    styling_tools: ["blow_dryer", "flat_iron"],
+    goals: ["shine"],
+    cuticle_condition: null,
+    protein_moisture_balance: null,
+    scalp_type: null,
+    scalp_condition: null,
+    chemical_treatment: [],
+    desired_volume: null,
+    routine_preference: null,
+    current_routine_products: ["conditioner"],
+    towel_material: null,
+    towel_technique: null,
+    drying_method: null,
+    brush_type: null,
+    night_protection: null,
+    uses_heat_protection: false,
+    additional_notes: null,
+    conversation_memory: null,
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  }
+}
+
+test("buildCompactProductFacts returns whitelisted leave-in facts for a Wella-like product", () => {
+  assert.deepEqual(buildCompactProductFacts(createWellaLikeLeaveIn()), [
+    { label: "Lotion", source: "format" },
+    { label: "Hitzeschutz", source: "heat_protection" },
+    { label: "Pflege: ausgewogen", source: "care_focus" },
+  ])
+})
+
+test("buildDrawerProductProfileRows maps leave-in metadata to user-facing profile rows", () => {
+  assert.deepEqual(buildDrawerProductProfileRows(createWellaLikeLeaveIn()), [
+    { label: "Textur/Form", value: "Lotion" },
+    { label: "Gefühl", value: "Mittel" },
+    { label: "Wirkung", value: "Ausgewogene Pflege" },
+    { label: "Hitzeschutz", value: "Ja" },
+    { label: "Rolle", value: "Booster nach dem Conditioner" },
+  ])
+})
+
+test("buildProductMatchSummary synthesizes product facts and profile signals without internal labels", () => {
+  const summary = buildProductMatchSummary(createWellaLikeLeaveIn(), createFineHairProfile())
+
+  assert.match(summary, /stylst regelmäßig mit Hitze/)
+  assert.match(summary, /mehr Glanz/)
+  assert.match(summary, /feines Haar/)
+  assert.match(summary, /schnell beschwert/)
+  assert.match(summary, /Leave-in-Lotion/)
+  assert.match(summary, /Hitzeschutz/)
+  assert.match(summary, /Booster nach dem Conditioner/)
+  assert.match(summary, /weil sie Hitzeschutz mit ausgewogener Pflege verbindet/)
+  assert.doesNotMatch(summary, /Dein Styling|Deine Haardicke|Dein Ziel|Routine-Rolle/)
+  assert.doesNotMatch(summary, /Leave-in-Zielprofil|grossen Teilen|Passt zum/)
+  assert.equal(summary.split(/\n+/).length, 1)
+})
+
+test("non-leave-in products get drawer profile rows and a match summary without leaking metadata", () => {
+  const product = createNonLeaveInShampoo()
+  const summary = buildProductMatchSummary(product, createFineHairProfile())
+  const rows = buildDrawerProductProfileRows(product)
+  const rendered = `${summary} ${rows.map((row) => `${row.label}: ${row.value}`).join(" ")}`
+
+  assert.notEqual(summary, "")
+  assert.ok(rows.length >= 3)
+  assert.match(summary, /Dieses Shampoo passt/)
+  assert.match(summary, /feines Haar/)
+  assert.match(summary, /Schuppen/)
+  assert.deepEqual(rows.slice(0, 3), [
+    { label: "Kategorie", value: "Shampoo" },
+    { label: "Geeignet für", value: "Feines Haar" },
+    { label: "Fokus", value: "Schuppen, Trockenheit" },
+  ])
+  assert.equal(
+    rows.some((row) => row.label === "Kurzprofil"),
+    false,
+  )
+
+  assert.doesNotMatch(
+    rendered,
+    /Score|Profil-Match|Empfehlungskontext|Shampoo-Bucket|Trade-offs|recommendation_meta/i,
+  )
+  assert.doesNotMatch(
+    rendered,
+    /internal:|matched_profile|raw_unknown_code|schuppen|dryness|fine|0\.87/,
+  )
+  assert.doesNotMatch(rendered, /[a-z]+_[a-z]+/)
+})
+
+test("formatProductPrice formats EUR prices for German UI", () => {
+  assert.equal(formatProductPrice(18.51, "EUR"), "18,51 €")
+})
+
+test("formatProductPrice falls back to EUR for unexpected currency values", () => {
+  assert.equal(formatProductPrice(18.51, "NOT_A_CURRENCY"), "18,51 €")
+})
+
+test("buildProductApplicationSentence returns a complete usage sentence", () => {
+  const sentence = buildProductApplicationSentence(
+    createWellaLikeLeaveIn(),
+    createFineHairProfile(),
+  )
+
+  assert.match(sentence, /^Sehr sparsam ins handtuchtrockene Haar geben/)
+  assert.doesNotMatch(sentence, /Bei feinem Haar lieber mit wenig Produkt starten/)
+  assert.match(sentence, /\.$/)
+})
+
+test("buildProductApplicationSentence does not duplicate existing fine-hair sparing guidance", () => {
+  const product = createWellaLikeLeaveIn()
+  product.recommendation_meta = product.recommendation_meta
+    ? {
+        ...product.recommendation_meta,
+        usage_hint: "Bei feinem Haar sparsam dosieren.",
+      }
+    : null
+
+  assert.equal(
+    buildProductApplicationSentence(product, createFineHairProfile()),
+    "Bei feinem Haar sparsam dosieren.",
+  )
+})
+
+test("buildProductMatchSummary falls back to Leave-in for leave-in specs without a category", () => {
+  const product = createWellaLikeLeaveIn()
+  product.category = null
+  product.recommendation_meta = null
+  product.leave_in_specs = {
+    product_id: product.id,
+    format: "lotion",
+    weight: "medium",
+    conditioner_relationship: "booster_only",
+    roles: ["extension_conditioner"],
+    provides_heat_protection: true,
+    heat_protection_max_c: null,
+    heat_activation_required: false,
+    care_benefits: ["shine"],
+    ingredient_flags: [],
+    application_stage: ["towel_dry"],
+  }
+
+  const summary = buildProductMatchSummary(product, createFineHairProfile())
+
+  assert.match(summary, /Diese Leave-in-Lotion passt/)
+  assert.doesNotMatch(summary, /Diese -Lotion/)
+})
+
+test("buildProductMatchSummary uses the right article for leave-in spray summaries", () => {
+  const product = createWellaLikeLeaveIn()
+  const meta = product.recommendation_meta
+  assert.equal(meta?.category, "leave_in")
+  product.recommendation_meta = {
+    ...meta,
+    product_format: "spray",
+    product_weight: "light",
+  }
+
+  const summary = buildProductMatchSummary(product, createFineHairProfile())
+
+  assert.match(summary, /Dieses Leave-in-Spray passt/)
+  assert.match(summary, /weil es Hitzeschutz mit ausgewogener Pflege verbindet/)
+  assert.doesNotMatch(summary, /Diese Leave-in-Spray/)
+  assert.doesNotMatch(summary, /Hitzeschutz und ausgewogener Pflege/)
+})
+
+test("getShopLabel derives a shop-aware buy label from affiliate hosts", () => {
+  assert.equal(
+    getShopLabel("https://www.dm.de/wella-ultimate-repair-leave-in-p4064666338183.html"),
+    "Bei dm kaufen",
+  )
+})
+
+test("affiliate links are trimmed and validated before display", () => {
+  const product = createWellaLikeLeaveIn()
+
+  product.affiliate_link = "  https://www.amazon.de/example-product?tag=test  "
+  assert.equal(
+    getValidAffiliateLink(product.affiliate_link),
+    "https://www.amazon.de/example-product?tag=test",
+  )
+  assert.equal(getShopLabel(product.affiliate_link), "Bei Amazon kaufen")
+  assert.equal(shouldShowAffiliateDisclosure(product), true)
+
+  product.affiliate_link = "javascript:alert(1)"
+  assert.equal(getValidAffiliateLink(product.affiliate_link), "")
+  assert.equal(getShopLabel(product.affiliate_link), "Kaufen")
+  assert.equal(shouldShowAffiliateDisclosure(product), false)
+
+  product.affiliate_link = "   "
+  assert.equal(getValidAffiliateLink(product.affiliate_link), "")
+  assert.equal(shouldShowAffiliateDisclosure(product), false)
+})
+
+test("category labels are public whitelist only", () => {
+  assert.equal(getProductCategoryLabel("Conditioner (Drogerie)"), "Conditioner")
+  assert.equal(getProductCategoryLabel("Öle"), "Öl")
+  assert.equal(getProductCategoryLabel("deep_cleansing_shampoo"), "Tiefenreinigung")
+  assert.equal(getProductCategoryLabel("internal_shampoo_bucket"), "")
+})
+
+test("fallback summaries drop internal-looking description text", () => {
+  const product = createNonLeaveInShampoo()
+  product.short_description = "internal:leave-in matched-profile:fine raw_code"
+
+  const summary = buildProductMatchSummary(product, createFineHairProfile())
+
+  assert.match(summary, /Dieses Shampoo passt/)
+  assert.doesNotMatch(summary, /internal:leave-in|matched-profile|raw_code/)
+})


### PR DESCRIPTION
## Summary

Product cards were leaking internal recommendation metadata in the user-facing compact card and drawer. This change replaces that with a public display model for compact facts, drawer rationale, application guidance, product profile rows, validated affiliate CTAs, and safer fallback copy.

## Product behavior

- Compact cards show product identity, whitelisted product facts, price, and a clear details affordance.
- Drawer removes internal vocabulary such as score, profile match, recommendation context, raw tags, buckets, trade-offs, and Kurzprofil.
- Drawer shows a concise `Warum es passt`, application guidance, product profile rows, price, and a shop-aware buy button when a valid affiliate URL exists.
- Affiliate buttons only render for valid `http`/`https` links.
- Category labels and fallback text are strict user-facing whitelists to avoid leaking raw codes.

## Verification

- `npm run test:node -- tests/product-display-model.test.ts tests/product-card-rendering.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## Notes

Affiliate link backfill is still needed for active products in Shampoo, Leave-in, Öle, Maske, and most Conditioner rows before the buy button appears broadly.
