### PR TITLE
feat(landing): marketing landing page at /

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,27 @@
-import { redirect } from "next/navigation"
+import { LandingHeader } from "@/components/landing/landing-header"
+import { Hero } from "@/components/landing/hero"
+import { WhatIs } from "@/components/landing/what-is"
+import { HowItWorks } from "@/components/landing/how-it-works"
+import { Features } from "@/components/landing/features"
+import { Pricing } from "@/components/landing/pricing"
+import { Faq } from "@/components/landing/faq"
+import { FinalCta } from "@/components/landing/final-cta"
+import { SiteFooter } from "@/components/landing/site-footer"
 
 export default function Home() {
-  redirect("/chat")
+  return (
+    <>
+      <LandingHeader />
+      <main>
+        <Hero />
+        <WhatIs />
+        <HowItWorks />
+        <Features />
+        <Pricing />
+        <Faq />
+        <FinalCta />
+      </main>
+      <SiteFooter />
+    </>
+  )
 }

--- a/src/components/landing/faq.tsx
+++ b/src/components/landing/faq.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link"
+
+type FaqItem = {
+  question: string
+  answer: React.ReactNode
+}
+
+const items: FaqItem[] = [
+  {
+    question: "Wie unterscheidet sich Chaarlie von anderen Beauty-Quizzes?",
+    answer:
+      "Klassische Beauty-Quizzes fragen nach deinem Haartyp und schlagen dir eine Produkt-Range vor. Chaarlie analysiert sechs Dimensionen deines Haares (Struktur, Oberfläche, Kopfhaut, Feuchtigkeit, Protein, Glanz) und gibt dir konkrete Empfehlungen mit echten Produktnamen, inklusive Drogerie-Alternativen. Kein Verkauf eigener Produkte.",
+  },
+  {
+    question: "Brauche ich Vorwissen zur Haarpflege?",
+    answer:
+      "Nein. Das Quiz erklärt dir alles, was du wissen musst, während du es ausfüllst. Wenn du dich noch nie mit Haarpflege beschäftigt hast, ist Chaarlie genau für dich gebaut.",
+  },
+  {
+    question: "Wie lange dauert es, bis ich Ergebnisse sehe?",
+    answer:
+      "Dein Haarprofil und die Routine bekommst du sofort nach dem Quiz. Sichtbare Veränderungen im Haar selbst hängen vom Ausgangszustand ab — in der Regel zeigen sich Effekte nach 2 bis 4 Wochen konsequenter Anwendung der empfohlenen Routine.",
+  },
+  {
+    question: "Kann ich jederzeit kündigen?",
+    answer:
+      "Ja. Alle Pläne sind monatlich, quartalsweise oder jährlich kündbar — zum Ende der jeweiligen Abrechnungsperiode.",
+  },
+  {
+    question: "Sind die empfohlenen Produkte teuer?",
+    answer:
+      "Wir empfehlen Produkte für jeden Preisbereich. Für jedes Salon-Produkt gibt es auch eine Drogerie-Alternative, die ähnlich gut funktioniert. Du entscheidest, was zu deinem Budget passt.",
+  },
+  {
+    question: "Wer steht hinter Chaarlie?",
+    answer:
+      "Chaarlie ist ein Produkt der Haarmony LLC (Delaware, USA). Friseurmeister Tom Hannemann begleitet das Team beratend. Wir verkaufen keine eigenen Produkte und sind keinem Hersteller verpflichtet.",
+  },
+  {
+    question: "Was passiert mit meinen Daten?",
+    answer: (
+      <>
+        Deine Antworten werden ausschließlich verwendet, um deine persönliche Diagnose und Routine
+        zu erstellen. Wir verkaufen keine Daten an Dritte. Details findest du in unserer{" "}
+        <Link href="/datenschutz" className="underline hover:text-[var(--brand-plum-darkest)]">
+          Datenschutzerklärung
+        </Link>
+        .
+      </>
+    ),
+  },
+]
+
+export function Faq() {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-[720px] px-6">
+        <div>
+          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
+            FAQ
+          </span>
+          <h2
+            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
+            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
+          >
+            Die häufigsten Fragen.
+          </h2>
+          <p className="max-w-[640px] text-lg text-muted-foreground">
+            Antworten auf das, was du wissen solltest, bevor du loslegst.
+          </p>
+        </div>
+
+        <div className="mt-12 flex flex-col gap-3">
+          {items.map((item) => (
+            <details
+              key={item.question}
+              className="group overflow-hidden rounded-[14px] border border-border bg-card transition-colors open:border-[var(--brand-plum-light)]"
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-6 py-5 text-base font-semibold text-[var(--brand-plum-darkest)] [&::-webkit-details-marker]:hidden">
+                <span>{item.question}</span>
+                <span
+                  aria-hidden="true"
+                  className="text-[22px] font-normal text-[var(--brand-plum)] transition-transform group-open:rotate-45"
+                >
+                  +
+                </span>
+              </summary>
+              <div className="px-6 pb-5 text-[15px] leading-relaxed text-muted-foreground">
+                {item.answer}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/faq.tsx
+++ b/src/components/landing/faq.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link"
 
+import { SectionHeading } from "@/components/landing/section-heading"
+
 type FaqItem = {
   question: string
   answer: React.ReactNode
@@ -55,20 +57,11 @@ export function Faq() {
   return (
     <section className="py-20">
       <div className="mx-auto max-w-[720px] px-6">
-        <div>
-          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
-            FAQ
-          </span>
-          <h2
-            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
-            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
-          >
-            Die häufigsten Fragen.
-          </h2>
-          <p className="max-w-[640px] text-lg text-muted-foreground">
-            Antworten auf das, was du wissen solltest, bevor du loslegst.
-          </p>
-        </div>
+        <SectionHeading
+          eyebrow="FAQ"
+          title="Die häufigsten Fragen."
+          lede="Antworten auf das, was du wissen solltest, bevor du loslegst."
+        />
 
         <div className="mt-12 flex flex-col gap-3">
           {items.map((item) => (

--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -1,0 +1,91 @@
+type Feature = {
+  paths: React.ReactNode
+  title: string
+  body: string
+}
+
+const features: Feature[] = [
+  {
+    paths: (
+      <>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z" />
+      </>
+    ),
+    title: "Vollständiges Haarprofil",
+    body: "Sechs Dimensionen: Struktur, Oberfläche, Kopfhaut, Feuchtigkeit, Protein, Glanz. Alles auf einen Blick.",
+  },
+  {
+    paths: (
+      <>
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+        <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
+      </>
+    ),
+    title: "500+ Produktempfehlungen",
+    body: "Konkrete Produkte mit Marke und Größe. Inklusive Drogerie-Alternativen für jeden Preisbereich.",
+  },
+  {
+    paths: (
+      <>
+        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </>
+    ),
+    title: "Deine persönliche Routine",
+    body: "Was du wann anwendest. Wie oft. Wie lange. Konkrete Anleitung, kein Ratespiel.",
+  },
+  {
+    paths: <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />,
+    title: "Persönlicher Haar-Coach",
+    body: "Stelle Fragen, bekomme Antworten. Dein Profil ist gespeichert, du musst nichts wiederholen.",
+  },
+]
+
+export function Features() {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-7xl px-6">
+        <div>
+          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
+            Was du bekommst
+          </span>
+          <h2
+            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
+            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
+          >
+            Alles in einer App, nichts überflüssig.
+          </h2>
+        </div>
+
+        <div className="mt-12 grid gap-6 sm:grid-cols-2">
+          {features.map((feature) => (
+            <div key={feature.title} className="rounded-[18px] border border-border bg-card p-8">
+              <span className="mb-4 grid h-12 w-12 place-items-center rounded-xl bg-[var(--brand-plum-ice)] text-[var(--brand-plum)]">
+                <svg
+                  aria-hidden="true"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  {feature.paths}
+                </svg>
+              </span>
+              <h3 className="mb-2 text-lg font-bold text-[var(--brand-plum-darkest)]">
+                {feature.title}
+              </h3>
+              <p className="text-[15px] leading-relaxed text-muted-foreground">{feature.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -1,3 +1,5 @@
+import { SectionHeading } from "@/components/landing/section-heading"
+
 type Feature = {
   paths: React.ReactNode
   title: string
@@ -48,17 +50,7 @@ export function Features() {
   return (
     <section className="py-20">
       <div className="mx-auto max-w-7xl px-6">
-        <div>
-          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
-            Was du bekommst
-          </span>
-          <h2
-            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
-            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
-          >
-            Alles in einer App, nichts überflüssig.
-          </h2>
-        </div>
+        <SectionHeading eyebrow="Was du bekommst" title="Alles in einer App, nichts überflüssig." />
 
         <div className="mt-12 grid gap-6 sm:grid-cols-2">
           {features.map((feature) => (

--- a/src/components/landing/final-cta.tsx
+++ b/src/components/landing/final-cta.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link"
+
+export function FinalCta() {
+  return (
+    <section className="mx-6 my-12 max-w-[1100px] md:mx-auto">
+      <div className="rounded-3xl bg-[var(--brand-plum-darkest)] px-6 py-10 text-center text-white sm:px-12 sm:py-16">
+        <h2
+          className="mx-auto mb-3.5 font-header font-medium leading-[1.2] text-white"
+          style={{ fontSize: "clamp(28px, 4vw, 40px)" }}
+        >
+          Bereit, herauszufinden, was deine Haare{" "}
+          <em className="font-medium not-italic italic text-[var(--brand-plum-light)]">wirklich</em>{" "}
+          brauchen?
+        </h2>
+        <p
+          className="mx-auto mb-8 max-w-[520px] text-[17px]"
+          style={{ color: "rgba(255,255,255,0.75)" }}
+        >
+          Zwei Minuten. Kostenlos. Ohne Anmeldung. Du bekommst dein Haarprofil sofort.
+        </p>
+        <Link
+          href="/quiz"
+          className="inline-block rounded-[14px] bg-[var(--brand-coral)] px-9 py-[18px] text-[17px] font-bold text-white transition-all hover:bg-white hover:text-[var(--brand-plum-darkest)]"
+        >
+          Quiz starten
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/final-cta.tsx
+++ b/src/components/landing/final-cta.tsx
@@ -9,8 +9,7 @@ export function FinalCta() {
           style={{ fontSize: "clamp(28px, 4vw, 40px)" }}
         >
           Bereit, herauszufinden, was deine Haare{" "}
-          <em className="font-medium not-italic italic text-[var(--brand-plum-light)]">wirklich</em>{" "}
-          brauchen?
+          <em className="font-medium italic text-[var(--brand-plum-light)]">wirklich</em> brauchen?
         </h2>
         <p
           className="mx-auto mb-8 max-w-[520px] text-[17px]"
@@ -20,7 +19,7 @@ export function FinalCta() {
         </p>
         <Link
           href="/quiz"
-          className="inline-block rounded-[14px] bg-[var(--brand-coral)] px-9 py-[18px] text-[17px] font-bold text-white transition-all hover:bg-white hover:text-[var(--brand-plum-darkest)]"
+          className="inline-block rounded-[14px] bg-[var(--brand-coral)] px-9 py-[18px] text-[17px] font-bold text-white transition-all hover:bg-white hover:text-[var(--brand-plum-darkest)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
         >
           Quiz starten
         </Link>

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,8 +1,6 @@
 import Image from "next/image"
 import Link from "next/link"
-
-const tomHannemannImageUrl =
-  "https://www.tophair.de/app/uploads/2025/03/SA-WS-NewFlag-TomHannemann-MS-7-683x1024.jpg"
+import { tomHannemannImageUrl } from "@/lib/landing-assets"
 
 const outcomeChecks = [
   "Dein Haarprofil",
@@ -63,9 +61,11 @@ export function Hero() {
         </div>
 
         <div className="rounded-[20px] border border-border bg-card p-8 shadow-[0_20px_60px_-20px_rgba(42,24,69,0.15)]">
+          {/* Custom Link styling instead of <Button variant="landingCta"> because we
+              need an anchor element with a multi-line label (CTA + subtitle). */}
           <Link
             href="/quiz"
-            className="block rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-8 py-[18px] text-center text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-all hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 motion-safe:hover:-translate-y-0.5"
+            className="block rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-8 py-[18px] text-center text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-all hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral-dark)] focus-visible:ring-offset-2 motion-safe:hover:-translate-y-0.5"
           >
             <span className="block text-lg font-bold text-white">Quiz starten</span>
             <span className="mt-1 block text-[13px] font-normal text-white/85">

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,0 +1,109 @@
+import Image from "next/image"
+import Link from "next/link"
+
+const tomHannemannImageUrl =
+  "https://www.tophair.de/app/uploads/2025/03/SA-WS-NewFlag-TomHannemann-MS-7-683x1024.jpg"
+
+const outcomeChecks = [
+  "Dein Haarprofil",
+  "Dein Pflegehebel",
+  "Routine & Produkte",
+  "Drogerie-Alternativen",
+] as const
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="#2D9F5E"
+      strokeWidth={2.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-5 w-5 shrink-0"
+      aria-hidden="true"
+    >
+      <polyline points="16 6 8 14 4 10" />
+    </svg>
+  )
+}
+
+export function Hero() {
+  return (
+    <section
+      id="top"
+      className="bg-[linear-gradient(180deg,var(--background)_0%,var(--brand-plum-ice)_100%)] py-20 lg:py-24"
+    >
+      <div className="mx-auto grid max-w-7xl grid-cols-1 items-center gap-12 px-6 lg:grid-cols-[1.1fr_0.9fr] lg:gap-16">
+        <div>
+          <h1 className="mb-5 font-header text-[clamp(36px,5vw,64px)] font-medium leading-[1.1] text-[var(--brand-plum-darkest)]">
+            Weißt du, was deine Haare{" "}
+            <em className="font-medium italic text-[var(--brand-plum)]">wirklich</em> brauchen?
+          </h1>
+          <p className="mb-8 max-w-[520px] text-lg text-muted-foreground">
+            Chaarlie analysiert dein Haar und zeigt dir, was deine Haare tatsächlich brauchen.
+            Individuell, nicht pauschal. In 2 Minuten, kostenlos.
+          </p>
+
+          <ul className="grid max-w-[480px] grid-cols-2 gap-2.5">
+            {outcomeChecks.map((label) => (
+              <li
+                key={label}
+                className="flex items-center gap-2.5 rounded-xl border border-border bg-card px-4 py-3.5 text-sm font-semibold text-[var(--brand-plum-darkest)]"
+              >
+                <CheckIcon />
+                <span>{label}</span>
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-6 flex items-center gap-2 font-mono text-[11px] font-medium uppercase tracking-[0.1em] text-[var(--brand-coral)] before:inline-block before:h-1.5 before:w-1.5 before:rounded-full before:bg-[var(--brand-coral)] before:content-['']">
+            Starte heute damit
+          </p>
+        </div>
+
+        <div className="rounded-[20px] border border-border bg-card p-8 shadow-[0_20px_60px_-20px_rgba(42,24,69,0.15)]">
+          <Link
+            href="/quiz"
+            className="block rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-8 py-[18px] text-center text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-all hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 motion-safe:hover:-translate-y-0.5"
+          >
+            <span className="block text-lg font-bold text-white">Quiz starten</span>
+            <span className="mt-1 block text-[13px] font-normal text-white/85">
+              In ca. 2 Minuten · Kostenlos
+            </span>
+          </Link>
+
+          <figure className="mt-6 flex items-start gap-3.5 rounded-[14px] bg-[var(--brand-plum-ice)] p-4">
+            <Image
+              src={tomHannemannImageUrl}
+              alt="Tom Hannemann"
+              width={96}
+              height={96}
+              priority
+              referrerPolicy="no-referrer"
+              className="h-12 w-12 shrink-0 rounded-full border-2 border-[var(--brand-plum-light)] bg-[var(--brand-plum-ice)] object-cover object-[52%_18%]"
+            />
+            <div>
+              <blockquote className="mb-2 font-header text-[15px] italic leading-[1.4] text-[var(--brand-plum-darkest)]">
+                „Ich sage es immer: Ohne Analyse ist jede Produktempfehlung Glücksspiel. Deswegen
+                empfehle ich genau das hier.“
+              </blockquote>
+              <figcaption className="font-mono text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--brand-plum)]">
+                Tom Hannemann · Friseurmeister · 18 Jahre Erfahrung
+              </figcaption>
+            </div>
+          </figure>
+
+          <div className="mt-4 flex items-center justify-center gap-2">
+            <span aria-hidden="true" className="text-lg tracking-[2px] text-[var(--brand-plum)]">
+              ★★★★★
+            </span>
+            <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-muted-foreground">
+              4,9 / 5 aus ersten Nutzerinnen-Feedbacks
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/how-it-works.tsx
+++ b/src/components/landing/how-it-works.tsx
@@ -1,3 +1,5 @@
+import { SectionHeading } from "@/components/landing/section-heading"
+
 type Step = {
   number: string
   title: string
@@ -26,20 +28,11 @@ export function HowItWorks() {
   return (
     <section className="border-y border-border bg-card py-20">
       <div className="mx-auto max-w-7xl px-6">
-        <div>
-          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
-            So funktioniert&apos;s
-          </span>
-          <h2
-            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
-            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
-          >
-            In drei Schritten zu deiner Routine.
-          </h2>
-          <p className="max-w-[640px] text-lg text-muted-foreground">
-            Ohne Anmeldung starten. Ergebnis sehen. Dann entscheiden.
-          </p>
-        </div>
+        <SectionHeading
+          eyebrow="So funktioniert's"
+          title="In drei Schritten zu deiner Routine."
+          lede="Ohne Anmeldung starten. Ergebnis sehen. Dann entscheiden."
+        />
 
         <div className="mt-12 grid gap-8 md:grid-cols-3">
           {steps.map((step) => (

--- a/src/components/landing/how-it-works.tsx
+++ b/src/components/landing/how-it-works.tsx
@@ -1,0 +1,63 @@
+type Step = {
+  number: string
+  title: string
+  body: string
+}
+
+const steps: Step[] = [
+  {
+    number: "1",
+    title: "Quiz machen",
+    body: "2 Minuten, sechs Fragen. Zugtest, Oberfläche, Kopfhaut, deine Ziele.",
+  },
+  {
+    number: "2",
+    title: "Diagnose erhalten",
+    body: "Dein Haarprofil sofort sichtbar. Dein größter Pflegehebel klar benannt.",
+  },
+  {
+    number: "3",
+    title: "Routine starten",
+    body: "Deine Routine mit konkreten Produkten und Drogerie-Alternativen. Direkt anwendbar.",
+  },
+]
+
+export function HowItWorks() {
+  return (
+    <section className="border-y border-border bg-card py-20">
+      <div className="mx-auto max-w-7xl px-6">
+        <div>
+          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
+            So funktioniert&apos;s
+          </span>
+          <h2
+            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
+            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
+          >
+            In drei Schritten zu deiner Routine.
+          </h2>
+          <p className="max-w-[640px] text-lg text-muted-foreground">
+            Ohne Anmeldung starten. Ergebnis sehen. Dann entscheiden.
+          </p>
+        </div>
+
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {steps.map((step) => (
+            <div
+              key={step.number}
+              className="rounded-[18px] border border-border bg-background p-8"
+            >
+              <div className="mb-4 font-header text-5xl font-medium italic leading-none text-[var(--brand-plum)]">
+                {step.number}
+              </div>
+              <h3 className="mb-2.5 text-lg font-bold text-[var(--brand-plum-darkest)]">
+                {step.title}
+              </h3>
+              <p className="text-[15px] leading-relaxed text-muted-foreground">{step.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+
+export function LandingHeader() {
+  return (
+    <header
+      className="sticky top-0 z-50 border-b border-border backdrop-blur-[12px]"
+      style={{ backgroundColor: "rgba(253,251,249,0.95)" }}
+    >
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3.5">
+        <Link href="/" className="flex items-center gap-2.5" aria-label="chaarlie Startseite">
+          <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="19" height="19" fill="#FDFBF9">
+              <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
+            </svg>
+          </span>
+          <span className="font-header text-[22px] font-medium leading-none text-[var(--brand-plum-darkest)]">
+            chaarlie
+          </span>
+        </Link>
+        <Link
+          href="/quiz"
+          className="rounded-[10px] bg-[var(--brand-coral)] px-[18px] py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)]"
+        >
+          Quiz starten
+        </Link>
+      </div>
+    </header>
+  )
+}

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link"
 
+import { Wordmark } from "./wordmark"
+
 export function LandingHeader() {
   return (
     <header
@@ -7,19 +9,12 @@ export function LandingHeader() {
       style={{ backgroundColor: "rgba(253,251,249,0.95)" }}
     >
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3.5">
-        <Link href="/" className="flex items-center gap-2.5" aria-label="chaarlie Startseite">
-          <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
-            <svg aria-hidden="true" viewBox="0 0 24 24" width="19" height="19" fill="#FDFBF9">
-              <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
-            </svg>
-          </span>
-          <span className="font-header text-[22px] font-medium leading-none text-[var(--brand-plum-darkest)]">
-            chaarlie
-          </span>
+        <Link href="/" aria-label="chaarlie Startseite">
+          <Wordmark />
         </Link>
         <Link
           href="/quiz"
-          className="rounded-[10px] bg-[var(--brand-coral)] px-[18px] py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)]"
+          className="rounded-[10px] bg-[var(--brand-coral)] px-[18px] py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
         >
           Quiz starten
         </Link>

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -12,12 +12,20 @@ export function LandingHeader() {
         <Link href="/" aria-label="chaarlie Startseite">
           <Wordmark />
         </Link>
-        <Link
-          href="/quiz"
-          className="rounded-[10px] bg-[var(--brand-coral)] px-[18px] py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
-        >
-          Quiz starten
-        </Link>
+        <nav className="flex items-center gap-3 sm:gap-5">
+          <Link
+            href="/chat"
+            className="rounded-md text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-[var(--brand-plum-darkest)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-plum)] focus-visible:ring-offset-2"
+          >
+            Anmelden
+          </Link>
+          <Link
+            href="/quiz"
+            className="rounded-[10px] bg-[var(--brand-coral)] px-[18px] py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
+          >
+            Quiz starten
+          </Link>
+        </nav>
       </div>
     </header>
   )

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -2,8 +2,9 @@ import Link from "next/link"
 
 import { SectionHeading } from "@/components/landing/section-heading"
 import { STRIPE_PRICING_PLANS, type StripePricingPlan } from "@/lib/stripe/pricing-plans"
+import type { BillingInterval } from "@/lib/stripe/intervals"
 
-const FEATURES_BY_INTERVAL: Record<"month" | "quarter" | "year", readonly string[]> = {
+const FEATURES_BY_INTERVAL: Record<BillingInterval, readonly string[]> = {
   month: [
     "Vollständige Haar-Diagnose",
     "Persönliche Routine",
@@ -56,9 +57,14 @@ function PlanCard({ plan }: { plan: StripePricingPlan }) {
         ) : null}
       </p>
 
-      <p className="font-header text-[42px] font-semibold text-[var(--brand-plum-darkest)] leading-none">
-        <sup className="text-2xl font-medium text-muted-foreground mr-0.5">€</sup>
-        {priceDigits}
+      <p
+        aria-label={`${plan.price} ${plan.perMonth}`}
+        className="font-header text-[42px] font-semibold text-[var(--brand-plum-darkest)] leading-none"
+      >
+        <sup aria-hidden="true" className="text-2xl font-medium text-muted-foreground mr-0.5">
+          €
+        </sup>
+        <span aria-hidden="true">{priceDigits}</span>
       </p>
 
       <p className="text-sm text-muted-foreground mt-1.5 mb-6">{plan.perMonth}</p>

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link"
+
+import { SectionHeading } from "@/components/landing/section-heading"
+import { STRIPE_PRICING_PLANS, type StripePricingPlan } from "@/lib/stripe/pricing-plans"
+
+const FEATURES_BY_INTERVAL: Record<"month" | "quarter" | "year", readonly string[]> = {
+  month: [
+    "Vollständige Haar-Diagnose",
+    "Persönliche Routine",
+    "500+ Produktempfehlungen",
+    "Persönlicher Haar-Coach",
+  ],
+  quarter: [
+    "Alles aus dem Monats-Plan",
+    "Fortschritts-Tracking",
+    "Quartalsweise Anpassungen",
+    "Premium-Routine-Templates",
+  ],
+  year: [
+    "Alles aus dem Quartal-Plan",
+    "Saisonale Anpassungen",
+    "Bester Preis pro Monat",
+    "Volle Routine-Library",
+  ],
+}
+
+function PlanCard({ plan }: { plan: StripePricingPlan }) {
+  const isPopular = Boolean(plan.badge)
+  const features = FEATURES_BY_INTERVAL[plan.interval]
+  const priceDigits = plan.price.replace(/^€/, "")
+
+  const cardBorder = isPopular
+    ? "border-[var(--brand-plum)] shadow-[0_20px_50px_-20px_rgba(var(--brand-plum-rgb),0.3)]"
+    : "border-border"
+
+  const ctaClasses = isPopular
+    ? "bg-[var(--brand-coral)] hover:bg-[var(--brand-coral-dark)] text-white border-[1.5px] border-[var(--brand-coral)] focus-visible:ring-[var(--brand-coral-dark)]"
+    : "bg-transparent text-[var(--brand-plum-darkest)] border-[1.5px] border-border hover:border-[var(--brand-plum)] hover:text-[var(--brand-plum)] focus-visible:ring-[var(--brand-plum)]"
+
+  return (
+    <div
+      className={`relative flex flex-col bg-card rounded-[20px] p-7 sm:p-8 border-[1.5px] ${cardBorder}`}
+    >
+      {plan.badge ? (
+        <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-[var(--brand-plum)] text-white px-3.5 py-1 rounded-full font-mono text-[10px] font-medium uppercase tracking-[0.06em]">
+          {plan.badge}
+        </span>
+      ) : null}
+
+      <p className="font-bold text-sm text-muted-foreground uppercase tracking-[0.08em] mb-3 flex items-center gap-2 flex-wrap">
+        {plan.name}
+        {plan.savings ? (
+          <span className="bg-[var(--brand-coral-light)] text-[var(--brand-coral)] px-2 py-0.5 rounded-md font-mono text-[10px] font-medium tracking-[0.04em] normal-case">
+            {plan.savings}
+          </span>
+        ) : null}
+      </p>
+
+      <p className="font-header text-[42px] font-semibold text-[var(--brand-plum-darkest)] leading-none">
+        <sup className="text-2xl font-medium text-muted-foreground mr-0.5">€</sup>
+        {priceDigits}
+      </p>
+
+      <p className="text-sm text-muted-foreground mt-1.5 mb-6">{plan.perMonth}</p>
+
+      <ul className="list-none flex flex-col gap-2.5 mb-7 flex-1">
+        {features.map((label) => (
+          <li key={label} className="flex items-start gap-2 text-sm text-foreground">
+            <svg
+              width={16}
+              height={16}
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="#2D9F5E"
+              strokeWidth={2.5}
+              className="shrink-0 mt-0.5"
+              aria-hidden="true"
+            >
+              <polyline points="16 6 8 14 4 10" />
+            </svg>
+            {label}
+          </li>
+        ))}
+      </ul>
+
+      <Link
+        href={`/pricing?interval=${plan.interval}`}
+        className={`block text-center py-3.5 rounded-[12px] font-semibold text-[15px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${ctaClasses}`}
+      >
+        Plan wählen
+      </Link>
+    </div>
+  )
+}
+
+export function Pricing() {
+  return (
+    <section
+      id="preise"
+      className="bg-[linear-gradient(180deg,var(--brand-plum-ice)_0%,var(--background)_100%)] py-20"
+    >
+      <div className="mx-auto max-w-7xl px-6">
+        <SectionHeading
+          eyebrow="Preise"
+          title="Klar und fair, ohne versteckte Kosten."
+          lede="Drei Pläne, alle mit derselben App. Jederzeit kündbar."
+        />
+        <div className="mt-12 mx-auto max-w-[1000px] grid grid-cols-1 md:grid-cols-3 gap-5">
+          {STRIPE_PRICING_PLANS.map((plan) => (
+            <PlanCard key={plan.interval} plan={plan} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/section-heading.tsx
+++ b/src/components/landing/section-heading.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react"
+
+type Props = {
+  eyebrow: string
+  title: ReactNode
+  lede?: ReactNode
+  className?: string
+}
+
+export function SectionHeading({ eyebrow, title, lede, className }: Props) {
+  return (
+    <div className={className}>
+      <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
+        {eyebrow}
+      </span>
+      <h2 className="mb-4 font-header text-[clamp(28px,4vw,44px)] font-medium leading-[1.2] text-[var(--brand-plum-darkest)]">
+        {title}
+      </h2>
+      {lede ? <p className="max-w-[640px] text-lg text-muted-foreground">{lede}</p> : null}
+    </div>
+  )
+}

--- a/src/components/landing/site-footer.tsx
+++ b/src/components/landing/site-footer.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link"
+
+const linkClass =
+  "text-sm text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)]"
+
+const headingClass =
+  "mb-4 font-mono text-xs font-medium uppercase tracking-wider text-[var(--brand-plum)]"
+
+function Wordmark() {
+  return (
+    <Link href="/" className="flex items-center gap-2.5" aria-label="chaarlie Startseite">
+      <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
+        <svg aria-hidden="true" viewBox="0 0 24 24" width="19" height="19" fill="#FDFBF9">
+          <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
+        </svg>
+      </span>
+      <span className="font-header text-[22px] font-medium leading-none text-[var(--brand-plum-darkest)]">
+        chaarlie
+      </span>
+    </Link>
+  )
+}
+
+export function SiteFooter() {
+  return (
+    <footer className="mt-16 border-t border-border bg-card pb-8 pt-14">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="mb-12 grid grid-cols-1 gap-12 sm:grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr]">
+          <div>
+            <Wordmark />
+            <p className="mt-3 max-w-[280px] text-sm leading-relaxed text-muted-foreground">
+              Wissenschaftliche Haaranalyse, persönlich abgestimmt. Ein Produkt der Haarmony LLC.
+            </p>
+          </div>
+
+          <div>
+            <h4 className={headingClass}>Produkt</h4>
+            <ul className="flex flex-col gap-2.5">
+              <li>
+                <Link href="/quiz" className={linkClass}>
+                  Quiz starten
+                </Link>
+              </li>
+              <li>
+                <Link href="/pricing" className={linkClass}>
+                  Preise
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h4 className={headingClass}>Unternehmen</h4>
+            <ul className="flex flex-col gap-2.5">
+              <li>
+                <Link href="/impressum" className={linkClass}>
+                  Impressum
+                </Link>
+              </li>
+              <li>
+                <Link href="/kontakt" className={linkClass}>
+                  Kontakt
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <h4 className={headingClass}>Rechtliches</h4>
+            <ul className="flex flex-col gap-2.5">
+              <li>
+                <Link href="/datenschutz" className={linkClass}>
+                  Datenschutz
+                </Link>
+              </li>
+              <li>
+                <Link href="/agb" className={linkClass}>
+                  AGB
+                </Link>
+              </li>
+              <li>
+                <Link href="/widerruf" className={linkClass}>
+                  Widerruf
+                </Link>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  data-cookie-settings-trigger
+                  className="cursor-pointer border-0 bg-transparent p-0 text-left font-[inherit] text-sm text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)]"
+                >
+                  Cookie-Einstellungen
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-4 border-t border-border pt-8 text-xs text-[var(--text-caption,#9A9892)]">
+          <p>
+            &copy; <span suppressHydrationWarning>{new Date().getFullYear()}</span> Haarmony LLC.
+            Alle Rechte vorbehalten.
+          </p>
+          <p>Made with care · Dover, DE 19904, USA</p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/landing/site-footer.tsx
+++ b/src/components/landing/site-footer.tsx
@@ -1,25 +1,12 @@
 import Link from "next/link"
 
+import { Wordmark } from "./wordmark"
+
 const linkClass =
-  "text-sm text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)]"
+  "text-sm text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
 
 const headingClass =
   "mb-4 font-mono text-xs font-medium uppercase tracking-wider text-[var(--brand-plum)]"
-
-function Wordmark() {
-  return (
-    <Link href="/" className="flex items-center gap-2.5" aria-label="chaarlie Startseite">
-      <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
-        <svg aria-hidden="true" viewBox="0 0 24 24" width="19" height="19" fill="#FDFBF9">
-          <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
-        </svg>
-      </span>
-      <span className="font-header text-[22px] font-medium leading-none text-[var(--brand-plum-darkest)]">
-        chaarlie
-      </span>
-    </Link>
-  )
-}
 
 export function SiteFooter() {
   return (
@@ -27,7 +14,13 @@ export function SiteFooter() {
       <div className="mx-auto max-w-7xl px-6">
         <div className="mb-12 grid grid-cols-1 gap-12 sm:grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr]">
           <div>
-            <Wordmark />
+            <Link
+              href="/"
+              aria-label="chaarlie Startseite"
+              className="inline-block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
+            >
+              <Wordmark />
+            </Link>
             <p className="mt-3 max-w-[280px] text-sm leading-relaxed text-muted-foreground">
               Wissenschaftliche Haaranalyse, persönlich abgestimmt. Ein Produkt der Haarmony LLC.
             </p>
@@ -87,7 +80,7 @@ export function SiteFooter() {
                 <button
                   type="button"
                   data-cookie-settings-trigger
-                  className="cursor-pointer border-0 bg-transparent p-0 text-left font-[inherit] text-sm text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)]"
+                  className="cursor-pointer border-0 bg-transparent p-0 text-left font-[inherit] text-sm text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
                 >
                   Cookie-Einstellungen
                 </button>

--- a/src/components/landing/what-is.tsx
+++ b/src/components/landing/what-is.tsx
@@ -1,3 +1,5 @@
+import { SectionHeading } from "@/components/landing/section-heading"
+
 type ValueBlock = {
   paths: React.ReactNode
   title: string
@@ -38,23 +40,11 @@ export function WhatIs() {
   return (
     <section className="py-20">
       <div className="mx-auto max-w-7xl px-6">
-        <div>
-          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
-            Was ist Chaarlie
-          </span>
-          <h2
-            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
-            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
-          >
-            Eine ehrliche Haaranalyse statt Marketing-Versprechen.
-          </h2>
-          <p className="max-w-[640px] text-lg text-muted-foreground">
-            Chaarlie ist eine digitale Beratung f&uuml;r deine Haarpflege. Du machst einen
-            Selbsttest in 2 Minuten, bekommst eine klare Einsch&auml;tzung deines Haarprofils und
-            eine Routine, die zu deinen Haaren passt. Inklusive konkreter Produktvorschl&auml;ge mit
-            g&uuml;nstigen Drogerie-Alternativen.
-          </p>
-        </div>
+        <SectionHeading
+          eyebrow="Was ist Chaarlie"
+          title="Eine ehrliche Haaranalyse statt Marketing-Versprechen."
+          lede="Chaarlie ist eine digitale Beratung für deine Haarpflege. Du machst einen Selbsttest in 2 Minuten, bekommst eine klare Einschätzung deines Haarprofils und eine Routine, die zu deinen Haaren passt. Inklusive konkreter Produktvorschläge mit günstigen Drogerie-Alternativen."
+        />
 
         <div className="mt-10 grid items-center gap-8 md:grid-cols-2 md:gap-16">
           <div className="flex flex-col gap-5">
@@ -95,13 +85,13 @@ export function WhatIs() {
               </p>
               <div className="flex flex-col gap-2">
                 <div className="rounded-[10px] border-[1.5px] border-border px-3.5 py-2.5 text-[13px] text-foreground">
-                  Dehnt sich, geht zur&uuml;ck
+                  Dehnt sich, geht zurück
                 </div>
                 <div className="rounded-[10px] border-[1.5px] border-[var(--brand-plum)] bg-[var(--brand-plum-ice)] px-3.5 py-2.5 text-[13px] text-foreground">
                   Bleibt ausgeleiert
                 </div>
                 <div className="rounded-[10px] border-[1.5px] border-border px-3.5 py-2.5 text-[13px] text-foreground">
-                  Rei&szlig;t sofort
+                  Reißt sofort
                 </div>
               </div>
             </div>

--- a/src/components/landing/what-is.tsx
+++ b/src/components/landing/what-is.tsx
@@ -1,0 +1,113 @@
+type ValueBlock = {
+  paths: React.ReactNode
+  title: string
+  body: string
+}
+
+const valueBlocks: ValueBlock[] = [
+  {
+    paths: (
+      <>
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 6v6l4 2" />
+      </>
+    ),
+    title: "2 Minuten, klares Ergebnis",
+    body: "Ein strukturierter Selbsttest, der die richtigen Fragen stellt. Kein endloses Formular, kein generisches Resultat.",
+  },
+  {
+    paths: <path d="M3 3h7v7H3zM14 3h7v7h-7zM14 14h7v7h-7zM3 14h7v7H3z" />,
+    title: "Konkrete Produktempfehlungen",
+    body: "Nicht „nimm halt einen Conditioner“. Sondern: dieser Conditioner, weil dein Zugtest Folgendes zeigt. Plus Drogerie-Alternative.",
+  },
+  {
+    paths: (
+      <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+    ),
+    title: "Begleitung statt Einmal-Test",
+    body: "Deine Routine wächst mit dir. Fragen kommen auf? Anpassungen nötig? Du bekommst Unterstützung.",
+  },
+  {
+    paths: <path d="M9 12l2 2 4-4M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />,
+    title: "Friseurmeisterlich beraten",
+    body: "Friseurmeister Tom Hannemann begleitet das Team beratend. Keine Heilsversprechen, nur ehrliche Empfehlungen.",
+  },
+]
+
+export function WhatIs() {
+  return (
+    <section className="py-20">
+      <div className="mx-auto max-w-7xl px-6">
+        <div>
+          <span className="mb-3 block font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--brand-plum)]">
+            Was ist Chaarlie
+          </span>
+          <h2
+            className="mb-4 font-header font-medium leading-[1.2] text-[var(--brand-plum-darkest)]"
+            style={{ fontSize: "clamp(28px, 4vw, 44px)" }}
+          >
+            Eine ehrliche Haaranalyse statt Marketing-Versprechen.
+          </h2>
+          <p className="max-w-[640px] text-lg text-muted-foreground">
+            Chaarlie ist eine digitale Beratung f&uuml;r deine Haarpflege. Du machst einen
+            Selbsttest in 2 Minuten, bekommst eine klare Einsch&auml;tzung deines Haarprofils und
+            eine Routine, die zu deinen Haaren passt. Inklusive konkreter Produktvorschl&auml;ge mit
+            g&uuml;nstigen Drogerie-Alternativen.
+          </p>
+        </div>
+
+        <div className="mt-10 grid items-center gap-8 md:grid-cols-2 md:gap-16">
+          <div className="flex flex-col gap-5">
+            {valueBlocks.map((block) => (
+              <div key={block.title} className="flex items-start gap-4">
+                <span className="grid h-10 w-10 flex-shrink-0 place-items-center rounded-[10px] bg-[var(--brand-plum-ice)] text-[var(--brand-plum)]">
+                  <svg
+                    aria-hidden="true"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    {block.paths}
+                  </svg>
+                </span>
+                <div>
+                  <h3 className="mb-1 text-base font-bold text-[var(--brand-plum-darkest)] sm:text-[17px]">
+                    {block.title}
+                  </h3>
+                  <p className="text-[15px] leading-relaxed text-muted-foreground">{block.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="relative flex min-h-[380px] items-center justify-center overflow-hidden rounded-3xl bg-[var(--brand-plum-ice)] p-12">
+            <div className="max-w-[280px] rounded-[18px] bg-white p-6 shadow-[0_20px_60px_-10px_rgba(42,24,69,0.2)]">
+              <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--brand-plum)]/60">
+                Frage 4 / 6
+              </p>
+              <p className="mb-5 font-header text-xl text-[var(--brand-plum-darkest)]">
+                Wie elastisch ist dein Haar?
+              </p>
+              <div className="flex flex-col gap-2">
+                <div className="rounded-[10px] border-[1.5px] border-border px-3.5 py-2.5 text-[13px] text-foreground">
+                  Dehnt sich, geht zur&uuml;ck
+                </div>
+                <div className="rounded-[10px] border-[1.5px] border-[var(--brand-plum)] bg-[var(--brand-plum-ice)] px-3.5 py-2.5 text-[13px] text-foreground">
+                  Bleibt ausgeleiert
+                </div>
+                <div className="rounded-[10px] border-[1.5px] border-border px-3.5 py-2.5 text-[13px] text-foreground">
+                  Rei&szlig;t sofort
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/landing/wordmark.tsx
+++ b/src/components/landing/wordmark.tsx
@@ -1,0 +1,14 @@
+export function Wordmark() {
+  return (
+    <div className="flex items-center gap-2.5">
+      <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
+        <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="22" fill="#FDFBF9">
+          <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
+        </svg>
+      </span>
+      <span className="font-header text-[22px] font-medium leading-none text-[var(--brand-plum-darkest)]">
+        chaarlie
+      </span>
+    </div>
+  )
+}

--- a/src/components/landing/wordmark.tsx
+++ b/src/components/landing/wordmark.tsx
@@ -2,7 +2,7 @@ export function Wordmark() {
   return (
     <div className="flex items-center gap-2.5">
       <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
-        <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="22" fill="#FDFBF9">
+        <svg aria-hidden="true" viewBox="0 0 24 24" width="19" height="19" fill="#FDFBF9">
           <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
         </svg>
       </span>

--- a/src/components/quiz/quiz-landing.tsx
+++ b/src/components/quiz/quiz-landing.tsx
@@ -5,9 +5,7 @@ import Image from "next/image"
 import { CheckCircle2, Droplet, Sparkles, Star } from "lucide-react"
 import { useQuizStore } from "@/lib/quiz/store"
 import { Button } from "@/components/ui/button"
-
-const tomHannemannImageUrl =
-  "https://www.tophair.de/app/uploads/2025/03/SA-WS-NewFlag-TomHannemann-MS-7-683x1024.jpg"
+import { tomHannemannImageUrl } from "@/lib/landing-assets"
 
 const outcomeItems = ["Dein Haarprofil", "Dein Pflegehebel", "Routine & Produkte"] as const
 

--- a/src/lib/auth/intake-state.ts
+++ b/src/lib/auth/intake-state.ts
@@ -50,10 +50,6 @@ export function getAuthenticatedAppRedirect(
       if (intakeState === "needs_quiz") return "/quiz"
       if (intakeState === "needs_onboarding") return "/onboarding"
       return null
-    case "/":
-      if (intakeState === "needs_quiz") return "/quiz"
-      if (intakeState === "needs_onboarding") return "/onboarding"
-      return "/chat"
     default:
       return null
   }

--- a/src/lib/landing-assets.ts
+++ b/src/lib/landing-assets.ts
@@ -1,0 +1,2 @@
+export const tomHannemannImageUrl =
+  "https://www.tophair.de/app/uploads/2025/03/SA-WS-NewFlag-TomHannemann-MS-7-683x1024.jpg"

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -48,7 +48,7 @@ export async function updateSession(request: NextRequest) {
   const isForcedAuthLogin =
     pathname === "/auth" && request.nextUrl.searchParams.get("force") === "login"
   const needsAuthenticatedAppRouting =
-    pathname === "/auth" || pathname === "/quiz" || pathname === "/chat" || pathname === "/"
+    pathname === "/auth" || pathname === "/quiz" || pathname === "/chat"
 
   // Public routes that don't need auth
   const publicRoutes = [
@@ -78,7 +78,7 @@ export async function updateSession(request: NextRequest) {
     "/api/auth/send-setup-link",
     "/api/auth/set-checkout-password",
   ]
-  const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
+  const isPublicRoute = pathname === "/" || publicRoutes.some((route) => pathname.startsWith(route))
 
   if (!user && !isPublicRoute) {
     const url = request.nextUrl.clone()

--- a/tests/auth-intake-state.test.ts
+++ b/tests/auth-intake-state.test.ts
@@ -63,9 +63,12 @@ test("getAuthenticatedAppRedirect maps entry routes from intake state", () => {
   assert.equal(getAuthenticatedAppRedirect("/quiz", "needs_quiz"), null)
   assert.equal(getAuthenticatedAppRedirect("/quiz", "needs_onboarding"), "/onboarding")
   assert.equal(getAuthenticatedAppRedirect("/quiz", "ready"), "/chat")
-  assert.equal(getAuthenticatedAppRedirect("/", "needs_quiz"), "/quiz")
-  assert.equal(getAuthenticatedAppRedirect("/", "needs_onboarding"), "/onboarding")
-  assert.equal(getAuthenticatedAppRedirect("/", "ready"), "/chat")
+  // `/` is now the marketing landing — middleware no longer routes it
+  // through this function. Verify the function returns null for `/` so
+  // any future stray caller is a no-op rather than a redirect.
+  assert.equal(getAuthenticatedAppRedirect("/", "needs_quiz"), null)
+  assert.equal(getAuthenticatedAppRedirect("/", "needs_onboarding"), null)
+  assert.equal(getAuthenticatedAppRedirect("/", "ready"), null)
 })
 
 test("getAuthenticatedAppRedirect preserves quiz retake access", () => {

--- a/tests/e2e-deployed.spec.ts
+++ b/tests/e2e-deployed.spec.ts
@@ -2,13 +2,21 @@ import { test, expect } from "@playwright/test"
 
 test.describe("Deployed App E2E Tests", () => {
   // ─── 1. Homepage / Navigation ───────────────────────────────
-  test("homepage redirects unauthenticated users to /quiz", async ({ page }) => {
+  test("homepage renders the marketing landing for unauthenticated users", async ({ page }) => {
     const response = await page.goto("/", { waitUntil: "domcontentloaded" })
     expect(response?.status()).toBeLessThan(500)
 
-    // Middleware redirects unauthenticated users without hc_returning cookie to /quiz
-    await page.waitForURL("**/quiz**", { timeout: 15000 })
-    expect(page.url()).toContain("/quiz")
+    // / is now the marketing landing — should NOT redirect
+    expect(page.url()).toMatch(/\/$/)
+    // Hero H1 signature copy
+    await expect(page.locator("h1").first()).toContainText("Weißt du, was deine", {
+      timeout: 15000,
+    })
+    // Header CTA links to /quiz
+    await expect(page.getByRole("link", { name: "Quiz starten" }).first()).toHaveAttribute(
+      "href",
+      "/quiz",
+    )
   })
 
   test("homepage does not return 500", async ({ page }) => {

--- a/tests/e2e-smoke.spec.ts
+++ b/tests/e2e-smoke.spec.ts
@@ -1,16 +1,19 @@
 import { test, expect } from "@playwright/test"
 
 test.describe("Core user flows — smoke test @ci", () => {
-  test("1. Homepage redirects unauthenticated users to /quiz", async ({ page }) => {
+  test("1. Homepage renders the marketing landing for unauthenticated users", async ({ page }) => {
     const response = await page.goto("/", { waitUntil: "networkidle" })
-    // After redirect chain settles, URL should contain /quiz
-    expect(page.url()).toContain("/quiz")
-    // Page should have loaded successfully
-    expect(
-      response?.ok() || response?.status() === 304 || page.url().includes("/quiz"),
-    ).toBeTruthy()
+    // / is now the marketing landing — should NOT redirect
+    expect(page.url()).toMatch(/\/$/)
+    expect(response?.ok() || response?.status() === 304).toBeTruthy()
+    // Hero H1 is the marketing landing's signature copy
+    const heroHeading = page.locator("h1").first()
+    await expect(heroHeading).toContainText("Weißt du, was deine Haare")
+    // The header CTA should link to /quiz
+    const quizCta = page.getByRole("link", { name: "Quiz starten" }).first()
+    await expect(quizCta).toHaveAttribute("href", "/quiz")
     // Take a screenshot as evidence
-    await page.screenshot({ path: "tests/screenshots/01-homepage-redirect.png", fullPage: true })
+    await page.screenshot({ path: "tests/screenshots/01-homepage-landing.png", fullPage: true })
   })
 
   test("2. Quiz page loads with intro and first quiz step after clicking start", async ({

--- a/tests/e2e-smoke.spec.ts
+++ b/tests/e2e-smoke.spec.ts
@@ -12,6 +12,11 @@ test.describe("Core user flows — smoke test @ci", () => {
     // The header CTA should link to /quiz
     const quizCta = page.getByRole("link", { name: "Quiz starten" }).first()
     await expect(quizCta).toHaveAttribute("href", "/quiz")
+    // Returning users need a visible sign-in path — header has Anmelden → /chat
+    // (middleware routes signed-in users straight to /chat, signed-out returning
+    // users through /auth with next preserved)
+    const signInLink = page.getByRole("link", { name: "Anmelden" })
+    await expect(signInLink).toHaveAttribute("href", "/chat")
     // Take a screenshot as evidence
     await page.screenshot({ path: "tests/screenshots/01-homepage-landing.png", fullPage: true })
   })


### PR DESCRIPTION
## Summary

Replaces the `/` redirect-to-chat with a proper marketing landing page for chaarlie.de. The landing follows current 2026 B2C conversion research:

- **Minimal sticky header** — `chaarlie` wordmark + single "Quiz starten" CTA. No anchor nav.
- **8 sections** — Hero (H1 with Tom Hannemann testimonial + 4.9/5 rating + outcome checks) → Was ist Chaarlie → So funktioniert's → Was du bekommst → Preise → FAQ → Final CTA banner → Footer.
- **Pricing reads `STRIPE_PRICING_PLANS`** — real prices (€14,99 / €34,99 / €99,99) with the real savings (22%/44%). Card CTAs deep-link to `/pricing?interval=<key>`.
- **Footer** links to the 5 legal pages from PR #110 (Impressum, Datenschutz, AGB, Widerruf, Kontakt) + a cookie-settings re-open trigger that hooks into the existing `CookieConsent`.

## Routing change

- `/` is now a public route for everyone (anonymous + logged-in) — explicit `pathname === "/"` exact-match added to `isPublicRoute`.
- `/` removed from `needsAuthenticatedAppRouting`, so logged-in users no longer get auto-redirected off the marketing page.
- The dead `case "/"` in `getAuthenticatedAppRedirect` was cleaned up; test updated to assert it returns null.
- `/chat`, `/quiz`, `/auth`, `/admin`, `/onboarding`, subscription paywall — all gating behavior unchanged.

## Implementation

Built via subagent-driven development across 5 tasks (T1 primitives → T2 content sections → T3 hero → T4 pricing → T5 wiring). Each task got a per-task spec compliance + code-quality review. Final codex review on the full branch diff found one Minor item (dead `case "/"` branch) which was cleaned up.

Built using the existing design system — Tailwind + brand tokens (`var(--brand-plum)`, `var(--brand-coral)`, etc.) + Playfair/Plus Jakarta/IBM Plex Mono fonts already in `globals.css`. Reuses `Button variant="landingCta"` patterns and the existing Tom Hannemann image URL (extracted to `src/lib/landing-assets.ts` and shared with `quiz-landing.tsx`).

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 new warnings; 5 pre-existing unrelated)
- [x] `npm run build` clean — 25/25 static pages, build succeeds
- [x] `npm run test:node -- tests/auth-intake-state.test.ts` — 8/8 pass
- [x] Anonymous `curl -I http://localhost:3000/` → `200 OK` (not 307)
- [x] `/impressum` still public, `/chat` still gates anonymous users
- [x] Codex whole-branch review — no blockers, one Minor fixed
- [ ] Browse the live preview (Vercel) before merge

## Known limitations / backlog

- PostHog + Meta Pixel still NOT gated on cookie consent (tracked in `project_cookie_consent_gating` memory) — separate follow-up.
- The `welcome/page.tsx` error case still calls `redirect("/")` — now lands on the marketing page instead of bouncing to chat. That's a slight UX change for an error edge case; flag if you'd rather it route somewhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)