### PR TITLE
feat(analytics): add Meta purchase tracking

### DIFF
--- a/plans/2026-05-26-meta-purchase-tracking.md
+++ b/plans/2026-05-26-meta-purchase-tracking.md
@@ -1,0 +1,157 @@
+# Meta Purchase tracking
+
+**Spec link:** Current decision thread, May 26 2026. No separate product spec yet.
+
+**User situation:** We already track lead, quiz, checkout start, and subscription confirmation with the browser Meta Pixel. We now need Meta to receive a value-bearing `Purchase` event after a paid Stripe checkout so Ads Manager can attribute paid subscriptions with amount and plan context.
+
+**Promised end-state:** After a successful Stripe subscription checkout returns to `/welcome?session_id=...`, Meta receives one browser `Purchase` event per Checkout Session with numeric value, currency, selected plan, and a coarse payment method type when safely available. The implementation must be shaped so a later server-side Conversions API event can reuse the same event ID and dedupe cleanly.
+
+**Branch:** `codex/meta-purchase-tracking` in `.worktrees/meta-purchase-tracking`.
+
+---
+
+## Decisions
+
+- **Immediate tracking layer:** Browser Pixel only, fired from the successful checkout return flow. This is fastest to ship and easiest to verify in Meta Events Manager.
+- **Purchase truth source:** Use a Stripe-verified Checkout Session on the server page, not client-side URL params or local plan state.
+- **Event identity:** Use the Stripe Checkout Session ID as the Meta `eventID` for `Purchase`. This gives us a stable future dedupe key for CAPI.
+- **Value/currency:** Use Stripe's actual first checkout total and currency from the verified session, normalized to a decimal value and uppercase ISO currency.
+- **Plan:** Derive the subscription interval from the retrieved subscription price, then send a stable content ID such as `premium_month`, `premium_quarter`, or `premium_year`.
+- **Payment method:** Send only a coarse payment method type if Stripe exposes it without fragile extra assumptions, e.g. `card`, `paypal`, or `sepa_debit`. Do not send card brand, last4, bank details, customer name, email, or any payment identifier to Meta. User approved this broad-only approach.
+- **Purchase + Subscribe:** Keep both `Subscribe` and `Purchase`. `Subscribe` remains the subscription conversion marker; `Purchase` adds value-bearing revenue data for Meta optimization/reporting.
+- **Purchase consent posture:** Fire `Purchase` regardless of marketing-cookie consent for the beta tracking phase. Keep all other Meta events on the existing marketing-consent gate.
+
+## Why Browser Now vs CAPI Later
+
+Browser `Purchase` now:
+
+- **Pros:** Smallest change, quick feedback in Meta Test Events, no Meta access token/env setup, no server event schema or hashing decisions.
+- **Cons:** Can be blocked by browsers/ad blockers, depends on the user reaching `/welcome`, and cannot help when the webhook confirms payment but the browser never returns.
+
+Server-side Conversions API later:
+
+- **Pros:** More reliable payment truth because it can run from Stripe webhook fulfillment, survives browser blockers and abandoned return flows, can improve event match quality when implemented carefully, and is the right long-term source for purchase attribution.
+- **Cons:** Needs Meta access token configuration, server payload construction, user-data hashing policy, event dedupe discipline, test-event plumbing, and careful privacy review.
+
+Chosen shape: ship browser `Purchase` now, but include `eventID: checkout_session_id` so CAPI can be added later without changing the event identity model.
+
+## Target File Map
+
+```
+src/lib/meta-pixel.ts
+  Add Purchase payload typing and a helper that sends `Purchase` with value/currency/plan/payment metadata and an eventID.
+
+src/app/welcome/page.tsx
+  Build verified purchase analytics data from the Stripe Checkout Session/subscription before rendering WelcomeClient.
+
+src/app/welcome/welcome-client.tsx
+  Fire `Purchase` once next to the existing `Subscribe` event.
+
+src/lib/stripe/checkout-activation.ts
+  Reuse or extract small helpers only if needed to derive interval/payment metadata without duplicating fragile Stripe parsing.
+
+tests/meta-pixel.test.ts
+  Assert Purchase sends value/currency/content IDs and passes Meta event options with eventID.
+
+tests/stripe-webhook-handlers.spec.ts or new focused test
+  Only if helper extraction touches Stripe subscription parsing.
+```
+
+## Scope Boundaries
+
+In scope:
+
+- Add browser Meta `Purchase` after verified successful Stripe checkout.
+- Include amount, currency, plan interval/content ID, and coarse payment method type if available.
+- Keep `Subscribe` as-is unless a tiny shared dedupe helper is needed.
+- Add focused tests for the Meta helper and any extracted Stripe purchase-data helper.
+
+Out of scope:
+
+- Meta Conversions API.
+- Hashing or sending email/name/IP/user-agent to Meta from the server.
+- Changing cookie consent behavior.
+- Changing Stripe checkout pricing, coupons, tax behavior, or entitlement logic.
+- Sending detailed payment details such as card brand, last4, issuer, bank, wallet account, or customer identifiers.
+
+## Implementation Steps
+
+- [x] Add a `MetaEventOptions` path to `trackMetaEvent` so a caller can pass `{ eventID }` as Meta's fourth `fbq` argument.
+- [x] Add `trackMetaPurchaseConfirmed(purchase)` in `src/lib/meta-pixel.ts`.
+  - Required fields: `eventId`, `value`, `currency`, `contentId`, `interval`.
+  - Optional field: `paymentMethodType`.
+  - Send standard event `Purchase`.
+  - Payload:
+    - `value`
+    - `currency`
+    - `content_name: "premium_subscription"`
+    - `content_ids: [contentId]` if array payloads fit the current helper typing, otherwise `content_id` as a custom field and revisit when CAPI lands.
+    - `content_type: "product"`
+    - `subscription_interval`
+    - `payment_method_type` only when present.
+  - Use sessionStorage dedupe keyed by Checkout Session ID.
+  - Intentionally initialize and fire even when marketing consent is absent; do not loosen the gate for other events.
+- [x] Create a small server-side purchase analytics builder for the welcome page.
+  - Input: verified Checkout Session plus Stripe client.
+  - Use `session.amount_total` and `session.currency` when available.
+  - Retrieve/inspect subscription price data to derive interval and content ID.
+  - Best-effort payment method type:
+    - Prefer the actual payment method type from an expanded payment intent/payment method when available.
+    - Fall back to omitting the field rather than sending an allowed-method list as if it were the actual method.
+- [x] Pass the purchase analytics object from `src/app/welcome/page.tsx` into `WelcomeClient`.
+- [x] In `WelcomeClient`, fire `trackMetaSubscriptionConfirmed(sessionId)` and `trackMetaPurchaseConfirmed(purchase)` from the same mount effect.
+- [x] Update tests.
+  - Existing consent tests must continue to prove revoked consent blocks all events.
+  - Add a test that Purchase includes numeric `value`, uppercase `currency`, product metadata, and the fourth fbq argument `{ eventID: sessionId }`.
+  - Add a dedupe test that repeating the same session ID does not send a second Purchase in the same browser session.
+
+## Verification
+
+Automated:
+
+- [x] `npx tsx --test tests/meta-pixel.test.ts tests/stripe-purchase-analytics.spec.ts`
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run build`
+
+Manual/browser:
+
+- [ ] Run the app with `npm run dev:worktree`.
+- [ ] Complete a Stripe test checkout from the quiz offer or pricing page.
+- [ ] Confirm `/welcome?session_id=...` renders normally.
+- [ ] In the browser console or Meta Pixel Helper, confirm one `Purchase` event fires with:
+  - `value`
+  - `currency: "EUR"`
+  - `content_name: "premium_subscription"`
+  - `content_ids` or equivalent stable content identifier
+  - `subscription_interval`
+  - `eventID` equal to the Checkout Session ID.
+- [ ] Refresh `/welcome?session_id=...` and confirm no duplicate Purchase fires in the same browser session.
+- [ ] In Meta Events Manager > Test Events, confirm `Purchase` appears after test checkout.
+
+## Locked Grill Decisions
+
+- Report actual Stripe `amount_total` because it includes discounts and tax and should reconcile better with revenue/ROAS.
+- Send only broad payment method type when safely available.
+- Keep both `Subscribe` and `Purchase`.
+- Fire `Purchase` regardless of marketing-cookie consent, while leaving other Meta events consent-gated.
+
+## CAPI Follow-Up Shape
+
+When ready, add server-side CAPI from the Stripe fulfillment path:
+
+- Fire from `checkout.session.completed` after `ensureCheckoutAccount` succeeds, and also handle delayed payment success if delayed payment methods are enabled.
+- Send `event_name: "Purchase"` and `event_id: checkout_session_id`.
+- Use the same value/currency/content ID model as browser Purchase.
+- Include only approved customer matching fields, hashed where Meta requires it.
+- Add env vars for Meta pixel ID/access token/test event code.
+- Verify in Meta Test Events that browser and server Purchase arrive as one deduplicated conversion, not two purchases.
+
+## Notes
+
+- Stripe's Checkout fulfillment docs describe webhooks plus the return page as the recommended fulfillment pattern, and note delayed payment methods separately. Our current account activation already uses this pattern.
+- Meta's Pixel/CAPI dedupe model depends on browser and server events sharing the same event name and event ID. Using the Checkout Session ID now avoids a future migration of purchase identity.
+
+## Next Skill
+
+Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` next, after the grill questions above are settled enough to implement.

