### PR TITLE
fix(langfuse): improve AgentV2 trace readability

### DIFF
--- a/src/lib/agent-v2/production/langfuse-observability.ts
+++ b/src/lib/agent-v2/production/langfuse-observability.ts
@@ -77,6 +77,14 @@ function readStringArray(value: unknown): string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string") ? value : []
 }
 
+function readPackageIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((entry) => {
+    const object = readObject(entry)
+    return typeof object?.package_id === "string" ? [object.package_id] : []
+  })
+}
+
 function readObject(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -92,17 +100,20 @@ export function summarizeAgentV2ToolOutput(name: string, output: unknown) {
     : Array.isArray(projection?.steps)
       ? projection.steps
       : null
-  const loadedGuidanceIds = [
+  const loadedGuidanceIds = new Set([
     ...readStringArray(object?.loaded_package_ids),
+    ...readStringArray(object?.loaded_guidance_ids),
+    ...readPackageIds(object?.packages),
     ...readStringArray(projection?.loaded_guidance_ids),
-  ]
+    ...readPackageIds(projection?.packages),
+  ])
 
   return {
     name,
     valid_product_ids: readStringArray(projection?.valid_product_ids),
     product_count: products ? products.length : null,
     routine_step_count: visibleSteps ? visibleSteps.length : null,
-    loaded_guidance_ids: loadedGuidanceIds,
+    loaded_guidance_ids: [...loadedGuidanceIds],
   }
 }
 

--- a/src/lib/langfuse/masking.ts
+++ b/src/lib/langfuse/masking.ts
@@ -2,6 +2,7 @@ import type { MaskFunction } from "@langfuse/otel"
 
 const EMAIL_REGEX = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
 const PHONE_REGEX = /(?:\+?\d{1,3}[\s./-]?)?(?:\(?\d{2,4}\)?[\s./-]?)?\d{3,4}[\s./-]?\d{3,4}\b/g
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 const REDACTED = "[redacted]"
 const REDACTED_TEXT = "[redacted_sensitive_text]"
@@ -12,11 +13,20 @@ const REDACTED_REASONING = "[redacted_reasoning]"
 const IDENTIFIER_KEYS = new Set([
   "email",
   "full_name",
-  "name",
   "first_name",
   "last_name",
   "phone",
   "telephone",
+])
+
+const SAFE_OBSERVABILITY_NAMES = new Set([
+  "load_advisor_guidance",
+  "select_products",
+  "build_or_fix_routine",
+  "set_current_care_context",
+  "submit_final_answer",
+  "production-chat-turn",
+  "agent-v2-responses-step",
 ])
 
 const SENSITIVE_TEXT_KEYS = new Set([
@@ -45,6 +55,7 @@ const AGENT_V2_HIDDEN_CONTEXT_PREFIXES = [
 ]
 
 function maskString(value: string): string {
+  if (UUID_REGEX.test(value)) return value.replace(EMAIL_REGEX, REDACTED)
   return value.replace(EMAIL_REGEX, REDACTED).replace(PHONE_REGEX, REDACTED)
 }
 
@@ -58,6 +69,14 @@ function parseJsonString(value: string): unknown {
 
 function isAgentV2HiddenContextMessage(value: string): boolean {
   return AGENT_V2_HIDDEN_CONTEXT_PREFIXES.some((prefix) => value.startsWith(prefix))
+}
+
+function isSafeObservabilityName(value: string): boolean {
+  return (
+    SAFE_OBSERVABILITY_NAMES.has(value) ||
+    value.startsWith("agent-v2-tool:") ||
+    value.startsWith("chaarlie-")
+  )
 }
 
 function maskOpenAIMessage(value: Record<string, unknown>): Record<string, unknown> {
@@ -87,6 +106,7 @@ function maskResponsesOutputItem(value: Record<string, unknown>): Record<string,
 
 function maskValue(value: unknown, key?: string): unknown {
   if (typeof value === "string") {
+    if (key === "name") return isSafeObservabilityName(value) ? maskString(value) : REDACTED
     if (key && IDENTIFIER_KEYS.has(key)) return REDACTED
     if (key && SENSITIVE_TEXT_KEYS.has(key)) return REDACTED_TEXT
     return maskString(value)

--- a/tests/agent-v2-langfuse-observability.spec.ts
+++ b/tests/agent-v2-langfuse-observability.spec.ts
@@ -103,6 +103,25 @@ test("AgentV2 tool summaries avoid raw hidden context", () => {
   assert.doesNotMatch(JSON.stringify({ inputSummary, outputSummary }), /secret|Private|RAW_PRODUCT/)
 })
 
+test("AgentV2 tool summaries expose guidance package ids from loaded guidance output", () => {
+  const outputSummary = summarizeAgentV2ToolOutput("load_advisor_guidance", {
+    packages: [
+      { package_id: "base.answer_contract.v1", markdown_brief: "RAW_GUIDANCE_SHOULD_NOT_LEAK" },
+      { package_id: "category.shampoo.v1", markdown_brief: "RAW_CATEGORY_SHOULD_NOT_LEAK" },
+    ],
+    hard_rules: [{ id: "rule-1", body: "raw rule" }],
+  })
+
+  assert.deepEqual(outputSummary, {
+    name: "load_advisor_guidance",
+    valid_product_ids: [],
+    product_count: null,
+    routine_step_count: null,
+    loaded_guidance_ids: ["base.answer_contract.v1", "category.shampoo.v1"],
+  })
+  assert.doesNotMatch(JSON.stringify(outputSummary), /RAW_GUIDANCE|RAW_CATEGORY|raw rule/)
+})
+
 test("AgentV2 Langfuse observation kill-switch disables observed client path", () => {
   const original = process.env.AGENT_V2_LANGFUSE_OBSERVATION
   try {

--- a/tests/langfuse-masking.test.ts
+++ b/tests/langfuse-masking.test.ts
@@ -66,3 +66,30 @@ test("maskLangfuseExport preserves root trace current user message field", () =>
   assert.match(serialized, /Welche Spuelung passt zu mir/)
   assert.match(serialized, /conversation-1/)
 })
+
+test("maskLangfuseExport preserves safe observability names and UUIDs", () => {
+  const productId = "6fde3fe0-2716-4973-b9f2-ebb17eb13bad"
+  const payload = JSON.stringify({
+    tool_summary: {
+      name: "select_products",
+      valid_product_ids: [productId],
+    },
+    prompt: {
+      name: "chaarlie-agent-v2-responses-care-balance",
+    },
+    user_profile: {
+      name: "Nick Beispiel",
+      full_name: "Nick Beispiel",
+      phone: "+49 170 1234567",
+    },
+  })
+
+  const masked = maskLangfuseExport({ data: payload })
+  const serialized = typeof masked === "string" ? masked : JSON.stringify(masked)
+
+  assert.match(serialized, /select_products/)
+  assert.match(serialized, /chaarlie-agent-v2-responses-care-balance/)
+  assert.match(serialized, new RegExp(productId))
+  assert.doesNotMatch(serialized, /Nick Beispiel/)
+  assert.doesNotMatch(serialized, /170 1234567/)
+})


### PR DESCRIPTION
## Summary
- preserve safe Langfuse observability names such as tool names and managed prompt names while continuing to redact user names
- stop phone-number masking from partially redacting UUID product ids
- expose guidance package ids in AgentV2 tool summaries without logging raw guidance text

## Verification
- `npx tsx --test tests/langfuse-prompts.test.ts tests/langfuse-masking.test.ts tests/agent-v2-langfuse-observability.spec.ts tests/agent-v2-production-chat-pipeline.spec.ts tests/agent-v2-responses-runtime.spec.ts`
- `npx playwright test tests/chat-debug-trace.spec.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run build`

## Notes
- This is a trace readability polish only; it does not change AgentV2 routing or model behavior.
