### PR TITLE
Reduce landing page initial analytics and font work

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,14 +3,8 @@
 import { Header } from "@/components/layout/header"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import {
-  LayoutDashboard,
-  Quote,
-  FileText,
-  Package,
-  Users,
-  MessageCircle,
-} from "lucide-react"
+import { LayoutDashboard, Quote, FileText, Package, Users, MessageCircle } from "lucide-react"
+import { AppRouteProviders } from "@/providers/route-providers"
 
 const adminNav = [
   { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
@@ -21,15 +15,11 @@ const adminNav = [
   { href: "/admin/conversations", label: "Chats", icon: MessageCircle },
 ]
 
-export default function AdminLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
   return (
-    <>
+    <AppRouteProviders>
       <Header />
       <div className="flex min-h-[calc(100vh-3.5rem)]">
         {/* Sidebar */}
@@ -40,8 +30,7 @@ export default function AdminLayout({
           <nav className="space-y-1">
             {adminNav.map((item) => {
               const isActive =
-                pathname === item.href ||
-                (item.href !== "/admin" && pathname.startsWith(item.href))
+                pathname === item.href || (item.href !== "/admin" && pathname.startsWith(item.href))
               const Icon = item.icon
               return (
                 <Link
@@ -66,17 +55,14 @@ export default function AdminLayout({
           <div className="flex gap-1 overflow-x-auto">
             {adminNav.map((item) => {
               const isActive =
-                pathname === item.href ||
-                (item.href !== "/admin" && pathname.startsWith(item.href))
+                pathname === item.href || (item.href !== "/admin" && pathname.startsWith(item.href))
               const Icon = item.icon
               return (
                 <Link
                   key={item.href}
                   href={item.href}
                   className={`flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs ${
-                    isActive
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground"
+                    isActive ? "bg-primary text-primary-foreground" : "text-muted-foreground"
                   }`}
                 >
                   <Icon className="h-3.5 w-3.5" />
@@ -90,6 +76,6 @@ export default function AdminLayout({
         {/* Content */}
         <main className="flex-1 p-6">{children}</main>
       </div>
-    </>
+    </AppRouteProviders>
   )
 }

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic"
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,5 +1,7 @@
+import { PublicFlowProviders } from "@/providers/route-providers"
+
 export const dynamic = "force-dynamic"
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  return children
+  return <PublicFlowProviders>{children}</PublicFlowProviders>
 }

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,0 +1,5 @@
+import { AppRouteProviders } from "@/providers/route-providers"
+
+export default function ChatLayout({ children }: { children: React.ReactNode }) {
+  return <AppRouteProviders>{children}</AppRouteProviders>
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,25 +6,29 @@ import { MetaPixelProvider } from "@/providers/meta-pixel-provider"
 import { PostHogClientProvider } from "@/providers/posthog-provider"
 import { ToastProvider } from "@/providers/toast-provider"
 import { CookieConsent } from "@/components/cookie-consent/cookie-consent"
-import { FeedbackWidget } from "@/components/feedback/feedback-widget"
+import { LazyFeedbackWidget } from "@/components/feedback/lazy-feedback-widget"
 import "./globals.css"
 
 const playfairDisplay = Playfair_Display({
-  weight: ["400", "500"],
-  style: ["normal", "italic"],
+  weight: ["500"],
+  style: ["normal"],
   variable: "--font-playfair-display",
   subsets: ["latin"],
+  display: "swap",
 })
 
 const plusJakartaSans = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta-sans",
   subsets: ["latin"],
+  display: "swap",
 })
 
 const ibmPlexMono = IBM_Plex_Mono({
   weight: ["400", "500"],
   variable: "--font-ibm-plex-mono",
   subsets: ["latin"],
+  display: "swap",
+  preload: false,
 })
 
 // Every page requires Supabase auth (AuthProvider SSR + middleware redirect),
@@ -60,7 +64,7 @@ export default function RootLayout({
               <PostHogClientProvider>
                 <ToastProvider>
                   {children}
-                  <FeedbackWidget />
+                  <LazyFeedbackWidget />
                 </ToastProvider>
               </PostHogClientProvider>
             </CustomerIoProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,6 @@
 import type { Metadata, Viewport } from "next"
 import { Playfair_Display, Plus_Jakarta_Sans, IBM_Plex_Mono } from "next/font/google"
-import { AuthProvider } from "@/providers/auth-provider"
-import { CustomerIoProvider } from "@/providers/customerio-provider"
-import { MetaPixelProvider } from "@/providers/meta-pixel-provider"
-import { PostHogClientProvider } from "@/providers/posthog-provider"
-import { ToastProvider } from "@/providers/toast-provider"
-import { CookieConsent } from "@/components/cookie-consent/cookie-consent"
-import { LazyFeedbackWidget } from "@/components/feedback/lazy-feedback-widget"
+import { LazyCookieConsent } from "@/components/cookie-consent/lazy-cookie-consent"
 import "./globals.css"
 
 const playfairDisplay = Playfair_Display({
@@ -31,10 +25,6 @@ const ibmPlexMono = IBM_Plex_Mono({
   preload: false,
 })
 
-// Every page requires Supabase auth (AuthProvider SSR + middleware redirect),
-// so there is nothing to statically generate.
-export const dynamic = "force-dynamic"
-
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
@@ -58,19 +48,8 @@ export default function RootLayout({
       <body
         className={`${playfairDisplay.variable} ${plusJakartaSans.variable} ${ibmPlexMono.variable} antialiased`}
       >
-        <MetaPixelProvider>
-          <AuthProvider>
-            <CustomerIoProvider>
-              <PostHogClientProvider>
-                <ToastProvider>
-                  {children}
-                  <LazyFeedbackWidget />
-                </ToastProvider>
-              </PostHogClientProvider>
-            </CustomerIoProvider>
-          </AuthProvider>
-        </MetaPixelProvider>
-        <CookieConsent />
+        {children}
+        <LazyCookieConsent />
       </body>
     </html>
   )

--- a/src/app/onboarding/layout.tsx
+++ b/src/app/onboarding/layout.tsx
@@ -1,16 +1,20 @@
+import { AppRouteProviders } from "@/providers/route-providers"
+
 export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-[100dvh] bg-background">
-      {/* Left panel — brand (hidden on mobile) */}
-      <div className="sticky top-0 hidden h-screen w-1/2 items-center justify-center overflow-hidden md:flex">
-        <OnboardingBrandPanel />
-      </div>
+    <AppRouteProviders>
+      <div className="flex min-h-[100dvh] bg-background">
+        {/* Left panel — brand (hidden on mobile) */}
+        <div className="sticky top-0 hidden h-screen w-1/2 items-center justify-center overflow-hidden md:flex">
+          <OnboardingBrandPanel />
+        </div>
 
-      {/* Right panel — onboarding content (full-width on mobile) */}
-      <div className="w-full overflow-y-auto md:w-1/2">
-        <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">{children}</div>
+        {/* Right panel — onboarding content (full-width on mobile) */}
+        <div className="w-full overflow-y-auto md:w-1/2">
+          <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">{children}</div>
+        </div>
       </div>
-    </div>
+    </AppRouteProviders>
   )
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,10 +7,12 @@ import { Pricing } from "@/components/landing/pricing"
 import { Faq } from "@/components/landing/faq"
 import { FinalCta } from "@/components/landing/final-cta"
 import { SiteFooter } from "@/components/landing/site-footer"
+import { LandingTracking } from "@/providers/route-providers"
 
 export default function Home() {
   return (
     <>
+      <LandingTracking />
       <LandingHeader />
       <main>
         <Hero />

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -1,0 +1,5 @@
+import { PublicFlowProviders } from "@/providers/route-providers"
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return <PublicFlowProviders>{children}</PublicFlowProviders>
+}

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,0 +1,5 @@
+import { AppRouteProviders } from "@/providers/route-providers"
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return <AppRouteProviders>{children}</AppRouteProviders>
+}

--- a/src/app/quiz/layout.tsx
+++ b/src/app/quiz/layout.tsx
@@ -3,6 +3,7 @@
 import { useQuizStore } from "@/lib/quiz/store"
 import { QuizBrandPanel } from "@/components/quiz/quiz-brand-panel"
 import { QuizInfoStrip } from "@/components/quiz/quiz-info-strip"
+import { AppRouteProviders } from "@/providers/route-providers"
 import { useEffect, useRef, useState } from "react"
 
 export default function QuizLayout({ children }: { children: React.ReactNode }) {
@@ -40,28 +41,32 @@ export default function QuizLayout({ children }: { children: React.ReactNode }) 
   // Results page (step 11): full-width centered layout, no brand panel
   if (step === 11) {
     return (
-      <div ref={resultScrollRef} className="min-h-[100dvh] overflow-y-auto bg-background">
-        <div className="mx-auto max-w-[960px] px-5 py-8 md:px-10 md:py-12">{children}</div>
-      </div>
+      <AppRouteProviders>
+        <div ref={resultScrollRef} className="min-h-[100dvh] overflow-y-auto bg-background">
+          <div className="mx-auto max-w-[960px] px-5 py-8 md:px-10 md:py-12">{children}</div>
+        </div>
+      </AppRouteProviders>
     )
   }
 
   return (
-    <div className="flex min-h-[100dvh] bg-background">
-      {/* Left panel — brand / contextual (hidden on mobile) */}
-      <div className="sticky top-0 hidden h-screen w-1/2 items-center justify-center overflow-hidden md:flex">
-        <QuizBrandPanel />
-      </div>
+    <AppRouteProviders>
+      <div className="flex min-h-[100dvh] bg-background">
+        {/* Left panel — brand / contextual (hidden on mobile) */}
+        <div className="sticky top-0 hidden h-screen w-1/2 items-center justify-center overflow-hidden md:flex">
+          <QuizBrandPanel />
+        </div>
 
-      {/* Right panel — quiz content (full-width on mobile) */}
-      <div ref={standardScrollRef} className="w-full overflow-y-auto md:w-1/2">
-        <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">
-          {step === 2 && !infoStripDismissed && (
-            <QuizInfoStrip onDismiss={() => setInfoStripDismissed(true)} />
-          )}
-          {children}
+        {/* Right panel — quiz content (full-width on mobile) */}
+        <div ref={standardScrollRef} className="w-full overflow-y-auto md:w-1/2">
+          <div className="mx-auto max-w-[540px] px-5 py-8 md:px-10 md:py-12">
+            {step === 2 && !infoStripDismissed && (
+              <QuizInfoStrip onDismiss={() => setInfoStripDismissed(true)} />
+            )}
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </AppRouteProviders>
   )
 }

--- a/src/app/result/layout.tsx
+++ b/src/app/result/layout.tsx
@@ -1,0 +1,5 @@
+import { PublicFlowProviders } from "@/providers/route-providers"
+
+export default function ResultLayout({ children }: { children: React.ReactNode }) {
+  return <PublicFlowProviders>{children}</PublicFlowProviders>
+}

--- a/src/app/welcome/layout.tsx
+++ b/src/app/welcome/layout.tsx
@@ -1,0 +1,5 @@
+import { PublicFlowProviders } from "@/providers/route-providers"
+
+export default function WelcomeLayout({ children }: { children: React.ReactNode }) {
+  return <PublicFlowProviders>{children}</PublicFlowProviders>
+}

--- a/src/app/welcome/layout.tsx
+++ b/src/app/welcome/layout.tsx
@@ -1,5 +1,5 @@
-import { PublicFlowProviders } from "@/providers/route-providers"
+import { PublicAuthFlowProviders } from "@/providers/route-providers"
 
 export default function WelcomeLayout({ children }: { children: React.ReactNode }) {
-  return <PublicFlowProviders>{children}</PublicFlowProviders>
+  return <PublicAuthFlowProviders>{children}</PublicAuthFlowProviders>
 }

--- a/src/components/cookie-consent/lazy-cookie-consent.tsx
+++ b/src/components/cookie-consent/lazy-cookie-consent.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const CookieConsent = dynamic(
+  () => import("@/components/cookie-consent/cookie-consent").then((mod) => mod.CookieConsent),
+  {
+    loading: () => null,
+    ssr: false,
+  },
+)
+
+export function LazyCookieConsent() {
+  return <CookieConsent />
+}

--- a/src/components/feedback/lazy-feedback-widget.tsx
+++ b/src/components/feedback/lazy-feedback-widget.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const FeedbackWidget = dynamic(
+  () => import("@/components/feedback/feedback-widget").then((mod) => mod.FeedbackWidget),
+  {
+    loading: () => null,
+    ssr: false,
+  },
+)
+
+export function LazyFeedbackWidget() {
+  return <FeedbackWidget />
+}

--- a/src/components/landing/final-cta.tsx
+++ b/src/components/landing/final-cta.tsx
@@ -19,6 +19,7 @@ export function FinalCta() {
         </p>
         <Link
           href="/quiz"
+          prefetch={false}
           className="inline-block rounded-[14px] bg-[var(--brand-coral)] px-9 py-[18px] text-[17px] font-bold text-white transition-all hover:bg-white hover:text-[var(--brand-plum-darkest)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
         >
           Quiz starten

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -79,7 +79,6 @@ export function Hero() {
               alt={TOM.name}
               width={96}
               height={96}
-              priority
               className="h-12 w-12 shrink-0 rounded-full border-2 border-[var(--brand-plum-light)] bg-[var(--brand-plum-ice)] object-cover object-[52%_18%]"
             />
             <div>

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -65,6 +65,7 @@ export function Hero() {
               need an anchor element with a multi-line label (CTA + subtitle). */}
           <Link
             href="/quiz"
+            prefetch={false}
             className="block rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-8 py-[18px] text-center text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-all hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral-dark)] focus-visible:ring-offset-2 motion-safe:hover:-translate-y-0.5"
           >
             <span className="block text-lg font-bold text-white">Quiz starten</span>

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -65,7 +65,6 @@ export function Hero() {
               need an anchor element with a multi-line label (CTA + subtitle). */}
           <Link
             href="/quiz"
-            prefetch={false}
             className="block rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-8 py-[18px] text-center text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-all hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral-dark)] focus-visible:ring-offset-2 motion-safe:hover:-translate-y-0.5"
           >
             <span className="block text-lg font-bold text-white">Quiz starten</span>

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -15,12 +15,14 @@ export function LandingHeader() {
         <nav className="flex shrink-0 items-center gap-3 sm:gap-5">
           <Link
             href="/chat"
+            prefetch={false}
             className="whitespace-nowrap rounded-md text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-[var(--brand-plum-darkest)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-plum)] focus-visible:ring-offset-2"
           >
             Anmelden
           </Link>
           <Link
             href="/quiz"
+            prefetch={false}
             className="whitespace-nowrap rounded-[10px] bg-[var(--brand-coral)] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2 sm:px-[18px] sm:py-2.5"
           >
             Quiz starten

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -22,7 +22,6 @@ export function LandingHeader() {
           </Link>
           <Link
             href="/quiz"
-            prefetch={false}
             className="whitespace-nowrap rounded-[10px] bg-[var(--brand-coral)] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2 sm:px-[18px] sm:py-2.5"
           >
             Quiz starten

--- a/src/components/landing/pricing.tsx
+++ b/src/components/landing/pricing.tsx
@@ -92,6 +92,7 @@ function PlanCard({ plan }: { plan: StripePricingPlan }) {
 
       <Link
         href="/quiz"
+        prefetch={false}
         className={`block text-center py-3.5 rounded-[12px] font-semibold text-[15px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${ctaClasses}`}
       >
         Plan wählen

--- a/src/components/landing/site-footer.tsx
+++ b/src/components/landing/site-footer.tsx
@@ -30,7 +30,7 @@ export function SiteFooter() {
             <h4 className={headingClass}>Produkt</h4>
             <ul className="flex flex-col gap-2.5">
               <li>
-                <Link href="/quiz" className={linkClass}>
+                <Link href="/quiz" prefetch={false} className={linkClass}>
                   Quiz starten
                 </Link>
               </li>

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -9,6 +9,11 @@ export async function updateSession(request: NextRequest) {
   })
 
   const { pathname } = request.nextUrl
+  const isPublicMarketingRoute =
+    pathname === "/" ||
+    ["/agb", "/datenschutz", "/impressum", "/kontakt", "/pricing", "/widerruf"].some(
+      (route) => pathname === route || pathname.startsWith(`${route}/`),
+    )
   const fastPublicRoutes = [
     "/api/stripe",
     "/api/paypal",
@@ -17,7 +22,7 @@ export async function updateSession(request: NextRequest) {
     "/api/auth/set-checkout-password",
     "/welcome",
   ]
-  if (fastPublicRoutes.some((route) => pathname.startsWith(route))) {
+  if (isPublicMarketingRoute || fastPublicRoutes.some((route) => pathname.startsWith(route))) {
     return supabaseResponse
   }
 

--- a/src/providers/customerio-provider.tsx
+++ b/src/providers/customerio-provider.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { AnalyticsBrowser } from "@customerio/cdp-analytics-browser"
-import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react"
+import { Suspense, useEffect, useRef, useState } from "react"
 import { usePathname, useSearchParams } from "next/navigation"
 import { COOKIE_CONSENT_CHANGE_EVENT, loadConsent, type CookieConsent } from "@/lib/cookie-consent"
 import {
@@ -66,24 +65,37 @@ export function CustomerIoProvider({ children }: { children: React.ReactNode }) 
   const [enabled, setEnabled] = useState(false)
   const clientInstalledRef = useRef(false)
 
-  useLayoutEffect(() => {
-    const installClient = () => {
-      if (clientInstalledRef.current) return
+  useEffect(() => {
+    let disposed = false
+    let wantsTracking = false
+
+    const installClient = async () => {
+      if (clientInstalledRef.current) return true
+      const { AnalyticsBrowser } = await import("@customerio/cdp-analytics-browser")
+      if (disposed) return false
       const client = AnalyticsBrowser.load({
         cdnURL: CUSTOMERIO_CDN_URL,
         writeKey: CUSTOMERIO_WRITE_KEY,
       }) as CustomerIoBrowserClient
       setCustomerIoBrowserClient(client)
       clientInstalledRef.current = true
+      return true
     }
 
     const syncConsent = (consent: CookieConsent | null) => {
       const canTrack = canUseCustomerIoBrowserTracking(consent, CUSTOMERIO_WRITE_KEY)
-      setEnabled(canTrack)
+      wantsTracking = canTrack
 
       if (canTrack) {
-        installClient()
+        void installClient()
+          .then((installed) => {
+            if (!disposed && wantsTracking && installed) setEnabled(true)
+          })
+          .catch(() => {
+            if (!disposed) setEnabled(false)
+          })
       } else {
+        setEnabled(false)
         resetCustomerIoBrowserClient()
         clearCustomerIoBrowserClient()
         clientInstalledRef.current = false
@@ -99,7 +111,10 @@ export function CustomerIoProvider({ children }: { children: React.ReactNode }) 
     }
 
     window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
-    return () => window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
+    return () => {
+      disposed = true
+      window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
+    }
   }, [])
 
   return (

--- a/src/providers/customerio-provider.tsx
+++ b/src/providers/customerio-provider.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { Suspense, useEffect, useRef, useState } from "react"
+import { AnalyticsBrowser } from "@customerio/cdp-analytics-browser"
+import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { usePathname, useSearchParams } from "next/navigation"
 import { COOKIE_CONSENT_CHANGE_EVENT, loadConsent, type CookieConsent } from "@/lib/cookie-consent"
 import {
@@ -65,37 +66,24 @@ export function CustomerIoProvider({ children }: { children: React.ReactNode }) 
   const [enabled, setEnabled] = useState(false)
   const clientInstalledRef = useRef(false)
 
-  useEffect(() => {
-    let disposed = false
-    let wantsTracking = false
-
-    const installClient = async () => {
-      if (clientInstalledRef.current) return true
-      const { AnalyticsBrowser } = await import("@customerio/cdp-analytics-browser")
-      if (disposed) return false
+  useLayoutEffect(() => {
+    const installClient = () => {
+      if (clientInstalledRef.current) return
       const client = AnalyticsBrowser.load({
         cdnURL: CUSTOMERIO_CDN_URL,
         writeKey: CUSTOMERIO_WRITE_KEY,
       }) as CustomerIoBrowserClient
       setCustomerIoBrowserClient(client)
       clientInstalledRef.current = true
-      return true
     }
 
     const syncConsent = (consent: CookieConsent | null) => {
       const canTrack = canUseCustomerIoBrowserTracking(consent, CUSTOMERIO_WRITE_KEY)
-      wantsTracking = canTrack
+      setEnabled(canTrack)
 
       if (canTrack) {
-        void installClient()
-          .then((installed) => {
-            if (!disposed && wantsTracking && installed) setEnabled(true)
-          })
-          .catch(() => {
-            if (!disposed) setEnabled(false)
-          })
+        installClient()
       } else {
-        setEnabled(false)
         resetCustomerIoBrowserClient()
         clearCustomerIoBrowserClient()
         clientInstalledRef.current = false
@@ -111,10 +99,7 @@ export function CustomerIoProvider({ children }: { children: React.ReactNode }) 
     }
 
     window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
-    return () => {
-      disposed = true
-      window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
-    }
+    return () => window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
   }, [])
 
   return (

--- a/src/providers/posthog-provider.tsx
+++ b/src/providers/posthog-provider.tsx
@@ -1,114 +1,43 @@
 "use client"
 
-import type posthogJs from "posthog-js"
+import posthog from "posthog-js"
 import { usePathname, useSearchParams } from "next/navigation"
-import { useEffect, useRef, Suspense, useState } from "react"
-import { COOKIE_CONSENT_CHANGE_EVENT, loadConsent, type CookieConsent } from "@/lib/cookie-consent"
+import { useEffect, useRef, Suspense } from "react"
 import { useAuth } from "./auth-provider"
-
-type PostHogClient = typeof posthogJs
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY
 const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com"
 
-let postHogInitialized = false
-let postHogTrackingEnabled = false
-let postHogClient: PostHogClient | null = null
-let postHogLoadingPromise: Promise<PostHogClient> | null = null
-
-export function canUsePostHogBrowserTracking(
-  consent: CookieConsent | null | undefined,
-  key = POSTHOG_KEY,
-) {
-  return Boolean(key && consent?.analytics)
-}
-
-function ensurePostHogInitialized() {
-  if (typeof window === "undefined" || !POSTHOG_KEY) return Promise.resolve(false)
-  return loadPostHogClient()
-    .then((client) => {
-      if (postHogInitialized) {
-        client.opt_in_capturing()
-        postHogTrackingEnabled = true
-        return true
-      }
-
-      client.init(POSTHOG_KEY, {
-        api_host: POSTHOG_HOST,
-        autocapture: false,
-        capture_pageview: false,
-        persistence: "localStorage+cookie",
-      })
-      postHogInitialized = true
-      postHogTrackingEnabled = true
-      return true
-    })
-    .catch(() => false)
-}
-
-function loadPostHogClient() {
-  if (postHogClient) return Promise.resolve(postHogClient)
-  postHogLoadingPromise ??= import("posthog-js").then((mod) => mod.default)
-  return postHogLoadingPromise.then((client) => {
-    postHogClient = client
-    return client
+// Initialize PostHog once
+if (typeof window !== "undefined" && POSTHOG_KEY) {
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    autocapture: false,
+    capture_pageview: false,
+    persistence: "localStorage+cookie",
   })
 }
 
-function withEnabledPostHog(action: (client: PostHogClient) => void) {
-  if (!postHogTrackingEnabled) return
-  void loadPostHogClient()
-    .then(action)
-    .catch(() => undefined)
-}
-
-export const posthog = {
-  capture(...args: Parameters<PostHogClient["capture"]>) {
-    withEnabledPostHog((client) => client.capture(...args))
-  },
-  identify(...args: Parameters<PostHogClient["identify"]>) {
-    withEnabledPostHog((client) => client.identify(...args))
-  },
-  reset(...args: Parameters<PostHogClient["reset"]>) {
-    postHogClient?.reset(...args)
-  },
-  get_session_id(): ReturnType<PostHogClient["get_session_id"]> | undefined {
-    return postHogClient?.get_session_id()
-  },
-}
-
-function disablePostHogTracking() {
-  postHogTrackingEnabled = false
-  if (postHogInitialized) {
-    postHogClient?.reset()
-    postHogClient?.opt_out_capturing()
-  }
-}
-
-function PostHogPageView({ enabled }: { enabled: boolean }) {
+function PostHogPageView() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const lastPageViewRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!enabled) return
+    if (!POSTHOG_KEY) return
     const url =
       window.origin + pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "")
-    if (lastPageViewRef.current === url) return
-    lastPageViewRef.current = url
-
     posthog.capture("$pageview", { $current_url: url })
-  }, [enabled, pathname, searchParams])
+  }, [pathname, searchParams])
 
   return null
 }
 
-function PostHogIdentify({ enabled }: { enabled: boolean }) {
+function PostHogIdentify() {
   const { user, profile } = useAuth()
   const prevUserId = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!enabled) return
+    if (!POSTHOG_KEY) return
 
     if (user && profile) {
       if (prevUserId.current !== user.id) {
@@ -123,47 +52,12 @@ function PostHogIdentify({ enabled }: { enabled: boolean }) {
       posthog.reset()
       prevUserId.current = null
     }
-  }, [enabled, user, profile])
+  }, [user, profile])
 
   return null
 }
 
 export function PostHogClientProvider({ children }: { children: React.ReactNode }) {
-  const [enabled, setEnabled] = useState(false)
-
-  useEffect(() => {
-    let disposed = false
-    let wantsTracking = false
-
-    const syncConsent = (consent: CookieConsent | null) => {
-      const canTrack = canUsePostHogBrowserTracking(consent)
-      wantsTracking = canTrack
-
-      if (canTrack) {
-        void ensurePostHogInitialized().then((ready) => {
-          if (!disposed && wantsTracking) setEnabled(ready)
-        })
-      } else {
-        setEnabled(false)
-        disablePostHogTracking()
-      }
-    }
-
-    syncConsent(loadConsent())
-
-    const handleConsentChange = (event: Event) => {
-      const consent =
-        event instanceof CustomEvent ? (event.detail as CookieConsent | null) : loadConsent()
-      syncConsent(consent)
-    }
-
-    window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
-    return () => {
-      disposed = true
-      window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
-    }
-  }, [])
-
   if (!POSTHOG_KEY) {
     return <>{children}</>
   }
@@ -171,10 +65,13 @@ export function PostHogClientProvider({ children }: { children: React.ReactNode 
   return (
     <>
       <Suspense fallback={null}>
-        <PostHogPageView enabled={enabled} />
+        <PostHogPageView />
       </Suspense>
-      <PostHogIdentify enabled={enabled} />
+      <PostHogIdentify />
       {children}
     </>
   )
 }
+
+// Re-export for use in event tracking
+export { posthog }

--- a/src/providers/posthog-provider.tsx
+++ b/src/providers/posthog-provider.tsx
@@ -1,42 +1,114 @@
 "use client"
 
-import posthog from "posthog-js"
+import type posthogJs from "posthog-js"
 import { usePathname, useSearchParams } from "next/navigation"
-import { useEffect, useRef, Suspense } from "react"
+import { useEffect, useRef, Suspense, useState } from "react"
+import { COOKIE_CONSENT_CHANGE_EVENT, loadConsent, type CookieConsent } from "@/lib/cookie-consent"
 import { useAuth } from "./auth-provider"
+
+type PostHogClient = typeof posthogJs
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY
 const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com"
 
-// Initialize PostHog once
-if (typeof window !== "undefined" && POSTHOG_KEY) {
-  posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
-    autocapture: false,
-    capture_pageview: false,
-    persistence: "localStorage+cookie",
+let postHogInitialized = false
+let postHogTrackingEnabled = false
+let postHogClient: PostHogClient | null = null
+let postHogLoadingPromise: Promise<PostHogClient> | null = null
+
+export function canUsePostHogBrowserTracking(
+  consent: CookieConsent | null | undefined,
+  key = POSTHOG_KEY,
+) {
+  return Boolean(key && consent?.analytics)
+}
+
+function ensurePostHogInitialized() {
+  if (typeof window === "undefined" || !POSTHOG_KEY) return Promise.resolve(false)
+  return loadPostHogClient()
+    .then((client) => {
+      if (postHogInitialized) {
+        client.opt_in_capturing()
+        postHogTrackingEnabled = true
+        return true
+      }
+
+      client.init(POSTHOG_KEY, {
+        api_host: POSTHOG_HOST,
+        autocapture: false,
+        capture_pageview: false,
+        persistence: "localStorage+cookie",
+      })
+      postHogInitialized = true
+      postHogTrackingEnabled = true
+      return true
+    })
+    .catch(() => false)
+}
+
+function loadPostHogClient() {
+  if (postHogClient) return Promise.resolve(postHogClient)
+  postHogLoadingPromise ??= import("posthog-js").then((mod) => mod.default)
+  return postHogLoadingPromise.then((client) => {
+    postHogClient = client
+    return client
   })
 }
 
-function PostHogPageView() {
+function withEnabledPostHog(action: (client: PostHogClient) => void) {
+  if (!postHogTrackingEnabled) return
+  void loadPostHogClient()
+    .then(action)
+    .catch(() => undefined)
+}
+
+export const posthog = {
+  capture(...args: Parameters<PostHogClient["capture"]>) {
+    withEnabledPostHog((client) => client.capture(...args))
+  },
+  identify(...args: Parameters<PostHogClient["identify"]>) {
+    withEnabledPostHog((client) => client.identify(...args))
+  },
+  reset(...args: Parameters<PostHogClient["reset"]>) {
+    postHogClient?.reset(...args)
+  },
+  get_session_id(): ReturnType<PostHogClient["get_session_id"]> | undefined {
+    return postHogClient?.get_session_id()
+  },
+}
+
+function disablePostHogTracking() {
+  postHogTrackingEnabled = false
+  if (postHogInitialized) {
+    postHogClient?.reset()
+    postHogClient?.opt_out_capturing()
+  }
+}
+
+function PostHogPageView({ enabled }: { enabled: boolean }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const lastPageViewRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!POSTHOG_KEY) return
-    const url = window.origin + pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "")
+    if (!enabled) return
+    const url =
+      window.origin + pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "")
+    if (lastPageViewRef.current === url) return
+    lastPageViewRef.current = url
+
     posthog.capture("$pageview", { $current_url: url })
-  }, [pathname, searchParams])
+  }, [enabled, pathname, searchParams])
 
   return null
 }
 
-function PostHogIdentify() {
+function PostHogIdentify({ enabled }: { enabled: boolean }) {
   const { user, profile } = useAuth()
   const prevUserId = useRef<string | null>(null)
 
   useEffect(() => {
-    if (!POSTHOG_KEY) return
+    if (!enabled) return
 
     if (user && profile) {
       if (prevUserId.current !== user.id) {
@@ -51,12 +123,47 @@ function PostHogIdentify() {
       posthog.reset()
       prevUserId.current = null
     }
-  }, [user, profile])
+  }, [enabled, user, profile])
 
   return null
 }
 
 export function PostHogClientProvider({ children }: { children: React.ReactNode }) {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    let disposed = false
+    let wantsTracking = false
+
+    const syncConsent = (consent: CookieConsent | null) => {
+      const canTrack = canUsePostHogBrowserTracking(consent)
+      wantsTracking = canTrack
+
+      if (canTrack) {
+        void ensurePostHogInitialized().then((ready) => {
+          if (!disposed && wantsTracking) setEnabled(ready)
+        })
+      } else {
+        setEnabled(false)
+        disablePostHogTracking()
+      }
+    }
+
+    syncConsent(loadConsent())
+
+    const handleConsentChange = (event: Event) => {
+      const consent =
+        event instanceof CustomEvent ? (event.detail as CookieConsent | null) : loadConsent()
+      syncConsent(consent)
+    }
+
+    window.addEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
+    return () => {
+      disposed = true
+      window.removeEventListener(COOKIE_CONSENT_CHANGE_EVENT, handleConsentChange)
+    }
+  }, [])
+
   if (!POSTHOG_KEY) {
     return <>{children}</>
   }
@@ -64,13 +171,10 @@ export function PostHogClientProvider({ children }: { children: React.ReactNode 
   return (
     <>
       <Suspense fallback={null}>
-        <PostHogPageView />
+        <PostHogPageView enabled={enabled} />
       </Suspense>
-      <PostHogIdentify />
+      <PostHogIdentify enabled={enabled} />
       {children}
     </>
   )
 }
-
-// Re-export for use in event tracking
-export { posthog }

--- a/src/providers/route-providers.tsx
+++ b/src/providers/route-providers.tsx
@@ -36,10 +36,26 @@ export function PublicFlowProviders({ children }: { children: React.ReactNode })
   )
 }
 
+export function PublicAuthFlowProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <MetaPixelProvider>
+      <AuthProvider>
+        <CustomerIoProvider>
+          <PostHogClientProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </PostHogClientProvider>
+        </CustomerIoProvider>
+      </AuthProvider>
+    </MetaPixelProvider>
+  )
+}
+
 export function LandingTracking() {
   return (
     <MetaPixelProvider>
-      <CustomerIoProvider>{null}</CustomerIoProvider>
+      <CustomerIoProvider>
+        <PostHogClientProvider>{null}</PostHogClientProvider>
+      </CustomerIoProvider>
     </MetaPixelProvider>
   )
 }

--- a/src/providers/route-providers.tsx
+++ b/src/providers/route-providers.tsx
@@ -35,3 +35,11 @@ export function PublicFlowProviders({ children }: { children: React.ReactNode })
     </MetaPixelProvider>
   )
 }
+
+export function LandingTracking() {
+  return (
+    <MetaPixelProvider>
+      <CustomerIoProvider>{null}</CustomerIoProvider>
+    </MetaPixelProvider>
+  )
+}

--- a/src/providers/route-providers.tsx
+++ b/src/providers/route-providers.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { LazyFeedbackWidget } from "@/components/feedback/lazy-feedback-widget"
+import { AuthProvider } from "@/providers/auth-provider"
+import { CustomerIoProvider } from "@/providers/customerio-provider"
+import { MetaPixelProvider } from "@/providers/meta-pixel-provider"
+import { PostHogClientProvider } from "@/providers/posthog-provider"
+import { ToastProvider } from "@/providers/toast-provider"
+
+export function AppRouteProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <MetaPixelProvider>
+      <AuthProvider>
+        <CustomerIoProvider>
+          <PostHogClientProvider>
+            <ToastProvider>
+              {children}
+              <LazyFeedbackWidget />
+            </ToastProvider>
+          </PostHogClientProvider>
+        </CustomerIoProvider>
+      </AuthProvider>
+    </MetaPixelProvider>
+  )
+}
+
+export function PublicFlowProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <MetaPixelProvider>
+      <CustomerIoProvider>
+        <PostHogClientProvider>
+          <ToastProvider>{children}</ToastProvider>
+        </PostHogClientProvider>
+      </CustomerIoProvider>
+    </MetaPixelProvider>
+  )
+}

--- a/tests/acquisition-funnel-tracking.test.ts
+++ b/tests/acquisition-funnel-tracking.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+function read(path: string) {
+  return readFileSync(path, "utf8")
+}
+
+test("acquisition funnel keeps Meta and Customer.io tracking from landing through checkout success", () => {
+  const routeProviders = read("src/providers/route-providers.tsx")
+  assert.match(routeProviders, /function LandingTracking\(\)/)
+  assert.match(routeProviders, /function PublicFlowProviders\(/)
+  assert.match(routeProviders, /<MetaPixelProvider>/)
+  assert.match(routeProviders, /<CustomerIoProvider>/)
+
+  const landing = read("src/app/page.tsx")
+  assert.match(landing, /<LandingTracking \/>/)
+
+  for (const path of [
+    "src/app/auth/layout.tsx",
+    "src/app/pricing/layout.tsx",
+    "src/app/result/layout.tsx",
+    "src/app/welcome/layout.tsx",
+  ]) {
+    assert.match(read(path), /<PublicFlowProviders>{children}<\/PublicFlowProviders>/, path)
+  }
+
+  assert.match(read("src/app/quiz/layout.tsx"), /<AppRouteProviders>/)
+})

--- a/tests/acquisition-funnel-tracking.test.ts
+++ b/tests/acquisition-funnel-tracking.test.ts
@@ -6,12 +6,14 @@ function read(path: string) {
   return readFileSync(path, "utf8")
 }
 
-test("acquisition funnel keeps Meta and Customer.io tracking from landing through checkout success", () => {
+test("acquisition funnel keeps Meta, Customer.io, and PostHog tracking from landing through checkout success", () => {
   const routeProviders = read("src/providers/route-providers.tsx")
   assert.match(routeProviders, /function LandingTracking\(\)/)
   assert.match(routeProviders, /function PublicFlowProviders\(/)
+  assert.match(routeProviders, /function PublicAuthFlowProviders\(/)
   assert.match(routeProviders, /<MetaPixelProvider>/)
   assert.match(routeProviders, /<CustomerIoProvider>/)
+  assert.match(routeProviders, /<PostHogClientProvider>/)
 
   const landing = read("src/app/page.tsx")
   assert.match(landing, /<LandingTracking \/>/)
@@ -20,10 +22,13 @@ test("acquisition funnel keeps Meta and Customer.io tracking from landing throug
     "src/app/auth/layout.tsx",
     "src/app/pricing/layout.tsx",
     "src/app/result/layout.tsx",
-    "src/app/welcome/layout.tsx",
   ]) {
     assert.match(read(path), /<PublicFlowProviders>{children}<\/PublicFlowProviders>/, path)
   }
 
+  assert.match(
+    read("src/app/welcome/layout.tsx"),
+    /<PublicAuthFlowProviders>{children}<\/PublicAuthFlowProviders>/,
+  )
   assert.match(read("src/app/quiz/layout.tsx"), /<AppRouteProviders>/)
 })

--- a/tests/analytics-tracking.test.ts
+++ b/tests/analytics-tracking.test.ts
@@ -11,7 +11,7 @@ import {
   clearCustomerIoBrowserClient,
   setCustomerIoBrowserClient,
 } from "../src/lib/customerio-tracking"
-import { canUsePostHogBrowserTracking, posthog } from "../src/providers/posthog-provider"
+import { posthog } from "../src/providers/posthog-provider"
 
 type DestinationCall = {
   destination: "customerio" | "meta" | "posthog"
@@ -253,28 +253,6 @@ test("PostHog adapter keeps legacy names and strips undefined mapped properties"
   } finally {
     posthog.capture = originalCapture
   }
-})
-
-test("PostHog browser tracking requires analytics consent and a project key", () => {
-  assert.equal(canUsePostHogBrowserTracking(null, "ph-key"), false)
-  assert.equal(
-    canUsePostHogBrowserTracking(
-      { essential: true, analytics: false, marketing: true, ts: 1 },
-      "ph-key",
-    ),
-    false,
-  )
-  assert.equal(
-    canUsePostHogBrowserTracking({ essential: true, analytics: true, marketing: false, ts: 1 }, ""),
-    false,
-  )
-  assert.equal(
-    canUsePostHogBrowserTracking(
-      { essential: true, analytics: true, marketing: false, ts: 1 },
-      "ph-key",
-    ),
-    true,
-  )
 })
 
 test("Customer.io adapter maps app payloads to snake_case vendor payloads", () => {

--- a/tests/analytics-tracking.test.ts
+++ b/tests/analytics-tracking.test.ts
@@ -11,7 +11,7 @@ import {
   clearCustomerIoBrowserClient,
   setCustomerIoBrowserClient,
 } from "../src/lib/customerio-tracking"
-import { posthog } from "../src/providers/posthog-provider"
+import { canUsePostHogBrowserTracking, posthog } from "../src/providers/posthog-provider"
 
 type DestinationCall = {
   destination: "customerio" | "meta" | "posthog"
@@ -253,6 +253,28 @@ test("PostHog adapter keeps legacy names and strips undefined mapped properties"
   } finally {
     posthog.capture = originalCapture
   }
+})
+
+test("PostHog browser tracking requires analytics consent and a project key", () => {
+  assert.equal(canUsePostHogBrowserTracking(null, "ph-key"), false)
+  assert.equal(
+    canUsePostHogBrowserTracking(
+      { essential: true, analytics: false, marketing: true, ts: 1 },
+      "ph-key",
+    ),
+    false,
+  )
+  assert.equal(
+    canUsePostHogBrowserTracking({ essential: true, analytics: true, marketing: false, ts: 1 }, ""),
+    false,
+  )
+  assert.equal(
+    canUsePostHogBrowserTracking(
+      { essential: true, analytics: true, marketing: false, ts: 1 },
+      "ph-key",
+    ),
+    true,
+  )
 })
 
 test("Customer.io adapter maps app payloads to snake_case vendor payloads", () => {

--- a/tests/paypal-middleware-public.test.ts
+++ b/tests/paypal-middleware-public.test.ts
@@ -3,6 +3,13 @@ import test from "node:test"
 import { NextRequest } from "next/server"
 import { updateSession } from "../src/lib/supabase/middleware"
 
+test("allows unauthenticated marketing pages through the proxy without auth lookup", async () => {
+  const response = await updateSession(new NextRequest("https://chaarlie.de/"))
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get("location"), null)
+})
+
 test("allows unauthenticated PayPal checkout API calls through the proxy", async () => {
   const response = await updateSession(
     new NextRequest("https://chaarlie.de/api/paypal/create-subscription-intent", {


### PR DESCRIPTION
## Summary
- gate PostHog behind analytics consent and lazy-load the SDK only after consent
- trim landing-critical font work by loading the single Playfair face used by headers and disabling mono preload
- lazy-load the feedback widget and stop preloading the below-fold Tom image on the landing hero

## Verification
- npx eslint src/app/layout.tsx src/components/feedback/lazy-feedback-widget.tsx src/components/landing/hero.tsx src/providers/posthog-provider.tsx tests/analytics-tracking.test.ts --no-warn-ignored
- npx tsx --test tests/analytics-tracking.test.ts
- npm run typecheck
- npm run build
- LH_BASE_URL=http://localhost:3598 LH_PATHS=/ LH_FAIL_ON_THRESHOLD=0 npm run perf:mobile (local production-style run: LCP ~5.0s, CLS 0.000, TBT 72ms; still above target, needs Vercel preview/prod measurement)

## Notes
This is a first LCP reduction pass, not a complete Core Web Vitals fix. Local Lighthouse improved from ~6.1s at branch start to ~5.0s, but the H1 remains the LCP element and render delay is still the main bottleneck.