### PR TITLE
fix(cookie): hide banner behind settings dialog

### DIFF
--- a/src/components/cookie-consent/cookie-consent.tsx
+++ b/src/components/cookie-consent/cookie-consent.tsx
@@ -68,7 +68,7 @@ export function CookieConsent() {
 
   return (
     <>
-      {bannerVisible && (
+      {bannerVisible && !settingsOpen && (
         <div
           role="dialog"
           aria-label="Cookie-Einstellungen"

--- a/tests/payment-method-checkout.test.tsx
+++ b/tests/payment-method-checkout.test.tsx
@@ -113,6 +113,7 @@ test("Cookie banner stacks above PayPal checkout iframes", () => {
   )
 
   assert.match(cookieConsentSource, /aria-label="Cookie-Einstellungen"/)
+  assert.match(cookieConsentSource, /bannerVisible && !settingsOpen/)
   assert.match(cookieConsentSource, /z-\[100\]/)
   assert.doesNotMatch(cookieConsentSource, /z-40/)
 })


### PR DESCRIPTION
## Summary
- Hide the cookie banner while the cookie settings dialog is open.
- Keep the raised banner z-index for PayPal/payment iframe overlap, without letting the banner sit above its own modal.
- Add a regression assertion for the banner/settings render condition.

## Verification
- `npx tsx --test tests/payment-method-checkout.test.tsx`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `NEXT_PUBLIC_PAYPAL_ENABLED=true NEXT_PUBLIC_PAYPAL_CLIENT_ID=test-paypal-client-id npm run build`

## Review context
Follow-up from the requested code review on PR #130: reviewer found the raised cookie banner could stack above the cookie settings dialog because the dialog uses the app's default `z-50` layer.
