### PR TITLE
feat(billing): add manual access grants

### DIFF
--- a/src/app/api/billing/access/route.ts
+++ b/src/app/api/billing/access/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server"
+import { cookies } from "next/headers"
+import { createServerClient } from "@supabase/ssr"
+import { hasCurrentAppAccess } from "@/lib/billing/subscriptions"
+
+export const runtime = "nodejs"
+
+export async function GET() {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
+      },
+    },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ hasAccess: false }, { status: 401 })
+  }
+
+  const hasAccess = await hasCurrentAppAccess(supabase, {
+    userId: user.id,
+    email: user.email,
+  })
+
+  return NextResponse.json({ hasAccess })
+}

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -55,6 +55,13 @@ export async function POST(req: NextRequest) {
       authenticatedUserId,
     )
     if (conflictResponse) return conflictResponse
+    if (user?.email) {
+      const emailConflictResponse = await createStripeCheckoutEmailAccessConflictResponse(
+        adminSupabase,
+        user.email,
+      )
+      if (emailConflictResponse) return emailConflictResponse
+    }
   }
 
   if (leadId) {

--- a/src/app/result/[leadId]/page.tsx
+++ b/src/app/result/[leadId]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next"
+import { cookies } from "next/headers"
 import { notFound } from "next/navigation"
+import { createServerClient } from "@supabase/ssr"
 
 import { ResultPageClient } from "./result-client"
+import { hasCurrentAppAccess } from "@/lib/billing/subscriptions"
 import { normalizeStoredQuizAnswers } from "@/lib/quiz/normalization"
 import type { QuizAnswers } from "@/lib/quiz/types"
 import { quizAnswersSchema } from "@/lib/quiz/validators"
@@ -50,9 +53,37 @@ function parseQuizAnswers(raw: unknown): QuizAnswers | null {
   return parsed.success ? parsed.data : null
 }
 
+async function getAuthenticatedResultAccess(): Promise<boolean> {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: () => {},
+      },
+    },
+  )
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return false
+
+  return hasCurrentAppAccess(supabase, { userId: user.id, email: user.email }).catch((error) => {
+    console.warn("[result-page] failed to resolve authenticated access", error)
+    return false
+  })
+}
+
 export default async function ResultPage({ params, searchParams }: Props) {
   const [{ leadId }, sp] = await Promise.all([params, searchParams])
-  const lead = await getLeadResult(leadId)
+  const [lead, hasAccess] = await Promise.all([
+    getLeadResult(leadId),
+    getAuthenticatedResultAccess(),
+  ])
   const quizAnswers = lead ? parseQuizAnswers(lead.quiz_answers) : null
 
   if (!lead || !quizAnswers) {
@@ -65,6 +96,7 @@ export default async function ResultPage({ params, searchParams }: Props) {
       name={lead.name}
       quizAnswers={quizAnswers}
       focusRoutine={sp.focus === "routine"}
+      hasAccess={hasAccess}
     />
   )
 }

--- a/src/app/result/[leadId]/result-client.tsx
+++ b/src/app/result/[leadId]/result-client.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from "react"
 
 import { QuizResultOfferPage } from "@/components/quiz/quiz-result-offer-page"
+import { QuizResultsView } from "@/components/quiz/quiz-results-view"
+import { getQuizResultCta } from "@/lib/quiz/result-cta"
 import { buildQuizResultNarrative } from "@/lib/quiz/result-narrative"
 import type { QuizAnswers } from "@/lib/quiz/types"
 
@@ -11,13 +13,16 @@ export function ResultPageClient({
   name,
   quizAnswers,
   focusRoutine,
+  hasAccess,
 }: {
   leadId: string
   name: string
   quizAnswers: QuizAnswers
   focusRoutine: boolean
+  hasAccess: boolean
 }) {
   const narrative = buildQuizResultNarrative(quizAnswers)
+  const cta = getQuizResultCta({ canGoStraightToRoutine: hasAccess })
 
   useEffect(() => {
     if (!focusRoutine) return
@@ -26,6 +31,20 @@ export function ResultPageClient({
       document.getElementById("pricing")?.scrollIntoView({ behavior: "smooth", block: "start" })
     })
   }, [focusRoutine])
+
+  if (hasAccess) {
+    return (
+      <QuizResultsView
+        name={name}
+        narrative={{ ...narrative, cta }}
+        primaryAction={{
+          label: cta.label,
+          href: `/onboarding?lead=${encodeURIComponent(leadId)}`,
+        }}
+        secondaryAction={null}
+      />
+    )
+  }
 
   return (
     <QuizResultOfferPage

--- a/src/components/quiz/quiz-results.tsx
+++ b/src/components/quiz/quiz-results.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { buildQuizResultNarrative } from "@/lib/quiz/result-narrative"
 import { getQuizResultCta } from "@/lib/quiz/result-cta"
@@ -49,13 +49,28 @@ export function QuizResults() {
   const searchParams = useSearchParams()
   const { user, profile, loading } = useAuth()
   const { lead, answers, leadId, goNext } = useQuizStore()
+  const [serverAccessCheck, setServerAccessCheck] = useState<{
+    key: string
+    hasAccess: boolean
+  } | null>(null)
   const checkoutAnalyticsCapturedRef = useRef(false)
   const resultArtifactEmailLeadRef = useRef<string | null>(null)
   const narrative = buildQuizResultNarrative(answers)
   const returnTo = searchParams.get("returnTo")
   const isRetakeMode = searchParams.get("mode") === "retake"
-  const canGoStraightToRoutine = Boolean(user && leadId && isSubscriptionActive(profile))
-  const isCheckingSignedInSubscription = Boolean(user && leadId && (loading || profile === null))
+  const profileHasAccess = isSubscriptionActive(profile)
+  const serverAccessKey =
+    user && leadId && !loading && !profileHasAccess ? `${user.id}:${leadId}` : null
+  const serverHasAccess = Boolean(
+    serverAccessKey && serverAccessCheck?.key === serverAccessKey && serverAccessCheck.hasAccess,
+  )
+  const isCheckingServerAccess = Boolean(
+    serverAccessKey && serverAccessCheck?.key !== serverAccessKey,
+  )
+  const canGoStraightToRoutine = Boolean(user && leadId && (profileHasAccess || serverHasAccess))
+  const isCheckingSignedInSubscription = Boolean(
+    user && leadId && (loading || profile === null || isCheckingServerAccess),
+  )
   const cta = getQuizResultCta({ canGoStraightToRoutine })
 
   const captureQuizCompleted = useCallback(() => {
@@ -74,6 +89,40 @@ export function QuizResults() {
   useEffect(() => {
     captureQuizCompleted()
   }, [captureQuizCompleted])
+
+  useEffect(() => {
+    if (!serverAccessKey) return
+
+    let cancelled = false
+
+    void fetch("/api/billing/access", {
+      headers: { Accept: "application/json" },
+    })
+      .then(async (response) => {
+        if (!response.ok) return { hasAccess: false }
+        return (await response.json()) as { hasAccess?: unknown }
+      })
+      .then((body) => {
+        if (!cancelled) {
+          setServerAccessCheck({
+            key: serverAccessKey,
+            hasAccess: body.hasAccess === true,
+          })
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setServerAccessCheck({
+            key: serverAccessKey,
+            hasAccess: false,
+          })
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [serverAccessKey])
 
   useEffect(() => {
     if (

--- a/src/lib/billing/subscriptions.ts
+++ b/src/lib/billing/subscriptions.ts
@@ -12,7 +12,16 @@ type LegacyProfileSubscription = {
   current_period_end: string | null
 }
 
+export interface ManualAccessGrantRow {
+  id: string
+  user_id: string | null
+  email: string | null
+  expires_at: string | null
+  revoked_at: string | null
+}
+
 const OPEN_ENTITLEMENTS = new Set<BillingEntitlementStatus>(["active", "past_due"])
+const ACCESS_ALREADY_EXISTS_ERROR = "User already has access through an existing subscription"
 
 export async function upsertBillingSubscription(
   supabase: SupabaseBillingClient,
@@ -114,7 +123,12 @@ export async function assertCanStartCheckout(
 ): Promise<void> {
   const current = await findCurrentBillingSubscriptionForUser(supabase, userId, now)
   if (current) {
-    throw new Error("User already has access through an existing subscription")
+    throw new Error(ACCESS_ALREADY_EXISTS_ERROR)
+  }
+
+  const manualGrant = await findCurrentManualAccessGrant(supabase, { userId }, now)
+  if (manualGrant) {
+    throw new Error(ACCESS_ALREADY_EXISTS_ERROR)
   }
 
   const { data, error } = await supabase
@@ -127,7 +141,7 @@ export async function assertCanStartCheckout(
   const profile = data as LegacyProfileSubscription | null
 
   if (profile && hasCurrentLegacyProfileAccess(profile, now)) {
-    throw new Error("User already has access through an existing subscription")
+    throw new Error(ACCESS_ALREADY_EXISTS_ERROR)
   }
 }
 
@@ -136,6 +150,11 @@ export async function assertCanStartCheckoutForEmail(
   email: string,
   now: Date = new Date(),
 ): Promise<void> {
+  const manualGrant = await findCurrentManualAccessGrant(supabase, { email }, now)
+  if (manualGrant) {
+    throw new Error(ACCESS_ALREADY_EXISTS_ERROR)
+  }
+
   const { data, error } = await supabase
     .from("profiles")
     .select("id, subscription_status, current_period_end")
@@ -147,6 +166,69 @@ export async function assertCanStartCheckoutForEmail(
   if (!profile?.id) return
 
   await assertCanStartCheckout(supabase, profile.id, now)
+}
+
+export async function hasCurrentAppAccess(
+  supabase: SupabaseBillingClient,
+  lookup: { userId: string; email?: string | null },
+  now: Date = new Date(),
+): Promise<boolean> {
+  const current = await findCurrentBillingSubscriptionForUser(supabase, lookup.userId, now)
+  if (current) return true
+
+  const manualGrant = await findCurrentManualAccessGrant(supabase, lookup, now)
+  if (manualGrant) return true
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("subscription_status, current_period_end")
+    .eq("id", lookup.userId)
+    .maybeSingle()
+
+  if (error) throw error
+  const profile = data as LegacyProfileSubscription | null
+  return profile ? hasCurrentLegacyProfileAccess(profile, now) : false
+}
+
+export async function findCurrentManualAccessGrant(
+  supabase: SupabaseBillingClient,
+  lookup: { userId?: string | null; email?: string | null },
+  now: Date = new Date(),
+): Promise<ManualAccessGrantRow | null> {
+  const grants: ManualAccessGrantRow[] = []
+
+  if (lookup.userId) {
+    const { data, error } = await supabase
+      .from("manual_access_grants")
+      .select("id, user_id, email, expires_at, revoked_at")
+      .eq("user_id", lookup.userId)
+
+    if (error) throw error
+    grants.push(...((data as ManualAccessGrantRow[] | null) ?? []))
+  }
+
+  const email = lookup.email?.trim().toLowerCase()
+  if (email) {
+    const { data, error } = await supabase
+      .from("manual_access_grants")
+      .select("id, user_id, email, expires_at, revoked_at")
+      .eq("email", email)
+
+    if (error) throw error
+    grants.push(...((data as ManualAccessGrantRow[] | null) ?? []))
+  }
+
+  const current = grants.filter((grant) => hasCurrentManualAccess(grant, now))
+  current.sort((left, right) => compareNullableIsoDesc(left.expires_at, right.expires_at))
+  return current[0] ?? null
+}
+
+export function hasCurrentManualAccess(
+  grant: Pick<ManualAccessGrantRow, "expires_at" | "revoked_at">,
+  now: Date = new Date(),
+): boolean {
+  if (grant.revoked_at) return false
+  return !grant.expires_at || isFutureIso(grant.expires_at, now)
 }
 
 export function hasCurrentBillingAccess(

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 import { getAuthenticatedAppRedirect, resolveIntakeState } from "@/lib/auth/intake-state"
+import { findCurrentManualAccessGrant } from "@/lib/billing/subscriptions"
 import { getUnauthenticatedRedirectTarget } from "@/lib/auth/unauthenticated-redirect"
 
 export async function updateSession(request: NextRequest) {
@@ -161,6 +162,18 @@ export async function updateSession(request: NextRequest) {
         legacyStatus === "active" ||
         legacyStatus === "past_due" ||
         (legacyStatus === "canceled" && Number.isFinite(legacyPeriodEnd) && legacyPeriodEnd > now)
+    }
+
+    if (!active) {
+      const manualGrant = await findCurrentManualAccessGrant(
+        supabase,
+        { userId: user.id, email: user.email },
+        new Date(now),
+      ).catch((error) => {
+        console.warn("[billing] manual access grant check failed", error)
+        return null
+      })
+      active = Boolean(manualGrant)
     }
 
     if (!active) {

--- a/supabase/migrations/20260602120000_add_manual_access_grants.sql
+++ b/supabase/migrations/20260602120000_add_manual_access_grants.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS manual_access_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES profiles (id) ON DELETE CASCADE,
+  email text,
+  reason text NOT NULL CHECK (reason IN ('friend', 'tester', 'admin', 'support')),
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (user_id IS NOT NULL OR email IS NOT NULL),
+  CHECK (email IS NULL OR email = lower(email)),
+  CHECK (expires_at IS NULL OR expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_manual_access_grants_user_id
+  ON manual_access_grants (user_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_manual_access_grants_email
+  ON manual_access_grants (email)
+  WHERE email IS NOT NULL AND revoked_at IS NULL;
+
+CREATE TRIGGER set_updated_at_manual_access_grants
+  BEFORE UPDATE ON manual_access_grants
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE manual_access_grants ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own manual access grants"
+  ON manual_access_grants
+  FOR SELECT
+  TO authenticated
+  USING (
+    auth.uid() = user_id
+    OR (
+      email IS NOT NULL
+      AND lower(auth.jwt() ->> 'email') = email
+    )
+  );
+
+COMMENT ON TABLE manual_access_grants IS
+  'Internal non-payment Premium access grants for friends, testers, support, and admin use.';
+COMMENT ON COLUMN manual_access_grants.email IS
+  'Lowercase email address. Allows granting access before the profile row is linked.';
+COMMENT ON COLUMN manual_access_grants.expires_at IS
+  'Null means indefinite-time manual access. Set revoked_at to remove access immediately.';

--- a/tests/billing-paypal-server.test.ts
+++ b/tests/billing-paypal-server.test.ts
@@ -4,7 +4,10 @@ import test from "node:test"
 import {
   assertCanStartCheckout,
   assertCanStartCheckoutForEmail,
+  findCurrentManualAccessGrant,
   findCurrentBillingSubscriptionForUser,
+  hasCurrentAppAccess,
+  hasCurrentManualAccess,
   upsertBillingSubscription,
 } from "../src/lib/billing/subscriptions"
 import type { SupabaseBillingClient } from "../src/lib/billing/types"
@@ -53,8 +56,24 @@ function pastIso() {
   return new Date(Date.now() - 86_400_000).toISOString()
 }
 
+function sqlLikePatternToRegExp(pattern: string) {
+  let source = "^"
+  for (const char of pattern) {
+    if (char === "%") {
+      source += ".*"
+    } else if (char === "_") {
+      source += "."
+    } else {
+      source += char.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
+    }
+  }
+  source += "$"
+  return new RegExp(source, "i")
+}
+
 function createSupabaseStub(seed?: {
   billing?: Partial<BillingSubscriptionRow>[]
+  manualGrants?: Array<Record<string, unknown>>
   profiles?: Record<string, Record<string, unknown>>
   authUsers?: Record<string, { id: string; email: string; app_metadata?: Record<string, unknown> }>
   paypalIntents?: Array<Record<string, unknown>>
@@ -76,6 +95,7 @@ function createSupabaseStub(seed?: {
     created_at: row.created_at ?? new Date().toISOString(),
     updated_at: row.updated_at ?? new Date().toISOString(),
   }))
+  const manualGrants = seed?.manualGrants ?? []
   const profiles = seed?.profiles ?? {}
   const authUsers = seed?.authUsers ?? {}
   const paypalIntents = seed?.paypalIntents ?? []
@@ -93,6 +113,7 @@ function createSupabaseStub(seed?: {
 
     function rows() {
       if (table === "billing_subscriptions") return billing
+      if (table === "manual_access_grants") return manualGrants
       if (table === "profiles") return Object.values(profiles)
       if (table === "paypal_checkout_intents") return paypalIntents
       return []
@@ -104,8 +125,8 @@ function createSupabaseStub(seed?: {
           if (filter.op === "eq") return row[filter.column] === filter.value
           if (filter.op === "is") return row[filter.column] === filter.value
           if (filter.op === "ilike") {
-            return (
-              String(row[filter.column] ?? "").toLowerCase() === String(filter.value).toLowerCase()
+            return sqlLikePatternToRegExp(String(filter.value)).test(
+              String(row[filter.column] ?? ""),
             )
           }
           if (filter.op === "in") return (filter.value as unknown[]).includes(row[filter.column])
@@ -272,6 +293,7 @@ function createSupabaseStub(seed?: {
   return {
     calls,
     billing,
+    manualGrants,
     profiles,
     authUsers,
     paypalIntents,
@@ -374,6 +396,80 @@ test("upsertBillingSubscription preserves optional fields during partial status 
   assert.equal(billing[0].interval, "quarter")
   assert.equal(billing[0].current_period_end, periodEnd)
   assert.deepEqual(billing[0].metadata, { plan_id: "P-quarter" })
+})
+
+test("hasCurrentManualAccess only allows unrevoked and unexpired grants", () => {
+  const now = new Date("2026-06-02T10:00:00.000Z")
+
+  assert.equal(hasCurrentManualAccess({ expires_at: null, revoked_at: null }, now), true)
+  assert.equal(
+    hasCurrentManualAccess({ expires_at: "2026-06-03T10:00:00.000Z", revoked_at: null }, now),
+    true,
+  )
+  assert.equal(
+    hasCurrentManualAccess({ expires_at: "2026-06-01T10:00:00.000Z", revoked_at: null }, now),
+    false,
+  )
+  assert.equal(
+    hasCurrentManualAccess(
+      {
+        expires_at: "2026-06-03T10:00:00.000Z",
+        revoked_at: "2026-06-02T09:00:00.000Z",
+      },
+      now,
+    ),
+    false,
+  )
+})
+
+test("findCurrentManualAccessGrant finds user and email grants case-insensitively", async () => {
+  const now = new Date("2026-06-02T10:00:00.000Z")
+  const { supabase } = createSupabaseStub({
+    manualGrants: [
+      {
+        id: "expired",
+        user_id: "user-1",
+        email: "expired@example.com",
+        expires_at: "2026-06-01T10:00:00.000Z",
+        revoked_at: null,
+      },
+      {
+        id: "email-grant",
+        user_id: null,
+        email: "friend@example.com",
+        expires_at: null,
+        revoked_at: null,
+      },
+    ],
+  })
+
+  assert.equal(await findCurrentManualAccessGrant(supabase, { userId: "user-1" }, now), null)
+  assert.deepEqual(
+    await findCurrentManualAccessGrant(supabase, { email: "Friend@Example.com" }, now),
+    {
+      id: "email-grant",
+      user_id: null,
+      email: "friend@example.com",
+      expires_at: null,
+      revoked_at: null,
+    },
+  )
+})
+
+test("findCurrentManualAccessGrant treats grant emails as exact values, not LIKE patterns", async () => {
+  const { supabase } = createSupabaseStub({
+    manualGrants: [
+      {
+        id: "underscore-grant",
+        user_id: null,
+        email: "axb@example.com",
+        expires_at: null,
+        revoked_at: null,
+      },
+    ],
+  })
+
+  assert.equal(await findCurrentManualAccessGrant(supabase, { email: "a_b@example.com" }), null)
 })
 
 test("findCurrentBillingSubscriptionForUser prefers active before past_due before future paid-through canceled", async () => {
@@ -504,6 +600,23 @@ test("assertCanStartCheckout allows incomplete rows so users can retry checkout"
   await assert.doesNotReject(() => assertCanStartCheckout(supabase, "user-1"))
 })
 
+test("assertCanStartCheckout blocks users with active manual grants", async () => {
+  const { supabase } = createSupabaseStub({
+    profiles: { "user-1": { id: "user-1", subscription_status: null } },
+    manualGrants: [
+      {
+        id: "grant-1",
+        user_id: "user-1",
+        email: "friend@example.com",
+        expires_at: null,
+        revoked_at: null,
+      },
+    ],
+  })
+
+  await assert.rejects(() => assertCanStartCheckout(supabase, "user-1"), /already has access/)
+})
+
 test("assertCanStartCheckoutForEmail blocks lead checkout for an already subscribed profile", async () => {
   const { supabase } = createSupabaseStub({
     billing: [{ user_id: "user-1", entitlement_status: "active" }],
@@ -515,6 +628,58 @@ test("assertCanStartCheckoutForEmail blocks lead checkout for an already subscri
   await assert.rejects(
     () => assertCanStartCheckoutForEmail(supabase, "paid@example.com"),
     /already has access/,
+  )
+})
+
+test("assertCanStartCheckoutForEmail blocks active manual grants before a profile exists", async () => {
+  const { supabase } = createSupabaseStub({
+    manualGrants: [
+      {
+        id: "grant-1",
+        user_id: null,
+        email: "friend@example.com",
+        expires_at: null,
+        revoked_at: null,
+      },
+    ],
+  })
+
+  await assert.rejects(
+    () => assertCanStartCheckoutForEmail(supabase, "Friend@Example.com"),
+    /already has access/,
+  )
+})
+
+test("hasCurrentAppAccess accepts paid, legacy, and manual access sources", async () => {
+  const paid = createSupabaseStub({
+    billing: [{ user_id: "paid-user", entitlement_status: "active" }],
+    profiles: { "paid-user": { id: "paid-user", subscription_status: null } },
+  })
+  assert.equal(await hasCurrentAppAccess(paid.supabase, { userId: "paid-user" }), true)
+
+  const legacy = createSupabaseStub({
+    profiles: { "legacy-user": { id: "legacy-user", subscription_status: "past_due" } },
+  })
+  assert.equal(await hasCurrentAppAccess(legacy.supabase, { userId: "legacy-user" }), true)
+
+  const manual = createSupabaseStub({
+    profiles: { "manual-user": { id: "manual-user", subscription_status: null } },
+    manualGrants: [
+      {
+        id: "grant-1",
+        user_id: null,
+        email: "friend@example.com",
+        expires_at: null,
+        revoked_at: null,
+      },
+    ],
+  })
+  assert.equal(
+    await hasCurrentAppAccess(manual.supabase, {
+      userId: "manual-user",
+      email: "Friend@Example.com",
+    }),
+    true,
   )
 })
 
@@ -1444,6 +1609,27 @@ test("Stripe checkout lead-email conflict uses provider-neutral access guard", a
   const response = await createStripeCheckoutEmailAccessConflictResponse(
     active.supabase,
     "paid@example.com",
+  )
+
+  assert.equal(response?.status, 409)
+})
+
+test("Stripe checkout email conflict blocks email-only manual grants", async () => {
+  const active = createSupabaseStub({
+    manualGrants: [
+      {
+        id: "grant-1",
+        user_id: null,
+        email: "friend@example.com",
+        expires_at: null,
+        revoked_at: null,
+      },
+    ],
+  })
+
+  const response = await createStripeCheckoutEmailAccessConflictResponse(
+    active.supabase,
+    "Friend@Example.com",
   )
 
   assert.equal(response?.status, 409)

--- a/tests/result-page-client.test.tsx
+++ b/tests/result-page-client.test.tsx
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { renderToStaticMarkup } from "react-dom/server"
+
+import { ResultPageClient } from "../src/app/result/[leadId]/result-client"
+import type { QuizAnswers } from "../src/lib/quiz/types"
+
+const quizAnswers: QuizAnswers = {
+  structure: "wavy",
+  thickness: "normal",
+  fingertest: "leicht_uneben",
+  pulltest: "stretches_bounces",
+  concerns: ["dryness"],
+  goals: ["shine"],
+}
+
+test("result page client sends manually granted users to onboarding instead of the paid offer", () => {
+  const html = renderToStaticMarkup(
+    <ResultPageClient
+      leadId="11111111-1111-4111-8111-111111111111"
+      name="Lea"
+      quizAnswers={quizAnswers}
+      focusRoutine={false}
+      hasAccess
+    />,
+  )
+
+  assert.match(html, /SO KOMMEN WIR DEINEM HAARZIEL NÄHER/i)
+  assert.match(html, /href="\/onboarding\?lead=11111111-1111-4111-8111-111111111111"/)
+  assert.doesNotMatch(html, /Angebot:/i)
+})


### PR DESCRIPTION
## Summary
Adds a dedicated manual access path for selected users without pretending they paid through Stripe or PayPal. The intended flow is: create/invite the Supabase auth user, insert a manual access grant for their email, then send them through the normal auth -> quiz -> onboarding -> chat journey.

## Behavior
- Adds a `manual_access_grants` table with RLS, expiry/revocation fields, indexes, and `updated_at` maintenance.
- Lets billing access checks include active manual grants by user id or exact normalized email.
- Prevents manually granted users from starting checkout, including signed-in users whose grant exists only by email.
- Unlocks the quiz result and persistent result page for manually granted users so they can continue to onboarding.
- Keeps first `/chat` access gated by the existing intake requirement, so users are redirected to `/quiz` before chat renders.

## Verification
- `npm run typecheck`
- `npx tsx --test tests/billing-paypal-server.test.ts tests/result-page-client.test.tsx`
- `git diff --check`
- `npm run test:node`
- `npm run lint` (passes with existing warnings in unrelated files)
- `npm run build`

## Notes / risks
- Auth users still need to exist first because `/auth` uses magic links with `shouldCreateUser: false`.
- This PR does not add an admin UI or bulk-import command; initial grants are expected to be inserted via SQL/Supabase CLI.
- GitHub reports existing Dependabot vulnerabilities on the default branch; this change does not touch dependency versions.