### PR TITLE
Clarify Stripe payment option copy

### DIFF
--- a/src/components/checkout/payment-method-checkout.tsx
+++ b/src/components/checkout/payment-method-checkout.tsx
@@ -92,19 +92,30 @@ export function PaymentMethodCheckout({
             <span className="h-px bg-border" aria-hidden="true" />
           </div>
 
-          <button
-            type="button"
-            aria-controls="card-sepa-checkout"
-            aria-expanded={cardCheckoutOpen}
-            onClick={() => setCardCheckoutOpen(true)}
-            className={`min-h-[52px] rounded-[12px] border bg-white px-4 text-[16px] font-bold text-[var(--brand-plum-darkest)] transition-colors ${
-              cardCheckoutOpen
-                ? "border-[var(--brand-plum)] bg-[var(--brand-plum-ice)]"
-                : "border-border hover:border-[var(--brand-plum-light)]"
-            }`}
-          >
-            Karte / SEPA
-          </button>
+          <div>
+            <button
+              type="button"
+              aria-controls="card-sepa-checkout"
+              aria-describedby={!cardCheckoutOpen ? "payment-method-helper" : undefined}
+              aria-expanded={cardCheckoutOpen}
+              onClick={() => setCardCheckoutOpen(true)}
+              className={`min-h-[52px] w-full rounded-[12px] border bg-white px-4 text-[16px] font-bold text-[var(--brand-plum-darkest)] transition-colors ${
+                cardCheckoutOpen
+                  ? "border-[var(--brand-plum)] bg-[var(--brand-plum-ice)]"
+                  : "border-border hover:border-[var(--brand-plum-light)]"
+              }`}
+            >
+              Karte, SEPA & weitere
+            </button>
+            {!cardCheckoutOpen ? (
+              <p
+                id="payment-method-helper"
+                className="mt-3 text-center text-[11px] leading-relaxed text-[var(--text-caption)]"
+              >
+                Im sicheren Checkout siehst du alle verfügbaren Zahlungsarten.
+              </p>
+            ) : null}
+          </div>
         </div>
       ) : null}
 

--- a/tests/payment-method-checkout.test.tsx
+++ b/tests/payment-method-checkout.test.tsx
@@ -63,7 +63,9 @@ test("PayPal enabled checkout renders express PayPal first and keeps card checko
   assert.match(html, /Jetzt starten — €17,49 im Quartal/)
   assert.match(html, /PayPal öffnet sich zur Bestätigung\. Danach aktivieren wir dein Konto\./)
   assert.match(html, />oder</)
-  assert.match(html, /Karte \/ SEPA/)
+  assert.match(html, /Karte, SEPA &amp; weitere/)
+  assert.match(html, /Im sicheren Checkout siehst du alle verfügbaren Zahlungsarten\./)
+  assert.doesNotMatch(html, /Karte \/ SEPA/)
   assert.match(html, /aria-expanded="false"/)
   assert.doesNotMatch(html, /min-h-\[560px\]|min-h-\[600px\]/)
   assert.doesNotMatch(html, /Stripe|native|nativ integriert|über Stripe|keine doppelte Zahlung/i)
@@ -78,7 +80,23 @@ test("PayPal disabled checkout preserves the immediate card and SEPA checkout su
   assert.doesNotMatch(html, /PayPal öffnet sich zur Bestätigung/)
   assert.doesNotMatch(html, />oder</)
   assert.doesNotMatch(html, /Karte \/ SEPA/)
+  assert.doesNotMatch(html, /Im sicheren Checkout siehst du alle verfügbaren Zahlungsarten\./)
   assert.match(html, /min-h-\[560px\]/)
+})
+
+test("Stripe payment helper copy is only shown before the embedded checkout expands", () => {
+  const source = readFileSync(
+    new URL("../src/components/checkout/payment-method-checkout.tsx", import.meta.url),
+    "utf8",
+  )
+
+  assert.match(
+    source,
+    /aria-describedby=\{!cardCheckoutOpen \? "payment-method-helper" : undefined\}/,
+  )
+  assert.match(source, /!cardCheckoutOpen \? \(/)
+  assert.match(source, /id="payment-method-helper"/)
+  assert.match(source, /Im sicheren Checkout siehst du alle verfügbaren Zahlungsarten\./)
 })
 
 test("PayPal approval redirects to the provider-aware welcome URL", () => {


### PR DESCRIPTION
## Summary

The checkout section currently labels the Stripe-backed option as `Karte / SEPA`, which underrepresents the payment methods Stripe may show in embedded checkout.

This change updates the collapsed Stripe option to broader German copy, keeps PayPal as the separate express option, and adds a short helper line that appears only before the embedded Stripe checkout opens. The helper is associated with the button via `aria-describedby` and disappears once the inline checkout is visible so it does not become stale above the form.

## Verification

- `npx tsx --test tests/payment-method-checkout.test.tsx` passed 9/9
- `npx eslint src/components/checkout/payment-method-checkout.tsx --max-warnings=0` passed
- `git diff --check HEAD~1..HEAD` passed
- pre-commit hook ran `eslint --fix`, `prettier --write`, and `npm run typecheck`

## Notes

- Draft PR by default per repo shipping workflow.
- The `& weitere` wording assumes the live Stripe Dashboard has additional eligible subscription payment methods enabled beyond card/SEPA.