### PR TITLE
fix(landing-faq): correct the 'Wie unterscheidet sich Chaarlie' answer

### DIFF
--- a/src/components/landing/faq.tsx
+++ b/src/components/landing/faq.tsx
@@ -11,7 +11,7 @@ const items: FaqItem[] = [
   {
     question: "Wie unterscheidet sich Chaarlie von anderen Beauty-Quizzes?",
     answer:
-      "Klassische Beauty-Quizzes fragen nach deinem Haartyp und schlagen dir eine Produkt-Range vor. Chaarlie analysiert sechs Dimensionen deines Haares (Struktur, Oberfläche, Kopfhaut, Feuchtigkeit, Protein, Glanz) und gibt dir konkrete Empfehlungen mit echten Produktnamen, inklusive Drogerie-Alternativen. Kein Verkauf eigener Produkte.",
+      "Klassische Beauty-Quizzes fragen nach deinem Haartyp und schlagen dir eine Produkt-Range vor. Chaarlie kombiniert zwei Dinge: dein vollständiges Haarprofil (Struktur, Oberfläche, Protein-Feuchtigkeit-Balance, Kopfhaut, chemische Behandlung) und deine tatsächliche Routine (Wäsche, Hitze-Styling, Trocknung, Bürste, Nachtpflege). Daraus bekommst du konkrete Empfehlungen mit echten Produktnamen — inklusive Drogerie-Alternativen. Kein Verkauf eigener Produkte.",
   },
   {
     question: "Brauche ich Vorwissen zur Haarpflege?",


### PR DESCRIPTION
## Summary
- Old answer claimed *'sechs Dimensionen (Struktur, Oberfläche, Kopfhaut, Feuchtigkeit, Protein, Glanz)'* — but:
  - Feuchtigkeit + Protein come from **one** Zugtest, not two dimensions
  - Glanz is not analysed — it's just a Goal option (`src/lib/vocabulary/concerns-goals.ts:40`)
  - 'sechs' didn't map to any engine output
- New framing splits the answer into the two real surfaces we capture: **hair profile** (quiz diagnostic) + **routine** (onboarding habits — wash, heat, drying, brush, night care)
- More honest *and* explains why Chaarlie is doing more than other quizzes

## Test plan
- [x] `npm run ci:verify` — typecheck + lint + build pass
- [x] `npm run test:node` — 267/267 pass (no test touches this string)
- [ ] Visual check on Vercel preview — confirm FAQ rendering looks right

## Follow-ups (NOT in this PR, flagged for cofounder)
- FAQ #5 *'Für jedes Salon-Produkt gibt es auch eine Drogerie-Alternative'* — universal claim; would be safer as *'meistens'*
- FAQ #6 Tom's role currently *'Friseurmeister Tom Hannemann begleitet das Team beratend'* — could be updated to reflect the new standardized *'Friseurmeister & Content Creator'* label from PR #117 (left untouched per that PR's note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)