--- a/src/app/welcome/checkout-return-analytics.tsx
+++ b/src/app/welcome/checkout-return-analytics.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect, useRef } from "react"
+import { trackMetaPurchaseConfirmed, trackMetaSubscriptionConfirmed } from "@/lib/meta-pixel"
+import type { MetaPurchasePayload } from "@/lib/meta-pixel"
+
+export function CheckoutReturnAnalytics({
+  purchase,
+  redirectTo,
+  sessionId,
+}: {
+  purchase: MetaPurchasePayload | null
+  redirectTo?: string
+  sessionId: string
+}) {
+  const router = useRouter()
+  const trackedRef = useRef(false)
+
+  useEffect(() => {
+    if (trackedRef.current) return
+    trackedRef.current = true
+
+    try {
+      trackMetaSubscriptionConfirmed(sessionId)
+      if (purchase) {
+        trackMetaPurchaseConfirmed(purchase)
+      }
+    } catch (err) {
+      console.error("[welcome] checkout analytics failed:", err)
+    } finally {
+      if (redirectTo) {
+        router.replace(redirectTo)
+      }
+    }
+  }, [purchase, redirectTo, router, sessionId])
+
+  return null
+}

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -9,6 +9,7 @@ import {
   ensureCheckoutAccount,
   verifyCheckoutSessionForActivation,
 } from "@/lib/stripe/checkout-activation"
