### PR TITLE
fix(routing): redirect www to apex domain

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,14 @@
 import { updateSession } from "@/lib/supabase/middleware"
 import { type NextRequest } from "next/server"
+import { NextResponse } from "next/server"
 
 export async function proxy(request: NextRequest) {
+  if (request.nextUrl.hostname === "www.chaarlie.de") {
+    const url = request.nextUrl.clone()
+    url.hostname = "chaarlie.de"
+    return NextResponse.redirect(url, 308)
+  }
+
   return await updateSession(request)
 }
 


### PR DESCRIPTION
## Summary
- redirects `www.chaarlie.de` to `chaarlie.de` with a permanent 308 in the Next proxy
- keeps existing app/session routing unchanged for the apex domain

## Verification
- `npm run typecheck`
- deployed to production with Vercel CLI
- verified `https://www.chaarlie.de/quiz` returns `308` to `https://chaarlie.de/quiz`
- verified `https://chaarlie.de/quiz` returns `200`

## Notes
- Vercel `NEXT_PUBLIC_SITE_URL` was updated to `https://chaarlie.de` for production and preview.
- Supabase redirect URLs still need to be saved in the dashboard as discussed.