### PR TITLE
feat(quiz): double the lever decision tree (5 branches → 11)

### DIFF
--- a/src/components/quiz/quiz-result-transformation-card.tsx
+++ b/src/components/quiz/quiz-result-transformation-card.tsx
@@ -47,14 +47,14 @@ export function QuizResultTransformationCard({ rows }: QuizResultTransformationC
           return (
             <Fragment key={row.label}>
               <div
-                className={`flex items-center px-4 pr-[42px] sm:px-5 sm:pr-[42px] ${topPad} ${bottomPad}`}
+                className={`flex min-h-[80px] items-center px-4 pr-[42px] sm:px-5 sm:pr-[42px] ${topPad} ${bottomPad}`}
               >
                 <span className="font-header text-[16px] italic leading-[1.3] text-[#6B3439] opacity-95 sm:text-[17px]">
                   {row.before}
                 </span>
               </div>
               <div
-                className={`flex items-center px-4 pl-[42px] sm:px-5 sm:pl-[42px] ${topPad} ${bottomPad}`}
+                className={`flex min-h-[80px] items-center px-4 pl-[42px] sm:px-5 sm:pl-[42px] ${topPad} ${bottomPad}`}
               >
                 <span className="font-header text-[16px] font-medium italic leading-[1.3] text-[#1F4D33] sm:text-[17px]">
                   {row.after}

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -1002,9 +1002,7 @@ function buildNeedsSection(
     primaryConcern === "dryness" ||
     primaryConcern === "tangling" ||
     primaryGoal === "less_frizz" ||
-    primaryGoal === "moisture" ||
-    primaryGoal === "shine" ||
-    primaryGoal === "curl_definition"
+    primaryGoal === "moisture"
 
   if (needsSurfaceSupport) {
     return {

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -902,13 +902,11 @@ function buildNeedsSection(
     }
   }
 
-  const needsStructuralRepair =
-    primaryConcern === "breakage" ||
-    primaryConcern === "hair_damage" ||
-    hasColorTreatment(answers) ||
-    answers.pulltest === "stretches_stays"
+  // Severe bond damage (concern-driven, preserves today's "any severity signal" routing).
+  const hasSeveritySignal =
+    primaryConcern === "breakage" || primaryConcern === "hair_damage" || hasColorTreatment(answers)
 
-  if (needsStructuralRepair) {
+  if (hasSeveritySignal) {
     return {
       title: "Was dein Haar jetzt braucht",
       mainLeverTitle: "Mehr Stabilität in die Längen bringen",
@@ -919,6 +917,47 @@ function buildNeedsSection(
       products: [
         { name: "Bondbuilder", description: "Stabilisiert die Längen von innen." },
         { name: "Stärkende Maske", description: "Macht die Längen wieder belastbar." },
+      ],
+    }
+  }
+
+  // Protein-needs (moderate) — fires when pulltest=stretches_stays without severity signals.
+  if (answers.pulltest === "stretches_stays") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Überdehnten Längen wieder Struktur geben",
+      mainLeverWhy:
+        "Wenn die Längen überdehnt sind und langsam zurückspringen, fehlt ihnen Struktur — nicht unbedingt Feuchtigkeit.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einer Protein-Maske; zusätzlich kann ein Conditioner für strapaziertes Haar helfen, die Längen zwischen den Wäschen zu stützen.",
+      products: [
+        { name: "Protein-Maske", description: "Gibt überdehnten Längen wieder Struktur." },
+        {
+          name: "Conditioner für strapaziertes Haar",
+          description: "Stützt die Längen zwischen den Masken.",
+        },
+      ],
+    }
+  }
+
+  // Moisture-needs — fires when pulltest=snaps.
+  if (answers.pulltest === "snaps") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Den Längen mehr Feuchtigkeit zurückgeben",
+      mainLeverWhy:
+        "Wenn die Längen schnell brechen statt nachzugeben, fehlt ihnen Feuchtigkeit — nicht mehr Protein.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einer Feuchtigkeitsmaske; zusätzlich kann ein Conditioner für trockenes Haar helfen, die Längen zwischen den Masken geschmeidig zu halten.",
+      products: [
+        {
+          name: "Feuchtigkeitsmaske",
+          description: "Versorgt trockene Längen tief mit Feuchtigkeit.",
+        },
+        {
+          name: "Conditioner für trockenes Haar",
+          description: "Hält die Längen geschmeidig zwischen den Masken.",
+        },
       ],
     }
   }

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -400,7 +400,7 @@ function buildHairFeelRow(
       label: "Haargefühl",
       scope: "HAAR",
       before: "strapazierte Längen",
-      after: "kräftiger & geschützter",
+      after: "spürbar fester",
       iconKey: "shield",
       tickBefore: "strapaziert",
       tickAfter: "geschützt",
@@ -438,12 +438,12 @@ function buildHairFeelRow(
             : "rau & unruhig",
     after:
       primaryConcern === "dryness" || primaryGoal === "moisture"
-        ? "weicher & geschmeidiger"
+        ? "weich in der Hand"
         : primaryConcern === "frizz" || primaryGoal === "less_frizz"
-          ? "ruhiger & glänzender"
+          ? "ruhig & geordnet"
           : isDefinitionLed
-            ? "mehr Form & Bündelung"
-            : "ruhiger & glänzender",
+            ? "Bündelung im Griff"
+            : "ausgeglichen im Griff",
     iconKey:
       primaryConcern === "dryness" || primaryGoal === "moisture"
         ? "droplet"

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -962,6 +962,25 @@ function buildNeedsSection(
     }
   }
 
+  // Curl definition — fires when curl is the user's clean goal and there's no concern to address first.
+  const hasTexture =
+    answers.structure === "wavy" || answers.structure === "curly" || answers.structure === "coily"
+
+  if (primaryGoal === "curl_definition" && hasTexture && !primaryConcern) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Wellen und Locken besser definieren",
+      mainLeverWhy:
+        "Wenn die Locken sich verlieren, fehlt es selten an Pflege — sondern an einem Produkt, das die Bündelung hält.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem Curl-Leave-in; zusätzlich kann ein pflegender Conditioner helfen, die Locken weich und beweglich zu halten.",
+      products: [
+        { name: "Curl-Leave-in", description: "Definiert Wellen und Locken zwischen den Wäschen." },
+        { name: "Pflegender Conditioner", description: "Hält die Locken weich und beweglich." },
+      ],
+    }
+  }
+
   const needsSurfaceSupport =
     primaryConcern === "frizz" ||
     primaryConcern === "dryness" ||

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -843,7 +843,12 @@ function buildNeedsSection(
     answers.scalp_type === "trocken" ||
     primaryGoal === "healthy_scalp"
 
-  if (primaryGoal === "healthy_scalp" || (!primaryConcern && hasScalpSignals)) {
+  const scalpAllowed = primaryGoal === "healthy_scalp" || (!primaryConcern && hasScalpSignals)
+
+  if (
+    scalpAllowed &&
+    (answers.scalp_condition === "schuppen" || answers.scalp_condition === "trockene_schuppen")
+  ) {
     return {
       title: "Was dein Haar jetzt braucht",
       mainLeverTitle: "Die Kopfhaut gezielter ausgleichen",
@@ -854,6 +859,45 @@ function buildNeedsSection(
       products: [
         { name: "Anti-Schuppen-Shampoo", description: "Reguliert die Kopfhaut bei jeder Wäsche." },
         { name: "Kopfhautserum", description: "Hält die Kopfhaut zwischen den Wäschen ruhig." },
+      ],
+    }
+  }
+
+  if (scalpAllowed && answers.scalp_condition === "gereizt") {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Die Kopfhaut beruhigen",
+      mainLeverWhy:
+        "Wenn die Kopfhaut gereizt ist, fällt das ganze Haarbild stumpfer und uneinheitlicher aus.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem beruhigenden Shampoo; zusätzlich kann ein leichtes Leave-in helfen, die Längen zu pflegen, ohne die Kopfhaut zu belasten.",
+      products: [
+        {
+          name: "Beruhigendes Shampoo",
+          description: "Mildert die Kopfhautreizung bei jeder Wäsche.",
+        },
+        {
+          name: "Leichtes Leave-in",
+          description: "Pflegt die Längen, ohne die Kopfhaut zu belasten.",
+        },
+      ],
+    }
+  }
+
+  if (scalpAllowed) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Die Kopfhaut in Balance bringen",
+      mainLeverWhy:
+        "Wenn die Kopfhaut zu schnell fettet oder austrocknet, verliert das Haar Frische und Volumen schon nach kurzer Zeit.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem Balance-Shampoo; zusätzlich kann ein Trockenshampoo helfen, zwischen den Wäschen frisch zu wirken.",
+      products: [
+        {
+          name: "Balance-Shampoo",
+          description: "Bringt die Kopfhaut in Balance, ohne sie auszutrocknen.",
+        },
+        { name: "Trockenshampoo", description: "Hält den Ansatz zwischen den Wäschen frisch." },
       ],
     }
   }

--- a/src/lib/quiz/result-narrative.ts
+++ b/src/lib/quiz/result-narrative.ts
@@ -981,6 +981,22 @@ function buildNeedsSection(
     }
   }
 
