### PR TITLE
fix(pricing): restore Quartal/Jährlich longer-commitment savings (22% / 44%)

### DIFF
--- a/src/lib/stripe/pricing-plans.ts
+++ b/src/lib/stripe/pricing-plans.ts
@@ -29,7 +29,9 @@ export const STRIPE_PRICING_PLANS: readonly StripePricingPlan[] = [
     discountedPrice: "€17,49",
     perMonth: "~€5,83 / Monat",
     badge: "Beliebteste Wahl",
-    savings: "50% sparen",
+    // savings reflects per-month savings vs the monthly plan (longer-commitment benefit),
+    // NOT the Stripe coupon — the coupon's 50% off is communicated via the strikethrough.
+    savings: "22% sparen",
     ctaLabel: "Jetzt starten — €17,49 im Quartal",
   },
   {
@@ -38,7 +40,8 @@ export const STRIPE_PRICING_PLANS: readonly StripePricingPlan[] = [
     price: "€99,99",
     discountedPrice: "€49,99",
     perMonth: "~€4,16 / Monat",
-    savings: "50% sparen",
+    // savings reflects per-month savings vs the monthly plan, not the Stripe coupon.
+    savings: "44% sparen",
     ctaLabel: "Jetzt starten — €49,99 / Jahr",
   },
 ] as const


### PR DESCRIPTION
## Summary
The Quartal/Jährlich 'savings' badge had been overwritten to '50% sparen' in PR #117, conflating two distinct concepts on the page:

| Concept | Applies to | Communicated via |
|---------|-----------|------------------|
| Stripe coupon (50% off anchor) | All 3 plans equally | Strikethrough on every tier |
| Longer-commitment savings | Quartal (~22%), Jährlich (~44%) | `savings` badge |

Restoring the correct per-tier savings (22% / 44%) makes the page accurate again. The 50% beta-tester message will be communicated separately in copy.

## Test plan
- [x] `npm run ci:verify` passes
- [x] `npm run test:node` 267/267 pass
- [ ] Visual check on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)