### PR TITLE
fix(payments): restrict PayPal checkout button

### DIFF
--- a/src/components/checkout/paypal-subscription-button.tsx
+++ b/src/components/checkout/paypal-subscription-button.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRef, useState } from "react"
-import { PayPalButtons, PayPalScriptProvider } from "@paypal/react-paypal-js"
+import { FUNDING, PayPalButtons, PayPalScriptProvider } from "@paypal/react-paypal-js"
 import type { CreateSubscriptionActions, OnApproveData } from "@paypal/paypal-js"
 
 import type { BillingInterval } from "@/lib/stripe/intervals"
@@ -32,7 +32,7 @@ export function PayPalSubscriptionButton({
 }) {
   const [error, setError] = useState<string | null>(null)
   const intentTokenRef = useRef<string | null>(null)
-  const clientId = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
+  const clientId = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID?.trim()
 
   if (!clientId) {
     return (
@@ -55,6 +55,7 @@ export function PayPalSubscriptionButton({
       >
         <PayPalButtons
           className="w-full"
+          fundingSource={FUNDING.PAYPAL}
           createSubscription={async (
             _data: Record<string, unknown>,
             actions: CreateSubscriptionActions,

--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -72,7 +72,7 @@ export function CookieConsent() {
         <div
           role="dialog"
           aria-label="Cookie-Einstellungen"
-          className="fixed bottom-2 left-2 right-2 z-40 max-w-md rounded-xl border border-border bg-card p-3.5 shadow-2xl sm:bottom-6 sm:left-6 sm:right-auto sm:rounded-2xl sm:p-5"
+          className="fixed bottom-2 left-2 right-2 z-[100] max-w-md rounded-xl border border-border bg-card p-3.5 shadow-2xl sm:bottom-6 sm:left-6 sm:right-auto sm:rounded-2xl sm:p-5"
         >
           <h2 className="text-sm font-semibold text-foreground sm:text-base">
             Wir verwenden Cookies

--- a/tests/payment-method-checkout.test.tsx
+++ b/tests/payment-method-checkout.test.tsx
@@ -93,6 +93,8 @@ test("PayPal plan IDs are resolved by the server intent route", () => {
     new URL("../src/components/checkout/paypal-subscription-button.tsx", import.meta.url),
     "utf8",
   )
+  assert.match(buttonSource, /fundingSource=\{FUNDING\.PAYPAL\}/)
+  assert.match(buttonSource, /NEXT_PUBLIC_PAYPAL_CLIENT_ID\?\.trim\(\)/)
   assert.doesNotMatch(buttonSource, /PAYPAL_PLAN_ID_/)
   assert.match(buttonSource, /create-subscription-intent/)
   assert.match(buttonSource, /shipping_preference: "NO_SHIPPING"/)
@@ -102,6 +104,17 @@ test("PayPal plan IDs are resolved by the server intent route", () => {
     "utf8",
   )
   assert.match(routeSource, /getPayPalPlanId/)
+})
+
+test("Cookie banner stacks above PayPal checkout iframes", () => {
+  const cookieConsentSource = readFileSync(
+    new URL("../src/components/cookie-consent/cookie-consent.tsx", import.meta.url),
+    "utf8",
+  )
+
+  assert.match(cookieConsentSource, /aria-label="Cookie-Einstellungen"/)
+  assert.match(cookieConsentSource, /z-\[100\]/)
+  assert.doesNotMatch(cookieConsentSource, /z-40/)
 })
 
 test("PayPal approval validates the provider custom id before accepting a bound intent", () => {


### PR DESCRIPTION
## Summary
- Render the PayPal SDK button with `FUNDING.PAYPAL` so PayPal does not offer its own card/debit card button.
- Raise the cookie consent banner above payment iframes.
- Trim the public PayPal client id before loading the SDK to avoid hidden newline characters breaking the SDK script selector.

## Verification
- `npx tsx --test tests/payment-method-checkout.test.tsx`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `NEXT_PUBLIC_PAYPAL_ENABLED=true NEXT_PUBLIC_PAYPAL_CLIENT_ID=test-paypal-client-id npm run build`
- Local Playwright smoke against `http://localhost:3715/pricing` with PayPal enabled: cookie banner z-index reads `100`, no `Debit or Credit Card` text appears.
