### PR TITLE
feat(quiz): dismissible info strip on first question

### DIFF
--- a/src/app/quiz/layout.tsx
+++ b/src/app/quiz/layout.tsx
@@ -2,13 +2,19 @@
 
 import { useQuizStore } from "@/lib/quiz/store"
 import { QuizBrandPanel } from "@/components/quiz/quiz-brand-panel"
-import { useEffect, useRef } from "react"
+import { QuizInfoStrip } from "@/components/quiz/quiz-info-strip"
+import { useEffect, useRef, useState } from "react"
 
 export default function QuizLayout({ children }: { children: React.ReactNode }) {
   const step = useQuizStore((s) => s.step)
   const standardScrollRef = useRef<HTMLDivElement>(null)
   const resultScrollRef = useRef<HTMLDivElement>(null)
   const previousStepRef = useRef(step)
+  // Info strip is only shown on the first question (step 2). The dismiss
+  // state lives here (not in the strip) so it persists across step changes
+  // within the same session — the layout doesn't unmount when the user
+  // advances through questions.
+  const [infoStripDismissed, setInfoStripDismissed] = useState(false)
 
   useEffect(() => {
     if (previousStepRef.current === step) return
@@ -49,7 +55,12 @@ export default function QuizLayout({ children }: { children: React.ReactNode }) 
 
       {/* Right panel — quiz content (full-width on mobile) */}
       <div ref={standardScrollRef} className="w-full overflow-y-auto md:w-1/2">
-        <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">{children}</div>
+        <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">
+          {step === 2 && !infoStripDismissed && (
+            <QuizInfoStrip onDismiss={() => setInfoStripDismissed(true)} />
+          )}
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/src/components/landing/how-it-works.tsx
+++ b/src/components/landing/how-it-works.tsx
@@ -10,7 +10,7 @@ const steps: Step[] = [
   {
     number: "1",
     title: "Quiz machen",
-    body: "2 Minuten, sechs Fragen. Zugtest, Oberfläche, Kopfhaut, deine Ziele.",
+    body: "2 Minuten, neun Fragen. Zugtest, Oberfläche, Kopfhaut, deine Ziele.",
   },
   {
     number: "2",

--- a/src/components/quiz/quiz-info-strip.tsx
+++ b/src/components/quiz/quiz-info-strip.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { X, Info } from "lucide-react"
+
+type Props = {
+  onDismiss: () => void
+}
+
+export function QuizInfoStrip({ onDismiss }: Props) {
+  return (
+    <div
+      role="note"
+      className="mb-5 flex items-start gap-2.5 rounded-[10px] border border-[var(--brand-plum-light)]/50 bg-[var(--brand-plum-ice)] px-3.5 py-2.5 text-[13px] leading-snug text-[var(--brand-plum-darkest)]"
+    >
+      <Info
+        aria-hidden="true"
+        className="mt-px h-[18px] w-[18px] shrink-0 text-[var(--brand-plum)]"
+      />
+      <p className="flex-1">
+        <strong className="font-semibold">
+          Lass uns deine Haare verstehen — Schritt für Schritt.
+        </strong>{" "}
+        9 schnelle Fragen zur Basis, dann gehts an deine Routine und Produkte.
+      </p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Hinweis schließen"
+        className="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:text-[var(--brand-plum-darkest)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-plum)] focus-visible:ring-offset-2"
+      >
+        <X aria-hidden="true" className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/tests/e2e-smoke.spec.ts
+++ b/tests/e2e-smoke.spec.ts
@@ -34,6 +34,11 @@ test.describe("Core user flows — smoke test @ci", () => {
     await page.goto("/quiz", { waitUntil: "networkidle" })
     expect(page.url()).toContain("/quiz")
 
+    // Info strip is shown above the first question, framing the quiz
+    // before the user commits to answering.
+    const infoStrip = page.getByText("Lass uns deine Haare verstehen")
+    await expect(infoStrip).toBeVisible({ timeout: 10000 })
+
     // Wait for quiz content to render
     await page.waitForTimeout(2000)
 


### PR DESCRIPTION
## Summary

Adds a small info strip above the first quiz question that frames *why* users are answering — and quietly corrects the landing's stale "sechs Fragen" to match the actual quiz length (9).

Visible only on step 2 (the first question). Auto-hidden from step 3 onward. User can also dismiss it manually on step 2 via the `×` button. No localStorage — state lives in the layout's `useState`, persists across step changes within the session, hard reload resets (by then the strip would only re-appear on step 2 anyway, so it's idempotent).

## Locked copy

> **Lass uns deine Haare verstehen — Schritt für Schritt.** 9 schnelle Fragen zur Basis, dann gehts an deine Routine und Produkte.

## Files

- `src/components/quiz/quiz-info-strip.tsx` (new) — presentational, `onDismiss` prop
- `src/app/quiz/layout.tsx` — mounts the strip on `step === 2 && !dismissed`
- `src/components/landing/how-it-works.tsx:13` — `sechs Fragen` → `neun Fragen`
- `tests/e2e-smoke.spec.ts` — asserts strip presence on first `/quiz` visit

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Mobile dismiss test (iPhone 14 viewport, 6/6 assertions pass):
  - Strip visible on fresh `/quiz` visit at mobile width
  - Click dismiss → strip hidden
  - Question heading still visible after dismiss
  - Advance to step 3 → strip not in DOM
  - Hard reload → strip is back
- [x] Codex whole-branch review: no blocker / important / minor findings
- [ ] Browse-test against Vercel preview before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)