### PR TITLE
feat(agent): observe AgentV2 with Langfuse

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -51,6 +51,7 @@ async function loadChatRuntimeDeps() {
       summarizeEngineTraceForLangfuse,
       summarizeProductsForLangfuse,
     },
+    { summarizeAgentV2TraceForLangfuse },
     { persistConversationStateTransition },
     { chatMessageSchema },
     { generateConversationTitle },
@@ -60,6 +61,7 @@ async function loadChatRuntimeDeps() {
     import("@/lib/rag/chat-response"),
     import("@/lib/rag/memory-extractor"),
     import("@/lib/rag/debug-trace"),
+    import("@/lib/agent-v2/production/langfuse-observability"),
     import("@/lib/rag/conversation-state-store"),
     import("@/lib/validators"),
     import("@/lib/rag/title-generator"),
@@ -76,6 +78,7 @@ async function loadChatRuntimeDeps() {
     finalizeChatTurnTrace,
     summarizeEngineTraceForLangfuse,
     summarizeProductsForLangfuse,
+    summarizeAgentV2TraceForLangfuse,
     persistConversationStateTransition,
     chatMessageSchema,
     generateConversationTitle,
@@ -183,6 +186,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
       finalizeChatTurnTrace,
       summarizeEngineTraceForLangfuse,
       summarizeProductsForLangfuse,
+      summarizeAgentV2TraceForLangfuse,
       persistConversationStateTransition,
       chatMessageSchema,
       generateConversationTitle,
@@ -554,6 +558,9 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                     loaded_guidance_ids: completedTrace.agentic_tool_loop.loaded_guidance_ids,
                   }
                 : null
+              const agentV2Summary = completedTrace.agent_v2_trace
+                ? summarizeAgentV2TraceForLangfuse(completedTrace.agent_v2_trace)
+                : null
 
               deps
                 .persistConversationTurnTrace({
@@ -580,7 +587,8 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                   selected_products: summarizeProductsForLangfuse(
                     completedTrace.decision_context.matched_products,
                   ),
-                  agentic_tool_loop_summary: toolLoopSummary,
+                  agent_v2_summary: agentV2Summary,
+                  ...(toolLoopSummary ? { agentic_tool_loop_summary: toolLoopSummary } : {}),
                 },
               })
 
@@ -627,6 +635,9 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                   loaded_guidance_ids: failedTrace.agentic_tool_loop.loaded_guidance_ids,
                 }
               : null
+            const failedAgentV2Summary = failedTrace.agent_v2_trace
+              ? summarizeAgentV2TraceForLangfuse(failedTrace.agent_v2_trace)
+              : null
 
             deps
               .persistConversationTurnTrace({
@@ -652,7 +663,10 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                 selected_products: summarizeProductsForLangfuse(
                   failedTrace.decision_context.matched_products,
                 ),
-                agentic_tool_loop_summary: failedToolLoopSummary,
+                agent_v2_summary: failedAgentV2Summary,
+                ...(failedToolLoopSummary
+                  ? { agentic_tool_loop_summary: failedToolLoopSummary }
+                  : {}),
               },
               metadata: {
                 error: errorMessage,
@@ -685,6 +699,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
           },
         })
         chatObservation.end()
+        deps.flushLangfuseClient().catch(() => {})
       }
       return NextResponse.json({ error: fehler("Verarbeitung") }, { status: 500 })
     }

--- a/src/lib/agent-v2/production/chat-pipeline.ts
+++ b/src/lib/agent-v2/production/chat-pipeline.ts
@@ -1,4 +1,4 @@
-import { getOpenAI } from "@/lib/openai/client"
+import { getOpenAI, getObservedOpenAI } from "@/lib/openai/client"
 import { createBuildOrFixRoutineTool } from "@/lib/agent/tools/build-or-fix-routine"
 import { buildCareBalanceToolContext } from "@/lib/agent/tools/care-balance-context"
 import { getUserContext, type UserContextProjection } from "@/lib/agent/tools/get-user-context"
@@ -7,6 +7,11 @@ import {
   type SelectProductsToolResult,
 } from "@/lib/agent/tools/select-products"
 import { loadAgentV2ProductionConversationHistory } from "@/lib/agent-v2/production/conversation-history"
+import {
+  buildAgentV2GenerationMetadata,
+  isAgentV2LangfuseObservationEnabled,
+  observeAgentV2ToolCall,
+} from "@/lib/agent-v2/production/langfuse-observability"
 import { buildAgentV2ProductToolMessage } from "@/lib/agent-v2/runtime/product-tool-context"
 import {
   type AgentV2RoutineLayer,
@@ -50,6 +55,11 @@ import { loadAgentV2ConversationState as loadPersistedConversationState } from "
 import { buildPipelineTraceDraft } from "@/lib/rag/debug-trace"
 import type { PipelineParams, PipelineResult } from "@/lib/rag/contracts"
 import { loadUserMemoryContext, type UserMemoryContext } from "@/lib/rag/user-memory"
+import {
+  LANGFUSE_PROMPTS,
+  buildLangfusePromptConfig,
+  getManagedTextPromptTemplate,
+} from "@/lib/langfuse/prompts"
 import type { PersistenceRoutineItemRow } from "@/lib/recommendation-engine/adapters/from-persistence"
 import { buildRecommendationEngineRuntimeFromPersistence } from "@/lib/recommendation-engine/runtime"
 import type { EffectiveCareContext } from "@/lib/recommendation-engine/types"
@@ -87,6 +97,10 @@ interface ProductionAgentV2PipelineDeps {
   createSelectProductsTool?: typeof createSelectProductsTool
   createBuildOrFixRoutineTool?: typeof createBuildOrFixRoutineTool
   runAgentV2ResponsesTurn?: typeof runAgentV2ResponsesTurn
+  getOpenAI?: typeof getOpenAI
+  getObservedOpenAI?: typeof getObservedOpenAI
+  getManagedTextPromptTemplate?: typeof getManagedTextPromptTemplate
+  observeAgentV2ToolCall?: typeof observeAgentV2ToolCall
 }
 
 const ROUTINE_PRODUCT_CATEGORY_VALUES = new Set<RoutineProduct>([
@@ -151,19 +165,11 @@ function projectRecentMessages(messages: Message[]): RecentConversationMessage[]
   })
 }
 
