### PR TITLE
feat(beta): in-app feedback bubble (Variant A) — Supabase-backed

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -10,7 +10,18 @@ const feedbackSchema = z.object({
   userAgent: z.string().max(512).optional(),
 })
 
+// Strip query string + hash so we never persist auth tokens, Stripe/PayPal
+// session ids, magic-link codes, etc. Session Replay has the full context.
+function redactUrl(url: string | undefined): string | null {
+  if (!url) return null
+  return url.split("?")[0].split("#")[0].slice(0, 2048)
+}
+
 export async function POST(request: Request) {
+  if (process.env.NEXT_PUBLIC_BETA_FEEDBACK_ENABLED !== "true") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
   const supabase = await createClient()
   const {
     data: { user },
@@ -35,7 +46,7 @@ export async function POST(request: Request) {
   const { error } = await supabase.from("beta_feedback").insert({
     user_id: user.id,
     message: parsed.data.message,
-    page_url: parsed.data.pageUrl ?? null,
+    page_url: redactUrl(parsed.data.pageUrl),
     user_agent: parsed.data.userAgent ?? null,
   })
 

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { createClient } from "@/lib/supabase/server"
+import { ERR_INVALID_DATA, ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
+
+const feedbackSchema = z.object({
+  message: z.string().trim().min(1).max(4000),
+  pageUrl: z.string().max(2048).optional(),
+  userAgent: z.string().max(512).optional(),
+})
+
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: ERR_INVALID_DATA }, { status: 400 })
+  }
+
+  const parsed = feedbackSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: ERR_INVALID_DATA }, { status: 400 })
+  }
+
+  const { error } = await supabase.from("beta_feedback").insert({
+    user_id: user.id,
+    message: parsed.data.message,
+    page_url: parsed.data.pageUrl ?? null,
+    user_agent: parsed.data.userAgent ?? null,
+  })
+
+  if (error) {
+    return NextResponse.json({ error: fehler("Speichern", "des Feedbacks") }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { MetaPixelProvider } from "@/providers/meta-pixel-provider"
 import { PostHogClientProvider } from "@/providers/posthog-provider"
 import { ToastProvider } from "@/providers/toast-provider"
 import { CookieConsent } from "@/components/cookie-consent/cookie-consent"
+import { FeedbackWidget } from "@/components/feedback/feedback-widget"
 import "./globals.css"
 
 const playfairDisplay = Playfair_Display({
@@ -57,7 +58,10 @@ export default function RootLayout({
           <AuthProvider>
             <CustomerIoProvider>
               <PostHogClientProvider>
-                <ToastProvider>{children}</ToastProvider>
+                <ToastProvider>
+                  {children}
+                  <FeedbackWidget />
+                </ToastProvider>
               </PostHogClientProvider>
             </CustomerIoProvider>
           </AuthProvider>

--- a/src/components/feedback/feedback-widget.tsx
+++ b/src/components/feedback/feedback-widget.tsx
@@ -59,7 +59,9 @@ export function FeedbackWidget() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: trimmed,
-          pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
+          // Pathname only — query string can carry auth tokens / Stripe session ids.
+          // Server also redacts as defense-in-depth.
+          pageUrl: typeof window !== "undefined" ? window.location.pathname : undefined,
           userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
         }),
       })

--- a/src/components/feedback/feedback-widget.tsx
+++ b/src/components/feedback/feedback-widget.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import * as React from "react"
+import { MessageSquare, Check } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+import { useAuth } from "@/providers/auth-provider"
+import { useToast } from "@/providers/toast-provider"
+import { posthog } from "@/providers/posthog-provider"
+import { cn } from "@/lib/utils"
+
+const MAX_LENGTH = 4000
+const SUCCESS_AUTOCLOSE_MS = 1800
+
+export function FeedbackWidget() {
+  const { user, loading } = useAuth()
+  const { toast } = useToast()
+  const [open, setOpen] = React.useState(false)
+  const [message, setMessage] = React.useState("")
+  const [submitting, setSubmitting] = React.useState(false)
+  const [success, setSuccess] = React.useState(false)
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
+
+  const enabled = process.env.NEXT_PUBLIC_BETA_FEEDBACK_ENABLED === "true"
+
+  React.useEffect(() => {
+    if (open && !success) {
+      // Focus textarea after Dialog mounts (portal needs a tick)
+      const timer = setTimeout(() => textareaRef.current?.focus(), 80)
+      return () => clearTimeout(timer)
+    }
+  }, [open, success])
+
+  if (!enabled || loading || !user) return null
+
+  const trimmed = message.trim()
+  const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_LENGTH && !submitting
+
+  function handleOpenChange(next: boolean) {
+    if (submitting) return
+    setOpen(next)
+    if (!next) {
+      // Reset shortly after close animation finishes
+      setTimeout(() => {
+        setMessage("")
+        setSuccess(false)
+      }, 250)
+    }
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return
+    setSubmitting(true)
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: trimmed,
+          pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
+          userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null
+        throw new Error(data?.error ?? "Fehler beim Senden")
+      }
+
+      posthog.capture("feedback_submitted", {
+        page_url: typeof window !== "undefined" ? window.location.pathname : undefined,
+      })
+      setSuccess(true)
+      setTimeout(() => {
+        setOpen(false)
+        // Reset after close animation
+        setTimeout(() => {
+          setMessage("")
+          setSuccess(false)
+        }, 250)
+      }, SUCCESS_AUTOCLOSE_MS)
+    } catch (err) {
+      const description = err instanceof Error ? err.message : "Bitte versuche es nochmal."
+      toast({
+        title: "Hat nicht geklappt",
+        description,
+        variant: "destructive",
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Feedback geben"
+        onClick={() => setOpen(true)}
+        className={cn(
+          "fixed bottom-20 right-4 z-40",
+          "flex h-[52px] w-[52px] items-center justify-center",
+          "rounded-full bg-secondary text-secondary-foreground",
+          "shadow-[0_10px_24px_-6px_rgba(217,106,118,0.5)]",
+          "transition-transform duration-150",
+          "hover:scale-105 active:scale-95",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        )}
+      >
+        <MessageSquare className="h-6 w-6" />
+      </button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-md rounded-2xl">
+          {success ? (
+            <div className="flex flex-col items-center py-4 text-center">
+              <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-[hsl(140_45%_92%)] text-[hsl(140_50%_35%)]">
+                <Check className="h-7 w-7" strokeWidth={2.5} />
+              </div>
+              <h2 className="font-display text-xl font-semibold">Danke!</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Wir lesen&apos;s. Wenn du willst, schreib uns nochmal — jede Nachricht zählt.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div>
+                <h2 className="font-display text-xl font-semibold">Etwas stimmt nicht?</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Sag uns kurz Bescheid — wir lesen jede Nachricht.
+                </p>
+              </div>
+              <Textarea
+                ref={textareaRef}
+                value={message}
+                onChange={(e) => setMessage(e.target.value.slice(0, MAX_LENGTH))}
+                placeholder="Was ist los?"
+                maxLength={MAX_LENGTH}
+                rows={5}
+                className="resize-y"
+                disabled={submitting}
+              />
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs text-muted-foreground">
+                  {message.length} / {MAX_LENGTH}
+                </span>
+                <Button
+                  type="button"
+                  variant="cta"
+                  size="sm"
+                  onClick={handleSubmit}
+                  disabled={!canSubmit}
+                  className="w-auto px-5"
+                >
+                  {submitting ? "Senden …" : "Senden"}
+                </Button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/supabase/migrations/20260528120000_beta_feedback.sql
+++ b/supabase/migrations/20260528120000_beta_feedback.sql
@@ -1,0 +1,23 @@
+-- Beta-Feedback aus dem In-App-Bubble-Widget
+-- Authentifizierte User submitten Freitext; Kontext über PostHog Session Replay
+-- (user_id + created_at -> Session-Lookup).
+
+create table public.beta_feedback (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  message text not null check (length(message) between 1 and 4000),
+  page_url text,
+  user_agent text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.beta_feedback enable row level security;
+
+-- Authentifizierte User dürfen ausschließlich eigenes Feedback einreichen.
+create policy "users insert own feedback"
+  on public.beta_feedback for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+create index beta_feedback_created_at_idx
+  on public.beta_feedback (created_at desc);

--- a/supabase/migrations/20260528120000_beta_feedback.sql
+++ b/supabase/migrations/20260528120000_beta_feedback.sql
@@ -6,8 +6,8 @@ create table public.beta_feedback (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id) on delete set null,
   message text not null check (length(message) between 1 and 4000),
-  page_url text,
-  user_agent text,
+  page_url text check (page_url is null or length(page_url) <= 2048),
+  user_agent text check (user_agent is null or length(user_agent) <= 512),
   created_at timestamptz not null default now()
 );
 


### PR DESCRIPTION
## Summary

PR #1 of the beta-phase feedback infrastructure. Adds a floating, in-app feedback bubble (Variant A) so beta testers can send free-text feedback without leaving the app.

- New `public.beta_feedback` table with RLS (`insert own feedback`) + length constraints
- `POST /api/feedback` — Zod validated, auth-gated, server-side env-flag gate, URL redaction (defense-in-depth — strips query string / hash so we never persist auth tokens, Stripe/PayPal session ids, magic-link codes)
- `FeedbackWidget` FAB + Dialog — env-gated, auth-gated, success state, PostHog `feedback_submitted` event
- Mounted inside `ToastProvider` in root layout

See `docs/beta-feedback-konzept.md` and `docs/plans/2026-05-28-beta-feedback-impl.md`.

## Deploy notes

- **Env var required:** Set `NEXT_PUBLIC_BETA_FEEDBACK_ENABLED=true` in Vercel before the beta starts. Until then, the widget renders nothing and the API returns 404 — safe to deploy now.
- **Migration:** `20260528120000_beta_feedback.sql` applies on deploy. Additive, irreversible (new table, no destructive ops).
- **Follow-up:** PR #2 (Banner Tag 7) is blocked on the Typeform URL from Jonas — not in this PR.

## Verification

- `npm run ci:verify` passed locally (typecheck + lint + build)
- Codex review run on full branch diff; 3 findings fixed in commit 2 (server-side flag gate, URL redaction, SQL length constraints)
- Manual prod smoke-test will happen after deploy

## Test plan

- [ ] Set `NEXT_PUBLIC_BETA_FEEDBACK_ENABLED=true` in Vercel preview env
- [ ] Sign in, confirm FAB appears bottom-right
- [ ] Submit feedback → success state → row in `beta_feedback` table
- [ ] Confirm signed-out users do not see the FAB
- [ ] Confirm with flag unset, `/api/feedback` returns 404
- [ ] Confirm `page_url` in DB has no query string / hash