+import { buildMetaPurchaseAnalytics } from "@/lib/stripe/purchase-analytics"
 import { WelcomeClient } from "./welcome-client"
 
 export const dynamic = "force-dynamic"
@@ -32,6 +33,10 @@ export default async function WelcomePage({
 
   const email = session.customer_details?.email
   if (!email) redirect("/")
+  const purchaseAnalytics = await buildMetaPurchaseAnalytics(session, stripe).catch((err) => {
+    console.error("[welcome] purchase analytics unavailable:", err)
+    return null
+  })
 
   const supabase = await createClient()
   const {
@@ -45,10 +50,17 @@ export default async function WelcomePage({
       premiumTierId: await getPremiumTierId(admin),
       linkQuizToProfile,
     })
-    redirect("/onboarding")
+    return (
+      <WelcomeClient
+        email={email}
+        purchase={purchaseAnalytics}
+        redirectTo="/onboarding"
+        sessionId={session_id}
+      />
+    )
   }
 
-  return <WelcomeClient email={email} sessionId={session_id} />
+  return <WelcomeClient email={email} purchase={purchaseAnalytics} sessionId={session_id} />
 }
 
 async function getPremiumTierId(supabase: SupabaseClient): Promise<string> {

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -2,15 +2,18 @@
 
 import { CheckCircle, Mail } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useEffect, useRef, useState, type FormEvent } from "react"
+import { useState, type FormEvent } from "react"
 import { PasswordPolicyChecklist } from "@/components/auth/password-policy-checklist"
 import { Input } from "@/components/ui/input"
 import { validatePasswordDraft } from "@/lib/auth/password-policy"
-import { trackMetaSubscriptionConfirmed } from "@/lib/meta-pixel"
+import type { MetaPurchasePayload } from "@/lib/meta-pixel"
 import { createClient } from "@/lib/supabase/client"
+import { CheckoutReturnAnalytics } from "./checkout-return-analytics"
 
 interface WelcomeClientProps {
   email: string
+  purchase: MetaPurchasePayload | null
+  redirectTo?: string
   sessionId: string
 }
 
@@ -25,7 +28,7 @@ const UNKNOWN_ERROR = "Unbekannter Fehler"
 const MAGIC_LINK_BODY =
   "Wir senden dir einen sicheren Login-Link. Du klickst ihn im Postfach an und bist direkt angemeldet."
 
-export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
+export function WelcomeClient({ email, purchase, redirectTo, sessionId }: WelcomeClientProps) {
   const router = useRouter()
   const supabase = createClient()
 
@@ -35,13 +38,6 @@ export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
   const [confirmPassword, setConfirmPassword] = useState("")
   const [message, setMessage] = useState<string | null>(null)
   const [highlightMagicLink, setHighlightMagicLink] = useState(false)
-  const subscriptionTrackedRef = useRef(false)
-
-  useEffect(() => {
-    if (subscriptionTrackedRef.current) return
-    subscriptionTrackedRef.current = true
-    trackMetaSubscriptionConfirmed(sessionId)
-  }, [sessionId])
 
   async function handleCreatePassword(e: FormEvent) {
     e.preventDefault()
@@ -113,147 +109,177 @@ export function WelcomeClient({ email, sessionId }: WelcomeClientProps) {
     }
   }
 
+  if (redirectTo) {
+    return (
+      <>
+        <CheckoutReturnAnalytics
+          purchase={purchase}
+          redirectTo={redirectTo}
+          sessionId={sessionId}
+        />
+        <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-10">
+          <div className="w-full max-w-md space-y-4 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <CheckCircle className="h-6 w-6 text-green-600" />
+            </div>
+            <p className="text-sm font-medium text-primary">Zahlung erfolgreich</p>
+            <h1 className="font-header text-3xl">Weiterleitung...</h1>
+          </div>
+        </main>
+      </>
+    )
+  }
+
   if (state.view === "sent") {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-10">
-        <div className="w-full max-w-md space-y-6 text-center">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-            <Mail className="h-6 w-6 text-primary" />
+      <>
+        <CheckoutReturnAnalytics purchase={purchase} sessionId={sessionId} />
+        <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-10">
+          <div className="w-full max-w-md space-y-6 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <Mail className="h-6 w-6 text-primary" />
+            </div>
+            <h1 className="font-header text-3xl">Check deine E-Mails</h1>
+            <p className="text-base text-muted-foreground">
+              Wir haben dir einen Login-Link geschickt.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Keine E-Mail erhalten? Prüfe deinen Spam-Ordner oder warte 1-2 Minuten.
+            </p>
           </div>
-          <h1 className="font-header text-3xl">Check deine E-Mails</h1>
-          <p className="text-base text-muted-foreground">
-            Wir haben dir einen Login-Link geschickt.
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Keine E-Mail erhalten? Prüfe deinen Spam-Ordner oder warte 1-2 Minuten.
-          </p>
-        </div>
-      </main>
+        </main>
+      </>
     )
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8">
-      <div className="w-full max-w-4xl space-y-6">
-        <div className="space-y-4 text-center">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
-            <CheckCircle className="h-6 w-6 text-green-600" />
-          </div>
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-primary">Zahlung erfolgreich</p>
-            <h1 className="font-header text-3xl text-foreground sm:text-4xl">Konto aktivieren</h1>
-            <p className="text-base text-muted-foreground">
-              Wähle, wie du dich bei Chaarlie anmelden möchtest.
-            </p>
-          </div>
-        </div>
-
-        <div className="mx-auto w-full max-w-md space-y-2">
-          <label htmlFor="checkout-email" className="text-sm font-medium text-foreground">
-            E-Mail aus deinem Checkout
-          </label>
-          <Input
-            id="checkout-email"
-            value={email}
-            readOnly
-            aria-readonly="true"
-            className="h-11 bg-muted/60 text-center"
-          />
-        </div>
-
-        {message && (
-          <div className="mx-auto w-full max-w-2xl rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
-            {message}
-          </div>
-        )}
-
-        <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
-          <section className="flex min-h-[360px] flex-col rounded-lg border bg-card p-5 shadow-sm">
+    <>
+      <CheckoutReturnAnalytics purchase={purchase} sessionId={sessionId} />
+      <main className="flex min-h-screen flex-col items-center justify-center bg-background px-4 py-8">
+        <div className="w-full max-w-4xl space-y-6">
+          <div className="space-y-4 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <CheckCircle className="h-6 w-6 text-green-600" />
+            </div>
             <div className="space-y-2">
-              <h2 className="text-xl font-semibold text-foreground">Mit Passwort fortfahren</h2>
-              <p className="min-h-[72px] text-sm leading-6 text-muted-foreground">
-                Erstelle ein Passwort und melde dich künftig direkt mit deiner E-Mail an.
+              <p className="text-sm font-medium text-primary">Zahlung erfolgreich</p>
+              <h1 className="font-header text-3xl text-foreground sm:text-4xl">Konto aktivieren</h1>
+              <p className="text-base text-muted-foreground">
+                Wähle, wie du dich bei Chaarlie anmelden möchtest.
               </p>
             </div>
+          </div>
 
-            <form onSubmit={handleCreatePassword} className="mt-5 flex flex-1 flex-col">
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <label htmlFor="password" className="text-sm font-medium text-foreground">
-                    Passwort
-                  </label>
-                  <Input
-                    id="password"
-                    type="password"
-                    value={password}
-                    onChange={(event) => setPassword(event.target.value)}
-                    disabled={loading !== null}
-                    minLength={8}
-                    required
-                    autoComplete="new-password"
-                    className="h-11"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label htmlFor="confirm-password" className="text-sm font-medium text-foreground">
-                    Passwort wiederholen
-                  </label>
-                  <Input
-                    id="confirm-password"
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(event) => setConfirmPassword(event.target.value)}
-                    disabled={loading !== null}
-                    minLength={8}
-                    required
-                    autoComplete="new-password"
-                    className="h-11"
-                  />
-                </div>
-                <PasswordPolicyChecklist
-                  password={password}
-                  confirmPassword={confirmPassword}
-                  context="create"
-                />
+          <div className="mx-auto w-full max-w-md space-y-2">
+            <label htmlFor="checkout-email" className="text-sm font-medium text-foreground">
+              E-Mail aus deinem Checkout
+            </label>
+            <Input
+              id="checkout-email"
+              value={email}
+              readOnly
+              aria-readonly="true"
+              className="h-11 bg-muted/60 text-center"
+            />
+          </div>
+
+          {message && (
+            <div className="mx-auto w-full max-w-2xl rounded-lg bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
+              {message}
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
+            <section className="flex min-h-[360px] flex-col rounded-lg border bg-card p-5 shadow-sm">
+              <div className="space-y-2">
+                <h2 className="text-xl font-semibold text-foreground">Mit Passwort fortfahren</h2>
+                <p className="min-h-[72px] text-sm leading-6 text-muted-foreground">
+                  Erstelle ein Passwort und melde dich künftig direkt mit deiner E-Mail an.
+                </p>
               </div>
 
-              <button
-                type="submit"
-                disabled={loading !== null || !password || !confirmPassword}
-                className="mt-auto inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-primary bg-transparent px-6 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
-              >
-                {loading === "password" ? "Wird erstellt..." : "Passwort erstellen"}
-              </button>
-            </form>
-          </section>
+              <form onSubmit={handleCreatePassword} className="mt-5 flex flex-1 flex-col">
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <label htmlFor="password" className="text-sm font-medium text-foreground">
+                      Passwort
+                    </label>
+                    <Input
+                      id="password"
+                      type="password"
+                      value={password}
+                      onChange={(event) => setPassword(event.target.value)}
+                      disabled={loading !== null}
+                      minLength={8}
+                      required
+                      autoComplete="new-password"
+                      className="h-11"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="confirm-password"
+                      className="text-sm font-medium text-foreground"
+                    >
+                      Passwort wiederholen
+                    </label>
+                    <Input
+                      id="confirm-password"
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(event) => setConfirmPassword(event.target.value)}
+                      disabled={loading !== null}
+                      minLength={8}
+                      required
+                      autoComplete="new-password"
+                      className="h-11"
+                    />
+                  </div>
+                  <PasswordPolicyChecklist
+                    password={password}
+                    confirmPassword={confirmPassword}
+                    context="create"
+                  />
+                </div>
 
-          <section
-            className={[
-              "flex min-h-[360px] flex-col rounded-lg border bg-card p-5 shadow-sm transition-colors",
-              highlightMagicLink ? "border-primary bg-primary/5" : "",
-            ].join(" ")}
-          >
-            <div className="space-y-2">
-              <h2 className="text-xl font-semibold text-foreground">Ohne Passwort fortfahren</h2>
-              <p className="min-h-[72px] text-sm leading-6 text-muted-foreground">
-                {MAGIC_LINK_BODY}
-              </p>
-            </div>
+                <button
+                  type="submit"
+                  disabled={loading !== null || !password || !confirmPassword}
+                  className="mt-auto inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-primary bg-transparent px-6 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+                >
+                  {loading === "password" ? "Wird erstellt..." : "Passwort erstellen"}
+                </button>
+              </form>
+            </section>
 
-            <div className="mt-5 flex flex-1 flex-col justify-end">
-              <button
-                type="button"
-                onClick={handleMagicLink}
-                disabled={loading !== null}
-                className="inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-primary bg-transparent px-6 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
-              >
-                {loading === "magic_link" ? "Wird gesendet..." : "Login-Link senden"}
-              </button>
-            </div>
-          </section>
+            <section
+              className={[
+                "flex min-h-[360px] flex-col rounded-lg border bg-card p-5 shadow-sm transition-colors",
+                highlightMagicLink ? "border-primary bg-primary/5" : "",
+              ].join(" ")}
+            >
+              <div className="space-y-2">
+                <h2 className="text-xl font-semibold text-foreground">Ohne Passwort fortfahren</h2>
+                <p className="min-h-[72px] text-sm leading-6 text-muted-foreground">
+                  {MAGIC_LINK_BODY}
+                </p>
+              </div>
+
+              <div className="mt-5 flex flex-1 flex-col justify-end">
+                <button
+                  type="button"
+                  onClick={handleMagicLink}
+                  disabled={loading !== null}
+                  className="inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-primary bg-transparent px-6 py-3 text-sm font-medium text-primary transition-colors hover:bg-primary/10 disabled:opacity-50"
+                >
+                  {loading === "magic_link" ? "Wird gesendet..." : "Login-Link senden"}
+                </button>
+              </div>
+            </section>
+          </div>
         </div>
-      </div>
-    </main>
+      </main>
+    </>
   )
 }
 