-function promptRef(name: string): LangfusePromptReference {
-  return {
-    name,
-    version: null,
-    label: "code",
-    is_fallback: true,
-  }
-}
-
 function buildAgentV2PromptSnapshot(params: {
   message: string
   recentMessages: RecentConversationMessage[]
   model: string
+  promptRef: LangfusePromptReference
 }): ChatPromptSnapshot {
   const recentMessageRoles = params.recentMessages.slice(-4).map((message) => message.role)
 
@@ -171,7 +177,7 @@ function buildAgentV2PromptSnapshot(params: {
     kind: "agent_v2_responses",
     model: params.model,
     temperature: 0,
-    prompt_ref: promptRef("agent-v2-responses-care-balance"),
+    prompt_ref: params.promptRef,
     system_prompt: "agent_v2_responses_care_balance",
     messages: [
       {
@@ -443,10 +449,40 @@ export async function runAgentV2ProductionPipeline(
     conversationState.agent_v2.prior_selected_product_projections
   const sessionMemory = conversationState.agent_v2.session_memory
   const runTurn = deps.runAgentV2ResponsesTurn ?? runAgentV2ResponsesTurn
+  const safetyMode = classifyAgentV2ProductionSafetyMode(message)
+  const managedPrompt = await (deps.getManagedTextPromptTemplate ?? getManagedTextPromptTemplate)(
+    LANGFUSE_PROMPTS.agentV2ResponsesCareBalance,
+  )
+  const useInjectedRuntimeWithoutClient =
+    Boolean(deps.runAgentV2ResponsesTurn) && !deps.getOpenAI && !deps.getObservedOpenAI
+  const client =
+    deps.client ??
+    (useInjectedRuntimeWithoutClient
+      ? ({
+          responses: {
+            create: async () => {
+              throw new Error("Injected AgentV2 runtime did not use its model client.")
+            },
+          },
+        } satisfies AgentV2ResponsesClient)
+      : isAgentV2LangfuseObservationEnabled()
+        ? ((deps.getObservedOpenAI ?? getObservedOpenAI)({
+            generationName: "agent-v2-responses-step",
+            langfusePrompt: buildLangfusePromptConfig(managedPrompt.ref),
+            generationMetadata: buildAgentV2GenerationMetadata({
+              conversationId,
+              requestId,
+              safetyMode,
+              engine: "agent_v2",
+              endpoint: "responses",
+              migrationMode: "agent_v2_care_balance",
+            }),
+          }) as unknown as AgentV2ResponsesClient)
+        : ((deps.getOpenAI ?? getOpenAI)() as unknown as AgentV2ResponsesClient))
   const agentStart = performance.now()
 
   const result = await runTurn({
-    client: deps.client ?? (getOpenAI() as unknown as AgentV2ResponsesClient),
+    client,
     message,
     recentMessages,
     userContext: {
@@ -461,8 +497,9 @@ export async function runAgentV2ProductionPipeline(
     currentRoutineLayer: routineThreadContext?.active ? routineThreadContext.current_layer : null,
     routineThreadContext,
     priorSelectedProductProjections,
-    safetyMode: classifyAgentV2ProductionSafetyMode(message),
+    safetyMode,
     langfuseMode: "enabled",
+    observeToolCall: deps.observeAgentV2ToolCall ?? observeAgentV2ToolCall,
     tools: {
       load_advisor_guidance: async (input) => loadAgentV2AdvisorGuidance(input),
       select_products: async (input, executionContext?: AgentV2RuntimeToolExecutionContext) => {
@@ -567,6 +604,7 @@ export async function runAgentV2ProductionPipeline(
     message,
     recentMessages,
     model: result.trace.model,
+    promptRef: managedPrompt.ref,
   })
   const visibleRoutineSteps = buildRoutineThreadVisibleSteps(
     latestRoutineProjection as AgentV2RoutineProjection | null,
@@ -633,7 +671,7 @@ export async function runAgentV2ProductionPipeline(
     category_decision: exposedCategoryDecision,
     engine_trace: exposedEngineTrace,
     matched_products: matchedProducts,
-    classification_prompt_ref: promptRef("agent-v2-responses-care-balance"),
+    classification_prompt_ref: managedPrompt.ref,
     prompt,
     response_composition: {
       path: "agent_v2_responses",

--- a/src/lib/agent-v2/production/langfuse-observability.ts
+++ b/src/lib/agent-v2/production/langfuse-observability.ts
@@ -1,0 +1,138 @@
+import { startObservation } from "@langfuse/tracing"
+
+type AgentV2TraceLike = {
+  model_steps: readonly unknown[]
+  tool_calls: readonly { name?: unknown; latency_ms?: unknown }[]
+  blocked_tool_calls: readonly unknown[]
+  repair_attempts: readonly unknown[]
+  loaded_guidance_package_ids: readonly string[]
+  response_ids: readonly string[]
+  validation_errors: readonly unknown[]
+  validation_warnings: readonly unknown[]
+  answer_mode: string | null
+  safety_mode: string
+  failure_stage: string | null
+  routine_thread_context_active: boolean
+  final_product_ids: readonly string[]
+  langfuse?: { enabled?: boolean; trace_id?: string | null; trace_url?: string | null }
+}
+
+export function isAgentV2LangfuseObservationEnabled(): boolean {
+  return process.env.AGENT_V2_LANGFUSE_OBSERVATION !== "disabled"
+}
+
+export function buildAgentV2GenerationMetadata(params: {
+  conversationId: string
+  requestId: string
+  safetyMode: string
+  engine: "agent_v2"
+  endpoint: "responses"
+  migrationMode: "agent_v2_care_balance"
+}): Record<string, string | number | boolean | null> {
+  return {
+    conversation_id: params.conversationId,
+    request_id: params.requestId,
+    engine: params.engine,
+    endpoint: params.endpoint,
+    safety_mode: params.safetyMode,
+    migration_mode: params.migrationMode,
+  }
+}
+
+export function summarizeAgentV2TraceForLangfuse(trace: AgentV2TraceLike) {
+  return {
+    engine: "agent_v2",
+    model_step_count: trace.model_steps.length,
+    tool_call_count: trace.tool_calls.length,
+    blocked_tool_call_count: trace.blocked_tool_calls.length,
+    repair_count: trace.repair_attempts.length,
+    loaded_guidance_ids: trace.loaded_guidance_package_ids,
+    response_ids: trace.response_ids,
+    validation_error_count: trace.validation_errors.length,
+    validation_warning_count: trace.validation_warnings.length,
+    answer_mode: trace.answer_mode,
+    safety_mode: trace.safety_mode,
+    failure_stage: trace.failure_stage,
+    routine_thread_context_active: trace.routine_thread_context_active,
+    final_product_ids: trace.final_product_ids,
+    langfuse_enabled: trace.langfuse?.enabled ?? false,
+  }
+}
+
+export function summarizeAgentV2ToolInput(name: string, input: Record<string, unknown>) {
+  return {
+    name,
+    category: typeof input.category === "string" ? input.category : null,
+    requested_category:
+      typeof input.requested_category === "string" ? input.requested_category : null,
+    product_request_kind:
+      typeof input.product_request_kind === "string" ? input.product_request_kind : null,
+    requested_product_count:
+      typeof input.requested_product_count === "number" ? input.requested_product_count : null,
+    has_effective_care_context: Boolean(input.effective_care_context),
+  }
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string") ? value : []
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+export function summarizeAgentV2ToolOutput(name: string, output: unknown) {
+  const object = readObject(output)
+  const projection = readObject(object?.projection) ?? object
+  const products = Array.isArray(projection?.products) ? projection.products : null
+  const visibleSteps = Array.isArray(projection?.visible_steps)
+    ? projection.visible_steps
+    : Array.isArray(projection?.steps)
+      ? projection.steps
+      : null
+  const loadedGuidanceIds = [
+    ...readStringArray(object?.loaded_package_ids),
+    ...readStringArray(projection?.loaded_guidance_ids),
+  ]
+
+  return {
+    name,
+    valid_product_ids: readStringArray(projection?.valid_product_ids),
+    product_count: products ? products.length : null,
+    routine_step_count: visibleSteps ? visibleSteps.length : null,
+    loaded_guidance_ids: loadedGuidanceIds,
+  }
+}
+
+export async function observeAgentV2ToolCall<T>(params: {
+  name: string
+  input: Record<string, unknown>
+  run: () => Promise<T>
+}): Promise<T> {
+  const observation = startObservation(
+    `agent-v2-tool:${params.name}`,
+    {
+      input: summarizeAgentV2ToolInput(params.name, params.input),
+      metadata: { engine: "agent_v2" },
+    },
+    { asType: "tool" },
+  )
+
+  try {
+    const output = await params.run()
+    observation.update({
+      output: summarizeAgentV2ToolOutput(params.name, output),
+    })
+    return output
+  } catch (error) {
+    observation.update({
+      level: "ERROR",
+      statusMessage: error instanceof Error ? error.message : "agent_v2_tool_error",
+    })
+    throw error
+  } finally {
+    observation.end()
+  }
+}

--- a/src/lib/agent-v2/runtime/prompt.ts
+++ b/src/lib/agent-v2/runtime/prompt.ts
@@ -1,0 +1,2 @@
+export const AGENT_V2_RESPONSES_SYSTEM_PROMPT =
+  "You are AgentV2 for Chaarlie. Never return plain assistant text to the user. Every user-visible answer must be submitted by calling submit_final_answer exactly once. Clarify when a product recommendation, routine mutation, safety-sensitive answer, or product-specific claim lacks material information; for broad hair-care concerns with usable profile/context, give a best-effort answer instead of only asking what the user means. Keep user-facing prose German."

--- a/src/lib/agent-v2/runtime/responses-agent.ts
+++ b/src/lib/agent-v2/runtime/responses-agent.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/agent-v2/contracts"
 import { normalizeAgentV2EvidenceText } from "@/lib/agent-v2/evidence-normalization"
 import { getAgentV2ModelPolicy, type AgentV2ModelPolicy } from "@/lib/agent-v2/model-policy"
+import { AGENT_V2_RESPONSES_SYSTEM_PROMPT } from "@/lib/agent-v2/runtime/prompt"
 import { createAgentV2Trace } from "@/lib/agent-v2/runtime/trace"
 import { LoadAgentV2AdvisorGuidanceInputSchema } from "@/lib/agent-v2/tools/guidance-tool"
 import type { AgentV2RoutineProjection } from "@/lib/agent-v2/tools/routine-projection"
@@ -45,6 +46,7 @@ type AgentV2ToolName =
   | "set_current_care_context"
   | "select_products"
   | "build_or_fix_routine"
+type AgentV2RuntimeToolName = keyof AgentV2RuntimeTools
 type AgentV2RepairKind =
   | "terminal_only"
   | "missing_guidance_or_tools"
@@ -189,6 +191,11 @@ export async function runAgentV2ResponsesTurn(params: {
   safetyMode?: AgentV2SafetyMode
   policyOverrides?: Partial<AgentV2ModelPolicy>
   langfuseMode?: "disabled" | "enabled"
+  observeToolCall?: <T>(params: {
+    name: string
+    input: Record<string, unknown>
+    run: () => Promise<T>
+  }) => Promise<T>
 }): Promise<AgentV2ResponsesTurnResult> {
   const safetyMode = params.safetyMode ?? "normal"
   const policy = { ...getAgentV2ModelPolicy(), ...params.policyOverrides }
@@ -659,17 +666,31 @@ export async function runAgentV2ResponsesTurn(params: {
       }
 
       executableToolCalls += 1
+      if (!isAgentV2RuntimeToolName(call.name)) {
+        trace.blocked_tool_calls.push({ name: call.name, reason: "tool_not_allowed" })
+        inputItems.push(buildFunctionCallOutput(call.call_id, { error: "tool_not_allowed" }))
+        continue
+      }
+      const toolName = call.name
       const executableArguments = normalizeExecutableToolArguments({
-        name: call.name,
+        name: toolName,
         args: validatedArguments.value,
         currentRoutineLayer: params.currentRoutineLayer,
         routineThreadContext,
         hasCurrentRoutineInventory: hasEffectiveRoutineInventory(effectiveCareContext),
       })
       const toolStartedAt = performance.now()
-      const output = await params.tools[call.name](executableArguments, {
-        effectiveCareContext,
-      })
+      const runTool = () =>
+        params.tools[toolName](executableArguments, {
+          effectiveCareContext,
+        })
+      const output = params.observeToolCall
+        ? await params.observeToolCall({
+            name: toolName,
+            input: executableArguments,
+            run: runTool,
+          })
+        : await runTool()
       const toolLatencyMs = Math.round(performance.now() - toolStartedAt)
       inputItems.push(buildFunctionCallOutput(call.call_id, output))
       trace.tool_calls.push({
@@ -726,8 +747,7 @@ function buildInputItems(
   const items: unknown[] = [
     {
       role: "system",
-      content:
-        "You are AgentV2 for Chaarlie. Never return plain assistant text to the user. Every user-visible answer must be submitted by calling submit_final_answer exactly once. Clarify when a product recommendation, routine mutation, safety-sensitive answer, or product-specific claim lacks material information; for broad hair-care concerns with usable profile/context, give a best-effort answer instead of only asking what the user means. Keep user-facing prose German.",
+      content: AGENT_V2_RESPONSES_SYSTEM_PROMPT,
     },
     {
       role: "system",
@@ -1447,6 +1467,10 @@ function isExecutableToolName(name: string): name is AgentV2ToolName {
     name === "select_products" ||
     name === "build_or_fix_routine"
   )
+}
+
+function isAgentV2RuntimeToolName(name: AgentV2ToolName): name is AgentV2RuntimeToolName {
+  return name !== "set_current_care_context"
 }
 
 function buildRepairState(errors: AgentV2ValidationError[]): AgentV2RepairState {

--- a/src/lib/langfuse/masking.ts
+++ b/src/lib/langfuse/masking.ts
@@ -5,6 +5,9 @@ const PHONE_REGEX = /(?:\+?\d{1,3}[\s./-]?)?(?:\(?\d{2,4}\)?[\s./-]?)?\d{3,4}[\s
 
 const REDACTED = "[redacted]"
 const REDACTED_TEXT = "[redacted_sensitive_text]"
+const REDACTED_AGENT_V2_CONTEXT = "[redacted_agent_v2_context]"
+const REDACTED_RECENT_MESSAGE = "[redacted_recent_message]"
+const REDACTED_REASONING = "[redacted_reasoning]"
 
 const IDENTIFIER_KEYS = new Set([
   "email",
@@ -22,10 +25,64 @@ const SENSITIVE_TEXT_KEYS = new Set([
   "conversation_memory",
   "notes",
   "free_text",
+  "hairProfile",
+  "routineInventory",
+  "derivedSignals",
+  "relevantMemory",
+  "sessionMemory",
+  "careBalanceContext",
+  "routineThreadContext",
+  "priorSelectedProductProjections",
+  "recentMessages",
 ])
+
+const AGENT_V2_HIDDEN_CONTEXT_PREFIXES = [
+  "Loaded Chaarlie user context.",
+  "CareBalance product-usage context.",
+  "Active AgentV2 routine thread context,",
+  "Surfaced product facts from earlier turns",
+  "Conversation-scoped AgentV2 working memory.",
+]
 
 function maskString(value: string): string {
   return value.replace(EMAIL_REGEX, REDACTED).replace(PHONE_REGEX, REDACTED)
+}
+
+function parseJsonString(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+function isAgentV2HiddenContextMessage(value: string): boolean {
+  return AGENT_V2_HIDDEN_CONTEXT_PREFIXES.some((prefix) => value.startsWith(prefix))
+}
+
+function maskOpenAIMessage(value: Record<string, unknown>): Record<string, unknown> {
+  const role = value.role
+  const content = value.content
+  if (typeof content !== "string") return value
+
+  if (typeof role === "string" && isAgentV2HiddenContextMessage(content)) {
+    return { ...value, content: REDACTED_AGENT_V2_CONTEXT }
+  }
+
+  if (role === "user" || role === "assistant") {
+    // Root chat observations are canonical for current-turn text; generation inputs redact duplicated conversation messages.
+    return { ...value, content: REDACTED_RECENT_MESSAGE }
+  }
+
+  return { ...value, content: maskString(content) }
+}
+
+function maskResponsesOutputItem(value: Record<string, unknown>): Record<string, unknown> {
+  if (value.type === "reasoning") {
+    return { type: "reasoning", content: REDACTED_REASONING }
+  }
+
+  return value
 }
 
 function maskValue(value: unknown, key?: string): unknown {
@@ -40,6 +97,14 @@ function maskValue(value: unknown, key?: string): unknown {
   }
 
   if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>
+    if (typeof record.role === "string" && Object.hasOwn(record, "content")) {
+      return maskOpenAIMessage(record)
+    }
+    if (record.type === "reasoning") {
+      return maskResponsesOutputItem(record)
+    }
+
     return Object.fromEntries(
       Object.entries(value).map(([entryKey, entryValue]) => [
         entryKey,
@@ -51,7 +116,16 @@ function maskValue(value: unknown, key?: string): unknown {
   return value
 }
 
-export const maskLangfuseExport: MaskFunction = ({ data }) => maskValue(data)
+export const maskLangfuseExport: MaskFunction = ({ data }) => {
+  if (typeof data === "string") {
+    const parsed = parseJsonString(data)
+    if (parsed !== undefined) {
+      return JSON.stringify(maskValue(parsed))
+    }
+  }
+
+  return maskValue(data)
+}
 
 export function sanitizeLangfuseText(value: string | null | undefined): string | null {
   if (!value) return null

--- a/src/lib/langfuse/prompts.ts
+++ b/src/lib/langfuse/prompts.ts
@@ -1,5 +1,6 @@
 import type { LangfusePromptReference } from "@/lib/types"
 import type { LangfuseConfig as LangfuseOpenAIConfig } from "@langfuse/openai"
+import { AGENT_V2_RESPONSES_SYSTEM_PROMPT } from "@/lib/agent-v2/runtime/prompt"
 import {
   AGENT_FINAL_RENDER_PROMPT,
   AGENT_ROUTE_CLASSIFIER_PROMPT,
@@ -49,6 +50,10 @@ export const LANGFUSE_PROMPTS = {
   agentFinalRender: {
     name: "chaarlie-agent-final-render",
     fallback: AGENT_FINAL_RENDER_PROMPT,
+  },
+  agentV2ResponsesCareBalance: {
+    name: "chaarlie-agent-v2-responses-care-balance",
+    fallback: AGENT_V2_RESPONSES_SYSTEM_PROMPT,
   },
 } as const
 

--- a/tests/agent-v2-langfuse-observability.spec.ts
+++ b/tests/agent-v2-langfuse-observability.spec.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildAgentV2GenerationMetadata,
+  isAgentV2LangfuseObservationEnabled,
+  summarizeAgentV2ToolInput,
+  summarizeAgentV2ToolOutput,
+  summarizeAgentV2TraceForLangfuse,
+} from "../src/lib/agent-v2/production/langfuse-observability"
+
+test("AgentV2 generation metadata excludes hidden Supabase context", () => {
+  const metadata = buildAgentV2GenerationMetadata({
+    conversationId: "conversation-1",
+    requestId: "request-1",
+    safetyMode: "normal",
+    engine: "agent_v2",
+    endpoint: "responses",
+    migrationMode: "agent_v2_care_balance",
+  })
+
+  assert.deepEqual(metadata, {
+    conversation_id: "conversation-1",
+    request_id: "request-1",
+    engine: "agent_v2",
+    endpoint: "responses",
+    safety_mode: "normal",
+    migration_mode: "agent_v2_care_balance",
+  })
+  assert.doesNotMatch(JSON.stringify(metadata), /hairProfile|routineInventory|sessionMemory/)
+})
+
+test("AgentV2 Langfuse summary contains path counts without raw context", () => {
+  assert.deepEqual(
+    summarizeAgentV2TraceForLangfuse({
+      model_steps: [{ response_id: "resp_1" }, { response_id: "resp_2" }],
+      tool_calls: [{ name: "select_products", latency_ms: 42 }],
+      blocked_tool_calls: [],
+      repair_attempts: [{ reason: "missing_select_products", validation_errors: [] }],
+      loaded_guidance_package_ids: ["base.answer_contract.v1", "category.conditioner.v1"],
+      response_ids: ["resp_1", "resp_2"],
+      validation_errors: [],
+      validation_warnings: [],
+      answer_mode: "product_recommendation",
+      safety_mode: "normal",
+      failure_stage: null,
+      routine_thread_context_active: false,
+      final_product_ids: ["product-1"],
+      langfuse: { enabled: true, trace_id: "trace-1", trace_url: null },
+    }),
+    {
+      engine: "agent_v2",
+      model_step_count: 2,
+      tool_call_count: 1,
+      blocked_tool_call_count: 0,
+      repair_count: 1,
+      loaded_guidance_ids: ["base.answer_contract.v1", "category.conditioner.v1"],
+      response_ids: ["resp_1", "resp_2"],
+      validation_error_count: 0,
+      validation_warning_count: 0,
+      answer_mode: "product_recommendation",
+      safety_mode: "normal",
+      failure_stage: null,
+      routine_thread_context_active: false,
+      final_product_ids: ["product-1"],
+      langfuse_enabled: true,
+    },
+  )
+})
+
+test("AgentV2 tool summaries avoid raw hidden context", () => {
+  const inputSummary = summarizeAgentV2ToolInput("select_products", {
+    category: "conditioner",
+    product_request_kind: "specific_products",
+    requested_product_count: 2,
+    evidence_quote: "Welche Spuelung",
+    hairProfile: { additional_notes: "secret" },
+    routineInventory: [{ name: "Private Produktnotiz" }],
+    sessionMemory: [{ text: "private memory" }],
+    effective_care_context: { hidden: true },
+  })
+  const outputSummary = summarizeAgentV2ToolOutput("select_products", {
+    valid_product_ids: ["product-1", "product-2"],
+    products: [{ product_id: "product-1" }],
+    raw: "RAW_PRODUCT_OUTPUT_BLOB_SHOULD_NOT_PERSIST",
+  })
+
+  assert.deepEqual(inputSummary, {
+    name: "select_products",
+    category: "conditioner",
+    requested_category: null,
+    product_request_kind: "specific_products",
+    requested_product_count: 2,
+    has_effective_care_context: true,
+  })
+  assert.deepEqual(outputSummary, {
+    name: "select_products",
+    valid_product_ids: ["product-1", "product-2"],
+    product_count: 1,
+    routine_step_count: null,
+    loaded_guidance_ids: [],
+  })
+  assert.doesNotMatch(JSON.stringify({ inputSummary, outputSummary }), /secret|Private|RAW_PRODUCT/)
+})
+
+test("AgentV2 Langfuse observation kill-switch disables observed client path", () => {
+  const original = process.env.AGENT_V2_LANGFUSE_OBSERVATION
+  try {
+    delete process.env.AGENT_V2_LANGFUSE_OBSERVATION
+    assert.equal(isAgentV2LangfuseObservationEnabled(), true)
+
+    process.env.AGENT_V2_LANGFUSE_OBSERVATION = "disabled"
+    assert.equal(isAgentV2LangfuseObservationEnabled(), false)
+  } finally {
+    if (original === undefined) {
+      delete process.env.AGENT_V2_LANGFUSE_OBSERVATION
+    } else {
+      process.env.AGENT_V2_LANGFUSE_OBSERVATION = original
+    }
+  }
+})

--- a/tests/agent-v2-production-chat-pipeline.spec.ts
+++ b/tests/agent-v2-production-chat-pipeline.spec.ts
@@ -543,6 +543,165 @@ test("AgentV2 production pipeline returns cards, trace, and CareBalance context"
   assert.equal(failedDebugEvent.visible_failure, true)
 })
 
+test("AgentV2 production pipeline uses observed OpenAI and managed prompt refs by default", async () => {
+  const previousOpenAIKey = process.env.OPENAI_API_KEY
+  const previousObservationFlag = process.env.AGENT_V2_LANGFUSE_OBSERVATION
+  process.env.OPENAI_API_KEY = "test-openai-key"
+  delete process.env.AGENT_V2_LANGFUSE_OBSERVATION
+
+  const managedRef = {
+    name: "chaarlie-agent-v2-responses-care-balance",
+    version: 17,
+    label: "production",
+    is_fallback: false,
+  }
+  const observedClient = { responses: { create: async () => ({ output: [] }) } }
+  let observedConfig: { generationName?: unknown; langfusePrompt?: unknown } | null = null
+  let receivedClient: unknown = null
+
+  try {
+    const result = await runAgentV2ProductionPipeline(
+      {
+        message: "Welches Shampoo passt?",
+        conversationId: "conversation-1",
+        userId: "user-1",
+        requestId: "request-1",
+      },
+      {
+        loadConversationHistory: async () => [],
+        getUserContext: async () => ({
+          profile: createCompleteHairProfile(),
+          routine_inventory: [],
+          relevant_memory: [],
+          derived_signals: [],
+          suggested_overlays: [],
+          missing_profile: [],
+        }),
+        loadUserMemoryContext: async () => ({
+          enabled: true,
+          entries: [],
+          promptContext: null,
+          dislikedProductNames: [],
+        }),
+        loadConversationState: async (): Promise<ConversationState> =>
+          createDefaultConversationState(),
+        getManagedTextPromptTemplate: async () => ({
+          template: "Managed AgentV2 prompt",
+          ref: managedRef,
+        }),
+        getObservedOpenAI: (config) => {
+          observedConfig = config ?? {}
+          return observedClient as never
+        },
+        runAgentV2ResponsesTurn: async (params) => {
+          receivedClient = params.client
+          return createAgentV2Result()
+        },
+      },
+    )
+
+    assert.equal(receivedClient, observedClient)
+    assert.notEqual(observedConfig, null)
+    const capturedObservedConfig = observedConfig as unknown as {
+      generationName?: unknown
+      langfusePrompt?: unknown
+    }
+    assert.equal(capturedObservedConfig.generationName, "agent-v2-responses-step")
+    assert.deepEqual(capturedObservedConfig.langfusePrompt, {
+      name: managedRef.name,
+      version: managedRef.version,
+      isFallback: managedRef.is_fallback,
+    })
+    assert.deepEqual(result.debugTrace.prompt.prompt_ref, managedRef)
+    assert.deepEqual(result.debugTrace.prompt_refs.classification, managedRef)
+  } finally {
+    if (previousOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY
+    } else {
+      process.env.OPENAI_API_KEY = previousOpenAIKey
+    }
+    if (previousObservationFlag === undefined) {
+      delete process.env.AGENT_V2_LANGFUSE_OBSERVATION
+    } else {
+      process.env.AGENT_V2_LANGFUSE_OBSERVATION = previousObservationFlag
+    }
+  }
+})
+
+test("AgentV2 production pipeline can disable observed OpenAI via rollback flag", async () => {
+  const previousOpenAIKey = process.env.OPENAI_API_KEY
+  const previousObservationFlag = process.env.AGENT_V2_LANGFUSE_OBSERVATION
+  process.env.OPENAI_API_KEY = "test-openai-key"
+  process.env.AGENT_V2_LANGFUSE_OBSERVATION = "disabled"
+
+  const rawClient = { responses: { create: async () => ({ output: [] }) } }
+  const observedClient = { responses: { create: async () => ({ output: [] }) } }
+  let observedCalled = false
+  let receivedClient: unknown = null
+
+  try {
+    await runAgentV2ProductionPipeline(
+      {
+        message: "Welches Shampoo passt?",
+        conversationId: "conversation-1",
+        userId: "user-1",
+        requestId: "request-1",
+      },
+      {
+        loadConversationHistory: async () => [],
+        getUserContext: async () => ({
+          profile: createCompleteHairProfile(),
+          routine_inventory: [],
+          relevant_memory: [],
+          derived_signals: [],
+          suggested_overlays: [],
+          missing_profile: [],
+        }),
+        loadUserMemoryContext: async () => ({
+          enabled: true,
+          entries: [],
+          promptContext: null,
+          dislikedProductNames: [],
+        }),
+        loadConversationState: async (): Promise<ConversationState> =>
+          createDefaultConversationState(),
+        getManagedTextPromptTemplate: async () => ({
+          template: "Fallback AgentV2 prompt",
+          ref: {
+            name: "chaarlie-agent-v2-responses-care-balance",
+            version: null,
+            label: "staging",
+            is_fallback: true,
+          },
+        }),
+        getOpenAI: () => rawClient as never,
+        getObservedOpenAI: () => {
+          observedCalled = true
+          return observedClient as never
+        },
+        runAgentV2ResponsesTurn: async (params) => {
+          receivedClient = params.client
+          return createAgentV2Result()
+        },
+      },
+    )
+
+    assert.equal(observedCalled, false)
+    assert.equal(receivedClient, rawClient)
+  } finally {
+    if (previousOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY
+    } else {
+      process.env.OPENAI_API_KEY = previousOpenAIKey
+    }
+    if (previousObservationFlag === undefined) {
+      delete process.env.AGENT_V2_LANGFUSE_OBSERVATION
+    } else {
+      process.env.AGENT_V2_LANGFUSE_OBSERVATION = previousObservationFlag
+    }
+  }
+})
+
 test("AgentV2 production pipeline treats any runtime failure stage as visible failure", async () => {
   const hairProfile = createCompleteHairProfile()
   const product = createProduct("primary")

--- a/tests/agent-v2-responses-runtime.spec.ts
+++ b/tests/agent-v2-responses-runtime.spec.ts
@@ -3143,6 +3143,47 @@ test("AgentV2 runtime stores local trace even when Langfuse is unavailable", asy
   assert.equal(result.trace.langfuse.enabled, false)
 })
 
+test("AgentV2 runtime observes executable tool calls without hidden context", async () => {
+  const observed: Array<{
+    name: string
+    input: Record<string, unknown>
+    output: unknown
+  }> = []
+
+  const result = await runAgentV2ResponsesTurn({
+    client: fakeResponsesClientWithOutputs([
+      guidanceCall("call_1", {
+        answer_mode_hint: "general_advice",
+        categories: ["mask"],
+      }),
+      terminalGeneralAdvice("call_2"),
+    ]),
+    message: "Was hilft gegen trockene Laengen?",
+    recentMessages: [],
+    userContext: {
+      hairProfile: { additional_notes: "secret" } as never,
+      routineInventory: [{ name: "Private Produktnotiz" }] as never,
+      sessionMemory: [{ text: "private memory" }] as never,
+    },
+    tools: fakeAgentV2Tools(),
+    langfuseMode: "enabled",
+    observeToolCall: async ({ name, input, run }) => {
+      const output = await run()
+      observed.push({ name, input, output })
+      return output
+    },
+  })
+
+  assert.equal(result.trace.langfuse.enabled, true)
+  assert.equal(observed.length, 1)
+  assert.equal(observed[0].name, "load_advisor_guidance")
+  assert.equal(observed[0].input.answer_mode_hint, "general_advice")
+  assert.doesNotMatch(
+    JSON.stringify(observed),
+    /additional_notes|Private Produktnotiz|private memory/,
+  )
+})
+
 test("AgentV2 runtime rejects hard rule IDs that were not loaded", async () => {
   const result = await runAgentV2ResponsesTurn({
     client: fakeResponsesClientWithOutputs([

--- a/tests/chat-debug-trace.spec.ts
+++ b/tests/chat-debug-trace.spec.ts
@@ -11,6 +11,7 @@ import {
   buildRecommendationEngineRuntimeForChat,
   buildRecommendationEngineTrace,
 } from "../src/lib/recommendation-engine/chat"
+import { summarizeAgentV2TraceForLangfuse } from "../src/lib/agent-v2/production/langfuse-observability"
 import { createDefaultConversationState } from "../src/lib/rag/conversation-state"
 import type { RetrievedChunk } from "../src/lib/rag/retriever"
 import type {
@@ -24,6 +25,7 @@ import type {
   RoutinePlan,
 } from "../src/lib/types"
 import type { AgenticToolLoopTrace as RuntimeAgenticToolLoopTrace } from "../src/lib/agent/orchestrator/agentic-tool-loop-types"
+import type { AgentV2Trace } from "../src/lib/agent-v2/contracts"
 
 const legacyResponseComposition = {
   path: "legacy_synthesizer" as const,
@@ -1029,5 +1031,65 @@ test.describe("Chat debug trace", () => {
       },
     })
     expect(JSON.stringify(debugEvent)).not.toContain("System prompt snapshot")
+  })
+
+  test("summarizes AgentV2 trace for Langfuse root output without raw context", () => {
+    const agentV2Trace = {
+      engine: "agent_v2",
+      model: "gpt-5.4-mini",
+      endpoint: "responses",
+      reasoning_effort: "medium",
+      safety_mode: "normal",
+      answer_mode: "product_recommendation",
+      response_ids: ["resp_1"],
+      model_steps: [{ response_id: "resp_1", latency_ms: 12 }],
+      tool_calls: [{ call_id: "call_1", name: "select_products", latency_ms: 5 }],
+      blocked_tool_calls: [],
+      loaded_guidance_package_ids: ["base.answer_contract.v1"],
+      validation_errors: [],
+      validation_warnings: [],
+      request_interpretation: null,
+      request_interpretation_summary: null,
+      bounded_repair_kind: "missing_select_products",
+      repair_attempts: [{ reason: "missing_select_products", validation_errors: [] }],
+      routine_thread_context_active: false,
+      routine_thread_context: null,
+      final_product_ids: ["product-1"],
+      routine_layer: null,
+      session_memory_writes: [],
+      dropped_session_memory_writes: [],
+      injected_session_memory: [
+        {
+          type: "preference",
+          text: "RAW_SESSION_MEMORY_SHOULD_NOT_LEAK",
+          evidence_quote: "RAW_SESSION_MEMORY_SHOULD_NOT_LEAK",
+          confidence: 0.8,
+          ttl: "session",
+          affects_recommendations: true,
+          expires_at_turn: null,
+        },
+      ],
+      langfuse: {
+        enabled: true,
+        trace_id: null,
+        trace_url: null,
+      },
+      failure_stage: null,
+    } satisfies AgentV2Trace
+
+    const summary = summarizeAgentV2TraceForLangfuse(agentV2Trace)
+
+    expect(summary).toMatchObject({
+      engine: "agent_v2",
+      model_step_count: 1,
+      tool_call_count: 1,
+      blocked_tool_call_count: 0,
+      repair_count: 1,
+      loaded_guidance_ids: ["base.answer_contract.v1"],
+      response_ids: ["resp_1"],
+      answer_mode: "product_recommendation",
+      failure_stage: null,
+    })
+    expect(JSON.stringify(summary)).not.toContain("RAW_SESSION_MEMORY_SHOULD_NOT_LEAK")
   })
 })

--- a/tests/langfuse-masking.test.ts
+++ b/tests/langfuse-masking.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { maskLangfuseExport, sanitizeLangfuseText } from "../src/lib/langfuse/masking"
+
+test("sanitizeLangfuseText keeps normal chat text while masking direct identifiers", () => {
+  assert.equal(sanitizeLangfuseText("Meine Mail ist test@example.com"), "Meine Mail ist [redacted]")
+  assert.equal(sanitizeLangfuseText("Welche Spuelung passt?"), "Welche Spuelung passt?")
+})
+
+test("maskLangfuseExport redacts AgentV2 hidden system context from stringified generation input", () => {
+  const payload = JSON.stringify([
+    {
+      role: "system",
+      content:
+        'Loaded Chaarlie user context. Treat this as authoritative. {"hairProfile":{"additional_notes":"secret"},"routineInventory":[{"name":"Private Produktnotiz"}]}',
+    },
+    {
+      role: "system",
+      content:
+        'CareBalance product-usage context. {"rows":[{"category":"conditioner","private":"secret"}]}',
+    },
+    { role: "user", content: "alte Nachricht, die nicht erneut gespiegelt werden soll" },
+  ])
+
+  const masked = maskLangfuseExport({ data: payload })
+  const serialized = typeof masked === "string" ? masked : JSON.stringify(masked)
+
+  assert.doesNotMatch(serialized, /additional_notes/)
+  assert.doesNotMatch(serialized, /Private Produktnotiz/)
+  assert.doesNotMatch(serialized, /alte Nachricht/)
+  assert.match(serialized, /redacted_agent_v2_context/)
+})
+
+test("maskLangfuseExport drops Responses API reasoning output items", () => {
+  const payload = JSON.stringify([
+    {
+      type: "reasoning",
+      encrypted_content: "encrypted-reasoning-blob",
+      summary: [{ type: "summary_text", text: "private chain summary" }],
+    },
+    {
+      type: "message",
+      content: [{ type: "output_text", text: "Das ist die sichtbare Antwort." }],
+    },
+  ])
+
+  const masked = maskLangfuseExport({ data: payload })
+  const serialized = typeof masked === "string" ? masked : JSON.stringify(masked)
+
+  assert.doesNotMatch(serialized, /encrypted-reasoning-blob/)
+  assert.doesNotMatch(serialized, /private chain summary/)
+  assert.match(serialized, /redacted_reasoning/)
+  assert.match(serialized, /sichtbare Antwort/)
+})
+
+test("maskLangfuseExport preserves root trace current user message field", () => {
+  const payload = JSON.stringify({
+    user_message: "Welche Spuelung passt zu mir?",
+    conversation_id: "conversation-1",
+  })
+
+  const masked = maskLangfuseExport({ data: payload })
+  const serialized = typeof masked === "string" ? masked : JSON.stringify(masked)
+
+  assert.match(serialized, /Welche Spuelung passt zu mir/)
+  assert.match(serialized, /conversation-1/)
+})

--- a/tests/langfuse-prompts.test.ts
+++ b/tests/langfuse-prompts.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
+import { AGENT_V2_RESPONSES_SYSTEM_PROMPT } from "../src/lib/agent-v2/runtime/prompt"
 import { LANGFUSE_PROMPTS } from "../src/lib/langfuse/prompts"
 import {
   AGENT_FINAL_RENDER_PROMPT,
@@ -17,6 +18,17 @@ test("Langfuse prompt registry includes current agentic chat prompts", () => {
     AGENTIC_CONTEXTUAL_COMPOSER_PROMPT,
   )
   assert.equal(LANGFUSE_PROMPTS.agentFinalRender.fallback, AGENT_FINAL_RENDER_PROMPT)
+})
+
+test("Langfuse prompt registry includes AgentV2 Responses prompt", () => {
+  assert.equal(
+    LANGFUSE_PROMPTS.agentV2ResponsesCareBalance.name,
+    "chaarlie-agent-v2-responses-care-balance",
+  )
+  assert.equal(
+    LANGFUSE_PROMPTS.agentV2ResponsesCareBalance.fallback,
+    AGENT_V2_RESPONSES_SYSTEM_PROMPT,
+  )
 })
 
 test("Langfuse prompt names are unique", () => {


### PR DESCRIPTION
## Summary
- wire AgentV2 production chat runs through the Langfuse-observed OpenAI client by default
- add managed prompt registration for `chaarlie-agent-v2-responses-care-balance`
- add compact AgentV2 trace/tool summaries while masking hidden profile, routine, memory, and reasoning payloads
- attach `agent_v2_summary` to the root chat observation and preserve existing user feedback scoring

## Verification
- `npx tsx --test tests/langfuse-prompts.test.ts tests/langfuse-masking.test.ts tests/agent-v2-langfuse-observability.spec.ts tests/agent-v2-production-chat-pipeline.spec.ts tests/agent-v2-responses-runtime.spec.ts`
- `npx playwright test tests/chat-debug-trace.spec.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run build`
- `LANGFUSE_PROMPT_LABEL=production npm run langfuse:sync-prompts` created `chaarlie-agent-v2-responses-care-balance` version 1 for production

## Notes
- Runtime rollback is available with `AGENT_V2_LANGFUSE_OBSERVATION=disabled`.
- Merge and deployment are still separate decisions.
