### PR TITLE
fix(security): allow PayPal logo assets in CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const securityHeaders = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu.i.posthog.com https://cdp-eu.customer.io https://js.stripe.com https://checkout.stripe.com https://www.paypal.com https://www.paypalobjects.com",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://*.supabase.co https://www.tophair.de https://assets.cdn.filesafe.space",
+      "img-src 'self' data: blob: https://*.supabase.co https://www.tophair.de https://assets.cdn.filesafe.space https://www.paypalobjects.com",
       "font-src 'self' data:",
       "connect-src 'self' https://eu.i.posthog.com https://eu.posthog.com https://cdp-eu.customer.io https://*.supabase.co https://*.sentry.io https://api.stripe.com https://js.stripe.com https://checkout.stripe.com https://www.paypal.com https://www.sandbox.paypal.com https://api-m.paypal.com https://api-m.sandbox.paypal.com",
       "frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://checkout.stripe.com https://www.paypal.com https://www.sandbox.paypal.com",

--- a/tests/paypal-csp.test.ts
+++ b/tests/paypal-csp.test.ts
@@ -11,6 +11,7 @@ test("CSP allows PayPal SDK, API, and button frames", async () => {
   assert.ok(csp, "expected Content-Security-Policy-Report-Only header")
   assert.match(csp, /script-src[^;]*https:\/\/www\.paypal\.com/)
   assert.match(csp, /script-src[^;]*https:\/\/www\.paypalobjects\.com/)
+  assert.match(csp, /img-src[^;]*https:\/\/www\.paypalobjects\.com/)
   assert.match(csp, /connect-src[^;]*https:\/\/www\.paypal\.com/)
   assert.match(csp, /connect-src[^;]*https:\/\/www\.sandbox\.paypal\.com/)
   assert.match(csp, /connect-src[^;]*https:\/\/api-m\.paypal\.com/)


### PR DESCRIPTION
## Summary
- allow PayPal logo assets from www.paypalobjects.com in img-src
- extend the PayPal CSP regression test to cover image assets

## Verification
- npx tsx --test tests/paypal-csp.test.ts
- npm run typecheck
- npm run build

## Why
The first CSP update removed PayPal script/connect/frame warnings, but the live browser smoke test still reported PayPal button logo SVG violations under img-src.