### PR TITLE
fix(quiz): replace legacy desktop brand label

### DIFF
--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -41,11 +41,7 @@ function OnboardingBrandPanel() {
 
       {/* Content */}
       <div className="relative z-10 max-w-[360px] text-center">
-        <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
-          Hair
-          <br />
-          Concierge
-        </h2>
+        <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">Chaarlie</h2>
         <div className="mx-auto mb-6 h-1 w-12 rounded-full bg-[var(--brand-plum)]/40" />
         <p className="text-lg text-muted-foreground leading-relaxed">Dein Haar, dein Plan.</p>
       </div>

--- a/src/components/quiz/quiz-brand-panel.tsx
+++ b/src/components/quiz/quiz-brand-panel.tsx
@@ -52,11 +52,7 @@ export function QuizBrandPanel() {
 function LandingPanel({ description }: { description: string }) {
   return (
     <>
-      <h1 className="font-header text-6xl leading-[0.95] text-foreground mb-6">
-        Hair
-        <br />
-        Concierge
-      </h1>
+      <h1 className="font-header text-6xl leading-[0.95] text-foreground mb-6">Chaarlie</h1>
       <div className="mx-auto mb-6 h-1 w-16 rounded-full bg-[var(--brand-plum)]" />
       <p className="text-lg text-muted-foreground leading-relaxed">{description}</p>
     </>
@@ -81,11 +77,7 @@ function JourneyPanel({
           {eyebrow}
         </div>
       ) : null}
-      <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">
-        Hair
-        <br />
-        Concierge
-      </h2>
+      <h2 className="font-header text-5xl leading-[0.95] text-foreground mb-6">Chaarlie</h2>
       <div
         className="mx-auto mb-4 h-1 w-12 rounded-full"
         style={{ background: "rgba(var(--brand-plum-rgb), 0.4)" }}


### PR DESCRIPTION
## Summary
- Replace the legacy split `Hair / Concierge` desktop label with `Chaarlie` in the quiz brand panel.
- Apply the same cleanup to the desktop onboarding side panel.
- Leave the descriptive pricing headline unchanged.

## Verification
- `npm run typecheck`
- `npm run lint -- src/components/quiz/quiz-brand-panel.tsx src/app/onboarding/layout.tsx` (0 errors; existing unrelated warnings remain)
- `rg -n -i "Hair[[:space:]]*$|^[[:space:]]*Concierge[[:space:]]*$|Hair\\s*Concierge|hair-concierge|hair_concierge|hairconcierge" src/app src/components`
- Playwright desktop flow to quiz question 7 on `http://localhost:3724/quiz`: confirmed `oldBrand=false`, `hasChaarlie=true`, `hasQuestion7=true`.