--- a/src/lib/meta-pixel.ts
+++ b/src/lib/meta-pixel.ts
@@ -4,8 +4,9 @@ const DEFAULT_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || "9888925503575
 const META_SCRIPT_ID = "meta-pixel-script"
 const META_SCRIPT_SRC = "https://connect.facebook.net/en_US/fbevents.js"
 const SUBSCRIPTION_TRACKED_STORAGE_PREFIX = "chaarlie_meta_subscribe_tracked:"
+const PURCHASE_TRACKED_STORAGE_PREFIX = "chaarlie_meta_purchase_tracked:"
 
-type MetaEventValue = string | number | boolean | null | undefined
+type MetaEventValue = string | number | boolean | null | undefined | string[]
 export type MetaEventProperties = Record<string, MetaEventValue>
 export type MetaStandardEvent =
   | "PageView"
@@ -35,6 +36,23 @@ type BrowserTargets = {
   win?: MetaWindow
 }
 
+type MetaTrackOptions = BrowserTargets & {
+  eventID?: string
+}
+
+type MetaDispatchOptions = MetaTrackOptions & {
+  bypassConsent?: boolean
+}
+
+export type MetaPurchasePayload = {
+  contentId: string
+  currency: string
+  eventId: string
+  interval: string
+  paymentMethodType?: string
+  value: number
+}
+
 const initializedPixelsByWindow = new WeakMap<object, Set<string>>()
 const enabledWindows = new WeakMap<object, boolean>()
 
