### PR TITLE
Bound OpenAI chat timeouts and retries

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -9,6 +9,7 @@ import {
   getLangfuseRelease,
   resolveLangfuseTraceId,
 } from "@/lib/openai/client"
+import { classifyOpenAIError } from "@/lib/openai/errors"
 import { sanitizeLangfuseText } from "@/lib/langfuse/masking"
 import { ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
@@ -689,17 +690,22 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
       })
     } catch (error) {
       console.error("Chat pipeline error:", error)
+      const openAIError = classifyOpenAIError(error)
       if (chatObservation) {
         chatObservation.update({
           output: {
             status: "failed",
           },
           metadata: {
+            ...(openAIError ? { openai_failure_kind: openAIError.kind } : {}),
             error: error instanceof Error ? error.message : "chat_pipeline_error",
           },
         })
         chatObservation.end()
         deps.flushLangfuseClient().catch(() => {})
+      }
+      if (openAIError) {
+        return NextResponse.json({ error: openAIError.userMessage }, { status: openAIError.status })
       }
       return NextResponse.json({ error: fehler("Verarbeitung") }, { status: 500 })
     }

--- a/src/lib/langfuse/client.ts
+++ b/src/lib/langfuse/client.ts
@@ -4,6 +4,7 @@ import { observeOpenAI, type LangfuseConfig as LangfuseOpenAIConfig } from "@lan
 import { LangfuseSpanProcessor } from "@langfuse/otel"
 import { NodeSDK } from "@opentelemetry/sdk-node"
 import { maskLangfuseExport } from "./masking"
+import { getOpenAIMaxRetries, getOpenAIRequestTimeoutMs } from "@/lib/openai/errors"
 
 let openAIInstance: OpenAI | null = null
 let langfuseInstance: LangfuseClient | null | undefined
