### PR TITLE
fix(payments): allow PayPal checkout API through proxy

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -10,6 +10,7 @@ export async function updateSession(request: NextRequest) {
   const { pathname } = request.nextUrl
   const fastPublicRoutes = [
     "/api/stripe",
+    "/api/paypal",
     "/api/auth/send-magic-link",
     "/api/auth/send-setup-link",
     "/api/auth/set-checkout-password",
@@ -67,6 +68,7 @@ export async function updateSession(request: NextRequest) {
     "/pricing",
     "/welcome",
     "/api/stripe",
+    "/api/paypal",
     ...(process.env.NODE_ENV === "development" ? ["/labs", "/api/labs"] : []),
     ...(process.env.NODE_ENV === "development" && process.env.LOCAL_DEV_LOGIN_ENABLED === "1"
       ? ["/api/dev/login"]

--- a/tests/paypal-middleware-public.test.ts
+++ b/tests/paypal-middleware-public.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { NextRequest } from "next/server"
+import { updateSession } from "../src/lib/supabase/middleware"
+
+test("allows unauthenticated PayPal checkout API calls through the proxy", async () => {
+  const response = await updateSession(
+    new NextRequest("https://chaarlie.de/api/paypal/create-subscription-intent", {
+      method: "POST",
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get("location"), null)
+})
+
+test("allows unauthenticated PayPal webhook calls through the proxy", async () => {
+  const response = await updateSession(
+    new NextRequest("https://chaarlie.de/api/paypal/webhook", {
+      method: "POST",
+    }),
+  )
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get("location"), null)
+})


### PR DESCRIPTION
## Summary
- allow unauthenticated /api/paypal routes through the Supabase proxy, matching Stripe checkout routes
- add regression coverage for PayPal checkout intent and webhook POSTs not redirecting to /quiz

## Verification
- npx tsx --test tests/paypal-middleware-public.test.ts
- npx tsx --test tests/billing-paypal-server.test.ts tests/paypal-webhook-handlers.test.ts tests/paypal-cancel.test.ts
- npm run typecheck

## Production symptom
Before this fix, POST /api/paypal/create-subscription-intent returned 307 Location: /quiz on chaarlie.de, so the PayPal checkout button could not start for unauthenticated lead checkout.