@@ -50,7 +68,7 @@ function sanitizeProperties(properties?: MetaEventProperties) {
 
   return Object.fromEntries(
     Object.entries(properties).filter(([, value]) => value !== undefined),
-  ) as Record<string, string | number | boolean | null>
+  ) as Record<string, Exclude<MetaEventValue, undefined>>
 }
 
 function installFbq(win: MetaWindow, doc: Document) {
@@ -118,6 +136,32 @@ function isMetaPixelEnabled(win: MetaWindow) {
   return enabledWindows.get(win) === true
 }
 
+function getBrowserSessionStorage(win: MetaWindow | undefined) {
+  if (!win) return undefined
+  try {
+    if (typeof window !== "undefined" && win === window) return window.sessionStorage
+    return (win as MetaWindow & { sessionStorage?: Storage }).sessionStorage
+  } catch {
+    return undefined
+  }
+}
+
+function safeStorageGet(storage: Storage | undefined, key: string) {
+  try {
+    return storage?.getItem(key) ?? null
+  } catch {
+    return null
+  }
+}
+
+function safeStorageSet(storage: Storage | undefined, key: string, value: string) {
+  try {
+    storage?.setItem(key, value)
+  } catch {
+    // Tracking storage is best effort; never let analytics block checkout flow.
+  }
+}
+
 export function grantMetaPixelConsent(options: Pick<BrowserTargets, "win"> = {}) {
   const win =
     options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
@@ -141,18 +185,45 @@ export function revokeMetaPixelConsent(options: Pick<BrowserTargets, "win"> = {}
 export function trackMetaEvent(
   eventName: MetaStandardEvent,
   properties?: MetaEventProperties,
-  options: Pick<BrowserTargets, "win"> = {},
+  options: MetaTrackOptions = {},
+) {
+  return dispatchMetaEvent(eventName, properties, options)
+}
+
+function dispatchMetaEvent(
+  eventName: MetaStandardEvent,
+  properties?: MetaEventProperties,
+  options: MetaDispatchOptions = {},
 ) {
   const win =
     options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
-  if (!win?.fbq || !isMetaPixelReady({ win }) || !isMetaPixelEnabled(win)) return false
+  if (!win?.fbq || !isMetaPixelReady({ win })) return false
+  if (!options.bypassConsent && !isMetaPixelEnabled(win)) return false
 
   const cleanProperties = sanitizeProperties(properties)
+  const eventOptions = options.eventID ? { eventID: options.eventID } : undefined
+  const wasEnabled = isMetaPixelEnabled(win)
+
+  if (options.bypassConsent && !wasEnabled) {
+    win.fbq("consent", "grant")
+  }
+
   if (cleanProperties && Object.keys(cleanProperties).length > 0) {
-    win.fbq("track", eventName, cleanProperties)
+    if (eventOptions) {
+      win.fbq("track", eventName, cleanProperties, eventOptions)
+    } else {
+      win.fbq("track", eventName, cleanProperties)
+    }
+  } else if (eventOptions) {
+    win.fbq("track", eventName, {}, eventOptions)
   } else {
     win.fbq("track", eventName)
   }
+
+  if (options.bypassConsent && !wasEnabled) {
+    win.fbq("consent", "revoke")
+  }
+
   return true
 }
 
@@ -225,19 +296,70 @@ export function trackMetaCheckoutStarted(
   })
 }
 
-export function trackMetaSubscriptionConfirmed(sessionId: string) {
+export function trackMetaSubscriptionConfirmed(
+  sessionId: string,
+  options: Pick<BrowserTargets, "win"> = {},
+) {
   let storageKey: string | null = null
-  if (typeof window !== "undefined") {
+  const storage = getBrowserSessionStorage(
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow)),
+  )
+  if (storage) {
     storageKey = `${SUBSCRIPTION_TRACKED_STORAGE_PREFIX}${sessionId}`
-    if (window.sessionStorage.getItem(storageKey) === "1") return false
+    if (safeStorageGet(storage, storageKey) === "1") return false
   }
 
-  const tracked = trackMetaEvent("Subscribe", {
-    content_name: "premium_subscription",
-  })
+  const tracked = trackMetaEvent(
+    "Subscribe",
+    {
+      content_name: "premium_subscription",
+    },
+    options,
+  )
 
   if (tracked && storageKey) {
-    window.sessionStorage.setItem(storageKey, "1")
+    safeStorageSet(storage, storageKey, "1")
+  }
+
+  return tracked
+}
+
+export function trackMetaPurchaseConfirmed(
+  purchase: MetaPurchasePayload,
+  options: BrowserTargets = {},
+) {
+  let storageKey: string | null = null
+  const win =
+    options.win ?? (typeof window === "undefined" ? undefined : (window as unknown as MetaWindow))
+  const storage = getBrowserSessionStorage(win)
+
+  if (storage) {
+    storageKey = `${PURCHASE_TRACKED_STORAGE_PREFIX}${purchase.eventId}`
+    if (safeStorageGet(storage, storageKey) === "1") return false
+  }
+
+  if (!initMetaPixel(options)) return false
+
+  const tracked = dispatchMetaEvent(
+    "Purchase",
+    {
+      content_ids: [purchase.contentId],
+      content_name: "premium_subscription",
+      content_type: "product",
+      currency: purchase.currency.toUpperCase(),
+      payment_method_type: purchase.paymentMethodType,
+      subscription_interval: purchase.interval,
+      value: purchase.value,
+    },
+    {
+      ...options,
+      bypassConsent: true,
+      eventID: purchase.eventId,
+    },
+  )
+
+  if (tracked && storageKey) {
+    safeStorageSet(storage, storageKey, "1")
   }
 
   return tracked

--- a/src/lib/stripe/purchase-analytics.ts
+++ b/src/lib/stripe/purchase-analytics.ts
@@ -1,0 +1,65 @@
+import type Stripe from "stripe"
+import { intervalFromPrice, type BillingInterval } from "./intervals"
+import type { MetaPurchasePayload } from "@/lib/meta-pixel"
+
+type RetrievedSubscription = {
+  items: {
+    data: Array<{
+      price: {
+        recurring?: { interval: string; interval_count: number }
+        interval?: string
+        interval_count?: number
+      }
+    }>
+  }
+}
+
+function subscriptionIdFromSession(session: Stripe.Checkout.Session) {
+  if (typeof session.subscription === "string") return session.subscription
+  return session.subscription?.id
+}
+
+function singleAllowedPaymentMethodTypeFromSession(session: Stripe.Checkout.Session) {
+  const methodTypes = session.payment_method_types
+  if (methodTypes?.length !== 1) return undefined
+  return methodTypes[0]
+}
+
+function contentIdForInterval(interval: BillingInterval) {
+  return `premium_${interval}`
+}
+
+export async function buildMetaPurchaseAnalytics(
+  session: Stripe.Checkout.Session,
+  stripe: Stripe,
+): Promise<MetaPurchasePayload | null> {
+  const subscriptionId = subscriptionIdFromSession(session)
+  if (
+    !session.id ||
+    typeof session.amount_total !== "number" ||
+    !session.currency ||
+    !subscriptionId
+  ) {
+    return null
+  }
+
+  const subscription = (await stripe.subscriptions.retrieve(subscriptionId, {
+    expand: ["items.data.price"],
+  })) as unknown as RetrievedSubscription
+  const price = subscription.items.data[0]?.price
+  if (!price) return null
+
+  const interval = intervalFromPrice({
+    interval: price.recurring?.interval ?? price.interval ?? "",
+    interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
+  })
+
+  return {
+    contentId: contentIdForInterval(interval),
+    currency: session.currency.toUpperCase(),
+    eventId: session.id,
+    interval,
+    paymentMethodType: singleAllowedPaymentMethodTypeFromSession(session),
+    value: session.amount_total / 100,
+  }
+}

--- a/tests/meta-pixel.test.ts
+++ b/tests/meta-pixel.test.ts
@@ -9,11 +9,14 @@ import {
   trackMetaCustomEvent,
   trackMetaEvent,
   trackMetaPageView,
+  trackMetaPurchaseConfirmed,
+  trackMetaSubscriptionConfirmed,
 } from "../src/lib/meta-pixel"
 
-function createMetaDom() {
+function createMetaDom(options: { storageThrows?: boolean } = {}) {
   const calls: unknown[][] = []
   const insertedScripts: Array<{ async?: boolean; id?: string; src?: string }> = []
+  const storage = new Map<string, string>()
   const scriptParent = {
     insertBefore(node: { async?: boolean; id?: string; src?: string }) {
       insertedScripts.push(node)
@@ -32,7 +35,18 @@ function createMetaDom() {
   return {
     calls,
     insertedScripts,
-    win: {} as Window & { fbq?: (...args: unknown[]) => void },
+    win: {
+      sessionStorage: {
+        getItem: (key: string) => {
+          if (options.storageThrows) throw new Error("storage unavailable")
+          return storage.get(key) ?? null
+        },
+        setItem: (key: string, value: string) => {
+          if (options.storageThrows) throw new Error("storage unavailable")
+          storage.set(key, value)
+        },
+      },
+    } as unknown as Window & { fbq?: (...args: unknown[]) => void },
     doc,
   }
 }
@@ -105,4 +119,88 @@ test("meta tracking does nothing without a pixel id or initialized fbq", () => {
   assert.equal(trackMetaCustomEvent("QuizStarted", undefined, { win: dom.win }), false)
   assert.equal(trackMetaPageView({ win: dom.win }), false)
   assert.equal(dom.insertedScripts.length, 0)
+})
+
+test("purchase tracking fires with value metadata and event id even without consent", () => {
+  const dom = createMetaDom()
+  initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc })
+  dom.win.fbq = (...args: unknown[]) => dom.calls.push(args)
+
+  assert.equal(
+    trackMetaPurchaseConfirmed(
+      {
+        contentId: "premium_quarter",
+        currency: "EUR",
+        eventId: "cs_test_purchase",
+        interval: "quarter",
+        paymentMethodType: "card",
+        value: 17.49,
+      },
+      { doc: dom.doc, win: dom.win },
+    ),
+    true,
+  )
+
+  assert.deepEqual(dom.calls, [
+    ["consent", "grant"],
+    [
+      "track",
+      "Purchase",
+      {
+        content_ids: ["premium_quarter"],
+        content_name: "premium_subscription",
+        content_type: "product",
+        currency: "EUR",
+        payment_method_type: "card",
+        subscription_interval: "quarter",
+        value: 17.49,
+      },
+      { eventID: "cs_test_purchase" },
+    ],
+    ["consent", "revoke"],
+  ])
+})
+
+test("purchase tracking dedupes the same checkout session in browser storage", () => {
+  const dom = createMetaDom()
+  initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc })
+  dom.win.fbq = (...args: unknown[]) => dom.calls.push(args)
+
+  const purchase = {
+    contentId: "premium_month",
+    currency: "EUR",
+    eventId: "cs_test_dedupe",
+    interval: "month",
+    value: 7.49,
+  } as const
+
+  assert.equal(trackMetaPurchaseConfirmed(purchase, { doc: dom.doc, win: dom.win }), true)
+  assert.equal(trackMetaPurchaseConfirmed(purchase, { doc: dom.doc, win: dom.win }), false)
+
+  assert.equal(dom.calls.filter((call) => call[1] === "Purchase").length, 1)
+})
+
+test("subscription and purchase tracking remain best-effort when session storage throws", () => {
+  const dom = createMetaDom({ storageThrows: true })
+  initMetaPixel({ pixelId: "988892550357504", win: dom.win, doc: dom.doc })
+  dom.win.fbq = (...args: unknown[]) => dom.calls.push(args)
+  grantMetaPixelConsent({ win: dom.win })
+
+  assert.equal(trackMetaSubscriptionConfirmed("cs_storage_blocked", { win: dom.win }), true)
+  assert.equal(
+    trackMetaPurchaseConfirmed(
+      {
+        contentId: "premium_month",
+        currency: "EUR",
+        eventId: "cs_storage_blocked",
+        interval: "month",
+        value: 7.49,
+      },
+      { doc: dom.doc, win: dom.win },
+    ),
+    true,
+  )
+
+  assert.equal(dom.calls.filter((call) => call[1] === "Subscribe").length, 1)
+  assert.equal(dom.calls.filter((call) => call[1] === "Purchase").length, 1)
 })

--- a/tests/stripe-purchase-analytics.spec.ts
+++ b/tests/stripe-purchase-analytics.spec.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { buildMetaPurchaseAnalytics } from "../src/lib/stripe/purchase-analytics"
+
+test("buildMetaPurchaseAnalytics maps Stripe final total, currency, plan, and broad payment method", async () => {
+  const retrieveCalls: unknown[][] = []
+  const stripe = {
+    subscriptions: {
+      async retrieve(...args: unknown[]) {
+        retrieveCalls.push(args)
+        return {
+          id: "sub_123",
+          items: {
+            data: [
+              {
+                price: {
+                  recurring: { interval: "month", interval_count: 3 },
+                },
+              },
+            ],
+          },
+        }
+      },
+    },
+  }
+
+  const result = await buildMetaPurchaseAnalytics(
+    {
+      amount_total: 1749,
+      currency: "eur",
+      id: "cs_test_123",
+      payment_method_types: ["card"],
+      subscription: "sub_123",
+    } as any,
+    stripe as any,
+  )
+
+  assert.deepEqual(result, {
+    contentId: "premium_quarter",
+    currency: "EUR",
+    eventId: "cs_test_123",
+    interval: "quarter",
+    paymentMethodType: "card",
+    value: 17.49,
+  })
+  assert.equal(retrieveCalls.length, 1)
+})
+
+test("buildMetaPurchaseAnalytics omits ambiguous payment method lists", async () => {
+  const stripe = {
+    subscriptions: {
+      async retrieve() {
+        return {
+          id: "sub_123",
+          items: {
+            data: [
+              {
+                price: {
+                  recurring: { interval: "month", interval_count: 1 },
+                },
+              },
+            ],
+          },
+        }
+      },
+    },
+  }
+
+  const result = await buildMetaPurchaseAnalytics(
+    {
+      amount_total: 749,
+      currency: "eur",
+      id: "cs_test_ambiguous",
+      payment_method_types: ["card", "paypal"],
+      subscription: "sub_123",
+    } as any,
+    stripe as any,
+  )
+
+  assert.equal(result?.paymentMethodType, undefined)
+})


### PR DESCRIPTION
## Summary
- add a value-bearing Meta Pixel Purchase event on successful Stripe checkout return
- build Purchase payload from Stripe-verified checkout/subscription data with value, currency, plan interval, content ID, broad payment method, and Checkout Session eventID
- keep Subscribe tracking while making Purchase intentionally bypass marketing-cookie consent for beta tracking
- harden checkout-return analytics so tracking failures do not block logged-in users from reaching onboarding

## Verification
- npx tsx --test tests/meta-pixel.test.ts tests/stripe-purchase-analytics.spec.ts
- npm run typecheck
- npm run lint (passes with existing unrelated warnings)
- npm run build

## Notes
- Local /welcome smoke was blocked in the worktree because STRIPE_SECRET_KEY is absent from .env.local.
- CAPI remains a later follow-up; this branch uses the Checkout Session ID as eventID so browser/server dedupe can reuse it.