@@ -22,7 +23,11 @@ function requireEnv(name: string): string {
 
 export function getRawOpenAI(): OpenAI {
   if (!openAIInstance) {
-    openAIInstance = new OpenAI({ apiKey: requireEnv("OPENAI_API_KEY") })
+    openAIInstance = new OpenAI({
+      apiKey: requireEnv("OPENAI_API_KEY"),
+      maxRetries: getOpenAIMaxRetries(),
+      timeout: getOpenAIRequestTimeoutMs(),
+    })
   }
 
   return openAIInstance

--- a/src/lib/openai/errors.ts
+++ b/src/lib/openai/errors.ts
@@ -1,0 +1,109 @@
+export const DEFAULT_OPENAI_REQUEST_TIMEOUT_MS = 25_000
+export const DEFAULT_OPENAI_MAX_RETRIES = 1
+
+type EnvLike = Record<string, string | undefined>
+
+export type OpenAIFailureKind = "rate_limited" | "timeout" | "connection" | "server"
+
+export type OpenAIFailure = {
+  kind: OpenAIFailureKind
+  status: 429 | 503
+  userMessage: string
+}
+
+function readIntegerEnv(
+  env: EnvLike,
+  name: string,
+  fallback: number,
+  options: { min: number; max: number },
+) {
+  const raw = env[name]
+  if (!raw) return fallback
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return fallback
+
+  return Math.max(options.min, Math.min(options.max, parsed))
+}
+
+export function getOpenAIRequestTimeoutMs(env: EnvLike = process.env) {
+  return readIntegerEnv(env, "OPENAI_REQUEST_TIMEOUT_MS", DEFAULT_OPENAI_REQUEST_TIMEOUT_MS, {
+    min: 5_000,
+    max: 55_000,
+  })
+}
+
+export function getOpenAIMaxRetries(env: EnvLike = process.env) {
+  return readIntegerEnv(env, "OPENAI_MAX_RETRIES", DEFAULT_OPENAI_MAX_RETRIES, {
+    min: 0,
+    max: 2,
+  })
+}
+
+function readErrorRecord(error: unknown): Record<string, unknown> | null {
+  return error && typeof error === "object" ? (error as Record<string, unknown>) : null
+}
+
+function readErrorName(error: unknown): string {
+  const record = readErrorRecord(error)
+  if (typeof record?.name === "string") return record.name
+  return error instanceof Error ? error.name : ""
+}
+
+function readErrorMessage(error: unknown): string {
+  const record = readErrorRecord(error)
+  if (typeof record?.message === "string") return record.message
+  return error instanceof Error ? error.message : ""
+}
+
+function readErrorStatus(error: unknown): number | null {
+  const record = readErrorRecord(error)
+  return typeof record?.status === "number" ? record.status : null
+}
+
+export function classifyOpenAIError(error: unknown): OpenAIFailure | null {
+  const status = readErrorStatus(error)
+  const name = readErrorName(error)
+  const message = readErrorMessage(error).toLowerCase()
+
+  if (status === 429 || name === "RateLimitError") {
+    return {
+      kind: "rate_limited",
+      status: 429,
+      userMessage:
+        "Gerade sind zu viele KI-Anfragen gleichzeitig. Bitte versuche es gleich nochmal.",
+    }
+  }
+
+  if (
+    name === "APIConnectionTimeoutError" ||
+    name === "TimeoutError" ||
+    name === "AbortError" ||
+    message.includes("timed out") ||
+    message.includes("timeout")
+  ) {
+    return {
+      kind: "timeout",
+      status: 503,
+      userMessage: "Chaarlie braucht gerade zu lange. Bitte versuche es gleich nochmal.",
+    }
+  }
+
+  if (name === "APIConnectionError") {
+    return {
+      kind: "connection",
+      status: 503,
+      userMessage: "Die KI-Verbindung ist gerade instabil. Bitte versuche es gleich nochmal.",
+    }
+  }
+
+  if (typeof status === "number" && status >= 500) {
+    return {
+      kind: "server",
+      status: 503,
+      userMessage: "Der KI-Dienst ist gerade nicht stabil. Bitte versuche es gleich nochmal.",
+    }
+  }
+
+  return null
+}

--- a/tests/openai-errors.test.ts
+++ b/tests/openai-errors.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  DEFAULT_OPENAI_MAX_RETRIES,
+  DEFAULT_OPENAI_REQUEST_TIMEOUT_MS,
+  classifyOpenAIError,
+  getOpenAIMaxRetries,
+  getOpenAIRequestTimeoutMs,
+} from "../src/lib/openai/errors"
+
+test("OpenAI timeout and retry settings default conservatively for launch", () => {
+  assert.equal(getOpenAIRequestTimeoutMs({}), DEFAULT_OPENAI_REQUEST_TIMEOUT_MS)
+  assert.equal(getOpenAIMaxRetries({}), DEFAULT_OPENAI_MAX_RETRIES)
+})
+
+test("OpenAI timeout and retry settings clamp unsafe env values", () => {
+  assert.equal(getOpenAIRequestTimeoutMs({ OPENAI_REQUEST_TIMEOUT_MS: "1000" }), 5_000)
+  assert.equal(getOpenAIRequestTimeoutMs({ OPENAI_REQUEST_TIMEOUT_MS: "90000" }), 55_000)
+  assert.equal(getOpenAIRequestTimeoutMs({ OPENAI_REQUEST_TIMEOUT_MS: "abc" }), 25_000)
+  assert.equal(getOpenAIMaxRetries({ OPENAI_MAX_RETRIES: "-2" }), 0)
+  assert.equal(getOpenAIMaxRetries({ OPENAI_MAX_RETRIES: "9" }), 2)
+  assert.equal(getOpenAIMaxRetries({ OPENAI_MAX_RETRIES: "abc" }), 1)
+})
+
+test("OpenAI error classifier maps launch-critical provider failures", () => {
+  assert.deepEqual(classifyOpenAIError({ name: "RateLimitError", status: 429 }), {
+    kind: "rate_limited",
+    status: 429,
+    userMessage: "Gerade sind zu viele KI-Anfragen gleichzeitig. Bitte versuche es gleich nochmal.",
+  })
+  assert.deepEqual(classifyOpenAIError({ name: "APIConnectionTimeoutError" })?.kind, "timeout")
+  assert.deepEqual(classifyOpenAIError({ name: "APIConnectionError" })?.kind, "connection")
+  assert.deepEqual(classifyOpenAIError({ status: 503 })?.kind, "server")
+  assert.equal(classifyOpenAIError(new Error("regular app error")), null)
+})


### PR DESCRIPTION
## Summary
- set a conservative default OpenAI request timeout (25s) and retry cap (1) via the shared OpenAI client
- allow env overrides with clamping through OPENAI_REQUEST_TIMEOUT_MS and OPENAI_MAX_RETRIES
- classify OpenAI rate-limit, timeout, connection, and 5xx failures so /api/chat returns 429/503 with German user-facing copy instead of a generic 500

## Verification
- npx eslint src/lib/openai/errors.ts src/lib/langfuse/client.ts src/app/api/chat/route.ts tests/openai-errors.test.ts --no-warn-ignored
- npx tsx --test tests/openai-errors.test.ts
- npm run typecheck
- npm run build