### PR TITLE
Affiliate link backfill: 226/227 products linked + 43 name/brand corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,8 @@ test-screenshots*/
 
 # local eval / compare-lab artifacts
 /tmp/
+
+# Affiliate link research artefacts (regenerated; safe to delete)
+!/data/affiliate-research/
+/data/affiliate-research/*
+!/data/affiliate-research/.gitkeep

--- a/docs/plans/2026-05-14-affiliate-research-name-changes.md
+++ b/docs/plans/2026-05-14-affiliate-research-name-changes.md
@@ -1,0 +1,224 @@
+# Product Name & Brand Migration — Affiliate Link Enrichment Findings
+
+**Date opened:** 2026-05-14
+**Status:** Accumulating — apply as a migration after enrichment is complete.
+
+During the affiliate-link backfill, agents matched DB rows to canonical retailer SKUs. Several rows were renamed by manufacturers, sold under different translations in the DE market, or had typos in the source data. Rather than write these renames piecemeal, we queue them here and apply as a single migration after all 5 review buckets are processed.
+
+## How to apply
+
+When the queue is complete, generate a Supabase migration that issues one `UPDATE` per row below. The `id` column is authoritative — match by id, not by name. Each entry has the affiliate_link URL we ended up using as evidence.
+
+---
+
+## Bucket A — confirmed during manual review on 2026-05-14
+
+### Line-correction renames (DB had line/ingredient mix-ups; ingredient is correct, line was wrong)
+
+The original DB rows for these two products had inconsistent line attributions — likely a data-entry slip. After verification on brand-direct garnier.de pages, we kept the ingredient as the source of truth and corrected the line.
+
+### 1. id `5516009a-eecb-42dd-87f6-07c560161136`
+- **Current:** brand=`Garnier`, name=`Garnier Wahre Schätze Aloe Vera Spülung`
+- **Proposed:** brand=`Garnier`, name=`Garnier Fructis Hair Food Aloe Vera Feuchtigkeits-Spülung`
+- **Why:** Wahre Schätze line has no Aloe Vera variant; the actual Aloe Vera Spülung lives in the Fructis Hair Food line.
+- **Evidence:** https://www.garnier.de/haarpflege/haarpflege-marken/fructis/hair-food/feuchtigkeits-spuelung-mit-aloe-vera
+
+### 2. id `8c3eda97-5009-40bb-959b-1a7d90f48b09`
+- **Current:** brand=`Garnier`, name=`Garnier Hair Food Macadamia`
+- **Proposed:** brand=`Garnier`, name=`Garnier Wahre Schätze Kokosmilch & Macadamia Nährende Spülung`
+- **Why:** The Macadamia conditioner in DE retail is the Wahre Schätze Kokosmilch & Macadamia Spülung, not a Hair Food SKU.
+- **Evidence:** https://www.garnier.de/haarpflege/haarpflege-marken/wahre-schaetze/kokosmilch-macadamia/naehrende-spuelung
+
+### Renames to apply
+
+### 3. id `cce6346c-1458-42bf-a44d-1b23ecfd5516` *(actual id will resolve at apply time — see notes)*
+- Same id pattern: Maske Haarkur Lamination Intense Glaze
+- **Current:** brand=`Haarkur`, name=`Haarkur Lamination Intense Glaze`
+- **Proposed:** brand=`Syoss`, name=`Syoss Haarkur Lamination Intense Glaze`
+- **Why:** "Haarkur" is German for "hair treatment", not a brand. Product is Syoss.
+- **Evidence:** https://www.dm.de/syoss-haarkur-lamination-intense-glaze-p4015100867213.html
+
+### 4. id `6fde3fe2-...` (Pantene Volume Pur)
+- **Current:** brand=`Pantene`, name=`Pantene Volume Pur`
+- **Proposed:** brand=`Pantene`, name=`Pantene Pro-V Volumen Pur`
+- **Why:** German DE name uses "Volumen"; full line designation is Pro-V.
+- **Evidence:** https://www.dm.de/pantene-pro-v-shampoo-volumen-pur-p8700216885768.html
+
+### 5. id `a1c3dc8d-...` (Cantu Lockenshampoo)
+- **Current:** brand=`Cantu`, name=`Cantu Lockenshampoo`
+- **Proposed:** brand=`Cantu`, name=`Cantu Shampoo Locken Pflege`
+- **Why:** DM SKU name.
+- **Evidence:** https://www.dm.de/cantu-shampoo-locken-pflege-p810006943450.html
+
+### 6. id `d01de47e-...` (Balea Professional Ultra Volume)
+- **Current:** brand=`Balea`, name=`Balea Professional Ultra Volume`
+- **Proposed:** brand=`Balea`, name=`Balea Professional Ultimate Volume`
+- **Why:** DM never sold "Ultra Volume"; current SKU is "Ultimate Volume".
+- **Evidence:** https://www.dm.de/balea-professional-shampoo-ultimate-volume-p4067796075021.html
+
+### 7. id `e7bfd306-...` (Sebamed Everyday)
+- **Current:** brand=`Sebamed`, name=`Sebamed Everyday`
+- **Proposed:** brand=`Sebamed`, name=`Sebamed Every-Day Shampoo`
+- **Why:** Official Sebamed name uses hyphen.
+- **Evidence:** https://www.amazon.de/Sebamed-10970-Every-Day-Shampoo-200ml/dp/B000UGYCP8
+
+### 8. id `088b1427-...` (Head & Shoulders Derma X Aloe)
+- **Current:** brand=`Head & Shoulders`, name=`Head & Shoulders Derma X Aloe`
+- **Proposed:** brand=`Head & Shoulders`, name=`Head & Shoulders Derma X Pro Beruhigende Pflege`
+- **Why:** Aloe variant rebranded for DE market as "Beruhigende Pflege".
+- **Evidence:** https://www.dm.de/p/d/1343250/head-und-shoulders-shampoo-derma-x-pro-beruhigende-pflege
+
+### 9. id `6b01025d-...` (Elvital Öl Magique Serum)
+- **Current:** brand=`Elvital`, name=`Elvital Öl Magique Serum`
+- **Proposed:** brand=`Elvital`, name=`Elvital Öl Magique Midnight Serum`
+- **Why:** Only one Magique Serum exists on DM, and it's the Midnight variant.
+- **Evidence:** https://www.dm.de/l-oreal-paris-elvital-haarserum-oel-magique-midnight-serum-p3600524135805.html
+
+### 10. id `0756a919-...` (Living Proof Restore Instant Repair)
+- **Current:** brand=`Living Proof`, name=`Living Proof Restore Instant Repair`
+- **Proposed:** brand=`Living Proof`, name=`Living Proof Restore Repair Leave-In`
+- **Why:** Living Proof dropped "Instant" from the name.
+- **Evidence:** https://www.douglas.de/de/p/5011050022
+
+### 11. id `9b664b11-...` (Acina Hyaluron 2.0)
+- **Current:** brand=`Acina`, name=`Acina Hyaluron 2.0`
+- **Proposed:** brand=`Alcina`, name=`Alcina Hyaluron 2.0`
+- **Why:** "Acina" is a typo. Brand is Alcina.
+- **Evidence:** https://www.amazon.de/ALCINA-Hyaluron-2-0-Spray-125/dp/B08P7TMWGX
+
+### 12. id `e781ca9e-...` (Pantene Hydra Glow Leave-In)
+- **Current:** brand=`Pantene`, name=`Pantene Hydra Glow Leave-In`
+- **Proposed:** brand=`Pantene`, name=`Pantene Miracles Milk-to-Water Leave-In Serum`
+- **Why:** "Hydra Glow" is the line; the leave-in SKU is the Milk-to-Water serum.
+- **Evidence:** https://www.dm.de/pantene-pro-v-leave-in-haarserum-miracles-milk-to-water-p8700216181556.html
+
+### 13. id `4f373d4f-...` (Balea Natural Beauty Bio-Argan Haaröl)
+- **Current:** brand=`Balea`, name=`Balea Natural Beauty Bio-Argan Haaröl`
+- **Proposed:** brand=`Balea`, name=`Balea Natural Beauty Pflegeöl Bio`
+- **Why:** DM SKU name.
+- **Evidence:** https://www.dm.de/balea-natural-beauty-pflegeoel-bio-p4066447276800.html
+
+### 14. id `5827a3b9-...` (Pantene Pro-V 7in1 Spray)
+- **Current:** brand=`Pantene`, name=`Pantene Pro-V 7in1 Spray`
+- **Proposed:** brand=`Pantene`, name=`Pantene Pro-V Miracles 7in1 Öl-Spray`
+- **Why:** Full DE SKU name.
+- **Evidence:** https://www.mueller.de/p/pantene-pro-v-miracles-oel-spray-7-in-1-IPN2992303/
+
+### 15. id `c574ee6f-...` (Garnier Fructis Sleek & Stay Öl)
+- **Current:** brand=`Garnier`, name=`Garnier Fructis Sleek & Stay Öl`
+- **Proposed:** brand=`Garnier`, name=`Garnier Fructis Sleek & Stay Heat-Activated Serum`
+- **Why:** DE variant is sold as serum, not oil.
+- **Evidence:** https://www.rossmann.de/de/pflege-und-duft-garnier-fructis-sleek-und-stay-heat-activated-serum/p/3600542638852
+
+---
+
+## Bucket B — brand-direct premium, confirmed on 2026-05-26
+
+These rows were capped at `medium` confidence by the spec rule (brand-direct hosts get `medium` by design). Manual review confirmed they are legitimate brand-direct PDPs and got promoted.
+
+### 16. id `45f4fe15-c439-476d-8a86-3b2aac5053bd`
+- **Current:** brand=`Urban Alchemy`, name=`Urban Alchemy Repair`
+- **Proposed:** brand=`Urban Alchemy`, name=`Urban Alchemy Repair & Revive Leave-In Spray`
+- **Why:** Official PDP name; the DB row was a truncation of the marketing name.
+- **Evidence:** https://urban-alchemy.com/products/repair-revive-leave-in-spray-150-ml
+
+### 17. id `5ad6c978-fd27-469e-9f26-ff3f05b9f67a`
+- **Current:** brand=`Urban Alchemy`, name=`Urban Alchemy Smooth Serum`
+- **Proposed:** brand=`Urban Alchemy`, name=`Urban Alchemy Smooth Supreme Öl Serum`
+- **Why:** Official PDP name; DB row truncated "Supreme Öl".
+- **Evidence:** https://urban-alchemy.com/products/smooth-supreme-ol-serum-75ml
+
+### 18. id `7f5207e6-d281-416e-922c-3135dd9a8cc8`
+- **Current:** brand=`Innersense`, name=`Innersense Harmonic Healing Oil`
+- **Proposed:** brand=`Innersense`, name=`Innersense Harmonic Treatment Oil`
+- **Why:** Innersense rebranded the product from "Healing Oil" to "Treatment Oil" (same SKU, same formula). The old name is no longer used.
+- **Evidence:** https://innersensebeauty.com/products/harmonic-treatment-oil
+
+---
+
+## Bucket C — confirmed on 2026-05-26
+
+### Group 1: 16 generic-ingredient Öle promoted to canonical brand SKUs
+
+The original DB rows had `brand == name` (e.g. "Calendulaöl") — ingredient-level placeholders. We assigned a canonical retailer SKU per ingredient. **Recommendation engine is brand-agnostic** (uses `product_oil_eligibility` join table on thickness/subtype/purpose), so brand renames here have no recommendation-side effect — pure display-layer cleanup.
+
+For each row below: change BOTH `brand` and `name` to match the canonical SKU. Affiliate link is already written.
+
+| id | Old brand | Old name | New brand | New name |
+|---|---|---|---|---|
+| `1dce2c18-...` | Calendulaöl | Calendulaöl | Primavera | Primavera Calendulaöl Bio |
+| `19aea9c4-...` | Macadamiaöl | Macadamiaöl | wesentlich. | wesentlich. Macadamianussöl kaltgepresst |
+| `29e36443-...` | Distelöl | Distelöl | Rapunzel | Rapunzel Bio Distelöl |
+| `2ffeae68-...` | Schwarzkümmelöl | Schwarzkümmelöl | nedura | nedura Schwarzkümmelöl ungefiltert |
+| `38886b62-...` | Moringaöl | Moringaöl | MoriVeda | MoriVeda Premium Moringaöl |
+| `3acd3c18-...` | Rizinusöl | Rizinusöl | greenmade | greenmade Bio Rizinusöl |
+| `3eb198a5-...` | MCT-Öl | MCT-Öl | KoRo | KoRo MCT Öl |
+| `4a95e1de-...` | Jojoba | Jojoba | Dr. Scheller | Dr. Scheller Jojobaöl |
+| `517dca50-...` | Traubenkernöl | Traubenkernöl | Ölmühle Solling | Ölmühle Solling Bio Traubenkernöl |
+| `70ea52bc-...` | Arganöl | Arganöl | MARRAKESCH | MARRAKESCH Bio Arganöl |
+| `78e6f1b2-...` | Cacayöl | Cacayöl | (canonical brand TBD on review of Amazon SKU) | Cacayöl kaltgepresst |
+| `9bfe0a67-...` | Olivenöl | Olivenöl | dmBio | dmBio natives Olivenöl extra |
+| `a11855eb-...` | Aprikosenkernöl | Aprikosenkernöl | Kräuterland | Kräuterland Bio Aprikosenkernöl |
+| `acf9d5cd-...` | Kokosöl | Kokosöl | Rapunzel | Rapunzel Bio Kokosöl nativ |
+| `ca4ae209-...` | Mandelöl | Mandelöl | Mynatura | Mynatura Bio Mandelöl |
+| `ff13bc3a-...` | Avocadoöl | Avocadoöl | Kräuterland | Kräuterland Bio Avocadoöl |
+
+### Group 2: 8 substitutions / DE-successor renames
+
+### 19. id `4fd5f4c3-83b2-4893-be8c-ada29b8ca718`
+- **Current:** brand=`Head & Shoulders`, name=`Head & Shoulders Derma X 0%`
+- **Proposed:** brand=`Head & Shoulders`, name=`Head & Shoulders DERMAXPRO Sanfte Kopfhautpflege`
+- **Why:** "Derma X 0%" appears to be a catalog typo; the DERMAXPRO Sanfte Kopfhautpflege is the matching DE SKU on Rossmann.
+- **Evidence:** https://www.rossmann.de/de/pflege-und-duft-head-und-shoulders-derma-x-pro-sanfte-kopfhautpflege/p/8700216496056
+
+### 20. id `6dc65df2-2466-43e4-bdc2-3a05803f305c`
+- **Current:** brand=`Monday`, name=`Monday Volume`
+- **Proposed:** brand=`Monday Haircare`, name=`Monday Haircare Volume Kraft & Fülle Shampoo`
+- **Why:** Full DE SKU name on Flaconi.
+- **Evidence:** https://www.flaconi.de/haare/monday-haircare/volume/monday-haircare-volume-kraft-and-fuelle-haarshampoo.html
+
+### 21. id `8715f0f5-9104-46ec-b450-e73f1441c1fa`
+- **Current:** brand=`Curlsmith`, name=`Curlsmith Weightless Protein Leave-In Conditioner`
+- **Proposed:** brand=`Curlsmith`, name=`Curlsmith Weightless Air Dry Cream`
+- **Why:** Curlsmith Weightless line has no "Protein" Leave-In variant; Weightless Air Dry Cream is the closest leave-in (protein-leaning per brand page).
+- **Evidence:** https://de.curlsmith.com/products/weightless-air-dry-cream
+
+### 22. id `94cf6959-a53b-421b-9f0f-05efc239171c`
+- **Current:** brand=`Wella`, name=`Wella Ultimate Repair Leave-In`
+- **Proposed:** brand=`Wella Professionals`, name=`Wella Ultimate Repair Protective Leave-In`
+- **Why:** Official Wella Professionals DE PDP uses the "Protective Leave-In" naming.
+- **Evidence:** https://www.wella.com/professional/de-DE/products/haarpflege/ultimate-repair/ultimate-repair-protective-leave-in
+
+### 23. id `f8f3b51d-8e64-487d-bad5-4a47c58862ed`
+- **Current:** brand=`Pantene`, name=`Pantene Pro-V Keratin Protect 10-in-1 Spray`
+- **Proposed:** brand=`Pantene`, name=`Pantene Pro-V Miracles 7in1 Haaröl Spray`
+- **Why:** The 10-in-1 variant is US-only; the DE successor is the 7in1 Miracles Haaröl Spray.
+- **Evidence:** https://www.dm.de/pantene-pro-v-haarkur-miracles-7in1-haaroel-spray-p8700216178402.html
+
+### 24. id `c4b9eaef-dfeb-41ea-9d28-9901660406b7`
+- **Current:** brand=`Bali`, name=`Bali Curls Bond Repair`
+- **Proposed:** brand=`Bali Curls`, name=`Bali Curls Deep Repair Mask`
+- **Why:** No exact "Bond Repair" mask exists; Deep Repair Mask is the in-line equivalent (bond-repair functionality per brand description).
+- **Evidence:** https://www.dm.de/bali-curls-haarmaske-deep-repair-p4262391990001.html
+
+### 25. id `1bfa5b02-26d9-457b-a5e6-445cc2284490`
+- **Current:** brand=`OGX`, name=`OGX Keratin & Protein`
+- **Proposed:** brand=`OGX`, name=`OGX Bond Protein Repair Conditioner`
+- **Why:** No exact "Keratin & Protein" SKU; OGX's newer Bond Protein Repair line is the closest protein-repair conditioner.
+- **Evidence:** https://www.dm.de/ogx-conditioner-bond-protein-repair-p3574661818467.html
+
+### 26. id `663acf09-7090-40d8-9411-71154b9d60f3`
+- **Current:** brand=`Shiseido`, name=`Shiseido Fino Oil`
+- **Proposed:** brand=`Shiseido Fino`, name=`Shiseido Fino Premium Touch Penetrating Hair Oil Essence`
+- **Why:** Full DE-import SKU name on Amazon DE.
+- **Evidence:** https://www.amazon.de/Fino-Premium-Touch-Penetrating-Essence/dp/B0GVFQP34X
+
+---
+
+## Rows to delete (no viable SKU)
+
+These rows had no usable product after exhaustive research. `affiliate_link` is NULL; flag for deletion or `is_active=false` in the same migration.
+
+### id `3c769f60-283f-48c3-9549-cf84b73115d7`
+- **Row:** `Maria Nila` / `Maria Nila True Soft Leave-In` (category Leave-in)
+- **Why:** Maria Nila's True Soft line has no Leave-In SKU and never did. Closest in-line product is the True Soft Argan Oil, which is a different product class. User decision (2026-05-26): cut from catalog.

--- a/docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md
+++ b/docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md
@@ -1,0 +1,128 @@
+# Runbook — Affiliate Link Backfill Execution
+
+Spec: `docs/superpowers/specs/2026-05-13-affiliate-link-backfill-design.md`
+Plan: `docs/superpowers/plans/2026-05-13-affiliate-link-backfill.md`
+
+This runbook walks through a single end-to-end execution. Everything that mutates production data is explicit and confirm-able.
+
+## Prerequisites
+
+- `.env.local` is populated with `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+- `npm run ci:verify` passes on `main`.
+- `data/affiliate-research/` exists.
+
+## Step 1 — Export
+
+```bash
+npx tsx scripts/export-missing-affiliate-links.ts
+```
+
+Confirm the row count matches the audit (`209` at time of plan-writing). If the totals warning fires, update `SLICE_PLAN` in the export script and rerun.
+
+## Step 2 — Canary
+
+Dispatch one general-purpose subagent. From the Claude Code session, invoke the `Agent` tool with the prompt template below, parameterized for the canary slice:
+
+```
+INPUT  = data/affiliate-research/missing-canary.csv
+OUTPUT = data/affiliate-research/results-canary.csv
+CATEGORY = "mixed (canary)"
+PREFERENCE_ORDER = "DM > Rossmann > Müller > brand-direct > Amazon DE"
+```
+
+Wait for the agent to complete. Then:
+
+```bash
+npx tsx scripts/validate-slice.ts canary
+head -5 data/affiliate-research/results-canary.csv
+```
+
+Eyeball the chosen URLs. If the verification rules need tweaking (too many false `high`s, etc.), edit the prompt template before fanout.
+
+## Step 3 — Fanout
+
+In a single Claude Code message, dispatch 15 `Agent` calls in parallel — one per slice. Use the per-category preference orders from the spec. Each agent's prompt swaps in its slice's `SLUG`, `CATEGORY`, and `PREFERENCE_ORDER`.
+
+Slices:
+
+```
+shampoo-a, shampoo-b, shampoo-c, shampoo-d
+leave-in-a, leave-in-b, leave-in-c
+oele-a, oele-b, oele-c
+conditioner-a, conditioner-b, conditioner-c
+maske-a, maske-b
+```
+
+When all 15 return:
+
+```bash
+for slug in shampoo-a shampoo-b shampoo-c shampoo-d \
+            leave-in-a leave-in-b leave-in-c \
+            oele-a oele-b oele-c \
+            conditioner-a conditioner-b conditioner-c \
+            maske-a maske-b; do
+  npx tsx scripts/validate-slice.ts "$slug" || echo "FAILED: $slug"
+done
+```
+
+Any slice that fails: rerun ONLY that slice's subagent (point it at the same input/output paths). Re-validate.
+
+## Step 4 — Pre-aggregation diff check
+
+Confirm the subagents only wrote `results-*.csv` files (boundary check from the spec):
+
+```bash
+ls data/affiliate-research/
+git status -- data/affiliate-research/
+```
+
+Expected: only `missing-*.csv` (already-present) and `results-*.csv` (newly written) files. If anything else changed (e.g. someone touched `applied.log` already, or a stray script-output file appeared), STOP and investigate before aggregating.
+
+## Step 5 — Aggregate
+
+```bash
+npx tsx scripts/aggregate-affiliate-research.ts
+```
+
+Inspect:
+
+```bash
+wc -l data/affiliate-research/{results,approved,review-queue}.csv
+head -10 data/affiliate-research/approved.csv
+```
+
+## Step 6 — Manual review of `approved.csv`
+
+Open `approved.csv`. Sanity-check each row's `chosen_url` against `name` and `brand`. Delete any row that looks wrong. Move rows you'd like to escalate from `review-queue.csv` into `approved.csv` if you trust them.
+
+## Step 7 — Dry write-back
+
+```bash
+npx tsx scripts/write-affiliate-links.ts --dry
+```
+
+Confirm the printed UPDATE count matches `approved.csv` row count.
+
+## Step 8 — Real write-back
+
+```bash
+npx tsx scripts/write-affiliate-links.ts
+```
+
+Then re-audit:
+
+```bash
+npx tsx scripts/audit-affiliate-links.ts
+```
+
+`activeWithLink` should have increased by exactly the count in `applied.log`.
+
+## Rollback
+
+If a bad batch of URLs was written, regenerate from the previous audit and re-NULL specific rows:
+
+```sql
+UPDATE products SET affiliate_link = NULL WHERE id IN ('id1', 'id2', ...);
+```
+
+Then re-export, re-research only those rows, and re-aggregate.

--- a/docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md
+++ b/docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md
@@ -56,13 +56,18 @@ maske-a, maske-b
 When all 15 return:
 
 ```bash
+fail=0
 for slug in shampoo-a shampoo-b shampoo-c shampoo-d \
             leave-in-a leave-in-b leave-in-c \
             oele-a oele-b oele-c \
             conditioner-a conditioner-b conditioner-c \
             maske-a maske-b; do
-  npx tsx scripts/validate-slice.ts "$slug" || echo "FAILED: $slug"
+  npx tsx scripts/validate-slice.ts "$slug" || fail=1
 done
+if [ "$fail" -ne 0 ]; then
+  echo "One or more slices failed validation. Rerun those slices before aggregating."
+  exit 1
+fi
 ```
 
 Any slice that fails: rerun ONLY that slice's subagent (point it at the same input/output paths). Re-validate.

--- a/docs/superpowers/plans/2026-05-13-affiliate-link-backfill.md
+++ b/docs/superpowers/plans/2026-05-13-affiliate-link-backfill.md
@@ -1,0 +1,1889 @@
+# Affiliate Link Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the four scripts that drive the affiliate-link backfill workflow described in `docs/superpowers/specs/2026-05-13-affiliate-link-backfill-design.md`, so that we can dispatch research subagents and write reviewed URLs back to `products.affiliate_link`.
+
+**Architecture:** Four scripts (`export`, `validate-slice`, `aggregate`, `write`) plus a shared library under `src/lib/affiliate-research/` for pure logic (URL gate, brand-slug normalization, CSV utilities, slice validation, aggregation rules). Subagent dispatch is documented in a runbook but is not code — it's invoked from a Claude Code session. The DB write is the only place a service-role Supabase client is opened.
+
+**Tech Stack:**
+- Node 20+ via `tsx` (already in devDependencies)
+- `@supabase/supabase-js` (already a dependency) with service-role key from `.env.local`
+- `node:test` + `node:assert/strict` for unit tests (project convention)
+- Plain CSV (no external CSV library — write a tiny in-house reader/writer with RFC-4180 quoting)
+
+---
+
+## File Structure
+
+**New files (TS lib):**
+- `src/lib/affiliate-research/url-gate.ts` — pure: URL parsing, host allowlist/denylist, brand-slug normalization, brand-direct match, top-level `urlGate(row)` returning `{pass, reason}`.
+- `src/lib/affiliate-research/csv.ts` — pure: `readCsv(path)`, `writeCsv(path, header, rows)` with RFC-4180 quoting.
+- `src/lib/affiliate-research/slice-validator.ts` — pure: `validateSlice({inputPath, outputPath}) → {ok, errors, missing, duplicated}`.
+- `src/lib/affiliate-research/aggregate.ts` — pure: `dedupeByConfidence(rows)`, `classifyForOutput(row) → {bucket, reason}`.
+
+**New files (scripts):**
+- `scripts/export-missing-affiliate-links.ts` — queries Supabase, writes `missing.csv` + per-slice files.
+- `scripts/validate-slice.ts` — thin CLI wrapper around `slice-validator`.
+- `scripts/aggregate-affiliate-research.ts` — reads `results-*.csv`, writes `results.csv`, `approved.csv`, `review-queue.csv`.
+- `scripts/write-affiliate-links.ts` — reads `approved.csv`, issues `UPDATE`s, writes `applied.log`. Has `--dry`.
+
+**New files (tests):**
+- `tests/affiliate-research-url-gate.test.ts`
+- `tests/affiliate-research-csv.test.ts`
+- `tests/affiliate-research-slice-validator.test.ts`
+- `tests/affiliate-research-aggregate.test.ts`
+
+**New files (docs):**
+- `docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md` — step-by-step execution: export → canary → fanout → validate → aggregate → review → write.
+
+**New files (data, gitignored):**
+- `data/affiliate-research/` (created in Task 1; populated at execution time).
+
+**Modified files:**
+- `.gitignore` — add `data/affiliate-research/`.
+
+**Layout rationale:** Pure logic in `src/lib/affiliate-research/` keeps the scripts thin and unit-testable. Per project convention (`tests/*.test.ts` flat), test filenames are prefixed `affiliate-research-`. The lib does NOT import `@supabase/supabase-js` — scripts pull data and pass plain objects to lib functions.
+
+---
+
+## Tasks
+
+### Task 1: Set up gitignore + data directory
+
+**Files:**
+- Modify: `.gitignore`
+- Create: `data/affiliate-research/.gitkeep`
+
+- [ ] **Step 1: Add gitignore entry**
+
+Edit `.gitignore`. Append at the end:
+
+```
+# Affiliate link research artefacts (regenerated; safe to delete)
+/data/affiliate-research/
+!/data/affiliate-research/.gitkeep
+```
+
+- [ ] **Step 2: Create the directory with a placeholder**
+
+Run:
+```bash
+mkdir -p data/affiliate-research && touch data/affiliate-research/.gitkeep
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore data/affiliate-research/.gitkeep
+git commit -m "chore: scaffold data/affiliate-research/ for backfill workflow"
+```
+
+---
+
+### Task 2: URL gate library + tests
+
+This is the pure logic that the aggregator (and optionally the write-back) uses to decide if a URL is acceptable.
+
+**Files:**
+- Create: `src/lib/affiliate-research/url-gate.ts`
+- Create: `tests/affiliate-research-url-gate.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/affiliate-research-url-gate.test.ts`:
+
+```typescript
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  isUsableUrl,
+  hostOf,
+  isAllowedHost,
+  isDeniedHost,
+  normalizeBrandSlug,
+  passesBrandDirect,
+  urlGate,
+} from "../src/lib/affiliate-research/url-gate"
+
+test("isUsableUrl accepts http(s) URLs, rejects junk", () => {
+  assert.equal(isUsableUrl("https://www.dm.de/p/foo"), true)
+  assert.equal(isUsableUrl("http://example.com"), true)
+  assert.equal(isUsableUrl("ftp://example.com"), false)
+  assert.equal(isUsableUrl(""), false)
+  assert.equal(isUsableUrl("   "), false)
+  assert.equal(isUsableUrl(null), false)
+  assert.equal(isUsableUrl("not a url"), false)
+})
+
+test("hostOf returns lowercased host without port", () => {
+  assert.equal(hostOf("https://WWW.DM.de:443/x"), "www.dm.de")
+  assert.equal(hostOf("https://olaplex.com/products/n3"), "olaplex.com")
+})
+
+test("isAllowedHost matches with or without www. prefix", () => {
+  assert.equal(isAllowedHost("www.dm.de"), true)
+  assert.equal(isAllowedHost("dm.de"), true)
+  assert.equal(isAllowedHost("www.amazon.de"), true)
+  assert.equal(isAllowedHost("amazon.com"), false)
+  assert.equal(isAllowedHost("random.example"), false)
+})
+
+test("isDeniedHost catches aggregators and ebay/aliexpress/amazon.com", () => {
+  assert.equal(isDeniedHost("www.idealo.de"), true)
+  assert.equal(isDeniedHost("geizhals.de"), true)
+  assert.equal(isDeniedHost("ebay.de"), true)
+  assert.equal(isDeniedHost("amazon.com"), true)
+  assert.equal(isDeniedHost("www.dm.de"), false)
+})
+
+test("normalizeBrandSlug strips non-alphanumerics and normalizes umlauts", () => {
+  assert.equal(normalizeBrandSlug("OLAPLEX"), "olaplex")
+  assert.equal(normalizeBrandSlug("Sante"), "sante")
+  assert.equal(normalizeBrandSlug("Sante Naturkosmetik"), "santenaturkosmetik")
+  assert.equal(normalizeBrandSlug("Schwarzköpf"), "schwarzkoepf")
+  assert.equal(normalizeBrandSlug("K18"), "k18")
+})
+
+test("passesBrandDirect matches brand slug as hostname substring, min slug length 4", () => {
+  assert.equal(passesBrandDirect("olaplex.com", "OLAPLEX"), true)
+  assert.equal(passesBrandDirect("k18hair.com", "K18"), false, "K18 slug too short, fails brand-direct")
+  assert.equal(passesBrandDirect("sante.de", "Sante"), true)
+  assert.equal(passesBrandDirect("epres.com", "Epres"), true)
+  assert.equal(passesBrandDirect("unrelated.de", "Sante"), false)
+  assert.equal(passesBrandDirect("any.de", "AB"), false, "slug below 4 chars never matches")
+})
+
+test("urlGate returns pass=true for allowlisted host with valid URL", () => {
+  const res = urlGate({
+    chosen_url: "https://www.dm.de/p/foo",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, true)
+})
+
+test("urlGate rejects denylisted hosts", () => {
+  const res = urlGate({
+    chosen_url: "https://www.idealo.de/foo",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, false)
+  assert.match(res.reason, /denylisted/i)
+})
+
+test("urlGate rejects malformed URLs", () => {
+  const res = urlGate({
+    chosen_url: "not a url",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, false)
+  assert.match(res.reason, /parse/i)
+})
+
+test("urlGate accepts brand-direct when host contains slug (length >= 4)", () => {
+  const res = urlGate({
+    chosen_url: "https://sante.de/products/foo",
+    brand: "Sante",
+  })
+  assert.equal(res.pass, true)
+})
+
+test("urlGate rejects host that is neither allowlisted nor brand-direct", () => {
+  const res = urlGate({
+    chosen_url: "https://random-shop.example/foo",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, false)
+  assert.match(res.reason, /not on allowlist/i)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx tsx --test tests/affiliate-research-url-gate.test.ts
+```
+
+Expected: all tests FAIL with "Cannot find module" or similar.
+
+- [ ] **Step 3: Implement `url-gate.ts`**
+
+Create `src/lib/affiliate-research/url-gate.ts`:
+
+```typescript
+export const HOST_ALLOWLIST = new Set<string>([
+  "dm.de",
+  "www.dm.de",
+  "rossmann.de",
+  "www.rossmann.de",
+  "mueller.de",
+  "www.mueller.de",
+  "amazon.de",
+  "www.amazon.de",
+  "douglas.de",
+  "www.douglas.de",
+  "flaconi.de",
+  "www.flaconi.de",
+  "notino.de",
+  "www.notino.de",
+  "otto.de",
+  "www.otto.de",
+])
+
+export const HOST_DENYLIST = new Set<string>([
+  "idealo.de",
+  "www.idealo.de",
+  "geizhals.de",
+  "www.geizhals.de",
+  "billiger.de",
+  "www.billiger.de",
+  "preisvergleich.de",
+  "www.preisvergleich.de",
+  "ebay.de",
+  "www.ebay.de",
+  "ebay.com",
+  "www.ebay.com",
+  "kleinanzeigen.de",
+  "www.kleinanzeigen.de",
+  "aliexpress.com",
+  "www.aliexpress.com",
+  "amazon.com",
+  "www.amazon.com",
+])
+
+const MIN_BRAND_SLUG_LEN = 4
+
+export function isUsableUrl(value: string | null | undefined): boolean {
+  if (value == null) return false
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  try {
+    const u = new URL(trimmed)
+    return u.protocol === "http:" || u.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+export function hostOf(url: string): string {
+  return new URL(url).hostname.toLowerCase()
+}
+
+export function isAllowedHost(host: string): boolean {
+  return HOST_ALLOWLIST.has(host.toLowerCase())
+}
+
+export function isDeniedHost(host: string): boolean {
+  return HOST_DENYLIST.has(host.toLowerCase())
+}
+
+const UMLAUT_MAP: Record<string, string> = { ä: "ae", ö: "oe", ü: "ue", ß: "ss" }
+
+export function normalizeBrandSlug(brand: string | null | undefined): string {
+  if (!brand) return ""
+  const lowered = brand.toLowerCase()
+  const expanded = lowered.replace(/[äöüß]/g, (ch) => UMLAUT_MAP[ch] ?? ch)
+  return expanded.replace(/[^a-z0-9]/g, "")
+}
+
+export function passesBrandDirect(host: string, brand: string | null | undefined): boolean {
+  const slug = normalizeBrandSlug(brand)
+  if (slug.length < MIN_BRAND_SLUG_LEN) return false
+  return host.toLowerCase().includes(slug)
+}
+
+export type UrlGateInput = {
+  chosen_url: string | null | undefined
+  brand: string | null | undefined
+}
+
+export type UrlGateResult = { pass: true } | { pass: false; reason: string }
+
+export function urlGate(row: UrlGateInput): UrlGateResult {
+  if (!isUsableUrl(row.chosen_url)) {
+    return { pass: false, reason: "url failed to parse or is not http(s)" }
+  }
+  const host = hostOf(row.chosen_url as string)
+  if (isDeniedHost(host)) {
+    return { pass: false, reason: `host ${host} is denylisted (aggregator or wrong marketplace)` }
+  }
+  if (isAllowedHost(host)) {
+    return { pass: true }
+  }
+  if (passesBrandDirect(host, row.brand)) {
+    return { pass: true }
+  }
+  return { pass: false, reason: `host ${host} is not on allowlist and does not match brand-direct rule` }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx tsx --test tests/affiliate-research-url-gate.test.ts
+```
+
+Expected: all 11 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/affiliate-research/url-gate.ts tests/affiliate-research-url-gate.test.ts
+git commit -m "feat(affiliate-research): add URL gate with host allow/deny + brand-direct rule"
+```
+
+---
+
+### Task 3: CSV utilities + tests
+
+A tiny RFC-4180-shaped reader/writer. Quoted fields with embedded commas, quotes, and newlines must round-trip.
+
+**Files:**
+- Create: `src/lib/affiliate-research/csv.ts`
+- Create: `tests/affiliate-research-csv.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/affiliate-research-csv.test.ts`:
+
+```typescript
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { parseCsv, stringifyCsv, readCsv, writeCsv } from "../src/lib/affiliate-research/csv"
+
+test("parseCsv handles simple rows", () => {
+  const rows = parseCsv("id,name\n1,foo\n2,bar\n")
+  assert.deepEqual(rows, [
+    { id: "1", name: "foo" },
+    { id: "2", name: "bar" },
+  ])
+})
+
+test("parseCsv handles quoted fields with commas and quotes", () => {
+  const rows = parseCsv('id,name\n1,"foo, bar"\n2,"she said ""hi"""\n')
+  assert.deepEqual(rows, [
+    { id: "1", name: "foo, bar" },
+    { id: "2", name: 'she said "hi"' },
+  ])
+})
+
+test("parseCsv tolerates trailing newline and empty fields", () => {
+  const rows = parseCsv("id,name\n1,\n")
+  assert.deepEqual(rows, [{ id: "1", name: "" }])
+})
+
+test("stringifyCsv quotes only when necessary", () => {
+  const out = stringifyCsv(
+    ["id", "name"],
+    [
+      { id: "1", name: "foo" },
+      { id: "2", name: "has, comma" },
+      { id: "3", name: 'has "quotes"' },
+    ],
+  )
+  assert.equal(out, 'id,name\n1,foo\n2,"has, comma"\n3,"has ""quotes"""\n')
+})
+
+test("round-trip: writeCsv then readCsv recovers data", () => {
+  const dir = mkdtempSync(join(tmpdir(), "csv-test-"))
+  const path = join(dir, "x.csv")
+  const rows = [
+    { id: "a", url: "https://x.example/p?q=1,2" },
+    { id: "b", url: "https://y.example/p" },
+  ]
+  writeCsv(path, ["id", "url"], rows)
+  const back = readCsv(path)
+  assert.deepEqual(back, rows)
+})
+
+test("readCsv throws on header mismatch via callback", () => {
+  const dir = mkdtempSync(join(tmpdir(), "csv-test-"))
+  const path = join(dir, "x.csv")
+  writeFileSync(path, "id,brand\n1,Pantene\n")
+  assert.throws(
+    () => readCsv(path, { expectedHeader: ["id", "name"] }),
+    /header/i,
+  )
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx tsx --test tests/affiliate-research-csv.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `csv.ts`**
+
+Create `src/lib/affiliate-research/csv.ts`:
+
+```typescript
+import { readFileSync, writeFileSync } from "node:fs"
+
+export type CsvRow = Record<string, string>
+
+export function parseCsv(text: string): CsvRow[] {
+  const lines = splitCsvLines(text)
+  if (lines.length === 0) return []
+  const header = parseCsvLine(lines[0])
+  const out: CsvRow[] = []
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === "") continue
+    const cells = parseCsvLine(line)
+    const row: CsvRow = {}
+    for (let j = 0; j < header.length; j++) {
+      row[header[j]] = cells[j] ?? ""
+    }
+    out.push(row)
+  }
+  return out
+}
+
+function splitCsvLines(text: string): string[] {
+  const lines: string[] = []
+  let current = ""
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (ch === '"') {
+      inQuotes = !inQuotes
+      current += ch
+      continue
+    }
+    if (ch === "\n" && !inQuotes) {
+      lines.push(current)
+      current = ""
+      continue
+    }
+    if (ch === "\r" && !inQuotes) {
+      if (text[i + 1] === "\n") i++
+      lines.push(current)
+      current = ""
+      continue
+    }
+    current += ch
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = []
+  let cur = ""
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') {
+        cur += '"'
+        i++
+        continue
+      }
+      if (ch === '"') {
+        inQuotes = false
+        continue
+      }
+      cur += ch
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = true
+      continue
+    }
+    if (ch === ",") {
+      cells.push(cur)
+      cur = ""
+      continue
+    }
+    cur += ch
+  }
+  cells.push(cur)
+  return cells
+}
+
+function quoteField(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return '"' + value.replace(/"/g, '""') + '"'
+  }
+  return value
+}
+
+export function stringifyCsv(header: string[], rows: CsvRow[]): string {
+  const lines: string[] = [header.map(quoteField).join(",")]
+  for (const row of rows) {
+    lines.push(header.map((h) => quoteField(row[h] ?? "")).join(","))
+  }
+  return lines.join("\n") + "\n"
+}
+
+export type ReadCsvOptions = {
+  expectedHeader?: string[]
+}
+
+export function readCsv(path: string, opts: ReadCsvOptions = {}): CsvRow[] {
+  const text = readFileSync(path, "utf-8")
+  const rows = parseCsv(text)
+  if (opts.expectedHeader) {
+    const actual = rows.length > 0 ? Object.keys(rows[0]) : []
+    // header is the first parsed line — but parseCsv discards it as column names,
+    // so check by reading the first physical line:
+    const firstLine = text.split(/\r?\n/, 1)[0]
+    const headerActual = parseCsvLine(firstLine)
+    const equal =
+      headerActual.length === opts.expectedHeader.length &&
+      headerActual.every((h, i) => h === opts.expectedHeader![i])
+    if (!equal) {
+      throw new Error(
+        `csv header mismatch in ${path}: expected [${opts.expectedHeader.join(", ")}], got [${headerActual.join(", ")}]`,
+      )
+    }
+    void actual
+  }
+  return rows
+}
+
+export function writeCsv(path: string, header: string[], rows: CsvRow[]): void {
+  writeFileSync(path, stringifyCsv(header, rows), "utf-8")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx tsx --test tests/affiliate-research-csv.test.ts
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/affiliate-research/csv.ts tests/affiliate-research-csv.test.ts
+git commit -m "feat(affiliate-research): add RFC-4180 CSV reader/writer"
+```
+
+---
+
+### Task 4: Slice validator library + tests
+
+The per-slice validator checks a subagent's output CSV against its input slice CSV.
+
+**Files:**
+- Create: `src/lib/affiliate-research/slice-validator.ts`
+- Create: `tests/affiliate-research-slice-validator.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/affiliate-research-slice-validator.test.ts`:
+
+```typescript
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { validateSlice } from "../src/lib/affiliate-research/slice-validator"
+
+const INPUT_HEADER = "id,brand,name,description,category,price_eur"
+const OUTPUT_HEADER = "id,brand,name,chosen_url,host,confidence,matched_tokens,notes"
+
+function fixtureDir() {
+  return mkdtempSync(join(tmpdir(), "slice-val-"))
+}
+
+test("valid slice: ids match exactly, no duplicates", () => {
+  const dir = fixtureDir()
+  writeFileSync(
+    join(dir, "in.csv"),
+    `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\nb,Brand,Name2,Desc2,Shampoo,6\n`,
+  )
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,https://x.de/p,x.de,high,Foo,ok\nb,Brand,Name2,,,none,,not found\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, true)
+  assert.deepEqual(res.missing, [])
+  assert.deepEqual(res.duplicated, [])
+})
+
+test("missing id reported", () => {
+  const dir = fixtureDir()
+  writeFileSync(
+    join(dir, "in.csv"),
+    `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\nb,Brand,Name2,Desc2,Shampoo,6\n`,
+  )
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,,,none,,\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.deepEqual(res.missing, ["b"])
+})
+
+test("duplicate id reported", () => {
+  const dir = fixtureDir()
+  writeFileSync(join(dir, "in.csv"), `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\n`)
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,,,none,,\na,Brand,Name,,,none,,\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.deepEqual(res.duplicated, ["a"])
+})
+
+test("wrong output header reported as schemaError", () => {
+  const dir = fixtureDir()
+  writeFileSync(join(dir, "in.csv"), `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\n`)
+  writeFileSync(join(dir, "out.csv"), `id,brand,name,url\na,Brand,Name,https://x.de\n`)
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.match(res.errors.join("\n"), /header/i)
+})
+
+test("invalid confidence value reported", () => {
+  const dir = fixtureDir()
+  writeFileSync(join(dir, "in.csv"), `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\n`)
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,https://x.de,x.de,SUPER,Foo,ok\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.match(res.errors.join("\n"), /confidence/i)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx tsx --test tests/affiliate-research-slice-validator.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `slice-validator.ts`**
+
+Create `src/lib/affiliate-research/slice-validator.ts`:
+
+```typescript
+import { readCsv } from "./csv"
+
+export const INPUT_HEADER = ["id", "brand", "name", "description", "category", "price_eur"] as const
+export const OUTPUT_HEADER = [
+  "id",
+  "brand",
+  "name",
+  "chosen_url",
+  "host",
+  "confidence",
+  "matched_tokens",
+  "notes",
+] as const
+
+export type ValidateSliceInput = {
+  inputPath: string
+  outputPath: string
+}
+
+export type ValidateSliceResult = {
+  ok: boolean
+  errors: string[]
+  missing: string[]
+  duplicated: string[]
+  rowCount: number
+}
+
+const VALID_CONFIDENCE = new Set(["high", "medium", "none"])
+
+export function validateSlice({ inputPath, outputPath }: ValidateSliceInput): ValidateSliceResult {
+  const errors: string[] = []
+
+  let inputRows: ReturnType<typeof readCsv> = []
+  try {
+    inputRows = readCsv(inputPath, { expectedHeader: [...INPUT_HEADER] })
+  } catch (err) {
+    errors.push(`input: ${(err as Error).message}`)
+  }
+
+  let outputRows: ReturnType<typeof readCsv> = []
+  try {
+    outputRows = readCsv(outputPath, { expectedHeader: [...OUTPUT_HEADER] })
+  } catch (err) {
+    errors.push(`output: ${(err as Error).message}`)
+    return { ok: false, errors, missing: [], duplicated: [], rowCount: 0 }
+  }
+
+  const inputIds = new Set(inputRows.map((r) => r.id))
+  const seen = new Set<string>()
+  const duplicated: string[] = []
+  for (const r of outputRows) {
+    if (seen.has(r.id)) duplicated.push(r.id)
+    else seen.add(r.id)
+    if (r.confidence && !VALID_CONFIDENCE.has(r.confidence)) {
+      errors.push(`row ${r.id}: invalid confidence value '${r.confidence}'`)
+    }
+  }
+  const missing = [...inputIds].filter((id) => !seen.has(id))
+  const extras = [...seen].filter((id) => !inputIds.has(id))
+  if (extras.length > 0) {
+    errors.push(`output contains ${extras.length} ids not in input: ${extras.slice(0, 5).join(", ")}`)
+  }
+  if (missing.length > 0) {
+    errors.push(`output missing ${missing.length} input ids: ${missing.slice(0, 5).join(", ")}`)
+  }
+  if (duplicated.length > 0) {
+    errors.push(`output has duplicate ids: ${duplicated.slice(0, 5).join(", ")}`)
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    missing,
+    duplicated,
+    rowCount: outputRows.length,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx tsx --test tests/affiliate-research-slice-validator.test.ts
+```
+
+Expected: 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/affiliate-research/slice-validator.ts tests/affiliate-research-slice-validator.test.ts
+git commit -m "feat(affiliate-research): add per-slice CSV validator"
+```
+
+---
+
+### Task 5: Aggregator library + tests
+
+Pure functions for deduping and classifying rows into `approved` / `review` buckets.
+
+**Files:**
+- Create: `src/lib/affiliate-research/aggregate.ts`
+- Create: `tests/affiliate-research-aggregate.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/affiliate-research-aggregate.test.ts`:
+
+```typescript
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  dedupeByConfidence,
+  classifyForOutput,
+  type ResultRow,
+} from "../src/lib/affiliate-research/aggregate"
+
+function row(p: Partial<ResultRow>): ResultRow {
+  return {
+    id: "x",
+    brand: "Brand",
+    name: "Name",
+    chosen_url: "",
+    host: "",
+    confidence: "none",
+    matched_tokens: "",
+    notes: "",
+    ...p,
+  }
+}
+
+test("dedupeByConfidence keeps highest confidence per id", () => {
+  const rows = [
+    row({ id: "a", confidence: "none" }),
+    row({ id: "a", confidence: "high", chosen_url: "https://www.dm.de/p" }),
+    row({ id: "b", confidence: "medium" }),
+  ]
+  const out = dedupeByConfidence(rows)
+  assert.equal(out.length, 2)
+  const a = out.find((r) => r.id === "a")!
+  assert.equal(a.confidence, "high")
+})
+
+test("dedupeByConfidence tie-breaks on allowlisted host > brand-direct > other", () => {
+  const rows = [
+    row({ id: "a", confidence: "high", chosen_url: "https://other-shop.example/p", host: "other-shop.example" }),
+    row({ id: "a", confidence: "high", chosen_url: "https://www.dm.de/p", host: "www.dm.de" }),
+  ]
+  const out = dedupeByConfidence(rows)
+  assert.equal(out.length, 1)
+  assert.equal(out[0].host, "www.dm.de")
+})
+
+test("classifyForOutput approves confidence=high with allowlisted host and tokens", () => {
+  const r = row({
+    id: "a",
+    confidence: "high",
+    chosen_url: "https://www.dm.de/p/foo",
+    host: "www.dm.de",
+    matched_tokens: "Aqua|Revive",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "approved")
+})
+
+test("classifyForOutput sends confidence=medium to review", () => {
+  const r = row({
+    id: "a",
+    confidence: "medium",
+    chosen_url: "https://olaplex.com/p",
+    host: "olaplex.com",
+    matched_tokens: "No3",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "review")
+  assert.match(out.reason, /confidence/i)
+})
+
+test("classifyForOutput sends confidence=high but denylisted host to review", () => {
+  const r = row({
+    id: "a",
+    confidence: "high",
+    chosen_url: "https://idealo.de/p",
+    host: "idealo.de",
+    matched_tokens: "Foo",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "review")
+  assert.match(out.reason, /denylisted/i)
+})
+
+test("classifyForOutput sends confidence=high but empty matched_tokens to review", () => {
+  const r = row({
+    id: "a",
+    confidence: "high",
+    chosen_url: "https://www.dm.de/p",
+    host: "www.dm.de",
+    matched_tokens: "",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "review")
+  assert.match(out.reason, /matched_tokens/i)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx tsx --test tests/affiliate-research-aggregate.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `aggregate.ts`**
+
+Create `src/lib/affiliate-research/aggregate.ts`:
+
+```typescript
+import { isAllowedHost, passesBrandDirect, urlGate } from "./url-gate"
+
+export type Confidence = "high" | "medium" | "none"
+
+export type ResultRow = {
+  id: string
+  brand: string
+  name: string
+  chosen_url: string
+  host: string
+  confidence: Confidence | string
+  matched_tokens: string
+  notes: string
+}
+
+const CONFIDENCE_RANK: Record<string, number> = { high: 3, medium: 2, none: 1 }
+
+function hostRank(row: ResultRow): number {
+  if (!row.host) return 0
+  if (isAllowedHost(row.host)) return 3
+  if (passesBrandDirect(row.host, row.brand)) return 2
+  return 1
+}
+
+export function dedupeByConfidence(rows: ResultRow[]): ResultRow[] {
+  const best = new Map<string, ResultRow>()
+  for (const r of rows) {
+    const existing = best.get(r.id)
+    if (!existing) {
+      best.set(r.id, r)
+      continue
+    }
+    const a = CONFIDENCE_RANK[r.confidence] ?? 0
+    const b = CONFIDENCE_RANK[existing.confidence] ?? 0
+    if (a > b || (a === b && hostRank(r) > hostRank(existing))) {
+      best.set(r.id, r)
+    }
+  }
+  return [...best.values()]
+}
+
+export type ClassifyResult =
+  | { bucket: "approved"; reason: "" }
+  | { bucket: "review"; reason: string }
+
+export function classifyForOutput(row: ResultRow): ClassifyResult {
+  if (row.confidence !== "high") {
+    return { bucket: "review", reason: `confidence is '${row.confidence}', not 'high'` }
+  }
+  if (!row.matched_tokens || row.matched_tokens.trim() === "") {
+    return { bucket: "review", reason: "matched_tokens is empty" }
+  }
+  const gate = urlGate({ chosen_url: row.chosen_url, brand: row.brand })
+  if (gate.pass === false) {
+    return { bucket: "review", reason: gate.reason }
+  }
+  return { bucket: "approved", reason: "" }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx tsx --test tests/affiliate-research-aggregate.test.ts
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/affiliate-research/aggregate.ts tests/affiliate-research-aggregate.test.ts
+git commit -m "feat(affiliate-research): add dedupe + approve/review classifier"
+```
+
+---
+
+### Task 6: Export script
+
+Queries Supabase, applies the missing-link predicate, writes `missing.csv` and 16 per-slice files (1 canary + 15 fanout slices).
+
+**Files:**
+- Create: `scripts/export-missing-affiliate-links.ts`
+
+- [ ] **Step 1: Implement the export script**
+
+Create `scripts/export-missing-affiliate-links.ts`:
+
+```typescript
+import { config as loadEnv } from "dotenv"
+import { mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { createClient } from "@supabase/supabase-js"
+
+import { isUsableUrl } from "../src/lib/affiliate-research/url-gate"
+import { writeCsv } from "../src/lib/affiliate-research/csv"
+
+loadEnv({ path: ".env.local" })
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+type ProductRow = {
+  id: string
+  name: string
+  brand: string | null
+  description: string | null
+  category: string | null
+  affiliate_link: string | null
+  price_eur: number | string | null
+  is_active: boolean | null
+}
+
+const OUT_DIR = "data/affiliate-research"
+
+const EXPORT_HEADER = ["id", "brand", "name", "description", "category", "price_eur"] as const
+
+type SliceSpec = {
+  slug: string
+  category: string
+  startIndex: number // 0-based, inclusive
+  endIndex: number // exclusive
+}
+
+const SLICE_PLAN: ReadonlyArray<SliceSpec> = [
+  { slug: "shampoo-a", category: "Shampoo", startIndex: 0, endIndex: 13 },
+  { slug: "shampoo-b", category: "Shampoo", startIndex: 13, endIndex: 26 },
+  { slug: "shampoo-c", category: "Shampoo", startIndex: 26, endIndex: 39 },
+  { slug: "shampoo-d", category: "Shampoo", startIndex: 39, endIndex: 51 },
+  { slug: "leave-in-a", category: "Leave-in", startIndex: 0, endIndex: 14 },
+  { slug: "leave-in-b", category: "Leave-in", startIndex: 14, endIndex: 28 },
+  { slug: "leave-in-c", category: "Leave-in", startIndex: 28, endIndex: 42 },
+  { slug: "oele-a", category: "Öle", startIndex: 0, endIndex: 14 },
+  { slug: "oele-b", category: "Öle", startIndex: 14, endIndex: 28 },
+  { slug: "oele-c", category: "Öle", startIndex: 28, endIndex: 41 },
+  { slug: "conditioner-a", category: "Conditioner (Drogerie)", startIndex: 0, endIndex: 14 },
+  { slug: "conditioner-b", category: "Conditioner (Drogerie)", startIndex: 14, endIndex: 27 },
+  { slug: "conditioner-c", category: "Conditioner (Drogerie)", startIndex: 27, endIndex: 40 },
+  { slug: "maske-a", category: "Maske", startIndex: 0, endIndex: 18 },
+  { slug: "maske-b", category: "Maske", startIndex: 18, endIndex: 35 },
+]
+
+function toExportRow(r: ProductRow): Record<string, string> {
+  return {
+    id: r.id,
+    brand: r.brand ?? "",
+    name: r.name,
+    description: r.description ?? "",
+    category: r.category ?? "",
+    price_eur: r.price_eur != null ? String(r.price_eur) : "",
+  }
+}
+
+async function fetchAllMissing(): Promise<ProductRow[]> {
+  const pageSize = 1000
+  let from = 0
+  const all: ProductRow[] = []
+  while (true) {
+    const { data, error } = await supabase
+      .from("products")
+      .select("id, name, brand, description, category, affiliate_link, price_eur, is_active")
+      .order("category", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + pageSize - 1)
+    if (error) throw error
+    if (!data || data.length === 0) break
+    all.push(...(data as ProductRow[]))
+    if (data.length < pageSize) break
+    from += pageSize
+  }
+  return all.filter((r) => r.is_active && !isUsableUrl(r.affiliate_link))
+}
+
+function pickCanary(rows: ProductRow[]): ProductRow[] {
+  // 1-2 rows per category, prefer brand diversity
+  const byCat = new Map<string, ProductRow[]>()
+  for (const r of rows) {
+    const cat = r.category ?? "(none)"
+    const arr = byCat.get(cat) ?? []
+    arr.push(r)
+    byCat.set(cat, arr)
+  }
+  const out: ProductRow[] = []
+  for (const [, list] of byCat) {
+    out.push(list[0])
+    if (list.length > 1) out.push(list[Math.min(list.length - 1, 5)])
+    if (out.length >= 8) break
+  }
+  return out.slice(0, 8)
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true })
+
+  const missing = await fetchAllMissing()
+  console.log(`Found ${missing.length} active products missing a usable affiliate_link.`)
+
+  // Write master missing.csv
+  writeCsv(
+    join(OUT_DIR, "missing.csv"),
+    [...EXPORT_HEADER],
+    missing.map(toExportRow),
+  )
+
+  // Write canary slice
+  const canary = pickCanary(missing)
+  writeCsv(
+    join(OUT_DIR, "missing-canary.csv"),
+    [...EXPORT_HEADER],
+    canary.map(toExportRow),
+  )
+  console.log(`Wrote missing-canary.csv with ${canary.length} rows.`)
+
+  // Group by category, sort by id, slice
+  const byCategory = new Map<string, ProductRow[]>()
+  for (const r of missing) {
+    const list = byCategory.get(r.category ?? "") ?? []
+    list.push(r)
+    byCategory.set(r.category ?? "", list)
+  }
+  for (const list of byCategory.values()) {
+    list.sort((a, b) => a.id.localeCompare(b.id))
+  }
+
+  let totalWritten = 0
+  for (const slice of SLICE_PLAN) {
+    const pool = byCategory.get(slice.category) ?? []
+    const rows = pool.slice(slice.startIndex, slice.endIndex)
+    writeCsv(
+      join(OUT_DIR, `missing-${slice.slug}.csv`),
+      [...EXPORT_HEADER],
+      rows.map(toExportRow),
+    )
+    console.log(`Wrote missing-${slice.slug}.csv (${rows.length} rows from ${slice.category}).`)
+    totalWritten += rows.length
+  }
+
+  if (totalWritten !== missing.length) {
+    console.warn(
+      `WARNING: slice plan covers ${totalWritten} rows but ${missing.length} are missing. Adjust SLICE_PLAN ranges if category counts changed.`,
+    )
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Run the export script against the live DB**
+
+```bash
+npx tsx scripts/export-missing-affiliate-links.ts
+```
+
+Expected output:
+```
+Found 209 active products missing a usable affiliate_link.
+Wrote missing-canary.csv with 8 rows.
+Wrote missing-shampoo-a.csv (13 rows from Shampoo).
+...
+```
+
+If totals don't match (e.g. category counts have drifted), the warning fires — adjust `SLICE_PLAN` ranges and rerun.
+
+- [ ] **Step 3: Spot-check one slice file**
+
+```bash
+head -3 data/affiliate-research/missing-shampoo-a.csv
+```
+
+Expected: header row plus two product rows with valid id/brand/name.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/export-missing-affiliate-links.ts
+git commit -m "feat(affiliate-research): export missing-link products into slice CSVs"
+```
+
+---
+
+### Task 7: Validate-slice CLI
+
+Thin wrapper around `validateSlice`. Runs after each subagent's slice; exits non-zero on failure.
+
+**Files:**
+- Create: `scripts/validate-slice.ts`
+
+- [ ] **Step 1: Implement the validator CLI**
+
+Create `scripts/validate-slice.ts`:
+
+```typescript
+import { appendFileSync, existsSync } from "node:fs"
+import { join } from "node:path"
+
+import { validateSlice } from "../src/lib/affiliate-research/slice-validator"
+
+function usage(): never {
+  console.error(
+    "Usage: tsx scripts/validate-slice.ts <slug>\n" +
+      "  Reads data/affiliate-research/missing-<slug>.csv and results-<slug>.csv.\n" +
+      "  Appends one line to data/affiliate-research/validation.log.\n" +
+      "  Exits 0 on success, 1 on validation failure, 2 on missing files.",
+  )
+  process.exit(2)
+}
+
+const slug = process.argv[2]
+if (!slug) usage()
+if (!/^[a-z0-9-]+$/.test(slug)) {
+  console.error(`Invalid slug '${slug}' — must match [a-z0-9-]+`)
+  process.exit(2)
+}
+
+const DIR = "data/affiliate-research"
+const inputPath = join(DIR, `missing-${slug}.csv`)
+const outputPath = join(DIR, `results-${slug}.csv`)
+const logPath = join(DIR, "validation.log")
+
+if (!existsSync(inputPath)) {
+  console.error(`Missing input file: ${inputPath}`)
+  process.exit(2)
+}
+if (!existsSync(outputPath)) {
+  console.error(`Missing output file: ${outputPath} — subagent has not produced results yet.`)
+  process.exit(2)
+}
+
+const res = validateSlice({ inputPath, outputPath })
+const timestamp = new Date().toISOString()
+const summary = `${timestamp} slice=${slug} ok=${res.ok} rows=${res.rowCount} missing=${res.missing.length} duplicated=${res.duplicated.length}`
+appendFileSync(logPath, summary + "\n")
+console.log(summary)
+if (!res.ok) {
+  for (const err of res.errors) console.error("  - " + err)
+  process.exit(1)
+}
+process.exit(0)
+```
+
+- [ ] **Step 2: Smoke-test against a hand-built fixture**
+
+```bash
+mkdir -p data/affiliate-research
+cat > data/affiliate-research/missing-smoke.csv <<'EOF'
+id,brand,name,description,category,price_eur
+a,Brand,Name,Desc,Shampoo,5
+b,Brand,Name2,Desc2,Shampoo,6
+EOF
+cat > data/affiliate-research/results-smoke.csv <<'EOF'
+id,brand,name,chosen_url,host,confidence,matched_tokens,notes
+a,Brand,Name,https://www.dm.de/p,www.dm.de,high,Foo,ok
+b,Brand,Name2,,,none,,not found
+EOF
+npx tsx scripts/validate-slice.ts smoke
+```
+
+Expected output:
+```
+... slice=smoke ok=true rows=2 missing=0 duplicated=0
+```
+
+Exit code 0.
+
+- [ ] **Step 3: Negative test — corrupt the output**
+
+```bash
+echo "a,Brand,Name,,,WRONG,," >> data/affiliate-research/results-smoke.csv
+npx tsx scripts/validate-slice.ts smoke
+echo "exit code: $?"
+```
+
+Expected: ok=false, error mentioning duplicate id and/or invalid confidence. Exit code 1.
+
+- [ ] **Step 4: Clean up smoke files**
+
+```bash
+rm data/affiliate-research/missing-smoke.csv data/affiliate-research/results-smoke.csv
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate-slice.ts
+git commit -m "feat(affiliate-research): add per-slice CLI validator"
+```
+
+---
+
+### Task 8: Aggregate script
+
+Reads `data/affiliate-research/results-*.csv` (hard-coded glob, no flag), dedupes, classifies, writes `results.csv`, `approved.csv`, `review-queue.csv`.
+
+**Files:**
+- Create: `scripts/aggregate-affiliate-research.ts`
+
+- [ ] **Step 1: Implement the aggregator**
+
+Create `scripts/aggregate-affiliate-research.ts`:
+
+```typescript
+import { readdirSync } from "node:fs"
+import { join } from "node:path"
+
+import { readCsv, writeCsv, type CsvRow } from "../src/lib/affiliate-research/csv"
+import {
+  dedupeByConfidence,
+  classifyForOutput,
+  type ResultRow,
+} from "../src/lib/affiliate-research/aggregate"
+import {
+  INPUT_HEADER,
+  OUTPUT_HEADER,
+} from "../src/lib/affiliate-research/slice-validator"
+
+const DIR = "data/affiliate-research"
+const RESULTS_GLOB = /^results-[a-z0-9-]+\.csv$/
+
+const APPROVED_HEADER = ["id", "brand", "name", "chosen_url", "host", "matched_tokens", "notes"] as const
+const REVIEW_HEADER = [
+  "id",
+  "brand",
+  "name",
+  "chosen_url",
+  "host",
+  "confidence",
+  "matched_tokens",
+  "notes",
+  "review_reason",
+] as const
+
+function toResultRow(r: CsvRow): ResultRow {
+  return {
+    id: r.id,
+    brand: r.brand,
+    name: r.name,
+    chosen_url: r.chosen_url,
+    host: r.host,
+    confidence: r.confidence,
+    matched_tokens: r.matched_tokens,
+    notes: r.notes,
+  }
+}
+
+function loadCategoryByIdFromMissing(): Map<string, string> {
+  const path = join(DIR, "missing.csv")
+  const rows = readCsv(path, { expectedHeader: [...INPUT_HEADER] })
+  const map = new Map<string, string>()
+  for (const r of rows) map.set(r.id, r.category)
+  return map
+}
+
+function main(): void {
+  const files = readdirSync(DIR).filter((f) => RESULTS_GLOB.test(f))
+  if (files.length === 0) {
+    console.error(`No results-*.csv found in ${DIR}. Did the subagents run?`)
+    process.exit(2)
+  }
+
+  const categoryById = loadCategoryByIdFromMissing()
+
+  const all: ResultRow[] = []
+  for (const f of files) {
+    const rows = readCsv(join(DIR, f), { expectedHeader: [...OUTPUT_HEADER] })
+    for (const r of rows) all.push(toResultRow(r))
+    console.log(`Loaded ${rows.length} rows from ${f}`)
+  }
+
+  const deduped = dedupeByConfidence(all)
+  console.log(`Deduped ${all.length} → ${deduped.length} unique ids.`)
+
+  const approved: CsvRow[] = []
+  const review: CsvRow[] = []
+  for (const r of deduped) {
+    const cls = classifyForOutput(r)
+    if (cls.bucket === "approved") {
+      approved.push({
+        id: r.id,
+        brand: r.brand,
+        name: r.name,
+        chosen_url: r.chosen_url,
+        host: r.host,
+        matched_tokens: r.matched_tokens,
+        notes: r.notes,
+      })
+    } else {
+      review.push({
+        id: r.id,
+        brand: r.brand,
+        name: r.name,
+        chosen_url: r.chosen_url,
+        host: r.host,
+        confidence: r.confidence,
+        matched_tokens: r.matched_tokens,
+        notes: r.notes,
+        review_reason: cls.reason,
+      })
+    }
+  }
+
+  writeCsv(
+    join(DIR, "results.csv"),
+    [...OUTPUT_HEADER],
+    deduped.map((r) => ({
+      id: r.id,
+      brand: r.brand,
+      name: r.name,
+      chosen_url: r.chosen_url,
+      host: r.host,
+      confidence: r.confidence,
+      matched_tokens: r.matched_tokens,
+      notes: r.notes,
+    })),
+  )
+  writeCsv(join(DIR, "approved.csv"), [...APPROVED_HEADER], approved)
+  writeCsv(join(DIR, "review-queue.csv"), [...REVIEW_HEADER], review)
+
+  // Category × confidence summary (joined via missing.csv)
+  type Tallies = { high: number; medium: number; none: number; approved: number; review: number }
+  const summary = new Map<string, Tallies>()
+  for (const r of deduped) {
+    const cat = categoryById.get(r.id) ?? "(unknown)"
+    const slot: Tallies = summary.get(cat) ?? { high: 0, medium: 0, none: 0, approved: 0, review: 0 }
+    if (r.confidence === "high") slot.high++
+    else if (r.confidence === "medium") slot.medium++
+    else slot.none++
+    summary.set(cat, slot)
+  }
+  for (const row of approved) {
+    const cat = categoryById.get(row.id) ?? "(unknown)"
+    const slot = summary.get(cat)
+    if (slot) slot.approved++
+  }
+  for (const row of review) {
+    const cat = categoryById.get(row.id) ?? "(unknown)"
+    const slot = summary.get(cat)
+    if (slot) slot.review++
+  }
+
+  console.log("\n=== Summary ===")
+  console.log(`Total unique ids: ${deduped.length}`)
+  console.log(`Approved:         ${approved.length}`)
+  console.log(`Review queue:     ${review.length}`)
+  console.log("\ncategory                 | high | medium | none | approved | review")
+  for (const [cat, t] of [...summary.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    console.log(
+      `${cat.padEnd(24)} | ${String(t.high).padStart(4)} | ${String(t.medium).padStart(6)} | ${String(t.none).padStart(4)} | ${String(t.approved).padStart(8)} | ${String(t.review).padStart(6)}`,
+    )
+  }
+}
+
+main()
+```
+
+- [ ] **Step 2: Smoke-test against minimal fixtures**
+
+If a real `missing.csv` already exists (from Task 6), back it up first:
+
+```bash
+[ -f data/affiliate-research/missing.csv ] && mv data/affiliate-research/missing.csv data/affiliate-research/missing.csv.bak
+
+cat > data/affiliate-research/missing.csv <<'EOF'
+id,brand,name,description,category,price_eur
+a,Pantene,Aqua Glow,,Shampoo,5
+b,Sante,Aloe Conditioner,,Conditioner (Drogerie),6
+c,Bali,Bali Curls,,Leave-in,7
+d,Foo,Foo Mask,,Maske,8
+e,Cantu,Cantu Repair,,Conditioner (Drogerie),9
+EOF
+
+cat > data/affiliate-research/results-smoke1.csv <<'EOF'
+id,brand,name,chosen_url,host,confidence,matched_tokens,notes
+a,Pantene,Aqua Glow,https://www.dm.de/p/aqua-glow,www.dm.de,high,Aqua|Glow,ok
+b,Sante,Aloe Conditioner,https://sante.de/aloe,sante.de,high,Aloe,brand-direct
+c,Bali,Bali Curls,https://random.example/p,random.example,high,Bali|Curls,unknown shop
+EOF
+
+cat > data/affiliate-research/results-smoke2.csv <<'EOF'
+id,brand,name,chosen_url,host,confidence,matched_tokens,notes
+a,Pantene,Aqua Glow,https://other.example/p,other.example,medium,Aqua,older candidate
+d,Foo,Foo Mask,,,none,,no shop carries it
+e,Cantu,Cantu Repair,https://idealo.de/p,idealo.de,high,Repair,oops aggregator
+EOF
+
+npx tsx scripts/aggregate-affiliate-research.ts
+```
+
+Expected:
+- a → approved (high on dm.de; deduped against the medium other.example)
+- b → approved (high, brand-direct sante.de)
+- c → review (host not allowlisted, brand "Bali" too short for brand-direct)
+- d → review (confidence=none)
+- e → review (host denylisted)
+
+```
+Approved:     2
+Review queue: 3
+```
+
+- [ ] **Step 3: Clean up smoke files**
+
+```bash
+rm data/affiliate-research/results-smoke1.csv data/affiliate-research/results-smoke2.csv
+rm -f data/affiliate-research/results.csv data/affiliate-research/approved.csv data/affiliate-research/review-queue.csv
+rm data/affiliate-research/missing.csv
+[ -f data/affiliate-research/missing.csv.bak ] && mv data/affiliate-research/missing.csv.bak data/affiliate-research/missing.csv
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/aggregate-affiliate-research.ts
+git commit -m "feat(affiliate-research): aggregate subagent results into approved/review CSVs"
+```
+
+---
+
+### Task 9: Write-back script with --dry
+
+Reads `approved.csv`, runs the UPDATE with the safety-belt WHERE clause, appends to `applied.log`.
+
+**Files:**
+- Create: `scripts/write-affiliate-links.ts`
+
+- [ ] **Step 1: Implement the write-back script**
+
+Pattern: pre-fetch each candidate's current `affiliate_link`, decide locally whether the safety belt allows the write (mirroring the export predicate exactly: `null OR empty OR non-http(s)`), then `UPDATE`. Two round-trips per row, ~200 rows = ~400 calls. Acceptable.
+
+Create `scripts/write-affiliate-links.ts`:
+
+```typescript
+import { config as loadEnv } from "dotenv"
+import { appendFileSync } from "node:fs"
+import { join } from "node:path"
+import { createClient } from "@supabase/supabase-js"
+
+import { readCsv } from "../src/lib/affiliate-research/csv"
+import { isUsableUrl, urlGate } from "../src/lib/affiliate-research/url-gate"
+
+loadEnv({ path: ".env.local" })
+
+const DIR = "data/affiliate-research"
+const APPROVED_PATH = join(DIR, "approved.csv")
+const LOG_PATH = join(DIR, "applied.log")
+
+const APPROVED_HEADER = ["id", "brand", "name", "chosen_url", "host", "matched_tokens", "notes"]
+
+const dry = process.argv.includes("--dry")
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+// Mirrors the export predicate: write-eligible iff current value is null,
+// empty/whitespace, or not a usable http(s) URL.
+function safeToWrite(currentValue: string | null | undefined): boolean {
+  return !isUsableUrl(currentValue)
+}
+
+function appendLog(line: string): void {
+  appendFileSync(LOG_PATH, `${new Date().toISOString()} ${line}\n`)
+}
+
+async function main(): Promise<void> {
+  const rows = readCsv(APPROVED_PATH, { expectedHeader: APPROVED_HEADER })
+  console.log(`Read ${rows.length} approved rows from ${APPROVED_PATH}.`)
+
+  // Defensive re-gate — should be a no-op for a well-formed approved.csv.
+  const rejected: { id: string; reason: string }[] = []
+  const accepted = rows.filter((r) => {
+    const g = urlGate({ chosen_url: r.chosen_url, brand: r.brand })
+    if (g.pass === false) {
+      rejected.push({ id: r.id, reason: g.reason })
+      return false
+    }
+    return true
+  })
+  if (rejected.length > 0) {
+    console.warn(`REJECTED ${rejected.length} rows on re-validation:`)
+    for (const r of rejected) console.warn(`  - ${r.id}: ${r.reason}`)
+  }
+
+  let applied = 0
+  let skippedBySafetyBelt = 0
+  let failed = 0
+  for (const r of accepted) {
+    const { data: current, error: readErr } = await supabase
+      .from("products")
+      .select("id, affiliate_link")
+      .eq("id", r.id)
+      .maybeSingle()
+    if (readErr) {
+      console.error(`READ FAILED ${r.id}: ${readErr.message}`)
+      failed++
+      continue
+    }
+    if (!current) {
+      console.error(`NOT FOUND ${r.id} — product no longer exists`)
+      failed++
+      continue
+    }
+    if (!safeToWrite(current.affiliate_link as string | null)) {
+      skippedBySafetyBelt++
+      appendLog(`SKIP id=${r.id} reason=safety_belt_existing=${JSON.stringify(current.affiliate_link)}`)
+      continue
+    }
+    if (dry) {
+      console.log(`DRY  UPDATE products SET affiliate_link='${r.chosen_url}' WHERE id='${r.id}'`)
+      applied++
+      continue
+    }
+    const { error: writeErr } = await supabase
+      .from("products")
+      .update({ affiliate_link: r.chosen_url })
+      .eq("id", r.id)
+    if (writeErr) {
+      console.error(`WRITE FAILED ${r.id}: ${writeErr.message}`)
+      failed++
+      continue
+    }
+    appendLog(`OK   id=${r.id} url=${r.chosen_url}`)
+    applied++
+  }
+
+  console.log(
+    `\nDone. applied=${applied}, skipped_by_safety_belt=${skippedBySafetyBelt}, rejected_on_revalidate=${rejected.length}, failed=${failed}.`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Run --dry against a small approved.csv fixture**
+
+```bash
+cat > data/affiliate-research/approved.csv <<'EOF'
+id,brand,name,chosen_url,host,matched_tokens,notes
+test-id,Pantene,Aqua Glow,https://www.dm.de/p/aqua-glow,www.dm.de,Aqua|Glow,ok
+EOF
+npx tsx scripts/write-affiliate-links.ts --dry
+```
+
+Expected: prints a DRY UPDATE statement; no DB writes; reports `applied=1`.
+
+- [ ] **Step 3: Negative dry-run — junk URL**
+
+```bash
+cat > data/affiliate-research/approved.csv <<'EOF'
+id,brand,name,chosen_url,host,matched_tokens,notes
+junk-id,Pantene,Aqua,https://idealo.de/p,idealo.de,Aqua,oops
+EOF
+npx tsx scripts/write-affiliate-links.ts --dry
+```
+
+Expected: warns that `junk-id` was rejected on re-validation (denylisted host); applied=0.
+
+- [ ] **Step 4: Clean up fixture**
+
+```bash
+rm -f data/affiliate-research/approved.csv data/affiliate-research/applied.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/write-affiliate-links.ts
+git commit -m "feat(affiliate-research): write-back script with safety-belt UPDATE and --dry"
+```
+
+---
+
+### Task 10: Runbook
+
+Document the execution sequence so anyone (or the dispatcher in a fresh session) can run the workflow without re-reading the spec.
+
+**Files:**
+- Create: `docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md`:
+
+````markdown
+# Runbook — Affiliate Link Backfill Execution
+
+Spec: `docs/superpowers/specs/2026-05-13-affiliate-link-backfill-design.md`
+Plan: `docs/superpowers/plans/2026-05-13-affiliate-link-backfill.md`
+
+This runbook walks through a single end-to-end execution. Everything that mutates production data is explicit and confirm-able.
+
+## Prerequisites
+
+- `.env.local` is populated with `NEXT_PUBLIC_SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+- `npm run ci:verify` passes on `main`.
+- `data/affiliate-research/` exists.
+
+## Step 1 — Export
+
+```bash
+npx tsx scripts/export-missing-affiliate-links.ts
+```
+
+Confirm the row count matches the audit (`209` at time of plan-writing). If the totals warning fires, update `SLICE_PLAN` in the export script and rerun.
+
+## Step 2 — Canary
+
+Dispatch one general-purpose subagent. From the Claude Code session, invoke the `Agent` tool with the prompt template below, parameterized for the canary slice:
+
+```
+INPUT  = data/affiliate-research/missing-canary.csv
+OUTPUT = data/affiliate-research/results-canary.csv
+CATEGORY = "mixed (canary)"
+PREFERENCE_ORDER = "DM > Rossmann > Müller > brand-direct > Amazon DE"
+```
+
+Wait for the agent to complete. Then:
+
+```bash
+npx tsx scripts/validate-slice.ts canary
+head -5 data/affiliate-research/results-canary.csv
+```
+
+Eyeball the chosen URLs. If the verification rules need tweaking (too many false `high`s, etc.), edit the prompt template before fanout.
+
+## Step 3 — Fanout
+
+In a single Claude Code message, dispatch 15 `Agent` calls in parallel — one per slice. Use the per-category preference orders from the spec. Each agent's prompt swaps in its slice's `SLUG`, `CATEGORY`, and `PREFERENCE_ORDER`.
+
+Slices:
+
+```
+shampoo-a, shampoo-b, shampoo-c, shampoo-d
+leave-in-a, leave-in-b, leave-in-c
+oele-a, oele-b, oele-c
+conditioner-a, conditioner-b, conditioner-c
+maske-a, maske-b
+```
+
+When all 15 return:
+
+```bash
+for slug in shampoo-a shampoo-b shampoo-c shampoo-d \
+            leave-in-a leave-in-b leave-in-c \
+            oele-a oele-b oele-c \
+            conditioner-a conditioner-b conditioner-c \
+            maske-a maske-b; do
+  npx tsx scripts/validate-slice.ts "$slug" || echo "FAILED: $slug"
+done
+```
+
+Any slice that fails: rerun ONLY that slice's subagent (point it at the same input/output paths). Re-validate.
+
+## Step 4 — Pre-aggregation diff check
+
+Confirm the subagents only wrote `results-*.csv` files (boundary check from the spec):
+
+```bash
+ls data/affiliate-research/
+git status -- data/affiliate-research/
+```
+
+Expected: only `missing-*.csv` (already-present) and `results-*.csv` (newly written) files. If anything else changed (e.g. someone touched `applied.log` already, or a stray script-output file appeared), STOP and investigate before aggregating.
+
+## Step 5 — Aggregate
+
+```bash
+npx tsx scripts/aggregate-affiliate-research.ts
+```
+
+Inspect:
+
+```bash
+wc -l data/affiliate-research/{results,approved,review-queue}.csv
+head -10 data/affiliate-research/approved.csv
+```
+
+## Step 6 — Manual review of `approved.csv`
+
+Open `approved.csv`. Sanity-check each row's `chosen_url` against `name` and `brand`. Delete any row that looks wrong. Move rows you'd like to escalate from `review-queue.csv` into `approved.csv` if you trust them.
+
+## Step 7 — Dry write-back
+
+```bash
+npx tsx scripts/write-affiliate-links.ts --dry
+```
+
+Confirm the printed UPDATE count matches `approved.csv` row count.
+
+## Step 8 — Real write-back
+
+```bash
+npx tsx scripts/write-affiliate-links.ts
+```
+
+Then re-audit:
+
+```bash
+npx tsx scripts/audit-affiliate-links.ts
+```
+
+`activeWithLink` should have increased by exactly the count in `applied.log`.
+
+## Rollback
+
+If a bad batch of URLs was written, regenerate from the previous audit and re-NULL specific rows:
+
+```sql
+UPDATE products SET affiliate_link = NULL WHERE id IN ('id1', 'id2', ...);
+```
+
+Then re-export, re-research only those rows, and re-aggregate.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md
+git commit -m "docs(affiliate-research): runbook for end-to-end execution"
+```
+
+---
+
+### Task 11: Final verification
+
+Confirm all scripts run, all tests pass, and the type-check is clean before declaring the implementation done.
+
+- [ ] **Step 1: Run all affiliate-research tests**
+
+```bash
+npx tsx --test \
+  tests/affiliate-research-url-gate.test.ts \
+  tests/affiliate-research-csv.test.ts \
+  tests/affiliate-research-slice-validator.test.ts \
+  tests/affiliate-research-aggregate.test.ts
+```
+
+Expected: all tests pass (28 total across the four files).
+
+- [ ] **Step 2: Type-check the whole project**
+
+```bash
+npm run typecheck
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Lint the whole project**
+
+```bash
+npm run lint
+```
+
+Expected: zero errors.
+
+- [ ] **Step 4: Confirm script entry-points work without arguments**
+
+```bash
+npx tsx scripts/validate-slice.ts 2>&1 | head -5
+npx tsx scripts/aggregate-affiliate-research.ts 2>&1 | head -5
+npx tsx scripts/write-affiliate-links.ts --dry 2>&1 | head -5
+```
+
+Each should print a useful error or usage message (no uncaught crash).
+
+No commit needed; this task is verification only.
+
+---
+
+## Runbook (post-implementation)
+
+The implementation builds the tooling. **Running the workflow against the live DB is not part of this plan** — it's the runbook (Task 10) that the user (or a fresh Claude Code session) executes.

--- a/docs/superpowers/specs/2026-05-13-affiliate-link-backfill-design.md
+++ b/docs/superpowers/specs/2026-05-13-affiliate-link-backfill-design.md
@@ -1,0 +1,348 @@
+# Affiliate Link Backfill — Design
+
+**Date:** 2026-05-13
+**Status:** Approved (brainstorming)
+**Owner:** Nick
+
+## Goal
+
+Fill `products.affiliate_link` for the ~209 active products that are missing a usable shop URL, so that the product drawer can display its Buy CTA. The drawer derives shop label + disclosure from the URL host, so a plain product URL is sufficient — affiliate-program enrollment is out of scope here.
+
+## Scope
+
+In: 209 active rows with null / empty / non-http(s) `affiliate_link` across Shampoo (51), Leave-in (42), Öle (41), Conditioner Drogerie (40), Maske (35).
+
+Out: Bondbuilder (5) and Trockenshampoo (10) already have links. No schema changes. No affiliate-tagging. No shop-name field — host is derived.
+
+## Mechanism (one paragraph)
+
+Export missing rows → dispatch Claude Code general-purpose subagents (one per category, long poles split) that each research their slice with `WebSearch` + `WebFetch`, verify candidate URLs, and write a CSV → aggregate the per-slice CSVs into a master `results.csv`, an `approved.csv` (high-confidence only), and a `review-queue.csv` (medium + none) → user reviews `approved.csv` → `write-affiliate-links.ts` issues the UPDATEs.
+
+The crucial property: subagents auto-classify but **never write to the DB**. The DB write is its own explicit step against a human-reviewed CSV.
+
+## Pipeline
+
+```
+┌─ scripts/export-missing-affiliate-links.ts ──────────────────────────┐
+│  reads products → data/affiliate-research/missing.csv                 │
+│  + per-category slices: missing-shampoo-a.csv, missing-oele.csv, ...  │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─ CANARY ─────────────────────────────────────────────────────────────┐
+│  Agent(subagent_type=general-purpose) on data/.../missing-canary.csv  │
+│  → writes data/.../results-canary.csv                                 │
+│  → user inspects, tunes prompt if needed                              │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─ FULL FANOUT (~15 parallel subagents, ~13-18 rows each) ─────────────┐
+│  shampoo-a..d, leave-in-a..c, oele-a..c, conditioner-a..c, maske-a..b │
+│  each → data/affiliate-research/results-<slug>.csv                    │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─ scripts/validate-slice.ts (run after each slice completes) ─────────┐
+│  - CSV parses cleanly                                                 │
+│  - column header matches schema exactly                               │
+│  - row count matches input slice row count                            │
+│  - every id from missing-<slug>.csv appears exactly once              │
+│  - failure → flag slice for rerun; aggregator refuses to proceed      │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─ scripts/aggregate-affiliate-research.ts ────────────────────────────┐
+│  reads only data/affiliate-research/results-*.csv (no wider scope)    │
+│  merges, dedupes by id (keep highest confidence)                      │
+│  applies URL gate (parse + HOST_ALLOWLIST/DENYLIST/brand-in-host)     │
+│  → results.csv          (every researched row, all confidences)       │
+│  → approved.csv         (confidence='high' AND URL gate passes)       │
+│  → review-queue.csv     (everything else)                             │
+│  → prints summary table: category × confidence + reasons              │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                  ┌─── MANUAL APPROVAL GATE ───┐
+                  │  user reviews approved.csv │
+                  └────────────────────────────┘
+                              │
+                              ▼
+┌─ scripts/write-affiliate-links.ts [--dry] ───────────────────────────┐
+│  reads approved.csv                                                   │
+│  re-validates each URL (parse + host gate)                            │
+│  UPDATE products SET affiliate_link = ? WHERE id = ?                  │
+│      AND (affiliate_link IS NULL                                      │
+│           OR btrim(affiliate_link) = ''                               │
+│           OR affiliate_link !~* '^https?://')  -- matches export      │
+│  → appends to data/affiliate-research/applied.log                     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## Subagent contract
+
+**Dispatcher (Claude Code main session, executing the plan):**
+
+For each slice, invokes `Agent` with `subagent_type: "general-purpose"` and a prompt of the form below. All fanout agents (~15) go out in a single message → run in parallel.
+
+**Per-category preference orders:**
+
+| Category | Preference order |
+|---|---|
+| Shampoo | DM > Rossmann > Müller > brand-direct > Amazon DE |
+| Conditioner (Drogerie) | DM > Rossmann > Müller > brand-direct > Amazon DE |
+| Maske | DM > Rossmann > Müller > brand-direct > Amazon DE |
+| Leave-in | DM > brand-direct > Rossmann > Amazon DE |
+| Öle | brand-direct > Amazon DE > DM > Rossmann |
+
+**Host allowlist** (auto-approved at the aggregation gate):
+
+```
+www.dm.de, www.rossmann.de, www.mueller.de, www.amazon.de,
+www.douglas.de, www.flaconi.de, www.notino.de, www.otto.de
+(with or without the www. prefix)
+```
+
+**Host denylist** (always rejected — never confidence='high'):
+
+```
+idealo.de, geizhals.de, billiger.de, preisvergleich.de,
+ebay.de, ebay.com, kleinanzeigen.de, aliexpress.com,
+amazon.com (use amazon.de for the DE market)
+```
+
+**Brand-direct rule:** A host outside the allowlist passes if its hostname contains the brand name as a substring (lowercased, alphanumeric only — e.g. `olaplex.com` for brand "OLAPLEX", `k18hair.com` for "K18", `sante.de` for "Sante"). Anything else: confidence stays `medium` at best.
+
+**Subagent prompt skeleton** (parameterized per slice):
+
+```
+You are researching German online-shop URLs for {N} hair-care products
+in category "{CATEGORY}". You are running in parallel with other agents
+working on other slices — only research the rows in your input file.
+
+INPUT:  data/affiliate-research/missing-{SLUG}.csv
+        columns: id,brand,name,description,category,price_eur
+OUTPUT: data/affiliate-research/results-{SLUG}.csv
+        columns: id,brand,name,chosen_url,host,confidence,matched_tokens,notes
+
+Shop preference order for this category: {PREFERENCE_ORDER}
+
+ALLOWED TOOLS: WebSearch, WebFetch, Read (only on data/affiliate-research/),
+               Write (only to your OUTPUT path above).
+FORBIDDEN:     Bash, Edit, ToolSearch, npm/npx, reading .env files, reading
+               anything outside data/affiliate-research/, mutating any other
+               file, opening a database connection.
+
+For each input row:
+  1. WebSearch with query: '{brand} {name} site:{first preferred shop host}'.
+  2. If no relevant hit, walk down the preference order, dropping the
+     site: filter at the end if needed. Cap: ≤3 search calls per product.
+  3. Reject any URL whose path matches: /search, /suche, /s/, /category,
+     /kategorie, /c/, /marken, /marke/, /brand/, /b/, or is a brand
+     landing page (path ends at the brand slug with no product slug).
+  4. For the surviving top candidate URL, WebFetch it.
+  5. Verify ALL of:
+     - HTTP 200 (or 3xx redirecting within the same host)
+     - URL host is in the allowlist OR matches the brand-direct rule
+       (hostname contains the brand slug as substring)
+     - Host is NOT in the denylist (idealo, geizhals, billiger,
+       preisvergleich, ebay, kleinanzeigen, aliexpress)
+     - Brand string (case-insensitive, German umlauts normalized) appears
+       in the page HTML
+     - At least one DISTINCTIVE token from the product name appears in
+       <title> or H1. A "distinctive token" is a non-stopword token from
+       the name that is NOT a category noun ("Shampoo", "Spülung",
+       "Conditioner", "Maske", "Mask", "Öl", "Oil", "Treatment", "Cream",
+       "Repair", "Pflege", "Care", "Volume", "Volumen") and is at least
+       4 characters long. Record the tokens you matched.
+  6. Classify confidence:
+       high   = all verification checks pass, distinctive token in <title>/H1
+       medium = brand+token present in body but not title; OR only one
+                of brand/distinctive-token matched in title; OR host
+                is non-allowlisted but matches brand-direct rule
+       none   = couldn't find a candidate, denied host, denied path,
+                or any verification check failed
+  7. Append exactly one row to your output CSV. Quote any field containing
+     a comma. Empty fields are empty strings, not the word "null".
+
+HARD RULES
+  - Never invent or guess a URL. If not found, write confidence=none with
+    chosen_url and host empty.
+  - Never write confidence=high for a host on the denylist.
+  - Process EVERY row in your input, in order. Skip none.
+  - Output row count MUST equal input row count.
+  - Do NOT touch the database, run scripts, edit other files, or read
+    anything outside data/affiliate-research/.
+
+When done, return a one-paragraph summary: total processed, counts per
+confidence bucket, and any patterns worth noting (e.g. "Brand X has no
+DM presence — all fell back to Amazon").
+```
+
+## Slicing plan
+
+Target slice size: ~15 rows. Smaller slices reduce timeout / drift / CSV-truncation risk and make reruns cheap. Slices are sorted by id within their category and split evenly.
+
+| Stage | Slice | Category filter | Rows |
+|---|---|---|---|
+| 1 | canary | 8 mixed rows (≥1 per category, varied brand types) | 8 |
+| 2 | shampoo-a | Shampoo (rows 1-13 of 51 by id) | 13 |
+| 2 | shampoo-b | Shampoo (14-26) | 13 |
+| 2 | shampoo-c | Shampoo (27-39) | 13 |
+| 2 | shampoo-d | Shampoo (40-51) | 12 |
+| 2 | leave-in-a | Leave-in (1-14 of 42) | 14 |
+| 2 | leave-in-b | Leave-in (15-28) | 14 |
+| 2 | leave-in-c | Leave-in (29-42) | 14 |
+| 2 | oele-a | Öle (1-14 of 41) | 14 |
+| 2 | oele-b | Öle (15-28) | 14 |
+| 2 | oele-c | Öle (29-41) | 13 |
+| 2 | conditioner-a | Conditioner missing (1-14 of 40) | 14 |
+| 2 | conditioner-b | Conditioner missing (15-27) | 13 |
+| 2 | conditioner-c | Conditioner missing (28-40) | 13 |
+| 2 | maske-a | Maske (1-18 of 35) | 18 |
+| 2 | maske-b | Maske (19-35) | 17 |
+| | **Total fanout** | | **209** |
+
+Stage 1: canary runs alone. User inspects `results-canary.csv` and the agent's summary. If verification rules need tuning, edit the prompt skeleton, regenerate canary, repeat.
+
+Stage 2: 15 fanout agents dispatched in a single `Agent` tool-use message → run in parallel. (Canary rows are deduped during aggregation; if canary IDs reappear in a stage-2 slice, aggregator keeps the higher-confidence row.)
+
+**Rerun protocol:** if `validate-slice.ts` flags a slice (CSV malformed, missing IDs, row-count mismatch), dispatcher reruns only that slice. The validator's failure report tells the dispatcher exactly which IDs are missing or duplicated.
+
+## Boundary enforcement
+
+The "auto-classify but never write to DB" property is not just a prompt rule — it's enforced mechanically by what the subagent has access to:
+
+1. **Subagents have no DB credentials.** The TS scripts (`export-`, `aggregate-`, `write-`) read `SUPABASE_SERVICE_ROLE_KEY` from `.env.local`. Subagents are explicitly told not to read `.env*` and not to run scripts. Even if a subagent attempted to import `@supabase/supabase-js`, it has no service-role key in its conversation context to use it with.
+2. **Subagents are scoped to `data/affiliate-research/`.** The prompt enumerates ALLOWED TOOLS (WebSearch, WebFetch, Read on that dir only, Write to its single output CSV) and FORBIDDEN tools (Bash, npm/npx, Edit, anything else). The general-purpose agent type has access to more tools than that, so this is a prompt-level discipline — but combined with point 1, the worst a misbehaving subagent could do is corrupt its own output CSV, which the validator catches.
+3. **Aggregator is glob-scoped.** `aggregate-affiliate-research.ts` reads from a hard-coded glob `data/affiliate-research/results-*.csv` and rejects any file outside that pattern. It does not accept a `--results-path` flag.
+4. **Pre-aggregation diff check.** Before aggregating, dispatcher runs `git status -- data/affiliate-research/` (or just `ls`) and confirms only `results-*.csv` files appeared. If any other file under that dir changed unexpectedly, halt and investigate.
+5. **The DB write is a separate command.** `write-affiliate-links.ts` is the only script in the pipeline that opens a service-role Supabase client. It must be invoked explicitly by the user after they review `approved.csv`. It has a `--dry` flag that prints the SQL without executing.
+
+The combination makes the boundary defense-in-depth: even if a subagent ignored the prompt rule, it would lack the credential, lack the right tool, and have its output rejected by the aggregator.
+
+## File layout
+
+```
+scripts/
+  export-missing-affiliate-links.ts       (new)
+  validate-slice.ts                       (new — runs per slice)
+  aggregate-affiliate-research.ts         (new)
+  write-affiliate-links.ts                (new)
+  audit-affiliate-links.ts                (already exists)
+
+data/affiliate-research/                  (gitignored)
+  missing.csv
+  missing-canary.csv, missing-shampoo-a.csv, ...
+  results-canary.csv, results-shampoo-a.csv, ...
+  results.csv
+  approved.csv
+  review-queue.csv
+  applied.log
+  validation.log                          (one entry per slice validation)
+```
+
+Add `data/affiliate-research/` to `.gitignore`.
+
+## CSV schemas
+
+**missing-*.csv** (input to subagents):
+```
+id,brand,name,description,category,price_eur
+```
+
+**results-*.csv** (output from subagents):
+```
+id,brand,name,chosen_url,host,confidence,matched_tokens,notes
+```
+
+- `confidence` ∈ {`high`, `medium`, `none`}.
+- `matched_tokens` is a `|`-separated list of distinctive tokens the subagent found in `<title>`/H1 (e.g. `Aqua|Revive`). Empty when no candidate found.
+- `notes` is free text from the subagent — used by the human reviewer.
+
+**approved.csv** (input to write-back):
+```
+id,brand,name,chosen_url,host,matched_tokens,notes
+```
+
+A row lands in `approved.csv` only if ALL of the following hold:
+1. `confidence = 'high'`
+2. `chosen_url` parses as `http(s)://...`
+3. host is in `HOST_ALLOWLIST` **or** matches the brand-direct rule (hostname contains the brand slug)
+4. host is **not** in `HOST_DENYLIST`
+5. `matched_tokens` is non-empty
+
+Everything else goes to `review-queue.csv` with a reason column explaining which gate it failed.
+
+## Verification details
+
+**Category-noun stopword list** (these never count as distinctive tokens):
+
+```
+shampoo, spülung, spuelung, conditioner, maske, mask, öl, oel, oil,
+treatment, kur, pflege, care, cream, creme, repair, volume, volumen,
+hydration, feuchtigkeit, intense, intensiv, daily, täglich, taeglich
+```
+
+**Brand-slug normalization for the brand-direct rule:**
+- Lowercase, strip non-alphanumeric, normalize umlauts (ö→oe, ä→ae, ü→ue, ß→ss).
+- Match by substring against the lowercased hostname.
+- Example: brand "OLAPLEX" → slug `olaplex` → matches host `olaplex.com`. Brand "Sante Naturkosmetik" → slug `santenaturkosmetik` AND tries shorter `sante` → matches host `sante.de`.
+
+**Two-stage matching:** brand-slug match tries the full slug first, then progressively shorter prefixes (down to 4 chars). If the brand is "Bali" (too short), it falls below the threshold and only allowlisted hosts can clear the brand-direct gate.
+
+**Path rejection patterns** (regex, case-insensitive on URL path):
+
+```
+^/$                              (homepage)
+/search\b, /suche\b, /s/
+/category\b, /kategorie\b, /c/
+/marken?\b, /brand\b, /b/
+/sale\b, /angebot\b
+\.html?$  ← OK if the rest of the path has product slug components
+```
+
+**Write-back URL re-validation** is structural only:
+- `URL` constructor doesn't throw
+- protocol ∈ {`http:`, `https:`}
+- host parses, is in allowlist OR passes brand-slug rule, and is not in denylist
+
+No re-fetch at write time — subagent's verification is trusted at write time. (A separate `verify-links-live.ts` health-check is left as a future cron; out of scope here.)
+
+## Failure modes & handling
+
+- **No German shop carries the product:** confidence `none`, lands in review queue. Acceptable outcome.
+- **Wrong-product match passes verification:** the path-rejection list eliminates the bulk (category pages, brand landing pages). The distinctive-token requirement eliminates collisions on category nouns alone. Residual risk is on real PDPs of a different SKU of the same brand — caught by the user's `approved.csv` review and by post-write spot-checks.
+- **Rate limit on WebSearch / WebFetch:** ~3 searches + 1 fetch per row × 209 rows = ~836 web calls total, spread across 15 agents (~56 each). Well within tool limits. If a single tool call rate-limits, the agent should retry once with backoff then record `none`.
+- **Subagent crashes / truncates output mid-slice:** `validate-slice.ts` detects (row-count or missing-id mismatch) and the dispatcher reruns only that slice. Smaller slices (~15 rows) keep rerun cost low.
+- **Malformed CSV** (extra commas, missing quotes): `validate-slice.ts` rejects the slice; dispatcher reruns with an explicit reminder in the prompt about quoting comma-bearing fields.
+- **Duplicate hits across agents (canary overlap):** aggregator keeps highest confidence per id; ties broken by allowlisted host > brand-direct > other.
+
+## Acceptance criteria (deterministic)
+
+Every gate below is a script check, not a judgment call.
+
+1. **ID accounting.** `count(distinct id) in results.csv == count(rows) in missing.csv == 209`. Aggregator exits non-zero otherwise.
+2. **No malformed slices.** All `data/affiliate-research/results-*.csv` pass `validate-slice.ts` (correct header, row count == input row count, every input id appears exactly once). `validation.log` shows zero failures at run end.
+3. **Approved-URL gate passes for every row in `approved.csv`.** For each row: URL parses, scheme is http(s), host is in `HOST_ALLOWLIST` or matches brand-direct rule, host is not in `HOST_DENYLIST`, `matched_tokens` is non-empty. Aggregator drops rows that fail any check into `review-queue.csv` with the reason.
+4. **Zero denied hosts in `approved.csv`.** `grep -E '(idealo|geizhals|billiger|preisvergleich|ebay|kleinanzeigen|aliexpress)\.' approved.csv` returns no matches.
+5. **Write parity.** After `write-affiliate-links.ts` runs, `wc -l applied.log` == `wc -l approved.csv - 1` (minus header), modulo rows where the safety-belt WHERE clause filtered an id whose link had already been filled between research and write. The script prints exactly that delta if non-zero.
+6. **Predicate parity.** Export's WHERE clause and write-back's `WHERE` clause are identical (`affiliate_link IS NULL OR btrim(affiliate_link) = '' OR affiliate_link !~* '^https?://'`). Verified by inspecting both scripts.
+7. **Manual spot-check (post-write).** Open 10 newly-written links: ≥1 per category, plus 1 from every fallback shop that appears in `approved.csv` (e.g. if Amazon DE was used at all, at least one Amazon URL is in the sample). All 10 must load to the correct product. Failures are added to a follow-up review CSV.
+8. **Audit delta.** `audit-affiliate-links.ts` re-run shows `activeWithLink` increased by exactly `applied.log` line count. (No collateral writes.)
+
+Criterion 1, 2, 4, 5, 6, 8 are mechanical checks (exit codes / grep / wc). Criterion 3 is a script. Criterion 7 is manual but bounded.
+
+## Out of scope
+
+- Affiliate program enrollment (Amazon PartnerNet, DM partner) and tracking-param injection.
+- A separate `shop_name` column. (Host is derived in the drawer.)
+- Periodic link-rot monitoring. (Future cron — `verify-links-live.ts`.)
+- The 18 already-linked rows (Bondbuilder + Trockenshampoo + 3 Conditioner) — left untouched.
+- Filling rows that the workflow classifies as `medium` or `none` — handled separately in a follow-up review pass by the user against `review-queue.csv`.
+
+## Risks
+
+- **Generic SKU names** (e.g. "Repair Cream") collide across brands. Tightened verification (distinctive-token requirement + path rejection) cuts this materially. Residual risk handled by user review of `approved.csv`.
+- **DM SKU drift** — a researched URL today may 404 next month. Mitigated by a future health-check cron; not blocking.
+- **Subagent prompt-following variance** — agents may still write malformed CSVs or wrong columns. Per-slice validator catches; rerun is cheap because slices are small.
+- **Brand-direct rule false positives** — a hostname like `bali-curls-fanblog.de` would match brand "Bali". Mitigated by the path-rejection list and by the brand-direct rule only granting `medium` (not `high`) on its own; only allowlisted hosts can give `high` directly.

--- a/scripts/aggregate-affiliate-research.ts
+++ b/scripts/aggregate-affiliate-research.ts
@@ -70,6 +70,24 @@ function main(): void {
     console.log(`Loaded ${rows.length} rows from ${f}`)
   }
 
+  const seenIds = new Set(all.map((r) => r.id))
+  const missingIds = new Set(categoryById.keys())
+  const notSeen = [...missingIds].filter((id) => !seenIds.has(id))
+  const extras = [...seenIds].filter((id) => !missingIds.has(id))
+  if (notSeen.length > 0 || extras.length > 0) {
+    console.error(`ID accounting failed:`)
+    if (notSeen.length > 0)
+      console.error(
+        `  ${notSeen.length} ids in missing.csv but not in any results-*.csv: ${notSeen.slice(0, 10).join(", ")}${notSeen.length > 10 ? ", ..." : ""}`,
+      )
+    if (extras.length > 0)
+      console.error(
+        `  ${extras.length} ids in results-*.csv but not in missing.csv: ${extras.slice(0, 10).join(", ")}${extras.length > 10 ? ", ..." : ""}`,
+      )
+    console.error("Aggregator refuses to proceed. Rerun the missing slices.")
+    process.exit(1)
+  }
+
   const deduped = dedupeByConfidence(all)
   console.log(`Deduped ${all.length} → ${deduped.length} unique ids.`)
 

--- a/scripts/aggregate-affiliate-research.ts
+++ b/scripts/aggregate-affiliate-research.ts
@@ -1,0 +1,162 @@
+import { readdirSync } from "node:fs"
+import { join } from "node:path"
+
+import { readCsv, writeCsv, type CsvRow } from "../src/lib/affiliate-research/csv"
+import {
+  dedupeByConfidence,
+  classifyForOutput,
+  type ResultRow,
+} from "../src/lib/affiliate-research/aggregate"
+import { INPUT_HEADER, OUTPUT_HEADER } from "../src/lib/affiliate-research/slice-validator"
+
+const DIR = "data/affiliate-research"
+const RESULTS_GLOB = /^results-[a-z0-9-]+\.csv$/
+
+const APPROVED_HEADER = [
+  "id",
+  "brand",
+  "name",
+  "chosen_url",
+  "host",
+  "matched_tokens",
+  "notes",
+] as const
+const REVIEW_HEADER = [
+  "id",
+  "brand",
+  "name",
+  "chosen_url",
+  "host",
+  "confidence",
+  "matched_tokens",
+  "notes",
+  "review_reason",
+] as const
+
+function toResultRow(r: CsvRow): ResultRow {
+  return {
+    id: r.id,
+    brand: r.brand,
+    name: r.name,
+    chosen_url: r.chosen_url,
+    host: r.host,
+    confidence: r.confidence,
+    matched_tokens: r.matched_tokens,
+    notes: r.notes,
+  }
+}
+
+function loadCategoryByIdFromMissing(): Map<string, string> {
+  const path = join(DIR, "missing.csv")
+  const rows = readCsv(path, { expectedHeader: [...INPUT_HEADER] })
+  const map = new Map<string, string>()
+  for (const r of rows) map.set(r.id, r.category)
+  return map
+}
+
+function main(): void {
+  const files = readdirSync(DIR).filter((f) => RESULTS_GLOB.test(f))
+  if (files.length === 0) {
+    console.error(`No results-*.csv found in ${DIR}. Did the subagents run?`)
+    process.exit(2)
+  }
+
+  const categoryById = loadCategoryByIdFromMissing()
+
+  const all: ResultRow[] = []
+  for (const f of files) {
+    const rows = readCsv(join(DIR, f), { expectedHeader: [...OUTPUT_HEADER] })
+    for (const r of rows) all.push(toResultRow(r))
+    console.log(`Loaded ${rows.length} rows from ${f}`)
+  }
+
+  const deduped = dedupeByConfidence(all)
+  console.log(`Deduped ${all.length} → ${deduped.length} unique ids.`)
+
+  const approved: CsvRow[] = []
+  const review: CsvRow[] = []
+  for (const r of deduped) {
+    const cls = classifyForOutput(r)
+    if (cls.bucket === "approved") {
+      approved.push({
+        id: r.id,
+        brand: r.brand,
+        name: r.name,
+        chosen_url: r.chosen_url,
+        host: r.host,
+        matched_tokens: r.matched_tokens,
+        notes: r.notes,
+      })
+    } else {
+      review.push({
+        id: r.id,
+        brand: r.brand,
+        name: r.name,
+        chosen_url: r.chosen_url,
+        host: r.host,
+        confidence: r.confidence,
+        matched_tokens: r.matched_tokens,
+        notes: r.notes,
+        review_reason: cls.reason,
+      })
+    }
+  }
+
+  writeCsv(
+    join(DIR, "results.csv"),
+    [...OUTPUT_HEADER],
+    deduped.map((r) => ({
+      id: r.id,
+      brand: r.brand,
+      name: r.name,
+      chosen_url: r.chosen_url,
+      host: r.host,
+      confidence: r.confidence,
+      matched_tokens: r.matched_tokens,
+      notes: r.notes,
+    })),
+  )
+  writeCsv(join(DIR, "approved.csv"), [...APPROVED_HEADER], approved)
+  writeCsv(join(DIR, "review-queue.csv"), [...REVIEW_HEADER], review)
+
+  // Category × confidence summary (joined via missing.csv)
+  type Tallies = { high: number; medium: number; none: number; approved: number; review: number }
+  const summary = new Map<string, Tallies>()
+  for (const r of deduped) {
+    const cat = categoryById.get(r.id) ?? "(unknown)"
+    const slot: Tallies = summary.get(cat) ?? {
+      high: 0,
+      medium: 0,
+      none: 0,
+      approved: 0,
+      review: 0,
+    }
+    if (r.confidence === "high") slot.high++
+    else if (r.confidence === "medium") slot.medium++
+    else slot.none++
+    summary.set(cat, slot)
+  }
+  for (const row of approved) {
+    const cat = categoryById.get(row.id) ?? "(unknown)"
+    const slot = summary.get(cat)
+    if (slot) slot.approved++
+  }
+  for (const row of review) {
+    const cat = categoryById.get(row.id) ?? "(unknown)"
+    const slot = summary.get(cat)
+    if (slot) slot.review++
+  }
+
+  console.log("\n=== Summary ===")
+  console.log(`Total unique ids: ${deduped.length}`)
+  console.log(`Approved:         ${approved.length}`)
+  console.log(`Review queue:     ${review.length}`)
+  console.log("\ncategory                 | high | medium | none | approved | review")
+  for (const [cat, t] of [...summary.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    console.log(
+      `${cat.padEnd(24)} | ${String(t.high).padStart(4)} | ${String(t.medium).padStart(6)} | ${String(t.none).padStart(4)} | ${String(t.approved).padStart(8)} | ${String(t.review).padStart(6)}`,
+    )
+  }
+}
+
+main()

--- a/scripts/audit-affiliate-links.ts
+++ b/scripts/audit-affiliate-links.ts
@@ -1,0 +1,112 @@
+import { config as loadEnv } from "dotenv"
+import { createClient } from "@supabase/supabase-js"
+
+loadEnv({ path: ".env.local" })
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+type Row = {
+  id: string
+  name: string
+  brand: string | null
+  category: string | null
+  affiliate_link: string | null
+  is_active: boolean | null
+}
+
+function isUsableUrl(v: string | null): boolean {
+  if (!v) return false
+  const trimmed = v.trim()
+  if (!trimmed) return false
+  try {
+    const u = new URL(trimmed)
+    return u.protocol === "http:" || u.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+async function main() {
+  let from = 0
+  const pageSize = 1000
+  const all: Row[] = []
+  while (true) {
+    const { data, error } = await supabase
+      .from("products")
+      .select("id, name, brand, category, affiliate_link, is_active")
+      .order("category", { ascending: true })
+      .range(from, from + pageSize - 1)
+    if (error) throw error
+    if (!data || data.length === 0) break
+    all.push(...(data as Row[]))
+    if (data.length < pageSize) break
+    from += pageSize
+  }
+
+  const byCat = new Map<
+    string,
+    { total: number; active: number; activeMissing: number; activeWithLink: number }
+  >()
+  for (const r of all) {
+    const cat = r.category ?? "(none)"
+    const slot = byCat.get(cat) ?? {
+      total: 0,
+      active: 0,
+      activeMissing: 0,
+      activeWithLink: 0,
+    }
+    slot.total += 1
+    if (r.is_active) {
+      slot.active += 1
+      if (isUsableUrl(r.affiliate_link)) slot.activeWithLink += 1
+      else slot.activeMissing += 1
+    }
+    byCat.set(cat, slot)
+  }
+
+  const rows = Array.from(byCat.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+  console.log("category | total | active | activeWithLink | activeMissing")
+  for (const [cat, s] of rows) {
+    console.log(`${cat} | ${s.total} | ${s.active} | ${s.activeWithLink} | ${s.activeMissing}`)
+  }
+
+  const sampleMissing = all.filter((r) => r.is_active && !isUsableUrl(r.affiliate_link)).slice(0, 8)
+  console.log("\nSample active rows missing a link:")
+  for (const r of sampleMissing) {
+    console.log(
+      `- [${r.category}] ${r.brand ?? "(no brand)"} — ${r.name} (raw=${JSON.stringify(r.affiliate_link)})`,
+    )
+  }
+
+  const sampleWithLink = all.filter((r) => r.is_active && isUsableUrl(r.affiliate_link))
+  console.log("\nAll active rows that already have a link:")
+  for (const r of sampleWithLink) {
+    console.log(`- [${r.category}] ${r.brand ?? "(no brand)"} — ${r.name} → ${r.affiliate_link}`)
+  }
+
+  const hosts = new Map<string, number>()
+  for (const r of sampleWithLink) {
+    try {
+      const h = new URL(r.affiliate_link as string).host
+      hosts.set(h, (hosts.get(h) ?? 0) + 1)
+    } catch {}
+  }
+  console.log("\nHost frequency among existing links:")
+  for (const [h, c] of Array.from(hosts.entries()).sort((a, b) => b[1] - a[1])) {
+    console.log(`- ${h}: ${c}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/export-missing-affiliate-links.ts
+++ b/scripts/export-missing-affiliate-links.ts
@@ -1,0 +1,154 @@
+import { config as loadEnv } from "dotenv"
+import { mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { createClient } from "@supabase/supabase-js"
+
+import { isUsableUrl } from "../src/lib/affiliate-research/url-gate"
+import { writeCsv } from "../src/lib/affiliate-research/csv"
+
+loadEnv({ path: ".env.local" })
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+type ProductRow = {
+  id: string
+  name: string
+  brand: string | null
+  description: string | null
+  category: string | null
+  affiliate_link: string | null
+  price_eur: number | string | null
+  is_active: boolean | null
+}
+
+const OUT_DIR = "data/affiliate-research"
+
+const EXPORT_HEADER = ["id", "brand", "name", "description", "category", "price_eur"] as const
+
+type SliceSpec = {
+  slug: string
+  category: string
+  startIndex: number // 0-based, inclusive
+  endIndex: number // exclusive
+}
+
+const SLICE_PLAN: ReadonlyArray<SliceSpec> = [
+  { slug: "shampoo-a", category: "Shampoo", startIndex: 0, endIndex: 13 },
+  { slug: "shampoo-b", category: "Shampoo", startIndex: 13, endIndex: 26 },
+  { slug: "shampoo-c", category: "Shampoo", startIndex: 26, endIndex: 39 },
+  { slug: "shampoo-d", category: "Shampoo", startIndex: 39, endIndex: 51 },
+  { slug: "leave-in-a", category: "Leave-in", startIndex: 0, endIndex: 14 },
+  { slug: "leave-in-b", category: "Leave-in", startIndex: 14, endIndex: 28 },
+  { slug: "leave-in-c", category: "Leave-in", startIndex: 28, endIndex: 42 },
+  { slug: "oele-a", category: "Öle", startIndex: 0, endIndex: 14 },
+  { slug: "oele-b", category: "Öle", startIndex: 14, endIndex: 28 },
+  { slug: "oele-c", category: "Öle", startIndex: 28, endIndex: 41 },
+  { slug: "conditioner-a", category: "Conditioner (Drogerie)", startIndex: 0, endIndex: 14 },
+  { slug: "conditioner-b", category: "Conditioner (Drogerie)", startIndex: 14, endIndex: 27 },
+  { slug: "conditioner-c", category: "Conditioner (Drogerie)", startIndex: 27, endIndex: 40 },
+  { slug: "maske-a", category: "Maske", startIndex: 0, endIndex: 18 },
+  { slug: "maske-b", category: "Maske", startIndex: 18, endIndex: 35 },
+]
+
+function toExportRow(r: ProductRow): Record<string, string> {
+  return {
+    id: r.id,
+    brand: r.brand ?? "",
+    name: r.name,
+    description: r.description ?? "",
+    category: r.category ?? "",
+    price_eur: r.price_eur != null ? String(r.price_eur) : "",
+  }
+}
+
+async function fetchAllMissing(): Promise<ProductRow[]> {
+  const pageSize = 1000
+  let from = 0
+  const all: ProductRow[] = []
+  while (true) {
+    const { data, error } = await supabase
+      .from("products")
+      .select("id, name, brand, description, category, affiliate_link, price_eur, is_active")
+      .order("category", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + pageSize - 1)
+    if (error) throw error
+    if (!data || data.length === 0) break
+    all.push(...(data as ProductRow[]))
+    if (data.length < pageSize) break
+    from += pageSize
+  }
+  return all.filter((r) => r.is_active && !isUsableUrl(r.affiliate_link))
+}
+
+function pickCanary(rows: ProductRow[]): ProductRow[] {
+  // 1-2 rows per category, prefer brand diversity
+  const byCat = new Map<string, ProductRow[]>()
+  for (const r of rows) {
+    const cat = r.category ?? "(none)"
+    const arr = byCat.get(cat) ?? []
+    arr.push(r)
+    byCat.set(cat, arr)
+  }
+  const out: ProductRow[] = []
+  for (const [, list] of byCat) {
+    out.push(list[0])
+    if (list.length > 1) out.push(list[Math.min(list.length - 1, 5)])
+    if (out.length >= 8) break
+  }
+  return out.slice(0, 8)
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true })
+
+  const missing = await fetchAllMissing()
+  console.log(`Found ${missing.length} active products missing a usable affiliate_link.`)
+
+  // Write master missing.csv
+  writeCsv(join(OUT_DIR, "missing.csv"), [...EXPORT_HEADER], missing.map(toExportRow))
+
+  // Write canary slice
+  const canary = pickCanary(missing)
+  writeCsv(join(OUT_DIR, "missing-canary.csv"), [...EXPORT_HEADER], canary.map(toExportRow))
+  console.log(`Wrote missing-canary.csv with ${canary.length} rows.`)
+
+  // Group by category, sort by id, slice
+  const byCategory = new Map<string, ProductRow[]>()
+  for (const r of missing) {
+    const list = byCategory.get(r.category ?? "") ?? []
+    list.push(r)
+    byCategory.set(r.category ?? "", list)
+  }
+  for (const list of byCategory.values()) {
+    list.sort((a, b) => a.id.localeCompare(b.id))
+  }
+
+  let totalWritten = 0
+  for (const slice of SLICE_PLAN) {
+    const pool = byCategory.get(slice.category) ?? []
+    const rows = pool.slice(slice.startIndex, slice.endIndex)
+    writeCsv(join(OUT_DIR, `missing-${slice.slug}.csv`), [...EXPORT_HEADER], rows.map(toExportRow))
+    console.log(`Wrote missing-${slice.slug}.csv (${rows.length} rows from ${slice.category}).`)
+    totalWritten += rows.length
+  }
+
+  if (totalWritten !== missing.length) {
+    console.warn(
+      `WARNING: slice plan covers ${totalWritten} rows but ${missing.length} are missing. Adjust SLICE_PLAN ranges if category counts changed.`,
+    )
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/export-missing-affiliate-links.ts
+++ b/scripts/export-missing-affiliate-links.ts
@@ -1,5 +1,5 @@
 import { config as loadEnv } from "dotenv"
-import { mkdirSync } from "node:fs"
+import { mkdirSync, readdirSync, unlinkSync } from "node:fs"
 import { join } from "node:path"
 import { createClient } from "@supabase/supabase-js"
 
@@ -109,6 +109,16 @@ function pickCanary(rows: ProductRow[]): ProductRow[] {
 
 async function main() {
   mkdirSync(OUT_DIR, { recursive: true })
+
+  // Clear stale results from any prior run so the aggregator can't pick up
+  // results-*.csv that don't correspond to this export's slice plan.
+  // missing-*.csv are overwritten in place below; only stray files we worry about.
+  for (const f of readdirSync(OUT_DIR)) {
+    if (/^results-[a-z0-9-]+\.csv$/.test(f)) {
+      unlinkSync(join(OUT_DIR, f))
+      console.log(`  cleared stale: ${f}`)
+    }
+  }
 
   const missing = await fetchAllMissing()
   console.log(`Found ${missing.length} active products missing a usable affiliate_link.`)

--- a/scripts/validate-slice.ts
+++ b/scripts/validate-slice.ts
@@ -1,0 +1,46 @@
+import { appendFileSync, existsSync } from "node:fs"
+import { join } from "node:path"
+
+import { validateSlice } from "../src/lib/affiliate-research/slice-validator"
+
+function usage(): never {
+  console.error(
+    "Usage: tsx scripts/validate-slice.ts <slug>\n" +
+      "  Reads data/affiliate-research/missing-<slug>.csv and results-<slug>.csv.\n" +
+      "  Appends one line to data/affiliate-research/validation.log.\n" +
+      "  Exits 0 on success, 1 on validation failure, 2 on missing files.",
+  )
+  process.exit(2)
+}
+
+const slug = process.argv[2]
+if (!slug) usage()
+if (!/^[a-z0-9-]+$/.test(slug)) {
+  console.error(`Invalid slug '${slug}' — must match [a-z0-9-]+`)
+  process.exit(2)
+}
+
+const DIR = "data/affiliate-research"
+const inputPath = join(DIR, `missing-${slug}.csv`)
+const outputPath = join(DIR, `results-${slug}.csv`)
+const logPath = join(DIR, "validation.log")
+
+if (!existsSync(inputPath)) {
+  console.error(`Missing input file: ${inputPath}`)
+  process.exit(2)
+}
+if (!existsSync(outputPath)) {
+  console.error(`Missing output file: ${outputPath} — subagent has not produced results yet.`)
+  process.exit(2)
+}
+
+const res = validateSlice({ inputPath, outputPath })
+const timestamp = new Date().toISOString()
+const summary = `${timestamp} slice=${slug} ok=${res.ok} rows=${res.rowCount} missing=${res.missing.length} duplicated=${res.duplicated.length}`
+appendFileSync(logPath, summary + "\n")
+console.log(summary)
+if (!res.ok) {
+  for (const err of res.errors) console.error("  - " + err)
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/write-affiliate-links.ts
+++ b/scripts/write-affiliate-links.ts
@@ -1,0 +1,110 @@
+import { config as loadEnv } from "dotenv"
+import { appendFileSync } from "node:fs"
+import { join } from "node:path"
+import { createClient } from "@supabase/supabase-js"
+
+import { readCsv } from "../src/lib/affiliate-research/csv"
+import { isUsableUrl, urlGate } from "../src/lib/affiliate-research/url-gate"
+
+loadEnv({ path: ".env.local" })
+
+const DIR = "data/affiliate-research"
+const APPROVED_PATH = join(DIR, "approved.csv")
+const LOG_PATH = join(DIR, "applied.log")
+
+const APPROVED_HEADER = ["id", "brand", "name", "chosen_url", "host", "matched_tokens", "notes"]
+
+const dry = process.argv.includes("--dry")
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+// Mirrors the export predicate: write-eligible iff current value is null,
+// empty/whitespace, or not a usable http(s) URL.
+function safeToWrite(currentValue: string | null | undefined): boolean {
+  return !isUsableUrl(currentValue)
+}
+
+function appendLog(line: string): void {
+  appendFileSync(LOG_PATH, `${new Date().toISOString()} ${line}\n`)
+}
+
+async function main(): Promise<void> {
+  const rows = readCsv(APPROVED_PATH, { expectedHeader: APPROVED_HEADER })
+  console.log(`Read ${rows.length} approved rows from ${APPROVED_PATH}.`)
+
+  // Defensive re-gate — should be a no-op for a well-formed approved.csv.
+  const rejected: { id: string; reason: string }[] = []
+  const accepted = rows.filter((r) => {
+    const g = urlGate({ chosen_url: r.chosen_url, brand: r.brand })
+    if (g.pass === false) {
+      rejected.push({ id: r.id, reason: g.reason })
+      return false
+    }
+    return true
+  })
+  if (rejected.length > 0) {
+    console.warn(`REJECTED ${rejected.length} rows on re-validation:`)
+    for (const r of rejected) console.warn(`  - ${r.id}: ${r.reason}`)
+  }
+
+  let applied = 0
+  let skippedBySafetyBelt = 0
+  let failed = 0
+  for (const r of accepted) {
+    const { data: current, error: readErr } = await supabase
+      .from("products")
+      .select("id, affiliate_link")
+      .eq("id", r.id)
+      .maybeSingle()
+    if (readErr) {
+      console.error(`READ FAILED ${r.id}: ${readErr.message}`)
+      failed++
+      continue
+    }
+    if (!current) {
+      console.error(`NOT FOUND ${r.id} — product no longer exists`)
+      failed++
+      continue
+    }
+    if (!safeToWrite(current.affiliate_link as string | null)) {
+      skippedBySafetyBelt++
+      appendLog(
+        `SKIP id=${r.id} reason=safety_belt_existing=${JSON.stringify(current.affiliate_link)}`,
+      )
+      continue
+    }
+    if (dry) {
+      console.log(`DRY  UPDATE products SET affiliate_link='${r.chosen_url}' WHERE id='${r.id}'`)
+      applied++
+      continue
+    }
+    const { error: writeErr } = await supabase
+      .from("products")
+      .update({ affiliate_link: r.chosen_url })
+      .eq("id", r.id)
+    if (writeErr) {
+      console.error(`WRITE FAILED ${r.id}: ${writeErr.message}`)
+      failed++
+      continue
+    }
+    appendLog(`OK   id=${r.id} url=${r.chosen_url}`)
+    applied++
+  }
+
+  console.log(
+    `\nDone. applied=${applied}, skipped_by_safety_belt=${skippedBySafetyBelt}, rejected_on_revalidate=${rejected.length}, failed=${failed}.`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/write-affiliate-links.ts
+++ b/scripts/write-affiliate-links.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { createClient } from "@supabase/supabase-js"
 
 import { readCsv } from "../src/lib/affiliate-research/csv"
-import { isUsableUrl, urlGate } from "../src/lib/affiliate-research/url-gate"
+import { urlGate } from "../src/lib/affiliate-research/url-gate"
 
 loadEnv({ path: ".env.local" })
 
@@ -26,12 +26,6 @@ const supabase = createClient(supabaseUrl, serviceRoleKey, {
   auth: { autoRefreshToken: false, persistSession: false },
 })
 
-// Mirrors the export predicate: write-eligible iff current value is null,
-// empty/whitespace, or not a usable http(s) URL.
-function safeToWrite(currentValue: string | null | undefined): boolean {
-  return !isUsableUrl(currentValue)
-}
-
 function appendLog(line: string): void {
   appendFileSync(LOG_PATH, `${new Date().toISOString()} ${line}\n`)
 }
@@ -40,7 +34,6 @@ async function main(): Promise<void> {
   const rows = readCsv(APPROVED_PATH, { expectedHeader: APPROVED_HEADER })
   console.log(`Read ${rows.length} approved rows from ${APPROVED_PATH}.`)
 
-  // Defensive re-gate — should be a no-op for a well-formed approved.csv.
   const rejected: { id: string; reason: string }[] = []
   const accepted = rows.filter((r) => {
     const g = urlGate({ chosen_url: r.chosen_url, brand: r.brand })
@@ -59,40 +52,27 @@ async function main(): Promise<void> {
   let skippedBySafetyBelt = 0
   let failed = 0
   for (const r of accepted) {
-    const { data: current, error: readErr } = await supabase
-      .from("products")
-      .select("id, affiliate_link")
-      .eq("id", r.id)
-      .maybeSingle()
-    if (readErr) {
-      console.error(`READ FAILED ${r.id}: ${readErr.message}`)
-      failed++
-      continue
-    }
-    if (!current) {
-      console.error(`NOT FOUND ${r.id} — product no longer exists`)
-      failed++
-      continue
-    }
-    if (!safeToWrite(current.affiliate_link as string | null)) {
-      skippedBySafetyBelt++
-      appendLog(
-        `SKIP id=${r.id} reason=safety_belt_existing=${JSON.stringify(current.affiliate_link)}`,
-      )
-      continue
-    }
     if (dry) {
-      console.log(`DRY  UPDATE products SET affiliate_link='${r.chosen_url}' WHERE id='${r.id}'`)
+      console.log(
+        `DRY  UPDATE products SET affiliate_link='${r.chosen_url}' WHERE id='${r.id}' AND (affiliate_link IS NULL OR btrim(affiliate_link) = '' OR affiliate_link !~* '^https?://')`,
+      )
       applied++
       continue
     }
-    const { error: writeErr } = await supabase
+    const { data, error } = await supabase
       .from("products")
       .update({ affiliate_link: r.chosen_url })
       .eq("id", r.id)
-    if (writeErr) {
-      console.error(`WRITE FAILED ${r.id}: ${writeErr.message}`)
+      .or("affiliate_link.is.null,affiliate_link.eq.,affiliate_link.not.ilike.http%")
+      .select("id")
+    if (error) {
+      console.error(`WRITE FAILED ${r.id}: ${error.message}`)
       failed++
+      continue
+    }
+    if (!data || data.length === 0) {
+      skippedBySafetyBelt++
+      appendLog(`SKIP id=${r.id} reason=safety_belt_no_match`)
       continue
     }
     appendLog(`OK   id=${r.id} url=${r.chosen_url}`)

--- a/scripts/write-affiliate-links.ts
+++ b/scripts/write-affiliate-links.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { createClient } from "@supabase/supabase-js"
 
 import { readCsv } from "../src/lib/affiliate-research/csv"
-import { urlGate } from "../src/lib/affiliate-research/url-gate"
+import { isUsableUrl, urlGate } from "../src/lib/affiliate-research/url-gate"
 
 loadEnv({ path: ".env.local" })
 
@@ -25,6 +25,20 @@ if (!supabaseUrl || !serviceRoleKey) {
 const supabase = createClient(supabaseUrl, serviceRoleKey, {
   auth: { autoRefreshToken: false, persistSession: false },
 })
+
+// Non-atomic safety belt: read, check in JS, then write.
+//
+// The spec asked for an atomic UPDATE with the safety belt in the WHERE clause:
+//   WHERE id = ? AND (affiliate_link IS NULL OR btrim(...) = '' OR not http(s))
+// PostgREST's .or() filter rejects this on PATCH ("column does not exist" — a
+// known Supabase-side limitation for OR conditions on UPDATE/PATCH). An RPC
+// wrapper would solve it cleanly but isn't worth a migration for this 209-row
+// one-shot job on a low-write table. The race window (read → check → write)
+// is acceptable: the products table is only mutated by this script and the
+// admin UI, not by user traffic.
+function safeToWrite(currentValue: string | null | undefined): boolean {
+  return !isUsableUrl(currentValue)
+}
 
 function appendLog(line: string): void {
   appendFileSync(LOG_PATH, `${new Date().toISOString()} ${line}\n`)
@@ -52,27 +66,40 @@ async function main(): Promise<void> {
   let skippedBySafetyBelt = 0
   let failed = 0
   for (const r of accepted) {
-    if (dry) {
-      console.log(
-        `DRY  UPDATE products SET affiliate_link='${r.chosen_url}' WHERE id='${r.id}' AND (affiliate_link IS NULL OR btrim(affiliate_link) = '' OR affiliate_link !~* '^https?://')`,
-      )
-      applied++
-      continue
-    }
-    const { data, error } = await supabase
+    const { data: current, error: readErr } = await supabase
       .from("products")
-      .update({ affiliate_link: r.chosen_url })
+      .select("id, affiliate_link")
       .eq("id", r.id)
-      .or("affiliate_link.is.null,affiliate_link.eq.,affiliate_link.not.ilike.http%")
-      .select("id")
-    if (error) {
-      console.error(`WRITE FAILED ${r.id}: ${error.message}`)
+      .maybeSingle()
+    if (readErr) {
+      console.error(`READ FAILED ${r.id}: ${readErr.message}`)
       failed++
       continue
     }
-    if (!data || data.length === 0) {
+    if (!current) {
+      console.error(`NOT FOUND ${r.id} — product no longer exists`)
+      failed++
+      continue
+    }
+    if (!safeToWrite(current.affiliate_link as string | null)) {
       skippedBySafetyBelt++
-      appendLog(`SKIP id=${r.id} reason=safety_belt_no_match`)
+      appendLog(
+        `SKIP id=${r.id} reason=safety_belt_existing=${JSON.stringify(current.affiliate_link)}`,
+      )
+      continue
+    }
+    if (dry) {
+      console.log(`DRY  UPDATE products SET affiliate_link='${r.chosen_url}' WHERE id='${r.id}'`)
+      applied++
+      continue
+    }
+    const { error: writeErr } = await supabase
+      .from("products")
+      .update({ affiliate_link: r.chosen_url })
+      .eq("id", r.id)
+    if (writeErr) {
+      console.error(`WRITE FAILED ${r.id}: ${writeErr.message}`)
+      failed++
       continue
     }
     appendLog(`OK   id=${r.id} url=${r.chosen_url}`)

--- a/src/lib/affiliate-research/aggregate.ts
+++ b/src/lib/affiliate-research/aggregate.ts
@@ -1,0 +1,58 @@
+import { isAllowedHost, passesBrandDirect, urlGate } from "./url-gate"
+
+export type Confidence = "high" | "medium" | "none"
+
+export type ResultRow = {
+  id: string
+  brand: string
+  name: string
+  chosen_url: string
+  host: string
+  confidence: Confidence | string
+  matched_tokens: string
+  notes: string
+}
+
+const CONFIDENCE_RANK: Record<string, number> = { high: 3, medium: 2, none: 1 }
+
+function hostRank(row: ResultRow): number {
+  if (!row.host) return 0
+  if (isAllowedHost(row.host)) return 3
+  if (passesBrandDirect(row.host, row.brand)) return 2
+  return 1
+}
+
+export function dedupeByConfidence(rows: ResultRow[]): ResultRow[] {
+  const best = new Map<string, ResultRow>()
+  for (const r of rows) {
+    const existing = best.get(r.id)
+    if (!existing) {
+      best.set(r.id, r)
+      continue
+    }
+    const a = CONFIDENCE_RANK[r.confidence] ?? 0
+    const b = CONFIDENCE_RANK[existing.confidence] ?? 0
+    if (a > b || (a === b && hostRank(r) > hostRank(existing))) {
+      best.set(r.id, r)
+    }
+  }
+  return [...best.values()]
+}
+
+export type ClassifyResult =
+  | { bucket: "approved"; reason: "" }
+  | { bucket: "review"; reason: string }
+
+export function classifyForOutput(row: ResultRow): ClassifyResult {
+  if (row.confidence !== "high") {
+    return { bucket: "review", reason: `confidence is '${row.confidence}', not 'high'` }
+  }
+  if (!row.matched_tokens || row.matched_tokens.trim() === "") {
+    return { bucket: "review", reason: "matched_tokens is empty" }
+  }
+  const gate = urlGate({ chosen_url: row.chosen_url, brand: row.brand })
+  if (gate.pass === false) {
+    return { bucket: "review", reason: gate.reason }
+  }
+  return { bucket: "approved", reason: "" }
+}

--- a/src/lib/affiliate-research/csv.ts
+++ b/src/lib/affiliate-research/csv.ts
@@ -1,0 +1,128 @@
+import { readFileSync, writeFileSync } from "node:fs"
+
+export type CsvRow = Record<string, string>
+
+export function parseCsv(text: string): CsvRow[] {
+  const lines = splitCsvLines(text)
+  if (lines.length === 0) return []
+  const header = parseCsvLine(lines[0])
+  const out: CsvRow[] = []
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === "") continue
+    const cells = parseCsvLine(line)
+    const row: CsvRow = {}
+    for (let j = 0; j < header.length; j++) {
+      row[header[j]] = cells[j] ?? ""
+    }
+    out.push(row)
+  }
+  return out
+}
+
+function splitCsvLines(text: string): string[] {
+  const lines: string[] = []
+  let current = ""
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (ch === '"') {
+      inQuotes = !inQuotes
+      current += ch
+      continue
+    }
+    if (ch === "\n" && !inQuotes) {
+      lines.push(current)
+      current = ""
+      continue
+    }
+    if (ch === "\r" && !inQuotes) {
+      if (text[i + 1] === "\n") i++
+      lines.push(current)
+      current = ""
+      continue
+    }
+    current += ch
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = []
+  let cur = ""
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') {
+        cur += '"'
+        i++
+        continue
+      }
+      if (ch === '"') {
+        inQuotes = false
+        continue
+      }
+      cur += ch
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = true
+      continue
+    }
+    if (ch === ",") {
+      cells.push(cur)
+      cur = ""
+      continue
+    }
+    cur += ch
+  }
+  cells.push(cur)
+  return cells
+}
+
+function quoteField(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return '"' + value.replace(/"/g, '""') + '"'
+  }
+  return value
+}
+
+export function stringifyCsv(header: string[], rows: CsvRow[]): string {
+  const lines: string[] = [header.map(quoteField).join(",")]
+  for (const row of rows) {
+    lines.push(header.map((h) => quoteField(row[h] ?? "")).join(","))
+  }
+  return lines.join("\n") + "\n"
+}
+
+export type ReadCsvOptions = {
+  expectedHeader?: string[]
+}
+
+export function readCsv(path: string, opts: ReadCsvOptions = {}): CsvRow[] {
+  const text = readFileSync(path, "utf-8")
+  const rows = parseCsv(text)
+  if (opts.expectedHeader) {
+    const actual = rows.length > 0 ? Object.keys(rows[0]) : []
+    // header is the first parsed line — but parseCsv discards it as column names,
+    // so check by reading the first physical line:
+    const firstLine = text.split(/\r?\n/, 1)[0]
+    const headerActual = parseCsvLine(firstLine)
+    const equal =
+      headerActual.length === opts.expectedHeader.length &&
+      headerActual.every((h, i) => h === opts.expectedHeader![i])
+    if (!equal) {
+      throw new Error(
+        `csv header mismatch in ${path}: expected [${opts.expectedHeader.join(", ")}], got [${headerActual.join(", ")}]`,
+      )
+    }
+    void actual
+  }
+  return rows
+}
+
+export function writeCsv(path: string, header: string[], rows: CsvRow[]): void {
+  writeFileSync(path, stringifyCsv(header, rows), "utf-8")
+}

--- a/src/lib/affiliate-research/slice-validator.ts
+++ b/src/lib/affiliate-research/slice-validator.ts
@@ -1,0 +1,79 @@
+import { readCsv } from "./csv"
+
+export const INPUT_HEADER = ["id", "brand", "name", "description", "category", "price_eur"] as const
+export const OUTPUT_HEADER = [
+  "id",
+  "brand",
+  "name",
+  "chosen_url",
+  "host",
+  "confidence",
+  "matched_tokens",
+  "notes",
+] as const
+
+export type ValidateSliceInput = {
+  inputPath: string
+  outputPath: string
+}
+
+export type ValidateSliceResult = {
+  ok: boolean
+  errors: string[]
+  missing: string[]
+  duplicated: string[]
+  rowCount: number
+}
+
+const VALID_CONFIDENCE = new Set(["high", "medium", "none"])
+
+export function validateSlice({ inputPath, outputPath }: ValidateSliceInput): ValidateSliceResult {
+  const errors: string[] = []
+
+  let inputRows: ReturnType<typeof readCsv> = []
+  try {
+    inputRows = readCsv(inputPath, { expectedHeader: [...INPUT_HEADER] })
+  } catch (err) {
+    errors.push(`input: ${(err as Error).message}`)
+  }
+
+  let outputRows: ReturnType<typeof readCsv> = []
+  try {
+    outputRows = readCsv(outputPath, { expectedHeader: [...OUTPUT_HEADER] })
+  } catch (err) {
+    errors.push(`output: ${(err as Error).message}`)
+    return { ok: false, errors, missing: [], duplicated: [], rowCount: 0 }
+  }
+
+  const inputIds = new Set(inputRows.map((r) => r.id))
+  const seen = new Set<string>()
+  const duplicated: string[] = []
+  for (const r of outputRows) {
+    if (seen.has(r.id)) duplicated.push(r.id)
+    else seen.add(r.id)
+    if (r.confidence && !VALID_CONFIDENCE.has(r.confidence)) {
+      errors.push(`row ${r.id}: invalid confidence value '${r.confidence}'`)
+    }
+  }
+  const missing = [...inputIds].filter((id) => !seen.has(id))
+  const extras = [...seen].filter((id) => !inputIds.has(id))
+  if (extras.length > 0) {
+    errors.push(
+      `output contains ${extras.length} ids not in input: ${extras.slice(0, 5).join(", ")}`,
+    )
+  }
+  if (missing.length > 0) {
+    errors.push(`output missing ${missing.length} input ids: ${missing.slice(0, 5).join(", ")}`)
+  }
+  if (duplicated.length > 0) {
+    errors.push(`output has duplicate ids: ${duplicated.slice(0, 5).join(", ")}`)
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    missing,
+    duplicated,
+    rowCount: outputRows.length,
+  }
+}

--- a/src/lib/affiliate-research/url-gate.ts
+++ b/src/lib/affiliate-research/url-gate.ts
@@ -1,0 +1,107 @@
+export const HOST_ALLOWLIST = new Set<string>([
+  "dm.de",
+  "www.dm.de",
+  "rossmann.de",
+  "www.rossmann.de",
+  "mueller.de",
+  "www.mueller.de",
+  "amazon.de",
+  "www.amazon.de",
+  "douglas.de",
+  "www.douglas.de",
+  "flaconi.de",
+  "www.flaconi.de",
+  "notino.de",
+  "www.notino.de",
+  "otto.de",
+  "www.otto.de",
+])
+
+export const HOST_DENYLIST = new Set<string>([
+  "idealo.de",
+  "www.idealo.de",
+  "geizhals.de",
+  "www.geizhals.de",
+  "billiger.de",
+  "www.billiger.de",
+  "preisvergleich.de",
+  "www.preisvergleich.de",
+  "ebay.de",
+  "www.ebay.de",
+  "ebay.com",
+  "www.ebay.com",
+  "kleinanzeigen.de",
+  "www.kleinanzeigen.de",
+  "aliexpress.com",
+  "www.aliexpress.com",
+  "amazon.com",
+  "www.amazon.com",
+])
+
+const MIN_BRAND_SLUG_LEN = 4
+
+export function isUsableUrl(value: string | null | undefined): boolean {
+  if (value == null) return false
+  const trimmed = value.trim()
+  if (!trimmed) return false
+  try {
+    const u = new URL(trimmed)
+    return u.protocol === "http:" || u.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+export function hostOf(url: string): string {
+  return new URL(url).hostname.toLowerCase()
+}
+
+export function isAllowedHost(host: string): boolean {
+  return HOST_ALLOWLIST.has(host.toLowerCase())
+}
+
+export function isDeniedHost(host: string): boolean {
+  return HOST_DENYLIST.has(host.toLowerCase())
+}
+
+const UMLAUT_MAP: Record<string, string> = { ä: "ae", ö: "oe", ü: "ue", ß: "ss" }
+
+export function normalizeBrandSlug(brand: string | null | undefined): string {
+  if (!brand) return ""
+  const lowered = brand.toLowerCase()
+  const expanded = lowered.replace(/[äöüß]/g, (ch) => UMLAUT_MAP[ch] ?? ch)
+  return expanded.replace(/[^a-z0-9]/g, "")
+}
+
+export function passesBrandDirect(host: string, brand: string | null | undefined): boolean {
+  const slug = normalizeBrandSlug(brand)
+  if (slug.length < MIN_BRAND_SLUG_LEN) return false
+  return host.toLowerCase().includes(slug)
+}
+
+export type UrlGateInput = {
+  chosen_url: string | null | undefined
+  brand: string | null | undefined
+}
+
+export type UrlGateResult = { pass: true } | { pass: false; reason: string }
+
+export function urlGate(row: UrlGateInput): UrlGateResult {
+  if (!isUsableUrl(row.chosen_url)) {
+    return { pass: false, reason: "url failed to parse or is not http(s)" }
+  }
+  const host = hostOf(row.chosen_url as string)
+  if (isDeniedHost(host)) {
+    return { pass: false, reason: `host ${host} is denylisted (aggregator or wrong marketplace)` }
+  }
+  if (isAllowedHost(host)) {
+    return { pass: true }
+  }
+  if (passesBrandDirect(host, row.brand)) {
+    return { pass: true }
+  }
+  return {
+    pass: false,
+    reason: `host ${host} is not on allowlist and does not match brand-direct rule`,
+  }
+}

--- a/supabase/migrations/20260526120000_backfill_product_names_from_affiliate_research.sql
+++ b/supabase/migrations/20260526120000_backfill_product_names_from_affiliate_research.sql
@@ -1,0 +1,208 @@
+-- Backfill canonical product names + brands from affiliate-link research.
+--
+-- Source: docs/plans/2026-05-14-affiliate-research-name-changes.md
+-- 42 rename rows + 1 soft-delete, accumulated across review Buckets A/B/C
+-- during the 2026-05-14 to 2026-05-26 enrichment campaign.
+--
+-- These updates are display-only (name + brand) — the recommendation engine
+-- uses product_oil_eligibility / product_conditioner_specs / etc. join tables
+-- keyed on product_id, so renames don't affect what products surface.
+--
+-- Each statement is keyed on id (UUID), so the migration is idempotent: a
+-- second run no-ops because the new values match the current values.
+
+begin;
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Bucket A — Garnier line corrections (DB had Wahre Schätze ↔ Hair Food mix-ups)
+-- ──────────────────────────────────────────────────────────────────────────
+
+update products
+  set name = 'Garnier Fructis Hair Food Aloe Vera Feuchtigkeits-Spülung'
+  where id = '5516009a-eecb-42dd-87f6-07c560161136';
+
+update products
+  set name = 'Garnier Wahre Schätze Kokosmilch & Macadamia Nährende Spülung'
+  where id = '8c3eda97-5009-40bb-959b-1a7d90f48b09';
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Bucket A — typo/rename fixes
+-- ──────────────────────────────────────────────────────────────────────────
+
+-- "Haarkur" isn't a brand; product is Syoss
+update products
+  set brand = 'Syoss',
+      name = 'Syoss Haarkur Lamination Intense Glaze'
+  where id = 'cce6346c-8c92-4a17-b39b-cc7f300e84de';
+
+-- Pantene Pro-V Volumen Pur (DE name uses "Volumen")
+update products set name = 'Pantene Pro-V Volumen Pur'
+  where id = '6fde3fe2-3850-4502-b9f2-ebb17eb13bad';
+
+-- Cantu DM SKU name
+update products set name = 'Cantu Shampoo Locken Pflege'
+  where id = 'a1c3dc8d-2638-497f-8c7f-9b491c9003b0';
+
+-- DM never sold "Ultra"; SKU is "Ultimate"
+update products set name = 'Balea Professional Ultimate Volume'
+  where id = 'd01de47e-e360-4b31-9924-e3e5bc31ccdc';
+
+-- Official Sebamed name uses hyphen
+update products set name = 'Sebamed Every-Day Shampoo'
+  where id = 'e7bfd306-b128-4735-a9f8-0eeacdbd5013';
+
+-- Aloe variant rebranded for DE market
+update products set name = 'Head & Shoulders Derma X Pro Beruhigende Pflege'
+  where id = '088b1427-ed22-424e-8cfd-ea2578120ae6';
+
+-- Only Magique Serum on DM is the Midnight variant
+update products set name = 'Elvital Öl Magique Midnight Serum'
+  where id = '6b01025d-9e72-4514-b42e-bbb6065fbe1c';
+
+-- Living Proof dropped "Instant" from the name
+update products set name = 'Living Proof Restore Repair Leave-In'
+  where id = '0756a919-5fab-4b6c-a5da-8cb810869b6f';
+
+-- Brand typo: Acina → Alcina
+update products set brand = 'Alcina', name = 'Alcina Hyaluron 2.0'
+  where id = '9b664b11-fd11-47e3-9b7e-76e34736b43e';
+
+-- Pantene Hydra Glow leave-in is the Milk-to-Water serum
+update products set name = 'Pantene Miracles Milk-to-Water Leave-In Serum'
+  where id = 'e781ca9e-886d-40a1-bfe1-48177cfbf381';
+
+-- DM SKU name
+update products set name = 'Balea Natural Beauty Pflegeöl Bio'
+  where id = '4f373d4f-fef8-4434-91c7-055133d8427f';
+
+-- Full DE SKU name
+update products set name = 'Pantene Pro-V Miracles 7in1 Öl-Spray'
+  where id = '5827a3b9-a488-4c74-b13a-4d655f94f1c3';
+
+-- DE variant is sold as serum, not oil
+update products set name = 'Garnier Fructis Sleek & Stay Heat-Activated Serum'
+  where id = 'c574ee6f-ad22-45c0-b936-57b847d93433';
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Bucket B — brand-direct premium PDP renames
+-- ──────────────────────────────────────────────────────────────────────────
+
+update products
+  set name = 'Urban Alchemy Repair & Revive Leave-In Spray'
+  where id = '45f4fe15-c439-476d-8a86-3b2aac5053bd';
+
+update products
+  set name = 'Urban Alchemy Smooth Supreme Öl Serum'
+  where id = '5ad6c978-fd27-469e-9f26-ff3f05b9f67a';
+
+-- Brand rebranded the product from "Healing Oil" → "Treatment Oil" (same SKU)
+update products
+  set name = 'Innersense Harmonic Treatment Oil'
+  where id = '7f5207e6-d281-416e-922c-3135dd9a8cc8';
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Bucket C Group 1 — generic ingredient Öle → canonical retailer SKUs
+--
+-- 16 rows where brand == name (e.g. "Calendulaöl"). Promoted to actual
+-- retailer brand + full SKU name. Display-only change; recommendation
+-- engine uses product_oil_eligibility join table for matching.
+-- ──────────────────────────────────────────────────────────────────────────
+
+update products set brand = 'Primavera', name = 'Primavera Calendulaöl Bio'
+  where id = '1dce2c18-6a45-4017-a748-e3a7f1cba36f';
+
+update products set brand = 'wesentlich.', name = 'wesentlich. Macadamianussöl kaltgepresst'
+  where id = '19aea9c4-4b90-4ec4-8cb6-90cb270010f7';
+
+update products set brand = 'Rapunzel', name = 'Rapunzel Bio Distelöl'
+  where id = '29e36443-93ff-4b62-9cf0-55ad9f89f530';
+
+update products set brand = 'nedura', name = 'nedura Schwarzkümmelöl ungefiltert'
+  where id = '2ffeae68-c625-4df5-be02-0c1b620aa0fc';
+
+update products set brand = 'MoriVeda', name = 'MoriVeda Premium Moringaöl'
+  where id = '38886b62-2c45-4b34-9a24-7d831e97946e';
+
+update products set brand = 'greenmade', name = 'greenmade Bio Rizinusöl'
+  where id = '3acd3c18-0a4b-45f8-9178-5bd2f4e0a38b';
+
+update products set brand = 'KoRo', name = 'KoRo MCT Öl'
+  where id = '3eb198a5-9aab-4f28-9df1-c4869c6a12db';
+
+update products set brand = 'Dr. Scheller', name = 'Dr. Scheller Jojobaöl'
+  where id = '4a95e1de-54e9-4fcd-b227-72a5824d13c1';
+
+update products set brand = 'Ölmühle Solling', name = 'Ölmühle Solling Bio Traubenkernöl'
+  where id = '517dca50-5d55-4038-ba1d-f9b745708327';
+
+update products set brand = 'MARRAKESCH', name = 'MARRAKESCH Bio Arganöl'
+  where id = '70ea52bc-2194-4bb3-82a8-3f4a2aede041';
+
+-- Cacayöl: Amazon SKU has no clean brand; leave brand as ingredient placeholder
+update products set name = 'Cacayöl kaltgepresst'
+  where id = '78e6f1b2-7262-46af-b689-a92af6702739';
+
+update products set brand = 'dmBio', name = 'dmBio natives Olivenöl extra'
+  where id = '9bfe0a67-72ad-4951-bb99-9f2f5d5c724a';
+
+update products set brand = 'Kräuterland', name = 'Kräuterland Bio Aprikosenkernöl'
+  where id = 'a11855eb-64e5-438f-8880-1d3573efa9fa';
+
+update products set brand = 'Rapunzel', name = 'Rapunzel Bio Kokosöl nativ'
+  where id = 'acf9d5cd-76e4-49c7-9c04-0af1f20506ad';
+
+update products set brand = 'Mynatura', name = 'Mynatura Bio Mandelöl'
+  where id = 'ca4ae209-79d2-4f4d-8e44-46e586cec62d';
+
+update products set brand = 'Kräuterland', name = 'Kräuterland Bio Avocadoöl'
+  where id = 'ff13bc3a-8bc6-49df-85a0-7a67add26926';
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Bucket C Group 2 — DE-successor / closest-variant substitutions
+-- ──────────────────────────────────────────────────────────────────────────
+
+update products
+  set name = 'Head & Shoulders DERMAXPRO Sanfte Kopfhautpflege'
+  where id = '4fd5f4c3-83b2-4893-be8c-ada29b8ca718';
+
+update products
+  set brand = 'Monday Haircare',
+      name = 'Monday Haircare Volume Kraft & Fülle Shampoo'
+  where id = '6dc65df2-2466-43e4-bdc2-3a05803f305c';
+
+update products
+  set name = 'Curlsmith Weightless Air Dry Cream'
+  where id = '8715f0f5-9104-46ec-b450-e73f1441c1fa';
+
+update products
+  set brand = 'Wella Professionals',
+      name = 'Wella Ultimate Repair Protective Leave-In'
+  where id = '94cf6959-a53b-421b-9f0f-05efc239171c';
+
+update products
+  set name = 'Pantene Pro-V Miracles 7in1 Haaröl Spray'
+  where id = 'f8f3b51d-8e64-487d-bad5-4a47c58862ed';
+
+update products
+  set brand = 'Bali Curls',
+      name = 'Bali Curls Deep Repair Mask'
+  where id = 'c4b9eaef-dfeb-41ea-9d28-9901660406b7';
+
+update products
+  set name = 'OGX Bond Protein Repair Conditioner'
+  where id = '1bfa5b02-26d9-457b-a5e6-445cc2284490';
+
+update products
+  set brand = 'Shiseido Fino',
+      name = 'Shiseido Fino Premium Touch Penetrating Hair Oil Essence'
+  where id = '663acf09-7090-40d8-9411-71154b9d60f3';
+
+-- ──────────────────────────────────────────────────────────────────────────
+-- Soft-delete: row has no viable SKU (Maria Nila True Soft line has no Leave-In)
+-- ──────────────────────────────────────────────────────────────────────────
+
+update products
+  set is_active = false
+  where id = '3c769f60-283f-48c3-9549-cf84b73115d7';
+
+commit;

--- a/supabase/migrations/20260526120000_backfill_product_names_from_affiliate_research.sql
+++ b/supabase/migrations/20260526120000_backfill_product_names_from_affiliate_research.sql
@@ -10,6 +10,13 @@
 --
 -- Each statement is keyed on id (UUID), so the migration is idempotent: a
 -- second run no-ops because the new values match the current values.
+--
+-- NOTE: products has a UNIQUE(name, category) constraint (added in
+-- 20260316102000_allow_duplicate_product_names_across_categories.sql).
+-- On a fresh / divergent environment where a target name already exists in
+-- the same category from unrelated data, the matching UPDATE will fail.
+-- If that happens during deploy: investigate the colliding row first; do
+-- not blindly relax the constraint.
 
 begin;
 

--- a/tests/affiliate-research-aggregate.test.ts
+++ b/tests/affiliate-research-aggregate.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  dedupeByConfidence,
+  classifyForOutput,
+  type ResultRow,
+} from "../src/lib/affiliate-research/aggregate"
+
+function row(p: Partial<ResultRow>): ResultRow {
+  return {
+    id: "x",
+    brand: "Brand",
+    name: "Name",
+    chosen_url: "",
+    host: "",
+    confidence: "none",
+    matched_tokens: "",
+    notes: "",
+    ...p,
+  }
+}
+
+test("dedupeByConfidence keeps highest confidence per id", () => {
+  const rows = [
+    row({ id: "a", confidence: "none" }),
+    row({ id: "a", confidence: "high", chosen_url: "https://www.dm.de/p" }),
+    row({ id: "b", confidence: "medium" }),
+  ]
+  const out = dedupeByConfidence(rows)
+  assert.equal(out.length, 2)
+  const a = out.find((r) => r.id === "a")!
+  assert.equal(a.confidence, "high")
+})
+
+test("dedupeByConfidence tie-breaks on allowlisted host > brand-direct > other", () => {
+  const rows = [
+    row({
+      id: "a",
+      confidence: "high",
+      chosen_url: "https://other-shop.example/p",
+      host: "other-shop.example",
+    }),
+    row({ id: "a", confidence: "high", chosen_url: "https://www.dm.de/p", host: "www.dm.de" }),
+  ]
+  const out = dedupeByConfidence(rows)
+  assert.equal(out.length, 1)
+  assert.equal(out[0].host, "www.dm.de")
+})
+
+test("classifyForOutput approves confidence=high with allowlisted host and tokens", () => {
+  const r = row({
+    id: "a",
+    confidence: "high",
+    chosen_url: "https://www.dm.de/p/foo",
+    host: "www.dm.de",
+    matched_tokens: "Aqua|Revive",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "approved")
+})
+
+test("classifyForOutput sends confidence=medium to review", () => {
+  const r = row({
+    id: "a",
+    confidence: "medium",
+    chosen_url: "https://olaplex.com/p",
+    host: "olaplex.com",
+    matched_tokens: "No3",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "review")
+  assert.match(out.reason, /confidence/i)
+})
+
+test("classifyForOutput sends confidence=high but denylisted host to review", () => {
+  const r = row({
+    id: "a",
+    confidence: "high",
+    chosen_url: "https://idealo.de/p",
+    host: "idealo.de",
+    matched_tokens: "Foo",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "review")
+  assert.match(out.reason, /denylisted/i)
+})
+
+test("classifyForOutput sends confidence=high but empty matched_tokens to review", () => {
+  const r = row({
+    id: "a",
+    confidence: "high",
+    chosen_url: "https://www.dm.de/p",
+    host: "www.dm.de",
+    matched_tokens: "",
+  })
+  const out = classifyForOutput(r)
+  assert.equal(out.bucket, "review")
+  assert.match(out.reason, /matched_tokens/i)
+})

--- a/tests/affiliate-research-csv.test.ts
+++ b/tests/affiliate-research-csv.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { parseCsv, stringifyCsv, readCsv, writeCsv } from "../src/lib/affiliate-research/csv"
+
+test("parseCsv handles simple rows", () => {
+  const rows = parseCsv("id,name\n1,foo\n2,bar\n")
+  assert.deepEqual(rows, [
+    { id: "1", name: "foo" },
+    { id: "2", name: "bar" },
+  ])
+})
+
+test("parseCsv handles quoted fields with commas and quotes", () => {
+  const rows = parseCsv('id,name\n1,"foo, bar"\n2,"she said ""hi"""\n')
+  assert.deepEqual(rows, [
+    { id: "1", name: "foo, bar" },
+    { id: "2", name: 'she said "hi"' },
+  ])
+})
+
+test("parseCsv tolerates trailing newline and empty fields", () => {
+  const rows = parseCsv("id,name\n1,\n")
+  assert.deepEqual(rows, [{ id: "1", name: "" }])
+})
+
+test("stringifyCsv quotes only when necessary", () => {
+  const out = stringifyCsv(
+    ["id", "name"],
+    [
+      { id: "1", name: "foo" },
+      { id: "2", name: "has, comma" },
+      { id: "3", name: 'has "quotes"' },
+    ],
+  )
+  assert.equal(out, 'id,name\n1,foo\n2,"has, comma"\n3,"has ""quotes"""\n')
+})
+
+test("round-trip: writeCsv then readCsv recovers data", () => {
+  const dir = mkdtempSync(join(tmpdir(), "csv-test-"))
+  const path = join(dir, "x.csv")
+  const rows = [
+    { id: "a", url: "https://x.example/p?q=1,2" },
+    { id: "b", url: "https://y.example/p" },
+  ]
+  writeCsv(path, ["id", "url"], rows)
+  const back = readCsv(path)
+  assert.deepEqual(back, rows)
+})
+
+test("readCsv throws on header mismatch via callback", () => {
+  const dir = mkdtempSync(join(tmpdir(), "csv-test-"))
+  const path = join(dir, "x.csv")
+  writeFileSync(path, "id,brand\n1,Pantene\n")
+  assert.throws(() => readCsv(path, { expectedHeader: ["id", "name"] }), /header/i)
+})

--- a/tests/affiliate-research-slice-validator.test.ts
+++ b/tests/affiliate-research-slice-validator.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { validateSlice } from "../src/lib/affiliate-research/slice-validator"
+
+const INPUT_HEADER = "id,brand,name,description,category,price_eur"
+const OUTPUT_HEADER = "id,brand,name,chosen_url,host,confidence,matched_tokens,notes"
+
+function fixtureDir() {
+  return mkdtempSync(join(tmpdir(), "slice-val-"))
+}
+
+test("valid slice: ids match exactly, no duplicates", () => {
+  const dir = fixtureDir()
+  writeFileSync(
+    join(dir, "in.csv"),
+    `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\nb,Brand,Name2,Desc2,Shampoo,6\n`,
+  )
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,https://x.de/p,x.de,high,Foo,ok\nb,Brand,Name2,,,none,,not found\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, true)
+  assert.deepEqual(res.missing, [])
+  assert.deepEqual(res.duplicated, [])
+})
+
+test("missing id reported", () => {
+  const dir = fixtureDir()
+  writeFileSync(
+    join(dir, "in.csv"),
+    `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\nb,Brand,Name2,Desc2,Shampoo,6\n`,
+  )
+  writeFileSync(join(dir, "out.csv"), `${OUTPUT_HEADER}\na,Brand,Name,,,none,,\n`)
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.deepEqual(res.missing, ["b"])
+})
+
+test("duplicate id reported", () => {
+  const dir = fixtureDir()
+  writeFileSync(join(dir, "in.csv"), `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\n`)
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,,,none,,\na,Brand,Name,,,none,,\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.deepEqual(res.duplicated, ["a"])
+})
+
+test("wrong output header reported as schemaError", () => {
+  const dir = fixtureDir()
+  writeFileSync(join(dir, "in.csv"), `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\n`)
+  writeFileSync(join(dir, "out.csv"), `id,brand,name,url\na,Brand,Name,https://x.de\n`)
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.match(res.errors.join("\n"), /header/i)
+})
+
+test("invalid confidence value reported", () => {
+  const dir = fixtureDir()
+  writeFileSync(join(dir, "in.csv"), `${INPUT_HEADER}\na,Brand,Name,Desc,Shampoo,5\n`)
+  writeFileSync(
+    join(dir, "out.csv"),
+    `${OUTPUT_HEADER}\na,Brand,Name,https://x.de,x.de,SUPER,Foo,ok\n`,
+  )
+  const res = validateSlice({ inputPath: join(dir, "in.csv"), outputPath: join(dir, "out.csv") })
+  assert.equal(res.ok, false)
+  assert.match(res.errors.join("\n"), /confidence/i)
+})

--- a/tests/affiliate-research-url-gate.test.ts
+++ b/tests/affiliate-research-url-gate.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  isUsableUrl,
+  hostOf,
+  isAllowedHost,
+  isDeniedHost,
+  normalizeBrandSlug,
+  passesBrandDirect,
+  urlGate,
+} from "../src/lib/affiliate-research/url-gate"
+
+test("isUsableUrl accepts http(s) URLs, rejects junk", () => {
+  assert.equal(isUsableUrl("https://www.dm.de/p/foo"), true)
+  assert.equal(isUsableUrl("http://example.com"), true)
+  assert.equal(isUsableUrl("ftp://example.com"), false)
+  assert.equal(isUsableUrl(""), false)
+  assert.equal(isUsableUrl("   "), false)
+  assert.equal(isUsableUrl(null), false)
+  assert.equal(isUsableUrl("not a url"), false)
+})
+
+test("hostOf returns lowercased host without port", () => {
+  assert.equal(hostOf("https://WWW.DM.de:443/x"), "www.dm.de")
+  assert.equal(hostOf("https://olaplex.com/products/n3"), "olaplex.com")
+})
+
+test("isAllowedHost matches with or without www. prefix", () => {
+  assert.equal(isAllowedHost("www.dm.de"), true)
+  assert.equal(isAllowedHost("dm.de"), true)
+  assert.equal(isAllowedHost("www.amazon.de"), true)
+  assert.equal(isAllowedHost("amazon.com"), false)
+  assert.equal(isAllowedHost("random.example"), false)
+})
+
+test("isDeniedHost catches aggregators and ebay/aliexpress/amazon.com", () => {
+  assert.equal(isDeniedHost("www.idealo.de"), true)
+  assert.equal(isDeniedHost("geizhals.de"), true)
+  assert.equal(isDeniedHost("ebay.de"), true)
+  assert.equal(isDeniedHost("amazon.com"), true)
+  assert.equal(isDeniedHost("www.dm.de"), false)
+})
+
+test("normalizeBrandSlug strips non-alphanumerics and normalizes umlauts", () => {
+  assert.equal(normalizeBrandSlug("OLAPLEX"), "olaplex")
+  assert.equal(normalizeBrandSlug("Sante"), "sante")
+  assert.equal(normalizeBrandSlug("Sante Naturkosmetik"), "santenaturkosmetik")
+  assert.equal(normalizeBrandSlug("Schwarzköpf"), "schwarzkoepf")
+  assert.equal(normalizeBrandSlug("K18"), "k18")
+})
+
+test("passesBrandDirect matches brand slug as hostname substring, min slug length 4", () => {
+  assert.equal(passesBrandDirect("olaplex.com", "OLAPLEX"), true)
+  assert.equal(
+    passesBrandDirect("k18hair.com", "K18"),
+    false,
+    "K18 slug too short, fails brand-direct",
+  )
+  assert.equal(passesBrandDirect("sante.de", "Sante"), true)
+  assert.equal(passesBrandDirect("epres.com", "Epres"), true)
+  assert.equal(passesBrandDirect("unrelated.de", "Sante"), false)
+  assert.equal(passesBrandDirect("any.de", "AB"), false, "slug below 4 chars never matches")
+})
+
+test("urlGate returns pass=true for allowlisted host with valid URL", () => {
+  const res = urlGate({
+    chosen_url: "https://www.dm.de/p/foo",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, true)
+})
+
+test("urlGate rejects denylisted hosts", () => {
+  const res = urlGate({
+    chosen_url: "https://www.idealo.de/foo",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, false)
+  assert.match(res.reason, /denylisted/i)
+})
+
+test("urlGate rejects malformed URLs", () => {
+  const res = urlGate({
+    chosen_url: "not a url",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, false)
+  assert.match(res.reason, /parse/i)
+})
+
+test("urlGate accepts brand-direct when host contains slug (length >= 4)", () => {
+  const res = urlGate({
+    chosen_url: "https://sante.de/products/foo",
+    brand: "Sante",
+  })
+  assert.equal(res.pass, true)
+})
+
+test("urlGate rejects host that is neither allowlisted nor brand-direct", () => {
+  const res = urlGate({
+    chosen_url: "https://random-shop.example/foo",
+    brand: "Pantene",
+  })
+  assert.equal(res.pass, false)
+  assert.match(res.reason, /not on allowlist/i)
+})


### PR DESCRIPTION
## Summary

Builds the affiliate-link enrichment tooling and applies a one-time data backfill:

- **226 / 227 active products** now have a usable `affiliate_link` (was 18; +208). Remaining row is intentionally `is_active=false` (Maria Nila True Soft Leave-In — no SKU exists).
- **42 product renames + 1 soft-delete** via `supabase/migrations/20260526120000_backfill_product_names_from_affiliate_research.sql`. Display-only changes; recommendation engine uses `product_oil_eligibility` / `product_*_specs` join tables on `product_id`, so renames are surfacing-safe.

## How it was built

Workflow described in `docs/superpowers/specs/2026-05-13-affiliate-link-backfill-design.md` and `docs/runbooks/2026-05-13-affiliate-link-backfill-runbook.md`:

1. Export missing rows to per-slice CSVs (`scripts/export-missing-affiliate-links.ts`)
2. Dispatch 1 canary + 15 fanout subagents (parallel) to research candidate URLs via WebSearch + WebFetch
3. Validate each slice's output CSV (`scripts/validate-slice.ts`)
4. Aggregate + classify per `urlGate` rules (`scripts/aggregate-affiliate-research.ts`) → `approved.csv` + `review-queue.csv`
5. Manual review of the 48-row review queue across Buckets A/B/C (2026-05-14 → 2026-05-26)
6. Write-back with safety belt (`scripts/write-affiliate-links.ts` — read-then-update pattern; `--dry` flag)

Pure logic (URL gate, brand-slug normalization, CSV parser, slice validator, aggregator) lives under `src/lib/affiliate-research/` with 28 unit tests.

## Test plan

- [x] `npm run ci:verify` passes (typecheck + lint + build)
- [x] 28/28 unit tests pass (`tests/affiliate-research-*.test.ts`)
- [x] Codex review (`codex:codex-rescue` agent) on full branch diff — 2 P1 findings addressed in `cad0fab` (export wipes stale results; migration NOTE on UNIQUE constraint)
- [x] Migration applied to production via service-role client on 2026-05-26 (43/43 ok)
- [x] Audit script confirms 226/227 active products have affiliate_link set
- [ ] Open one product drawer in production to confirm Buy CTA renders for newly-linked rows
- [ ] Spot-check 5 random affiliate links by clicking them in the live drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)