+  // Shine — fires when shine is the user's clean goal and there's no concern to address first.
+  if (primaryGoal === "shine" && !primaryConcern) {
+    return {
+      title: "Was dein Haar jetzt braucht",
+      mainLeverTitle: "Mehr Glanz in die Längen bringen",
+      mainLeverWhy:
+        "Wenn die Oberfläche stumpf wirkt, reflektiert das Licht nicht — eine kleine Versiegelung reicht oft schon.",
+      mainLeverProducts:
+        "Am meisten erreichen wir hier mit einem Glanz-Leave-in; zusätzlich kann ein leichtes Haaröl helfen, die Oberfläche zu versiegeln.",
+      products: [
+        { name: "Glanz-Leave-in", description: "Bringt Glanz zurück in die Längen." },
+        { name: "Leichtes Haaröl", description: "Versiegelt die Oberfläche und betont den Glanz." },
+      ],
+    }
+  }
+
   const needsSurfaceSupport =
     primaryConcern === "frizz" ||
     primaryConcern === "dryness" ||

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -370,3 +370,58 @@ test("fixed row labels and CTA copy stay compact", () => {
   assert.equal(narrative.cta.label, "MEINE ROUTINE STARTEN")
   assert.equal(narrative.cta.subline, "Mit passenden Produkten, Reihenfolge und Anwendung.")
 })
