### PR TITLE
fix(landing-faq): trim FAQ #1 brackets to 3 examples + etc.

### DIFF
--- a/src/components/landing/faq.tsx
+++ b/src/components/landing/faq.tsx
@@ -11,7 +11,7 @@ const items: FaqItem[] = [
   {
     question: "Wie unterscheidet sich Chaarlie von anderen Beauty-Quizzes?",
     answer:
-      "Klassische Beauty-Quizzes fragen nach deinem Haartyp und schlagen dir eine Produkt-Range vor. Chaarlie kombiniert zwei Dinge: dein vollständiges Haarprofil (Struktur, Oberfläche, Protein-Feuchtigkeit-Balance, Kopfhaut, chemische Behandlung) und deine tatsächliche Routine (Wäsche, Hitze-Styling, Trocknung, Bürste, Nachtpflege). Daraus bekommst du konkrete Empfehlungen mit echten Produktnamen — inklusive Drogerie-Alternativen. Kein Verkauf eigener Produkte.",
+      "Klassische Beauty-Quizzes fragen nach deinem Haartyp und schlagen dir eine Produkt-Range vor. Chaarlie kombiniert zwei Dinge: dein vollständiges Haarprofil (Struktur, Protein-Feuchtigkeit-Balance, Kopfhaut etc.) und deine tatsächliche Routine (Wäsche, Hitze-Styling, Nachtpflege etc.). Daraus bekommst du konkrete Empfehlungen mit echten Produktnamen — inklusive Drogerie-Alternativen. Kein Verkauf eigener Produkte.",
   },
   {
     question: "Brauche ich Vorwissen zur Haarpflege?",


### PR DESCRIPTION
## Summary
Per cofounder feedback on the just-merged #119: the bracket lists were exhaustive ("everything we asked for"). Trimmed each to 3 examples + 'etc.' so it reads as a teaser, not a feature dump.

- **Haarprofil**: Struktur, Protein-Feuchtigkeit-Balance, Kopfhaut etc. *(was: 5 items)*
- **Routine**: Wäsche, Hitze-Styling, Nachtpflege etc. *(was: 5 items)*

## Test plan
- [x] `npm run ci:verify` passes
- [ ] Visual check on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)