### PR TITLE
fix(landing): mobile UX polish — header, wordmark, cookie banner

### DIFF
--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -78,8 +78,8 @@ export function CookieConsent() {
             Wir verwenden Cookies
           </h2>
           <p className="mt-1.5 text-[13px] leading-snug text-muted-foreground sm:mt-2 sm:text-sm sm:leading-relaxed">
-            Einige sind technisch notwendig, andere helfen uns, unseren Dienst zu verbessern. Mehr
-            in unserer{" "}
+            Einige sind technisch notwendig, andere helfen uns mit Analyse oder personalisierten
+            Inhalten. Mehr in unserer{" "}
             <Link href="/datenschutz" className="underline">
               Datenschutzerklärung
             </Link>

--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -72,18 +72,20 @@ export function CookieConsent() {
         <div
           role="dialog"
           aria-label="Cookie-Einstellungen"
-          className="fixed bottom-3 left-3 right-3 z-40 max-w-md rounded-2xl border border-border bg-card p-5 shadow-2xl sm:bottom-6 sm:left-6 sm:right-auto"
+          className="fixed bottom-2 left-2 right-2 z-40 max-w-md rounded-xl border border-border bg-card p-3.5 shadow-2xl sm:bottom-6 sm:left-6 sm:right-auto sm:rounded-2xl sm:p-5"
         >
-          <h2 className="text-base font-semibold text-foreground">Wir verwenden Cookies</h2>
-          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            Einige Cookies sind technisch notwendig, andere helfen uns, unseren Dienst zu verbessern
-            oder dir personalisierte Inhalte zu zeigen. Du kannst frei wählen. Mehr in unserer{" "}
+          <h2 className="text-sm font-semibold text-foreground sm:text-base">
+            Wir verwenden Cookies
+          </h2>
+          <p className="mt-1.5 text-[13px] leading-snug text-muted-foreground sm:mt-2 sm:text-sm sm:leading-relaxed">
+            Einige sind technisch notwendig, andere helfen uns, unseren Dienst zu verbessern. Mehr
+            in unserer{" "}
             <Link href="/datenschutz" className="underline">
               Datenschutzerklärung
             </Link>
             .
           </p>
-          <div className="mt-4 flex flex-wrap gap-2">
+          <div className="mt-3 flex flex-wrap gap-2 sm:mt-4">
             <Button
               type="button"
               variant="outline"

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -8,20 +8,20 @@ export function LandingHeader() {
       className="sticky top-0 z-50 border-b border-border backdrop-blur-[12px]"
       style={{ backgroundColor: "rgba(253,251,249,0.95)" }}
     >
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3.5">
-        <Link href="/" aria-label="chaarlie Startseite">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 py-3 sm:px-6 sm:py-3.5">
+        <Link href="/" aria-label="chaarlie Startseite" className="shrink-0">
           <Wordmark />
         </Link>
-        <nav className="flex items-center gap-3 sm:gap-5">
+        <nav className="flex shrink-0 items-center gap-3 sm:gap-5">
           <Link
             href="/chat"
-            className="rounded-md text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-[var(--brand-plum-darkest)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-plum)] focus-visible:ring-offset-2"
+            className="whitespace-nowrap rounded-md text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-[var(--brand-plum-darkest)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-plum)] focus-visible:ring-offset-2"
           >
             Anmelden
           </Link>
           <Link
             href="/quiz"
-            className="rounded-[10px] bg-[var(--brand-coral)] px-[18px] py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2"
+            className="whitespace-nowrap rounded-[10px] bg-[var(--brand-coral)] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2 sm:px-[18px] sm:py-2.5"
           >
             Quiz starten
           </Link>

--- a/src/components/landing/what-is.tsx
+++ b/src/components/landing/what-is.tsx
@@ -78,7 +78,7 @@ export function WhatIs() {
           <div className="relative flex min-h-[380px] items-center justify-center overflow-hidden rounded-3xl bg-[var(--brand-plum-ice)] p-12">
             <div className="max-w-[280px] rounded-[18px] bg-white p-6 shadow-[0_20px_60px_-10px_rgba(42,24,69,0.2)]">
               <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--brand-plum)]/60">
-                Frage 4 / 6
+                Frage 4 / 9
               </p>
               <p className="mb-5 font-header text-xl text-[var(--brand-plum-darkest)]">
                 Wie elastisch ist dein Haar?

--- a/src/components/landing/wordmark.tsx
+++ b/src/components/landing/wordmark.tsx
@@ -1,12 +1,17 @@
 export function Wordmark() {
   return (
-    <div className="flex items-center gap-2.5">
-      <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-[var(--brand-plum-darkest)]">
-        <svg aria-hidden="true" viewBox="0 0 24 24" width="19" height="19" fill="#FDFBF9">
+    <div className="flex items-center gap-2 sm:gap-2.5">
+      <span className="grid h-[30px] w-[30px] place-items-center rounded-[8px] bg-[var(--brand-plum-darkest)] sm:h-[34px] sm:w-[34px] sm:rounded-[9px]">
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="#FDFBF9"
+          className="h-[17px] w-[17px] sm:h-[19px] sm:w-[19px]"
+        >
           <path d="M12 2C9 7 5 11 5 15a7 7 0 0014 0c0-4-4-8-7-13z" />
         </svg>
       </span>
-      <span className="font-header text-[22px] font-medium leading-none text-[var(--brand-plum-darkest)]">
+      <span className="font-header text-[19px] font-medium leading-none text-[var(--brand-plum-darkest)] sm:text-[22px]">
         chaarlie
       </span>
     </div>


### PR DESCRIPTION
## Summary

Mobile UX audit at 320 / 360 / 375 widths surfaced three real issues plus one stale-copy nit. All four fixed in this PR.

### Header overflow at <375px (iPhone SE / smaller Android)

Wordmark, "Anmelden", and "Quiz starten" together exceeded the viewport. \`justify-between\` couldn't push them apart, gap collapsed ("chaarlieAnmelden" jammed), CTA wrapped to two lines.

Fix: \`gap-3\` on parent flex (minimum spacing guaranteed), \`whitespace-nowrap\` on both nav links, smaller mobile padding (\`px-4 py-3 sm:px-6 sm:py-3.5\`), smaller CTA padding on mobile (\`px-3.5 py-2 sm:px-[18px] sm:py-2.5\`), \`shrink-0\` on wordmark + nav.

### Wordmark too large on narrow viewports

Scaled the brand mark responsively: badge 30×30 → 34×34 at sm+, droplet SVG 17×17 → 19×19, wordmark text 19px → 22px at sm+. Used CSS sizing on the SVG (instead of HTML attrs) so the breakpoint actually applies.

### Cookie banner overlapped hero H1 on mobile

Padding + verbose copy + 3 stacked buttons made the fixed-bottom banner tall enough to cover the lede on iPhone SE. Reduced mobile padding (\`p-3.5\` vs \`p-5\`), smaller gutters (\`left-2/right-2\`), tighter body copy single-sentence. After fix, full H1 + first lede line are visible above the banner at 320; full H1 + full lede at 360+.

Codex review caught a follow-up: my tightened copy dropped the explicit "personalisierte Inhalte" mention. Since "Alle akzeptieren" enables marketing cookies, first-layer consent must name that purpose. Restored as "andere helfen uns mit Analyse oder personalisierten Inhalten" in commit \`fcdac94\`.

### Stale illustration text

\`what-is.tsx\` quiz mockup card said "Frage 4 / 6" — quiz is actually 9 questions. Now reads "Frage 4 / 9".

## Verification

- [x] \`npm run typecheck\` clean
- [x] Visual regression at 320 / 360 / 375 mobile widths — header lays out cleanly, banner sits below hero content
- [x] Cookie banner mobile copy is German + accurate to consent contract
- [x] Codex whole-branch review — one important finding (overflow at 320 in theory; not reproduced in actual render), one minor compliance finding (cookie copy — fixed)
- [ ] Browse-test against Vercel preview before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)