+
+test("scalp-irritated branch fires when scalp_condition === gereizt and no concern is set", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    scalp_type: "ausgeglichen",
+    has_scalp_issue: true,
+    scalp_condition: "gereizt",
+    goals: ["healthy_scalp"],
+    concerns: [],
+  })
+
+  assert.equal(narrative.needs.mainLeverTitle, "Die Kopfhaut beruhigen")
+  assert.match(narrative.needs.mainLeverWhy, /gereizt/i)
+  assert.match(narrative.needs.mainLeverProducts, /beruhigenden Shampoo/i)
+  assert.deepEqual(narrative.needs.products, [
+    {
+      name: "Beruhigendes Shampoo",
+      description: "Mildert die Kopfhautreizung bei jeder Wäsche.",
+    },
+    {
+      name: "Leichtes Leave-in",
+      description: "Pflegt die Längen, ohne die Kopfhaut zu belasten.",
+    },
+  ])
+})
+
+test("scalp-oily-balanced branch fires when scalp_type signals oily without a specific scalp_condition", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "fine",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    scalp_type: "fettig",
+    has_scalp_issue: false,
+    goals: ["healthy_scalp"],
+    concerns: [],
+  })
+
+  assert.equal(narrative.needs.mainLeverTitle, "Die Kopfhaut in Balance bringen")
+  assert.match(narrative.needs.mainLeverWhy, /Frische und Volumen/i)
+  assert.match(narrative.needs.mainLeverProducts, /Balance-Shampoo/i)
+  assert.deepEqual(narrative.needs.products, [
+    {
+      name: "Balance-Shampoo",
+      description: "Bringt die Kopfhaut in Balance, ohne sie auszutrocknen.",
+    },
+    {
+      name: "Trockenshampoo",
+      description: "Hält den Ansatz zwischen den Wäschen frisch.",
+    },
+  ])
+})

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -425,3 +425,55 @@ test("scalp-oily-balanced branch fires when scalp_type signals oily without a sp
     },
   ])
 })
+
+test("protein-moderate branch fires when pulltest=stretches_stays without severe-damage signals", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_stays",
+    treatment: ["natur"],
+    concerns: [],
+    goals: ["healthier_hair"],
+  })
+
+  assert.equal(narrative.needs.mainLeverTitle, "Überdehnten Längen wieder Struktur geben")
+  assert.match(narrative.needs.mainLeverWhy, /überdehnt/i)
+  assert.match(narrative.needs.mainLeverProducts, /Protein-Maske/i)
+  assert.deepEqual(narrative.needs.products, [
+    {
+      name: "Protein-Maske",
+      description: "Gibt überdehnten Längen wieder Struktur.",
+    },
+    {
+      name: "Conditioner für strapaziertes Haar",
+      description: "Stützt die Längen zwischen den Masken.",
+    },
+  ])
+})
+
+test("moisture-needs branch fires when pulltest=snaps", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "snaps",
+    treatment: ["natur"],
+    concerns: [],
+    goals: ["moisture"],
+  })
+
+  assert.equal(narrative.needs.mainLeverTitle, "Den Längen mehr Feuchtigkeit zurückgeben")
+  assert.match(narrative.needs.mainLeverWhy, /Feuchtigkeit/i)
+  assert.match(narrative.needs.mainLeverProducts, /Feuchtigkeitsmaske/i)
+  assert.deepEqual(narrative.needs.products, [
+    {
+      name: "Feuchtigkeitsmaske",
+      description: "Versorgt trockene Längen tief mit Feuchtigkeit.",
+    },
+    {
+      name: "Conditioner für trockenes Haar",
+      description: "Hält die Längen geschmeidig zwischen den Masken.",
+    },
+  ])
+})

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -477,3 +477,28 @@ test("moisture-needs branch fires when pulltest=snaps", () => {
     },
   ])
 })
