### PR TITLE
feat(analytics): add consent-gated Meta Pixel tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next"
 import { Playfair_Display, Plus_Jakarta_Sans, IBM_Plex_Mono } from "next/font/google"
 import { AuthProvider } from "@/providers/auth-provider"
+import { MetaPixelProvider } from "@/providers/meta-pixel-provider"
 import { PostHogClientProvider } from "@/providers/posthog-provider"
 import { ToastProvider } from "@/providers/toast-provider"
 import { CookieConsent } from "@/components/cookie-consent/cookie-consent"
@@ -51,11 +52,13 @@ export default function RootLayout({
       <body
         className={`${playfairDisplay.variable} ${plusJakartaSans.variable} ${ibmPlexMono.variable} antialiased`}
       >
-        <AuthProvider>
-          <PostHogClientProvider>
-            <ToastProvider>{children}</ToastProvider>
-          </PostHogClientProvider>
-        </AuthProvider>
+        <MetaPixelProvider>
+          <AuthProvider>
+            <PostHogClientProvider>
+              <ToastProvider>{children}</ToastProvider>
+            </PostHogClientProvider>
+          </AuthProvider>
+        </MetaPixelProvider>
         <CookieConsent />
       </body>
     </html>

--- a/src/app/pricing/pricing-cards.tsx
+++ b/src/app/pricing/pricing-cards.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { loadStripe } from "@stripe/stripe-js"
 import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js"
+import { trackMetaCheckoutStarted, trackMetaPricingViewed } from "@/lib/meta-pixel"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 import { STRIPE_PRICING_PLANS } from "@/lib/stripe/pricing-plans"
 
@@ -29,6 +30,10 @@ export function PricingCards({
   const [checkoutError, setCheckoutError] = useState<string | null>(() =>
     initialInterval && !stripePublishableKey ? checkoutStartError : null,
   )
+
+  useEffect(() => {
+    trackMetaPricingViewed("pricing_page")
+  }, [])
 
   function choosePlan(interval: PlanInterval) {
     if (interval === selectedInterval) return
@@ -63,6 +68,7 @@ export function PricingCards({
       setCheckoutError(checkoutStartError)
       throw new Error("checkout session response missing client secret")
     }
+    trackMetaCheckoutStarted("pricing_page", selectedInterval)
     return data.client_secret
   }, [selectedInterval, leadId])
 

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { notFound } from "next/navigation"
 import { useQuizStore } from "@/lib/quiz/store"
 import { getQuestionByStep } from "@/lib/quiz/questions"
@@ -12,6 +12,7 @@ import { QuizAnalysis } from "@/components/quiz/quiz-analysis"
 import { QuizResults } from "@/components/quiz/quiz-results"
 import { QuizGoals } from "@/components/quiz/quiz-goals"
 import { QuizWelcome } from "@/components/quiz/quiz-welcome"
+import { trackMetaQuizStarted, trackMetaQuizStepViewed } from "@/lib/meta-pixel"
 import { posthog } from "@/providers/posthog-provider"
 
 const STEP_NAMES: Record<number, string> = {
@@ -32,12 +33,25 @@ const STEP_NAMES: Record<number, string> = {
 
 export default function QuizPage() {
   const step = useQuizStore((s) => s.step)
+  const quizStartedRef = useRef(false)
+  const lastTrackedStepRef = useRef<number | null>(null)
 
   useEffect(() => {
+    if (lastTrackedStepRef.current === step) return
+    lastTrackedStepRef.current = step
+
+    const stepName = STEP_NAMES[step] || `step_${step}`
+
+    if (!quizStartedRef.current) {
+      quizStartedRef.current = true
+      trackMetaQuizStarted(stepName, step)
+    }
+
     posthog.capture("quiz_step_viewed", {
-      step_name: STEP_NAMES[step] || `step_${step}`,
+      step_name: stepName,
       step_number: step, // deprecated: use step_name after Phase 4 resequencing
     })
+    trackMetaQuizStepViewed(stepName, step)
   }, [step])
 
   // Step 6: custom scalp progressive disclosure

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -2,10 +2,11 @@
 
 import { CheckCircle, Mail } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useState, type FormEvent } from "react"
+import { useEffect, useRef, useState, type FormEvent } from "react"
 import { PasswordPolicyChecklist } from "@/components/auth/password-policy-checklist"
 import { Input } from "@/components/ui/input"
 import { validatePasswordDraft } from "@/lib/auth/password-policy"
+import { trackMetaSubscriptionConfirmed } from "@/lib/meta-pixel"
 import { createClient } from "@/lib/supabase/client"
 
 interface WelcomeClientProps {
@@ -34,6 +35,13 @@ export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
   const [confirmPassword, setConfirmPassword] = useState("")
   const [message, setMessage] = useState<string | null>(null)
   const [highlightMagicLink, setHighlightMagicLink] = useState(false)
+  const subscriptionTrackedRef = useRef(false)
+
+  useEffect(() => {
+    if (subscriptionTrackedRef.current) return
+    subscriptionTrackedRef.current = true
+    trackMetaSubscriptionConfirmed(sessionId)
+  }, [sessionId])
 
   async function handleCreatePassword(e: FormEvent) {
     e.preventDefault()

--- a/src/components/quiz/quiz-lead-capture.tsx
+++ b/src/components/quiz/quiz-lead-capture.tsx
@@ -9,6 +9,7 @@ import { QuizConsentSheet } from "./quiz-consent-sheet"
 import { ArrowLeft } from "lucide-react"
 import { Icon } from "@/components/ui/icon"
 import { posthog } from "@/providers/posthog-provider"
+import { trackMetaLeadCaptured } from "@/lib/meta-pixel"
 import { canonicalizeQuizAnswers } from "@/lib/quiz/normalization"
 import { QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
 
@@ -69,6 +70,7 @@ export function QuizLeadCapture() {
       posthog.capture("quiz_lead_captured", {
         marketing_consent: accepted,
       })
+      trackMetaLeadCaptured(accepted)
       goNext()
     } catch {
       setError("Etwas ist schiefgelaufen. Bitte versuche es erneut.")

--- a/src/components/quiz/quiz-results.tsx
+++ b/src/components/quiz/quiz-results.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useRef } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { buildQuizResultNarrative } from "@/lib/quiz/result-narrative"
 import { getQuizResultCta } from "@/lib/quiz/result-cta"
 import { buildQuizShareConfig } from "@/lib/quiz/share"
 import { useQuizStore } from "@/lib/quiz/store"
+import { trackMetaQuizCompleted } from "@/lib/meta-pixel"
 import { isSubscriptionActive } from "@/lib/stripe/gating"
 import { useAuth } from "@/providers/auth-provider"
 import { posthog } from "@/providers/posthog-provider"
@@ -41,7 +42,7 @@ export function QuizResults() {
   const isCheckingSignedInSubscription = Boolean(user && leadId && (loading || profile === null))
   const cta = getQuizResultCta({ canGoStraightToRoutine })
 
-  const captureQuizCompleted = () => {
+  const captureQuizCompleted = useCallback(() => {
     if (checkoutAnalyticsCapturedRef.current) return
     checkoutAnalyticsCapturedRef.current = true
 
@@ -51,7 +52,12 @@ export function QuizResults() {
       scalp_type: answers.scalp_type,
       scalp_condition: answers.scalp_condition,
     })
-  }
+    trackMetaQuizCompleted()
+  }, [answers.scalp_condition, answers.scalp_type, answers.structure, answers.thickness])
+
+  useEffect(() => {
+    captureQuizCompleted()
+  }, [captureQuizCompleted])
 
   const handleStart = () => {
     captureQuizCompleted()

--- a/src/components/quiz/result-offer-pricing.tsx
+++ b/src/components/quiz/result-offer-pricing.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { EmbeddedCheckout, EmbeddedCheckoutProvider } from "@stripe/react-stripe-js"
 import { loadStripe } from "@stripe/stripe-js"
 
 import { Button } from "@/components/ui/button"
+import { trackMetaCheckoutStarted, trackMetaPricingViewed } from "@/lib/meta-pixel"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 import {
   DEFAULT_PRICING_INTERVAL,
@@ -35,6 +36,10 @@ export function ResultOfferPricing({
   const [checkoutInterval, setCheckoutInterval] = useState<BillingInterval | null>(null)
   const [checkoutError, setCheckoutError] = useState<string | null>(null)
   const selectedPlan = getStripePricingPlan(selectedInterval)
+
+  useEffect(() => {
+    trackMetaPricingViewed("quiz_result_offer_pricing")
+  }, [])
 
   function choosePlan(interval: BillingInterval) {
     setSelectedInterval(interval)
@@ -81,6 +86,8 @@ export function ResultOfferPricing({
       setCheckoutError(checkoutStartError)
       throw new Error("checkout session response missing client secret")
     }
+
+    trackMetaCheckoutStarted("quiz_result_offer", checkoutInterval)
 
     return data.client_secret
   }, [checkoutInterval, leadId])

--- a/src/lib/meta-pixel.ts
+++ b/src/lib/meta-pixel.ts
@@ -1,0 +1,244 @@
+import type { CookieConsent } from "@/lib/cookie-consent"
+
+const DEFAULT_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || "988892550357504"
+const META_SCRIPT_ID = "meta-pixel-script"
+const META_SCRIPT_SRC = "https://connect.facebook.net/en_US/fbevents.js"
+const SUBSCRIPTION_TRACKED_STORAGE_PREFIX = "chaarlie_meta_subscribe_tracked:"
+
+type MetaEventValue = string | number | boolean | null | undefined
+export type MetaEventProperties = Record<string, MetaEventValue>
+export type MetaStandardEvent =
+  | "PageView"
+  | "Lead"
+  | "InitiateCheckout"
+  | "Purchase"
+  | "Subscribe"
+  | "CompleteRegistration"
+  | "ViewContent"
+
+type Fbq = ((command: string, ...args: unknown[]) => void) & {
+  callMethod?: (...args: unknown[]) => void
+  loaded?: boolean
+  push?: Fbq
+  queue?: unknown[][]
+  version?: string
+}
+
+type MetaWindow = {
+  _fbq?: Fbq
+  fbq?: Fbq
+}
+
+type BrowserTargets = {
+  doc?: Document
+  pixelId?: string
+  win?: MetaWindow
+}
+
+const initializedPixelsByWindow = new WeakMap<object, Set<string>>()
+const enabledWindows = new WeakMap<object, boolean>()
+
+function getBrowserTargets(options: BrowserTargets = {}) {
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  const doc = options.doc ?? (typeof document === "undefined" ? undefined : document)
+  return { doc, pixelId: options.pixelId ?? DEFAULT_PIXEL_ID, win }
+}
+
+function sanitizeProperties(properties?: MetaEventProperties) {
+  if (!properties) return undefined
+
+  return Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined),
+  ) as Record<string, string | number | boolean | null>
+}
+
+function installFbq(win: MetaWindow, doc: Document) {
+  if (!win.fbq) {
+    const fbq = ((command: string, ...args: unknown[]) => {
+      if (fbq.callMethod) {
+        fbq.callMethod(command, ...args)
+        return
+      }
+      fbq.queue?.push([command, ...args])
+    }) as Fbq
+
+    fbq.push = fbq
+    fbq.loaded = true
+    fbq.version = "2.0"
+    fbq.queue = []
+    win.fbq = fbq
+    win._fbq = fbq
+  }
+
+  if (doc.getElementById(META_SCRIPT_ID)) return
+
+  const script = doc.createElement("script")
+  script.id = META_SCRIPT_ID
+  script.async = true
+  script.src = META_SCRIPT_SRC
+
+  const firstScript = doc.getElementsByTagName("script")[0]
+  if (firstScript?.parentNode) {
+    firstScript.parentNode.insertBefore(script, firstScript)
+    return
+  }
+
+  doc.head.appendChild(script)
+}
+
+export function canUseMetaPixel(consent: CookieConsent | null | undefined) {
+  return Boolean(DEFAULT_PIXEL_ID && consent?.marketing === true)
+}
+
+export function initMetaPixel(options: BrowserTargets = {}) {
+  const { doc, pixelId, win } = getBrowserTargets(options)
+  if (!pixelId || !win || !doc) return false
+
+  installFbq(win, doc)
+
+  const initializedPixels = initializedPixelsByWindow.get(win) ?? new Set<string>()
+  if (!initializedPixels.has(pixelId)) {
+    win.fbq?.("init", pixelId)
+    initializedPixels.add(pixelId)
+    initializedPixelsByWindow.set(win, initializedPixels)
+  }
+
+  return true
+}
+
+export function isMetaPixelReady(options: Pick<BrowserTargets, "win"> = {}) {
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  if (!win?.fbq) return false
+  return Boolean(initializedPixelsByWindow.get(win)?.size)
+}
+
+function isMetaPixelEnabled(win: MetaWindow) {
+  return enabledWindows.get(win) === true
+}
+
+export function grantMetaPixelConsent(options: Pick<BrowserTargets, "win"> = {}) {
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  if (!win?.fbq || !isMetaPixelReady({ win })) return false
+
+  enabledWindows.set(win, true)
+  win.fbq("consent", "grant")
+  return true
+}
+
+export function revokeMetaPixelConsent(options: Pick<BrowserTargets, "win"> = {}) {
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  if (!win?.fbq) return false
+
+  enabledWindows.set(win, false)
+  win.fbq("consent", "revoke")
+  return true
+}
+
+export function trackMetaEvent(
+  eventName: MetaStandardEvent,
+  properties?: MetaEventProperties,
+  options: Pick<BrowserTargets, "win"> = {},
+) {
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  if (!win?.fbq || !isMetaPixelReady({ win }) || !isMetaPixelEnabled(win)) return false
+
+  const cleanProperties = sanitizeProperties(properties)
+  if (cleanProperties && Object.keys(cleanProperties).length > 0) {
+    win.fbq("track", eventName, cleanProperties)
+  } else {
+    win.fbq("track", eventName)
+  }
+  return true
+}
+
+export function trackMetaCustomEvent(
+  eventName: string,
+  properties?: MetaEventProperties,
+  options: Pick<BrowserTargets, "win"> = {},
+) {
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  if (!win?.fbq || !isMetaPixelReady({ win }) || !isMetaPixelEnabled(win)) return false
+
+  const cleanProperties = sanitizeProperties(properties)
+  if (cleanProperties && Object.keys(cleanProperties).length > 0) {
+    win.fbq("trackCustom", eventName, cleanProperties)
+  } else {
+    win.fbq("trackCustom", eventName)
+  }
+  return true
+}
+
+export function trackMetaPageView(options: Pick<BrowserTargets, "win"> = {}) {
+  return trackMetaEvent("PageView", undefined, options)
+}
+
+export function trackMetaQuizStarted(stepName: string, stepNumber: number) {
+  return trackMetaCustomEvent("QuizStarted", {
+    step_name: stepName,
+    step_number: stepNumber,
+  })
+}
+
+export function trackMetaQuizStepViewed(stepName: string, stepNumber: number) {
+  return trackMetaCustomEvent("QuizStepViewed", {
+    step_name: stepName,
+    step_number: stepNumber,
+  })
+}
+
+export function trackMetaQuizCompleted() {
+  const properties = {
+    content_name: "quiz",
+    funnel_step: "quiz_completed",
+  }
+  const standardTracked = trackMetaEvent("CompleteRegistration", properties)
+  const customTracked = trackMetaCustomEvent("QuizCompleted", properties)
+  return standardTracked || customTracked
+}
+
+export function trackMetaLeadCaptured(marketingConsent: boolean) {
+  return trackMetaEvent("Lead", {
+    content_name: "quiz_lead_capture",
+    marketing_consent: marketingConsent,
+  })
+}
+
+export function trackMetaPricingViewed(source: "pricing_page" | "quiz_result_offer_pricing") {
+  return trackMetaEvent("ViewContent", {
+    content_name: source,
+  })
+}
+
+export function trackMetaCheckoutStarted(
+  source: "pricing_page" | "quiz_result_offer",
+  interval: string | null,
+) {
+  return trackMetaEvent("InitiateCheckout", {
+    content_name: source,
+    interval,
+  })
+}
+
+export function trackMetaSubscriptionConfirmed(sessionId: string) {
+  let storageKey: string | null = null
+  if (typeof window !== "undefined") {
+    storageKey = `${SUBSCRIPTION_TRACKED_STORAGE_PREFIX}${sessionId}`
+    if (window.sessionStorage.getItem(storageKey) === "1") return false
+  }
+
+  const tracked = trackMetaEvent("Subscribe", {
+    content_name: "premium_subscription",
+  })
+
+  if (tracked && storageKey) {
+    window.sessionStorage.setItem(storageKey, "1")
+  }
+
+  return tracked
+}

--- a/src/providers/meta-pixel-provider.tsx
+++ b/src/providers/meta-pixel-provider.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { Suspense, useEffect, useRef, useState } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+import { COOKIE_CONSENT_CHANGE_EVENT, loadConsent, type CookieConsent } from "@/lib/cookie-consent"
+import {
+  canUseMetaPixel,
+  grantMetaPixelConsent,
+  initMetaPixel,
+  revokeMetaPixelConsent,
+  trackMetaPageView,
+} from "@/lib/meta-pixel"
+
+function MetaPixelPageView({ marketingConsent }: { marketingConsent: boolean }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const lastPageViewRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!marketingConsent) return
+    if (!initMetaPixel()) return
+
+    const pageViewKey = `${pathname}?${searchParams?.toString() ?? ""}`
+    if (lastPageViewRef.current === pageViewKey) return
+    lastPageViewRef.current = pageViewKey
+
+    trackMetaPageView()
+  }, [marketingConsent, pathname, searchParams])
+
+  return null
+}
+
+export function MetaPixelProvider({ children }: { children: React.ReactNode }) {
+  const [marketingConsent, setMarketingConsent] = useState(false)
+
+  useEffect(() => {
+    const syncConsent = (consent: CookieConsent | null) => {
+      const canTrack = canUseMetaPixel(consent)
+      setMarketingConsent(canTrack)
+
+      if (canTrack) {
+        initMetaPixel()
+        grantMetaPixelConsent()
+      } else {
+        revokeMetaPixelConsent()
+      }
+    }
+
+    syncConsent(loadConsent())
+
+    const handleConsentChange = (event: Event) => {
+      const consent =
+        event instanceof CustomEvent ? (event.detail as CookieConsent | null) : loadConsent()
+      syncConsent(consent)
+    }
+
+    window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
+    return () => window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
+  }, [])
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <MetaPixelPageView marketingConsent={marketingConsent} />
+      </Suspense>
+      {children}
+    </>
+  )
+}

--- a/tests/meta-pixel.test.ts
+++ b/tests/meta-pixel.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  initMetaPixel,
+  isMetaPixelReady,
+  grantMetaPixelConsent,
+  revokeMetaPixelConsent,
+  trackMetaCustomEvent,
+  trackMetaEvent,
+  trackMetaPageView,
+} from "../src/lib/meta-pixel"
+
+function createMetaDom() {
+  const calls: unknown[][] = []
+  const insertedScripts: Array<{ async?: boolean; id?: string; src?: string }> = []
+  const scriptParent = {
+    insertBefore(node: { async?: boolean; id?: string; src?: string }) {
+      insertedScripts.push(node)
+    },
+  }
+  const doc = {
+    getElementById: (id: string) => insertedScripts.find((script) => script.id === id) ?? null,
+    createElement: () => ({ async: false, id: "", src: "" }),
+    getElementsByTagName: () => [{ parentNode: scriptParent }],
+    head: {
+      appendChild: (node: { async?: boolean; id?: string; src?: string }) =>
+        insertedScripts.push(node),
+    },
+  } as unknown as Document
+
+  return {
+    calls,
+    insertedScripts,
+    win: {} as Window & { fbq?: (...args: unknown[]) => void },
+    doc,
+  }
+}
+
+test("initMetaPixel injects fbevents and initializes the configured pixel once", () => {
+  const dom = createMetaDom()
+
+  assert.equal(initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc }), true)
+  assert.equal(isMetaPixelReady({ win: dom.win }), true)
+
+  const fbq = dom.win.fbq as ((...args: unknown[]) => void) & { queue?: unknown[][] }
+  assert.deepEqual(fbq.queue, [["init", "988892550357504"]])
+
+  dom.win.fbq = (...args: unknown[]) => dom.calls.push(args)
+  initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc })
+
+  assert.equal(dom.insertedScripts.length, 1)
+  assert.equal(dom.insertedScripts[0].async, true)
+  assert.equal(dom.insertedScripts[0].src, "https://connect.facebook.net/en_US/fbevents.js")
+  assert.deepEqual(dom.calls, [])
+})
+
+test("track helpers dispatch standard, custom, and page view events after initialization", () => {
+  const dom = createMetaDom()
+  initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc })
+
+  dom.win.fbq = (...args: unknown[]) => dom.calls.push(args)
+  grantMetaPixelConsent({ win: dom.win })
+
+  assert.equal(trackMetaPageView({ win: dom.win }), true)
+  assert.equal(trackMetaEvent("Lead", { content_name: "quiz" }, { win: dom.win }), true)
+  assert.equal(trackMetaCustomEvent("QuizStarted", { step: 1 }, { win: dom.win }), true)
+
+  assert.deepEqual(dom.calls, [
+    ["consent", "grant"],
+    ["track", "PageView"],
+    ["track", "Lead", { content_name: "quiz" }],
+    ["trackCustom", "QuizStarted", { step: 1 }],
+  ])
+})
+
+test("meta tracking stops after consent revoke and resumes after consent grant", () => {
+  const dom = createMetaDom()
+  initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc })
+  dom.win.fbq = (...args: unknown[]) => dom.calls.push(args)
+
+  grantMetaPixelConsent({ win: dom.win })
+  assert.equal(trackMetaEvent("Lead", { content_name: "first" }, { win: dom.win }), true)
+
+  assert.equal(revokeMetaPixelConsent({ win: dom.win }), true)
+  assert.equal(trackMetaEvent("Lead", { content_name: "revoked" }, { win: dom.win }), false)
+
+  assert.equal(grantMetaPixelConsent({ win: dom.win }), true)
+  assert.equal(trackMetaEvent("Lead", { content_name: "second" }, { win: dom.win }), true)
+
+  assert.deepEqual(dom.calls, [
+    ["consent", "grant"],
+    ["track", "Lead", { content_name: "first" }],
+    ["consent", "revoke"],
+    ["consent", "grant"],
+    ["track", "Lead", { content_name: "second" }],
+  ])
+})
+
+test("meta tracking does nothing without a pixel id or initialized fbq", () => {
+  const dom = createMetaDom()
+
+  assert.equal(initMetaPixel({ pixelId: "", win: dom.win, doc: dom.doc }), false)
+  assert.equal(trackMetaEvent("Lead", undefined, { win: dom.win }), false)
+  assert.equal(trackMetaCustomEvent("QuizStarted", undefined, { win: dom.win }), false)
+  assert.equal(trackMetaPageView({ win: dom.win }), false)
+  assert.equal(dom.insertedScripts.length, 0)
+})


### PR DESCRIPTION
## Summary
- Add a consent-gated Meta Pixel provider for route PageView tracking
- Centralize Meta funnel event helpers for quiz, lead, checkout, and subscription events
- Add consent revoke/re-grant gating, subscription dedupe, and unit coverage

## Verification
- npx tsx --test tests/meta-pixel.test.ts
- npm run typecheck
- npm run lint (existing unrelated warnings only)
- npm run build
- Browser smoke test: Meta script loads only after Marketing consent; route and quiz events fire; revocation blocks later tracking calls