### PR TITLE
feat(quiz): before/after transformation card on result pages

### DIFF
--- a/src/components/quiz/quiz-result-lever-rows.tsx
+++ b/src/components/quiz/quiz-result-lever-rows.tsx
@@ -1,0 +1,47 @@
+// src/components/quiz/quiz-result-lever-rows.tsx
+import type { QuizResultNeedsProduct } from "@/lib/quiz/result-narrative"
+
+interface QuizResultLeverRowsProps {
+  products: readonly [QuizResultNeedsProduct, QuizResultNeedsProduct]
+}
+
+export function QuizResultLeverRows({ products }: QuizResultLeverRowsProps) {
+  const [primary, secondary] = products
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-3">
+        <span
+          aria-label="Primärer Hebel"
+          className="mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-[var(--brand-coral-light)] text-[14px] font-bold text-[var(--brand-coral-dark)]"
+        >
+          ★
+        </span>
+        <div>
+          <h3 className="font-header text-[17px] font-medium leading-[1.25] text-[var(--brand-plum-darkest)]">
+            {primary.name}
+          </h3>
+          <p className="mt-1 text-[13.5px] leading-[1.5] text-muted-foreground">
+            {primary.description}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-start gap-3">
+        <span
+          aria-label="Sekundärer Hebel"
+          className="mt-0.5 grid size-7 shrink-0 place-items-center rounded-full bg-[var(--brand-plum-ice)] text-[14px] font-bold text-[var(--brand-plum)]"
+        >
+          +
+        </span>
+        <div>
+          <h3 className="font-header text-[17px] font-medium leading-[1.25] text-[var(--brand-plum-darkest)]">
+            {secondary.name}
+          </h3>
+          <p className="mt-1 text-[13.5px] leading-[1.5] text-muted-foreground">
+            {secondary.description}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/quiz/quiz-result-offer-page.tsx
+++ b/src/components/quiz/quiz-result-offer-page.tsx
@@ -1,28 +1,11 @@
 import type { ReactNode } from "react"
-import type { LucideIcon } from "lucide-react"
-import {
-  Check,
-  Droplets,
-  Heart,
-  Leaf,
-  Link2Off,
-  LockKeyhole,
-  MessageCircle,
-  Palette,
-  Scissors,
-  Shield,
-  ShieldCheck,
-  Sparkles,
-  Waves,
-} from "lucide-react"
+import { Check, LockKeyhole, MessageCircle } from "lucide-react"
 
 import { ResultOfferCountdown } from "@/components/quiz/result-offer-countdown"
 import { ResultOfferPricing } from "@/components/quiz/result-offer-pricing"
-import type {
-  QuizResultIconKey,
-  QuizResultNarrative,
-  QuizResultNarrativeRow,
-} from "@/lib/quiz/result-narrative"
+import { QuizResultTransformationCard } from "@/components/quiz/quiz-result-transformation-card"
+import { QuizResultLeverRows } from "@/components/quiz/quiz-result-lever-rows"
+import type { QuizResultNarrative } from "@/lib/quiz/result-narrative"
 import { STRIPE_PRICING_PLANS } from "@/lib/stripe/pricing-plans"
 
 const TOM_IMAGE_URL =
@@ -36,21 +19,6 @@ const FEATURE_IMAGES = {
   routine:
     "https://assets.cdn.filesafe.space/ezJuYW8Fpy3PxAlRLr5w/media/69de921fe7237c4dd30efc6c.png",
 } as const
-
-const ICONS: Record<QuizResultIconKey, LucideIcon> = {
-  droplet: Droplets,
-  shield: Shield,
-  waves: Waves,
-  "shield-check": ShieldCheck,
-  scissors: Scissors,
-  "link-off": Link2Off,
-  heart: Heart,
-  sparkles: Sparkles,
-  leaf: Leaf,
-  "arrow-up": Sparkles,
-  "arrow-down": Sparkles,
-  palette: Palette,
-}
 
 const FEATURES = [
   {
@@ -90,64 +58,6 @@ const COMPARISON_ROWS = [
 
 function firstName(name: string): string {
   return name.trim().split(/\s+/)[0] ?? ""
-}
-
-function ResultSliderCard({ row }: { row: QuizResultNarrativeRow }) {
-  const Icon = ICONS[row.iconKey] ?? Sparkles
-
-  return (
-    <article className="rounded-[16px] border border-border bg-white px-4 py-5 shadow-[0_1px_2px_rgba(var(--brand-plum-rgb),0.03)]">
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2.5">
-          <span className="grid size-8 place-items-center rounded-full bg-[var(--brand-plum-ice)] text-[var(--brand-plum)]">
-            <Icon className="size-4 stroke-[1.75]" />
-          </span>
-          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--brand-plum)]">
-            {row.label}
-          </span>
-        </div>
-        <span className="rounded-full border border-[var(--brand-plum-light)] bg-background px-3 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.1em] text-[var(--brand-plum)]">
-          {row.scope}
-        </span>
-      </div>
-
-      <div className="mb-4 grid grid-cols-2 gap-3">
-        <div>
-          <p className="mb-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.1em] text-[#D4616A]">
-            Heute
-          </p>
-          <p className="font-header text-[19px] leading-[1.22] text-[var(--brand-plum-darkest)]">
-            {row.before}
-          </p>
-        </div>
-        <div className="text-right">
-          <p className="mb-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.1em] text-[#2D9F5E]">
-            Ziel
-          </p>
-          <p className="font-header text-[19px] leading-[1.22] text-[var(--brand-plum-darkest)]">
-            {row.after}
-          </p>
-        </div>
-      </div>
-
-      <div className="px-3">
-        <div className="relative h-2 rounded-full bg-[linear-gradient(90deg,#E47474_0%,#E8A557_33%,#D9C460_55%,#A8C76E_78%,#7AB582_100%)]">
-          <span
-            className="absolute top-1/2 size-[22px] rounded-full border-[2.5px] border-[#D4616A] bg-white after:absolute after:inset-[5px] after:rounded-full after:bg-[#D4616A]"
-            style={{ left: `${row.currentPosition}%`, transform: "translate(-50%, -50%)" }}
-          />
-          <span
-            className="absolute top-1/2 size-[22px] rounded-full border border-dashed border-[#2D9F5E] bg-white after:absolute after:inset-[6px] after:rounded-full after:border after:border-[#2D9F5E]"
-            style={{ left: `${row.targetPosition}%`, transform: "translate(-50%, -50%)" }}
-          />
-        </div>
-        <div className="mt-2 flex justify-between font-mono text-[9px] font-semibold uppercase tracking-[0.07em] text-[var(--text-caption)]">
-          <span>{row.tickBefore}</span>
-          <span>{row.tickAfter}</span>
-        </div>
-      </div>
-    </article>
-  )
 }
 
 function GuaranteeBadge() {
@@ -276,14 +186,12 @@ export function QuizResultOfferPageShell({
             {displayName ? `${displayName}, dein Ergebnis` : "Dein Ergebnis"}
           </p>
           <h1 className="font-header text-[clamp(24px,7vw,34px)] font-medium leading-[1.14] text-[var(--brand-plum-darkest)]">
-            {narrative.heroHeadline}
+            So fühlt sich dein Haar in 4 Wochen an.
           </h1>
         </section>
 
-        <section className="space-y-3 border-t border-border py-8">
-          {narrative.rows.map((row) => (
-            <ResultSliderCard key={row.label} row={row} />
-          ))}
+        <section className="space-y-4 border-t border-border py-8">
+          <QuizResultTransformationCard rows={narrative.rows} />
 
           <article className="rounded-[16px] border border-border bg-white p-6 shadow-[0_1px_2px_rgba(var(--brand-plum-rgb),0.03)]">
             <p className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--brand-plum)]">
@@ -295,9 +203,9 @@ export function QuizResultOfferPageShell({
             <p className="mt-4 text-[14.5px] leading-[1.65] text-[var(--brand-plum-darkest)]">
               {narrative.needs.mainLeverWhy}
             </p>
-            <p className="mt-3 text-[14.5px] leading-[1.65] text-muted-foreground">
-              {narrative.needs.mainLeverProducts}
-            </p>
+            <div className="mt-5">
+              <QuizResultLeverRows products={narrative.needs.products} />
+            </div>
           </article>
         </section>
 

--- a/src/components/quiz/quiz-result-transformation-card.tsx
+++ b/src/components/quiz/quiz-result-transformation-card.tsx
@@ -1,0 +1,90 @@
+// src/components/quiz/quiz-result-transformation-card.tsx
+import { Fragment } from "react"
+import type { QuizResultNarrativeRow } from "@/lib/quiz/result-narrative"
+
+interface QuizResultTransformationCardProps {
+  rows: readonly QuizResultNarrativeRow[]
+}
+
+export function QuizResultTransformationCard({ rows }: QuizResultTransformationCardProps) {
+  return (
+    <article
+      aria-label="Transformation"
+      className="relative overflow-hidden rounded-[22px] border border-black/6 bg-white shadow-[0_18px_40px_-28px_rgba(var(--brand-plum-rgb),0.3)] animate-fade-in-up"
+    >
+      {/* Background panels — each spans the full card height behind the grid */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 z-0 w-1/2 bg-[linear-gradient(180deg,var(--brand-coral-light)_0%,#FBDDE0_100%)]"
+      />
+      <div
+        aria-hidden="true"
+        className="absolute inset-y-0 right-0 z-0 w-1/2 bg-[linear-gradient(180deg,#E8F4ED_0%,#D2EBDB_100%)]"
+      />
+
+      {/* Paired grid — Heute/Ziel cells in the same row share grid-row height */}
+      <div className="relative z-[1] grid grid-cols-2">
+        {/* Header row — single-line label, same height both sides. Tighter padding because the stamp is below them. */}
+        <div className="px-4 pt-[20px] pb-[18px] pr-[14px] sm:px-5 sm:pr-[14px]">
+          <h4 className="font-mono text-[10.5px] font-semibold uppercase leading-[1.2] tracking-[0.16em] text-[var(--brand-coral-dark)]">
+            Heute
+          </h4>
+        </div>
+        <div className="px-4 pt-[20px] pb-[18px] pl-[14px] sm:px-5 sm:pl-[14px]">
+          <h4 className="font-mono text-[10.5px] font-semibold uppercase leading-[1.2] tracking-[0.16em] text-[#2D8A57]">
+            In 4 Wochen
+          </h4>
+        </div>
+
+        {/* One Fragment per row, emitting two sibling grid cells (heute / ziel).
+            Both cells flex-center so the shorter side sits on the centerline of the taller side.
+            42 px inner padding clears the stamp composition. */}
+        {rows.map((row, index) => {
+          const isFirst = index === 0
+          const isLast = index === rows.length - 1
+          const topPad = isFirst ? "pt-[14px]" : "pt-[10px]"
+          const bottomPad = isLast ? "pb-[22px]" : "pb-[10px]"
+          return (
+            <Fragment key={row.label}>
+              <div
+                className={`flex items-center px-4 pr-[42px] sm:px-5 sm:pr-[42px] ${topPad} ${bottomPad}`}
+              >
+                <span className="font-header text-[16px] italic leading-[1.3] text-[#6B3439] opacity-95 sm:text-[17px]">
+                  {row.before}
+                </span>
+              </div>
+              <div
+                className={`flex items-center px-4 pl-[42px] sm:px-5 sm:pl-[42px] ${topPad} ${bottomPad}`}
+              >
+                <span className="font-header text-[16px] font-medium italic leading-[1.3] text-[#1F4D33] sm:text-[17px]">
+                  {row.after}
+                </span>
+              </div>
+            </Fragment>
+          )
+        })}
+      </div>
+
+      {/* Brand stamp — vertical composition: small "mit / Chaarlie" pill above a big arrow circle */}
+      <div
+        aria-label="Mit Chaarlie"
+        className="absolute left-1/2 top-1/2 z-[2] flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-[5px]"
+      >
+        <div className="flex flex-col items-center gap-px rounded-[22px] bg-white/90 px-[10px] py-[5px] shadow-[0_3px_10px_-6px_rgba(45,138,87,0.35)]">
+          <span className="font-mono text-[8.5px] font-semibold uppercase leading-[1.15] tracking-[0.14em] text-[#2D8A57]">
+            mit
+          </span>
+          <span className="font-mono text-[8.5px] font-semibold uppercase leading-[1.15] tracking-[0.14em] text-[#2D8A57]">
+            Chaarlie
+          </span>
+        </div>
+        <div
+          className="grid size-[38px] place-items-center rounded-full bg-white text-[19px] font-bold leading-none text-[#2D8A57] shadow-[0_8px_20px_-12px_rgba(45,138,87,0.5),0_0_0_4px_rgba(255,255,255,0.9)]"
+          aria-hidden="true"
+        >
+          →
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/components/quiz/quiz-results-view.tsx
+++ b/src/components/quiz/quiz-results-view.tsx
@@ -1,44 +1,10 @@
 "use client"
 
 import Link from "next/link"
-import type { LucideIcon } from "lucide-react"
-import {
-  ArrowDown,
-  ArrowUp,
-  Droplets,
-  Heart,
-  Leaf,
-  Link2Off,
-  Palette,
-  Scissors,
-  Shield,
-  ShieldCheck,
-  Sparkles,
-  Waves,
-} from "lucide-react"
 import { Button } from "@/components/ui/button"
-import type {
-  QuizResultIconKey,
-  QuizResultNarrative,
-  QuizResultNarrativeRow,
-} from "@/lib/quiz/result-narrative"
-
-const ICONS: Record<QuizResultIconKey, LucideIcon> = {
-  droplet: Droplets,
-  shield: Shield,
-  waves: Waves,
-  "shield-check": ShieldCheck,
-  scissors: Scissors,
-  "link-off": Link2Off,
-  heart: Heart,
-  sparkles: Sparkles,
-  leaf: Leaf,
-  "arrow-up": ArrowUp,
-  "arrow-down": ArrowDown,
-  palette: Palette,
-}
-
-const CARD_DELAYS = [0.1, 0.22, 0.34]
+import { QuizResultTransformationCard } from "@/components/quiz/quiz-result-transformation-card"
+import { QuizResultLeverRows } from "@/components/quiz/quiz-result-lever-rows"
+import type { QuizResultNarrative } from "@/lib/quiz/result-narrative"
 
 export interface QuizResultsViewAction {
   label: string
@@ -51,84 +17,6 @@ interface QuizResultsViewProps {
   narrative: QuizResultNarrative
   primaryAction: QuizResultsViewAction
   secondaryAction?: QuizResultsViewAction | null
-}
-
-function SpectrumCard({ row, index }: { row: QuizResultNarrativeRow; index: number }) {
-  const Icon = ICONS[row.iconKey] ?? Sparkles
-
-  return (
-    <article
-      className="animate-fade-in-up rounded-[20px] border border-black/6 bg-white px-5 py-5 shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.04),0_8px_28px_-18px_rgba(var(--brand-plum-rgb),0.22)] transition-transform duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.06),0_18px_40px_-22px_rgba(var(--brand-plum-rgb),0.3)] sm:px-6 sm:py-6"
-      style={{ animationDelay: `${CARD_DELAYS[index] ?? 0}s` }}
-    >
-      <div className="mb-4 flex items-start justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <div className="grid size-10 shrink-0 place-items-center rounded-xl bg-[var(--brand-plum-ice)] text-[var(--brand-plum)]">
-            <Icon className="size-5 stroke-[1.75]" />
-          </div>
-          <span className="type-label text-[11px] font-semibold tracking-[0.22em] text-[var(--brand-plum)]">
-            {row.label}
-          </span>
-        </div>
-
-        <span className="rounded-full border border-[rgba(var(--brand-plum-rgb),0.14)] bg-[rgba(var(--brand-plum-rgb),0.04)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--brand-plum)]">
-          {row.scope}
-        </span>
-      </div>
-
-      <div className="mb-3.5 grid grid-cols-2 gap-3 sm:gap-6">
-        <div className="flex min-h-12 flex-col justify-center">
-          <div className="mb-1.5 inline-flex items-center gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.2em] text-[#E35858] [font-family:var(--font-mono)]">
-            <span className="size-[7px] rounded-full bg-[#E35858]" />
-            Heute
-          </div>
-          <div className="font-header text-[15px] leading-[1.25] text-foreground sm:text-lg">
-            {row.before}
-          </div>
-        </div>
-
-        <div className="flex min-h-12 flex-col justify-center text-right">
-          <div className="mb-1.5 inline-flex items-center justify-end gap-1.5 text-[10.5px] font-semibold uppercase tracking-[0.2em] text-[#4FAE7A] [font-family:var(--font-mono)]">
-            Ziel
-            <span className="size-[7px] rounded-full bg-[#4FAE7A]" />
-          </div>
-          <div className="font-header text-[15px] leading-[1.25] text-foreground sm:text-lg">
-            {row.after}
-          </div>
-        </div>
-      </div>
-
-      <div className="px-3.5 pb-1.5 pt-3.5">
-        <div className="relative h-2.5 rounded-full bg-[linear-gradient(90deg,#E35858_0%,#EA8247_28%,#F4B23C_50%,#9EC765_72%,#4FAE7A_100%)] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]">
-          <div
-            className="absolute top-1/2 grid size-[22px] place-items-center rounded-full bg-white"
-            style={{
-              left: `${row.currentPosition}%`,
-              transform: "translate(-50%, -50%)",
-              boxShadow: "0 0 0 2px #E35858, 0 4px 12px -2px rgba(227, 88, 88, 0.5)",
-            }}
-          >
-            <div className="size-[14px] rounded-full bg-[#E35858]" />
-          </div>
-          <div
-            className="absolute top-1/2 grid size-[22px] place-items-center rounded-full bg-white"
-            style={{
-              left: `${row.targetPosition}%`,
-              transform: "translate(-50%, -50%)",
-              boxShadow: "0 0 0 2px #4FAE7A",
-            }}
-          >
-            <div className="size-[14px] rounded-full border-2 border-dashed border-[#4FAE7A] bg-transparent" />
-          </div>
-        </div>
-
-        <div className="mt-2.5 flex justify-between px-0.5 text-[9.5px] uppercase tracking-[0.18em] text-[var(--text-sub)] [font-family:var(--font-mono)] sm:text-[10px]">
-          <span>{row.tickBefore}</span>
-          <span>{row.tickAfter}</span>
-        </div>
-      </div>
-    </article>
-  )
 }
 
 function ActionButton({
@@ -202,10 +90,8 @@ export function QuizResultsView({
         {narrative.intro}
       </p>
 
-      <div className="mb-8 flex flex-col gap-[18px] sm:gap-[22px]">
-        {narrative.rows.map((row, index) => (
-          <SpectrumCard key={row.label} row={row} index={index} />
-        ))}
+      <div className="mb-8">
+        <QuizResultTransformationCard rows={narrative.rows} />
       </div>
 
       <section className="mb-7 w-full rounded-[24px] border border-black/6 bg-white px-5 py-5 shadow-[0_1px_0_rgba(var(--brand-plum-rgb),0.04),0_8px_28px_-18px_rgba(var(--brand-plum-rgb),0.22)] sm:px-6 sm:py-6">
@@ -218,9 +104,9 @@ export function QuizResultsView({
         <p className="mt-3 max-w-[48ch] text-[15.5px] leading-[1.65] text-foreground sm:text-[17px]">
           {narrative.needs.mainLeverWhy}
         </p>
-        <p className="mt-4 max-w-[50ch] text-[15px] leading-[1.7] text-muted-foreground sm:text-[16px]">
-          {narrative.needs.mainLeverProducts}
-        </p>
+        <div className="mt-5">
+          <QuizResultLeverRows products={narrative.needs.products} />
+        </div>
       </section>
 
       <div className="mx-auto mt-1 flex w-full max-w-[480px] flex-col gap-3">

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -98,7 +98,7 @@ const CONCERN_COPY: Record<QuizConcern, QuizResultRowCopy> = {
   },
   dryness: {
     before: "Trockenheit",
-    after: "weichere, besser mit Feuchtigkeit versorgte Längen",
+    after: "weichere, geschmeidige Längen",
     iconKey: "droplet",
     tickBefore: "trocken",
     tickAfter: "versorgt",
@@ -126,7 +126,7 @@ const CONCERN_COPY: Record<QuizConcern, QuizResultRowCopy> = {
   },
   hair_damage: {
     before: "Haarschäden",
-    after: "kräftiger wirkende, besser geschützte Längen",
+    after: "kräftigere, geschützte Längen",
     iconKey: "shield",
     tickBefore: "angegriffen",
     tickAfter: "geschützt",
@@ -399,7 +399,7 @@ function buildHairFeelRow(
     return {
       label: "Haargefühl",
       scope: "HAAR",
-      before: "geschwächt & strapaziert",
+      before: "strapazierte Längen",
       after: "kräftiger & geschützter",
       iconKey: "shield",
       tickBefore: "strapaziert",
@@ -738,7 +738,7 @@ function buildFrictionRow(
   const copy = primaryConcern
     ? CONCERN_COPY[primaryConcern]
     : {
-        before: "Pflege, die noch nicht richtig zu deinem Haar passt",
+        before: "unpassende Pflege",
         after: "mehr Ruhe, Glanz & Ausgewogenheit",
         iconKey: "sparkles" as const,
         tickBefore: "unstimmig",

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -52,11 +52,14 @@ interface QuizResultRowCopy {
   tickAfter: string
 }
 
+export type QuizResultNeedsProduct = { name: string; description: string }
+
 interface QuizResultNeedsSection {
   title: string
   mainLeverTitle: string
   mainLeverWhy: string
   mainLeverProducts: string
+  products: readonly [QuizResultNeedsProduct, QuizResultNeedsProduct]
 }
 
 export interface QuizResultNarrativeRow {
@@ -848,6 +851,10 @@ function buildNeedsSection(
         "Wenn die Kopfhaut aus dem Gleichgewicht ist, bleibt sie leichter gereizt und Schuppen kommen schneller wieder.",
       mainLeverProducts:
         "Am meisten erreichen wir hier mit einem passenden Anti-Schuppen-Shampoo; zusätzlich kann ein beruhigendes Kopfhautserum helfen, die Kopfhaut zwischen den Haarwäschen ruhiger zu halten.",
+      products: [
+        { name: "Anti-Schuppen-Shampoo", description: "Reguliert die Kopfhaut bei jeder Wäsche." },
+        { name: "Kopfhautserum", description: "Hält die Kopfhaut zwischen den Wäschen ruhig." },
+      ],
     }
   }
 
@@ -865,6 +872,10 @@ function buildNeedsSection(
         "Wenn die Längen geschwächt sind, geben sie schneller nach und Spliss oder Haarbruch werden leichter weiter begünstigt.",
       mainLeverProducts:
         "Am meisten erreichen wir hier mit einem Bondbuilder; zusätzlich kann eine stärkende Maske helfen, die Längen belastbarer zu halten.",
+      products: [
+        { name: "Bondbuilder", description: "Stabilisiert die Längen von innen." },
+        { name: "Stärkende Maske", description: "Macht die Längen wieder belastbar." },
+      ],
     }
   }
 
@@ -885,6 +896,10 @@ function buildNeedsSection(
         "Wenn die Oberfläche aufraut, fallen die Längen schneller unruhig und lassen sich schwerer kontrollieren.",
       mainLeverProducts:
         "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein Leave-in helfen, die Längen zwischen den Wäschen ruhiger zu halten.",
+      products: [
+        { name: "Conditioner", description: "Stabilisiert die Oberfläche der Längen." },
+        { name: "Leave-in", description: "Hält die Wirkung zwischen den Wäschen." },
+      ],
     }
   }
 
@@ -896,6 +911,10 @@ function buildNeedsSection(
         "Wenn die Spitzen ausfransen, fühlen sie sich schneller trocken an und fallen weniger glatt.",
       mainLeverProducts:
         "Am meisten erreichen wir hier mit einem leichten Haaröl; zusätzlich kann ein Leave-in helfen, die Spitzen geschmeidiger und besser geschützt zu halten.",
+      products: [
+        { name: "Leichtes Haaröl", description: "Schützt und glättet die Spitzen." },
+        { name: "Leave-in", description: "Hält die Spitzen geschmeidig." },
+      ],
     }
   }
 
@@ -906,6 +925,10 @@ function buildNeedsSection(
       "Wenn die Pflegebasis besser passt, wirkt dein Haar insgesamt ruhiger und stimmiger.",
     mainLeverProducts:
       "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein leichtes Leave-in helfen, die Wirkung in den Längen zu halten.",
+    products: [
+      { name: "Conditioner", description: "Stimmt die Pflegebasis ab." },
+      { name: "Leichtes Leave-in", description: "Hält die Wirkung in den Längen." },
+    ],
   }
 }
 

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -209,7 +209,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await expect(page.getByText(/Analyse fertig/i)).toBeVisible({ timeout: 15_000 })
       await expect(
         page.getByRole("heading", {
-          name: /Dein Haar braucht mehr Protein als Feuchtigkeit/i,
+          name: /So fühlt sich dein Haar in 4 Wochen an/i,
         }),
       ).toBeVisible()
       await expect(
@@ -484,7 +484,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await expect(page.getByText(/Analyse fertig/i)).toBeVisible({ timeout: 15_000 })
       await expect(
         page.getByRole("heading", {
-          name: /Dein Haar braucht mehr Feuchtigkeit als Protein/i,
+          name: /So fühlt sich dein Haar in 4 Wochen an/i,
         }),
       ).toBeVisible()
       await expect(

--- a/tests/quiz-result-lever-rows.test.tsx
+++ b/tests/quiz-result-lever-rows.test.tsx
@@ -1,0 +1,25 @@
+// tests/quiz-result-lever-rows.test.tsx
+import assert from "node:assert/strict"
+import test from "node:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+// @ts-expect-error - Component not implemented yet (TDD red phase). Removed in Task 5's component creation step.
+import { QuizResultLeverRows } from "../src/components/quiz/quiz-result-lever-rows"
+
+test("lever rows renders the primary product with a star and the secondary product with a plus", () => {
+  const html = renderToStaticMarkup(
+    <QuizResultLeverRows
+      products={[
+        { name: "Conditioner", description: "Stabilisiert die Oberfläche der Längen." },
+        { name: "Leave-in", description: "Hält die Wirkung zwischen den Wäschen." },
+      ]}
+    />,
+  )
+
+  assert.match(html, /Conditioner/)
+  assert.match(html, /Stabilisiert die Oberfläche der Längen\./)
+  assert.match(html, /Leave-in/)
+  assert.match(html, /Hält die Wirkung zwischen den Wäschen\./)
+  assert.match(html, /aria-label="Primärer Hebel"/)
+  assert.match(html, /aria-label="Sekundärer Hebel"/)
+})

--- a/tests/quiz-result-lever-rows.test.tsx
+++ b/tests/quiz-result-lever-rows.test.tsx
@@ -3,7 +3,6 @@ import assert from "node:assert/strict"
 import test from "node:test"
 import { renderToStaticMarkup } from "react-dom/server"
 
-// @ts-expect-error - Component not implemented yet (TDD red phase). Removed in Task 5's component creation step.
 import { QuizResultLeverRows } from "../src/components/quiz/quiz-result-lever-rows"
 
 test("lever rows renders the primary product with a star and the secondary product with a plus", () => {

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -36,6 +36,10 @@ test("surface-led results expose scope labels, bucketed positions, concise goal 
   assert.match(narrative.needs.mainLeverProducts, /Conditioner/i)
   assert.match(narrative.needs.mainLeverProducts, /zusätzlich/i)
   assert.match(narrative.needs.mainLeverProducts, /Leave-in/i)
+  assert.deepEqual(narrative.needs.products, [
+    { name: "Conditioner", description: "Stabilisiert die Oberfläche der Längen." },
+    { name: "Leave-in", description: "Hält die Wirkung zwischen den Wäschen." },
+  ])
   assert.ok(!("reveal" in narrative))
 
   assert.equal(narrative.cta.lead, "Als Nächstes: dein persönlicher Plan")
@@ -142,6 +146,10 @@ test("no-concern fallback can become scalp-led when scalp is the strongest real 
   assert.match(narrative.needs.mainLeverWhy, /Schuppen/i)
   assert.match(narrative.needs.mainLeverProducts, /Anti-Schuppen-Shampoo/i)
   assert.match(narrative.needs.mainLeverProducts, /Kopfhautserum/i)
+  assert.deepEqual(narrative.needs.products, [
+    { name: "Anti-Schuppen-Shampoo", description: "Reguliert die Kopfhaut bei jeder Wäsche." },
+    { name: "Kopfhautserum", description: "Hält die Kopfhaut zwischen den Wäschen ruhig." },
+  ])
 })
 
 test("an explicit dryness concern keeps row two and the main lever out of the scalp fallback", () => {
@@ -218,6 +226,10 @@ test("severe structural signals can mention bondbuilder support in the main leve
   assert.match(narrative.needs.mainLeverProducts, /Bondbuilder/i)
   assert.match(narrative.needs.mainLeverProducts, /zusätzlich/i)
   assert.match(narrative.needs.mainLeverProducts, /Maske/i)
+  assert.deepEqual(narrative.needs.products, [
+    { name: "Bondbuilder", description: "Stabilisiert die Längen von innen." },
+    { name: "Stärkende Maske", description: "Macht die Längen wieder belastbar." },
+  ])
 })
 
 test("surface branch explains the main lever with multiple fitting categories", () => {
@@ -234,6 +246,10 @@ test("surface branch explains the main lever with multiple fitting categories", 
     narrative.needs.mainLeverProducts,
     "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein Leave-in helfen, die Längen zwischen den Wäschen ruhiger zu halten.",
   )
+  assert.deepEqual(narrative.needs.products, [
+    { name: "Conditioner", description: "Stabilisiert die Oberfläche der Längen." },
+    { name: "Leave-in", description: "Hält die Wirkung zwischen den Wäschen." },
+  ])
 })
 
 test("scalp branch explains the main lever with product-specific follow-through", () => {
@@ -269,6 +285,10 @@ test("split-ends branch explains the main lever with tip-focused product guidanc
     narrative.needs.mainLeverProducts,
     "Am meisten erreichen wir hier mit einem leichten Haaröl; zusätzlich kann ein Leave-in helfen, die Spitzen geschmeidiger und besser geschützt zu halten.",
   )
+  assert.deepEqual(narrative.needs.products, [
+    { name: "Leichtes Haaröl", description: "Schützt und glättet die Spitzen." },
+    { name: "Leave-in", description: "Hält die Spitzen geschmeidig." },
+  ])
 })
 
 test("fallback branch still offers a concise but fuller product bridge", () => {
@@ -285,6 +305,10 @@ test("fallback branch still offers a concise but fuller product bridge", () => {
     narrative.needs.mainLeverProducts,
     "Am meisten erreichen wir hier mit einem passenden Conditioner; zusätzlich kann ein leichtes Leave-in helfen, die Wirkung in den Längen zu halten.",
   )
+  assert.deepEqual(narrative.needs.products, [
+    { name: "Conditioner", description: "Stimmt die Pflegebasis ab." },
+    { name: "Leichtes Leave-in", description: "Hält die Wirkung in den Längen." },
+  ])
 })
 
 test("hero headline maps overextended pull test to protein-led result", () => {

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -168,7 +168,7 @@ test("an explicit dryness concern keeps row two and the main lever out of the sc
   assert.equal(narrative.rows[1]?.label, "Was dich gerade ausbremst")
   assert.equal(narrative.rows[1]?.scope, "LÄNGEN")
   assert.equal(narrative.rows[1]?.before, "Trockenheit")
-  assert.equal(narrative.rows[1]?.after, "weichere, besser mit Feuchtigkeit versorgte Längen")
+  assert.equal(narrative.rows[1]?.after, "weichere, geschmeidige Längen")
   assert.doesNotMatch(narrative.needs.mainLeverTitle, /Kopfhaut/i)
   assert.doesNotMatch(narrative.needs.mainLeverProducts, /Anti-Schuppen-Shampoo|Kopfhautserum/i)
 })

--- a/tests/quiz-result-transformation-card.test.tsx
+++ b/tests/quiz-result-transformation-card.test.tsx
@@ -3,9 +3,19 @@ import assert from "node:assert/strict"
 import test from "node:test"
 import { renderToStaticMarkup } from "react-dom/server"
 
-// @ts-expect-error - Component not implemented yet (TDD red phase, Task 3 will create it).
 import { QuizResultTransformationCard } from "../src/components/quiz/quiz-result-transformation-card"
 import { buildQuizResultNarrative } from "../src/lib/quiz/result-narrative"
+
+// React's renderToStaticMarkup escapes HTML-significant characters (e.g. `&` → `&amp;`),
+// so we compare assertions against the escaped form of the narrative strings.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;")
+}
 
 test("transformation card renders Heute / In 4 Wochen columns with each row's before and after copy", () => {
   const narrative = buildQuizResultNarrative({
@@ -24,10 +34,13 @@ test("transformation card renders Heute / In 4 Wochen columns with each row's be
 
   for (const row of narrative.rows) {
     assert.ok(
-      html.includes(row.before),
+      html.includes(escapeHtml(row.before)),
       `expected Heute column to contain row.before "${row.before}"`,
     )
-    assert.ok(html.includes(row.after), `expected Ziel column to contain row.after "${row.after}"`)
+    assert.ok(
+      html.includes(escapeHtml(row.after)),
+      `expected Ziel column to contain row.after "${row.after}"`,
+    )
   }
 
   // Old slider visuals gone

--- a/tests/quiz-result-transformation-card.test.tsx
+++ b/tests/quiz-result-transformation-card.test.tsx
@@ -1,0 +1,52 @@
+// tests/quiz-result-transformation-card.test.tsx
+import assert from "node:assert/strict"
+import test from "node:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+// @ts-expect-error - Component not implemented yet (TDD red phase, Task 3 will create it).
+import { QuizResultTransformationCard } from "../src/components/quiz/quiz-result-transformation-card"
+import { buildQuizResultNarrative } from "../src/lib/quiz/result-narrative"
+
+test("transformation card renders Heute / In 4 Wochen columns with each row's before and after copy", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "wavy",
+    thickness: "normal",
+    fingertest: "rau",
+    pulltest: "stretches_bounces",
+    concerns: ["dryness"],
+    goals: ["less_frizz", "shine"],
+  })
+
+  const html = renderToStaticMarkup(<QuizResultTransformationCard rows={narrative.rows} />)
+
+  assert.match(html, /Heute/)
+  assert.match(html, /In 4 Wochen/)
+
+  for (const row of narrative.rows) {
+    assert.ok(
+      html.includes(row.before),
+      `expected Heute column to contain row.before "${row.before}"`,
+    )
+    assert.ok(html.includes(row.after), `expected Ziel column to contain row.after "${row.after}"`)
+  }
+
+  // Old slider visuals gone
+  assert.doesNotMatch(html, /linear-gradient\(90deg,#E47474/)
+  assert.doesNotMatch(html, /linear-gradient\(90deg,#E35858/)
+  assert.doesNotMatch(html, /currentPosition|targetPosition/)
+})
+
+test("transformation card renders the green arrow connector", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: ["frizz"],
+    goals: ["less_frizz"],
+  })
+
+  const html = renderToStaticMarkup(<QuizResultTransformationCard rows={narrative.rows} />)
+
+  assert.match(html, /aria-label="Transformation"/i)
+})

--- a/tests/quiz-results-view.test.tsx
+++ b/tests/quiz-results-view.test.tsx
@@ -1,3 +1,4 @@
+// tests/quiz-results-view.test.tsx
 import assert from "node:assert/strict"
 import test from "node:test"
 import { renderToStaticMarkup } from "react-dom/server"
@@ -5,7 +6,7 @@ import { renderToStaticMarkup } from "react-dom/server"
 import { QuizResultsView } from "../src/components/quiz/quiz-results-view"
 import { buildQuizResultNarrative } from "../src/lib/quiz/result-narrative"
 
-test("shared results view renders the new narrative result experience instead of the legacy diagnosis copy", () => {
+test("shared results view renders transformation card + structured lever rows", () => {
   const narrative = buildQuizResultNarrative({
     structure: "wavy",
     thickness: "normal",
@@ -24,9 +25,23 @@ test("shared results view renders the new narrative result experience instead of
     />,
   )
 
+  // Headline + lever section still present
   assert.match(html, /SO KOMMEN WIR DEINEM HAARZIEL NÄHER/i)
   assert.match(html, /WAS DEIN HAAR JETZT BRAUCHT/i)
   assert.match(html, /ERGEBNIS TEILEN/i)
+
+  // New transformation card structure
+  assert.match(html, /Heute/)
+  assert.match(html, /In 4 Wochen/)
+
+  // Lever rows
+  assert.match(html, /Primärer Hebel/)
+  assert.match(html, /Sekundärer Hebel/)
+  assert.match(html, /Conditioner/)
+
+  // Old visuals removed
+  assert.doesNotMatch(html, /linear-gradient\(90deg,#E35858/)
+  assert.doesNotMatch(html, /Worauf wir hinarbeiten/i) // per-row label chips gone
   assert.doesNotMatch(html, /<a[^>]*>\s*<button/i)
   assert.doesNotMatch(html, /DEINE HAAR-DIAGNOSE|Teile deine Diagnose|ALS BILD SPEICHERN|WHATSAPP/i)
 })

--- a/tests/result-offer-page.test.tsx
+++ b/tests/result-offer-page.test.tsx
@@ -19,9 +19,18 @@ test("result offer page shell renders the unified diagnostic offer sections and 
 
   assert.match(html, /Angebot:/i)
   assert.match(html, /Sarah, dein Ergebnis/i)
-  assert.match(html, /Dein Haar braucht mehr Protein als Feuchtigkeit\./i)
-  assert.match(html, /Haargefühl/i)
+  // New fixed hero
+  assert.match(html, /So fühlt sich dein Haar in 4 Wochen an\./i)
+  // Transformation card
+  assert.match(html, /Heute/)
+  assert.match(html, /In 4 Wochen/)
+  // Lever block
   assert.match(html, /Was dein Haar jetzt braucht/i)
+  assert.match(html, /Primärer Hebel/)
+  assert.match(html, /Sekundärer Hebel/)
+  // Old per-row label chips gone
+  assert.doesNotMatch(html, /Haargefühl/i)
+  assert.doesNotMatch(html, /Worauf wir hinarbeiten/i)
   assert.match(html, /Dein 30-Tage-Plan ist fertig/i)
   assert.match(html, /Tom/i)
   assert.match(html, /Was Haarmony für dich tut/i)


### PR DESCRIPTION
## Summary
- Replaces 3 confusing red→green spectrum sliders with one Heute (coral/red) → In 4 Wochen (green) transformation card on both the post-quiz offer page and the public share page.
- New `QuizResultTransformationCard` uses a paired-grid layout so each row's Heute/Ziel cells share a grid row (shorter side flex-centered against the multi-line partner). Vertical brand stamp (mit/Chaarlie pill + ↻arrow circle) sits at the column divider with 42 px clearance.
- New `QuizResultLeverRows` renders the lever section as 2 styled rows (★ primary / + secondary) instead of the previous prose paragraph.
- Extends `narrative.needs` with structured `products: readonly [Product, Product]` populated in all 5 `buildNeedsSection` branches.
- Replaces the offer-page hero with the fixed "So fühlt sich dein Haar in 4 Wochen an." (Playwright spec pins updated at lines 210-214 and 485-489).
- Tightens four over-long German row strings (dryness/hair_damage `after`, structural/fallback `before`) so they don't wrap badly in tight columns.
- Legacy `mainLeverProducts` prose string, slider position fields (`currentPosition`, `targetPosition`, `tickBefore`, `tickAfter`, `iconKey`, `scope`) stay on the narrative type for backward compat — minimal blast radius.

## Mockup
Final approved design lives at `.tmp-previews/quiz-results-v1-implemented.html` (Option B from the redesign explorations).

## Test plan
- [x] `npx tsx --test tests/quiz-result-narrative.test.ts tests/quiz-results-view.test.tsx tests/result-offer-page.test.tsx tests/quiz-result-transformation-card.test.tsx tests/quiz-result-lever-rows.test.tsx` — 22/22 pass
- [x] `npm run ci:verify` (typecheck + lint + build) — clean, no new lint warnings introduced
- [x] Codex whole-branch review per CLAUDE.md — verdict: SHIP, no findings
- [ ] Playwright e2e (`tests/quiz-onboarding-e2e.spec.ts` + `tests/auth-intake-routing.e2e.spec.ts`) — run in CI
- [ ] Manual mobile check at 320 + 390 px on `/result/[leadId]` and post-quiz offer flow — to be eyeballed in deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)