+
+test("curl-definition branch fires when primaryGoal=curl_definition and structure is wavy/curly/coily", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "curly",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: [],
+    goals: ["curl_definition"],
+  })
+
+  assert.equal(narrative.needs.mainLeverTitle, "Wellen und Locken besser definieren")
+  assert.match(narrative.needs.mainLeverWhy, /Locken/i)
+  assert.match(narrative.needs.mainLeverProducts, /Curl-Leave-in/i)
+  assert.deepEqual(narrative.needs.products, [
+    {
+      name: "Curl-Leave-in",
+      description: "Definiert Wellen und Locken zwischen den Wäschen.",
+    },
+    {
+      name: "Pflegender Conditioner",
+      description: "Hält die Locken weich und beweglich.",
+    },
+  ])
+})

--- a/tests/quiz-result-narrative.test.ts
+++ b/tests/quiz-result-narrative.test.ts
@@ -502,3 +502,28 @@ test("curl-definition branch fires when primaryGoal=curl_definition and structur
     },
   ])
 })
+
+test("shine branch fires when primaryGoal=shine and no earlier branch matches", () => {
+  const narrative = buildQuizResultNarrative({
+    structure: "straight",
+    thickness: "normal",
+    fingertest: "glatt",
+    pulltest: "stretches_bounces",
+    concerns: [],
+    goals: ["shine"],
+  })
+
+  assert.equal(narrative.needs.mainLeverTitle, "Mehr Glanz in die Längen bringen")
+  assert.match(narrative.needs.mainLeverWhy, /Versiegelung|stumpf/i)
+  assert.match(narrative.needs.mainLeverProducts, /Glanz-Leave-in/i)
+  assert.deepEqual(narrative.needs.products, [
+    {
+      name: "Glanz-Leave-in",
+      description: "Bringt Glanz zurück in die Längen.",
+    },
+    {
+      name: "Leichtes Haaröl",
+      description: "Versiegelt die Oberfläche und betont den Glanz.",
+    },
+  ])
+})


### PR DESCRIPTION
## Summary
Expands `buildNeedsSection` in `src/lib/quiz/result-narrative.ts` from 5 lever branches to 11. Each new branch is catalog-backed by existing Supabase rerank tables (shampoo_bucket, balance_direction, need_bucket, bondbuilder_intensity).

**Splits + additions:**
- **Scalp split into 3** sub-branches (commit 11a7e07): dandruff (existing copy retained) + irritated (NEW) + oily/balanced (NEW)
- **Pulltest split** (commit ddc25df): refines severe-damage to `hasSeveritySignal` (concern-driven, no pulltest gate) + adds protein-moderate (pulltest=stretches_stays) + moisture-needs (pulltest=snaps)
- **Curl-definition branch** (commit 6e8cbf8): gated on `primaryGoal=curl_definition && structure ∈ {wavy,curly,coily} && !primaryConcern`
- **Shine branch** (commit d93f881): gated on `primaryGoal=shine && !primaryConcern`
- **Surface-support narrowed** (commit da13370): removed `curl_definition` and `shine` from condition (now handled upstream)

## Why this matters
Before: 5 branches covered scalp (single bucket), structural-repair (over-aggressive — recommended Bondbuilder to anyone with breakage concern regardless of severity), and surface support (catchall for frizz/dryness/curl/shine — all got Conditioner + Leave-in).

After: 11 branches that route on the actual diagnostic signals the catalog is built around — pulltest (protein vs moisture vs balanced), scalp_condition vs scalp_type, and goal-specific routing for curl and shine. Each branch ends in a product pair that the chat agent's RAG layer can actually surface from the catalog.

## Catalog gaps deferred
Volume / Anti-volume / Color-protection / Heat-protection — no catalog support today. Separate plan when the catalog is extended.

## Two pre-implementation blockers caught by codex (both addressed)
1. Severity decoupled from pulltest so breakage-concern users with non-stretches_stays pulltest still get the Bondbuilder branch (no silent regression to default fallback)
2. Curl + shine branches gated on `!primaryConcern` so they don't override real concerns (e.g., dryness-concern + shine-goal user stays on surface-support, not a Glanz-Leave-in on dry hair)

## Test plan
- [x] `npx tsx --test` across all 5 quiz test files — **28/28 pass** (17 baseline + 6 new + 5 unchanged UI/transformation-card tests)
- [x] `npm run ci:verify` — clean (no new lint warnings)
- [x] Codex whole-branch review — verdict: SHIP, no blockers
- [ ] Playwright e2e — covered by CI
- [ ] Manual mobile check across 7 lead profiles (one per new branch + dandruff regression) — to be eyeballed in deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)