### PR TITLE
feat(beta): longer success state + posthog session id linkage

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -8,6 +8,7 @@ const feedbackSchema = z.object({
   message: z.string().trim().min(1).max(4000),
   pageUrl: z.string().max(2048).optional(),
   userAgent: z.string().max(512).optional(),
+  posthogSessionId: z.string().max(128).optional(),
 })
 
 // Strip query string + hash so we never persist auth tokens, Stripe/PayPal
@@ -48,6 +49,7 @@ export async function POST(request: Request) {
     message: parsed.data.message,
     page_url: redactUrl(parsed.data.pageUrl),
     user_agent: parsed.data.userAgent ?? null,
+    posthog_session_id: parsed.data.posthogSessionId ?? null,
   })
 
   if (error) {

--- a/src/components/feedback/feedback-widget.tsx
+++ b/src/components/feedback/feedback-widget.tsx
@@ -12,7 +12,7 @@ import { posthog } from "@/providers/posthog-provider"
 import { cn } from "@/lib/utils"
 
 const MAX_LENGTH = 4000
-const SUCCESS_AUTOCLOSE_MS = 1800
+const SUCCESS_AUTOCLOSE_MS = 4000
 
 export function FeedbackWidget() {
   const { user, loading } = useAuth()
@@ -54,6 +54,16 @@ export function FeedbackWidget() {
     if (!canSubmit) return
     setSubmitting(true)
     try {
+      // Best-effort session-id capture — fails silently if PostHog isn't ready
+      // (e.g., recording not yet started). Empty string is treated as missing.
+      let posthogSessionId: string | undefined
+      try {
+        const id = posthog.get_session_id()
+        if (typeof id === "string" && id.length > 0) posthogSessionId = id
+      } catch {
+        // ignore
+      }
+
       const res = await fetch("/api/feedback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -63,6 +73,7 @@ export function FeedbackWidget() {
           // Server also redacts as defense-in-depth.
           pageUrl: typeof window !== "undefined" ? window.location.pathname : undefined,
           userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+          posthogSessionId,
         }),
       })
 

--- a/supabase/migrations/20260528160000_beta_feedback_posthog_session.sql
+++ b/supabase/migrations/20260528160000_beta_feedback_posthog_session.sql
@@ -1,0 +1,6 @@
+-- Capture PostHog session id alongside feedback so triage can deep-link
+-- straight to the Session Replay instead of hunting by user_id + timestamp.
+
+alter table public.beta_feedback
+  add column posthog_session_id text
+    check (posthog_session_id is null or length(posthog_session_id) <= 128);


### PR DESCRIPTION
## Summary

Two small polish changes after the first round of in-prod testing of the beta feedback widget (follow-up to #132 and #133).

- **Longer success state.** `SUCCESS_AUTOCLOSE_MS` 1800 → 4000 so users actually have time to read the "Danke!" copy before the dialog auto-closes.
- **PostHog session id linkage.** Widget captures `posthog.get_session_id()` (best-effort, try/catch fallback for when recording hasn't started); server persists it on `beta_feedback.posthog_session_id` so triage can deep-link straight into Session Replay instead of hunting by user_id + timestamp.

## Migration

`supabase/migrations/20260528160000_beta_feedback_posthog_session.sql` adds a single nullable `text` column with a length check (≤128). **The migration is already applied to production Supabase via MCP** — additive, nullable, zero risk to existing code. The schema is in sync; no extra deploy step needed.

## Files

- `supabase/migrations/20260528160000_beta_feedback_posthog_session.sql` (additive nullable column)
- `src/app/api/feedback/route.ts` (zod field + insert mapping)
- `src/components/feedback/feedback-widget.tsx` (constant bump + posthog session id capture)

## Test plan

- [x] `npm run ci:verify` passes (typecheck + lint + build)
- [x] Pre-commit hooks (Prettier + ESLint --fix) clean
- [ ] In prod: submit feedback, confirm row has `posthog_session_id` populated and the "Danke!" state stays visible for ~4s before auto-closing.