### PR TITLE
fix(billing): keep checkout alive during manual grant schema drift

### DIFF
--- a/src/lib/billing/subscriptions.ts
+++ b/src/lib/billing/subscriptions.ts
@@ -203,7 +203,10 @@ export async function findCurrentManualAccessGrant(
       .select("id, user_id, email, expires_at, revoked_at")
       .eq("user_id", lookup.userId)
 
-    if (error) throw error
+    if (error) {
+      if (isMissingManualAccessGrantsTableError(error)) return null
+      throw error
+    }
     grants.push(...((data as ManualAccessGrantRow[] | null) ?? []))
   }
 
@@ -214,13 +217,24 @@ export async function findCurrentManualAccessGrant(
       .select("id, user_id, email, expires_at, revoked_at")
       .eq("email", email)
 
-    if (error) throw error
+    if (error) {
+      if (isMissingManualAccessGrantsTableError(error)) return null
+      throw error
+    }
     grants.push(...((data as ManualAccessGrantRow[] | null) ?? []))
   }
 
   const current = grants.filter((grant) => hasCurrentManualAccess(grant, now))
   current.sort((left, right) => compareNullableIsoDesc(left.expires_at, right.expires_at))
   return current[0] ?? null
+}
+
+function isMissingManualAccessGrantsTableError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const candidate = error as { code?: unknown; message?: unknown }
+  const code = typeof candidate.code === "string" ? candidate.code : ""
+  const message = typeof candidate.message === "string" ? candidate.message : ""
+  return (code === "PGRST205" || code === "42P01") && message.includes("manual_access_grants")
 }
 
 export function hasCurrentManualAccess(

--- a/tests/billing-paypal-server.test.ts
+++ b/tests/billing-paypal-server.test.ts
@@ -74,11 +74,13 @@ function sqlLikePatternToRegExp(pattern: string) {
 function createSupabaseStub(seed?: {
   billing?: Partial<BillingSubscriptionRow>[]
   manualGrants?: Array<Record<string, unknown>>
+  tableErrors?: Record<string, { code?: string; message: string }>
   profiles?: Record<string, Record<string, unknown>>
   authUsers?: Record<string, { id: string; email: string; app_metadata?: Record<string, unknown> }>
   paypalIntents?: Array<Record<string, unknown>>
 }) {
   const calls: Array<Record<string, unknown>> = []
+  const tableErrors = seed?.tableErrors ?? {}
   const billing: BillingSubscriptionRow[] = (seed?.billing ?? []).map((row, index) => ({
     id: row.id ?? `billing-${index + 1}`,
     user_id: row.user_id ?? "user-1",
@@ -153,6 +155,9 @@ function createSupabaseStub(seed?: {
     }
 
     async function resolveRows() {
+      const tableError = tableErrors[table]
+      if (tableError) return { data: null, error: tableError }
+
       if (state.op === "update" && state.patch) {
         const matched = applyFilters(rows() as Record<string, unknown>[])
         for (const row of matched) Object.assign(row, state.patch)
@@ -275,11 +280,13 @@ function createSupabaseStub(seed?: {
         return builder
       },
       maybeSingle: async () => {
-        const { data } = await resolveRows()
+        const { data, error } = await resolveRows()
+        if (error) return { data: null, error }
         return { data: data[0] ?? null, error: null }
       },
       single: async () => {
-        const { data } = await resolveRows()
+        const { data, error } = await resolveRows()
+        if (error) return { data: null, error }
         return { data: data[0] ?? null, error: null }
       },
       then(resolve: (value: unknown) => void, reject: (error: unknown) => void) {
@@ -1633,6 +1640,24 @@ test("Stripe checkout email conflict blocks email-only manual grants", async () 
   )
 
   assert.equal(response?.status, 409)
+})
+
+test("Stripe checkout email conflict ignores missing manual grants table", async () => {
+  const active = createSupabaseStub({
+    tableErrors: {
+      manual_access_grants: {
+        code: "PGRST205",
+        message: "Could not find the table 'public.manual_access_grants' in the schema cache",
+      },
+    },
+  })
+
+  const response = await createStripeCheckoutEmailAccessConflictResponse(
+    active.supabase,
+    "friend@example.com",
+  )
+
+  assert.equal(response, null)
 })
 
 test("getPayPalPlanId reads interval-specific server env vars", () => {


### PR DESCRIPTION
## Summary
Production checkout failed after the manual access grant deploy because the application queried `manual_access_grants` before the production database migration had been applied. The DB migration has since been applied and checkout is returning 200 again, but this patch prevents the optional manual-grant lookup from taking checkout down during schema drift.

## Behavior
- Treats only missing-table errors for `manual_access_grants` (`PGRST205` / `42P01`) as “no manual grant”.
- Keeps all other Supabase errors fail-closed.
- Adds a regression test for Stripe checkout email conflict detection when PostgREST cannot see `manual_access_grants`.

## Verification
- Reproduced production failure mode with a failing regression test.
- `npx tsx --test tests/billing-paypal-server.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `git diff --check`
- `npm run test:node`
- `npm run build`

## Production note
The immediate incident was fixed by applying the missing Supabase migration. A production retest of `/api/stripe/create-checkout-session` returned HTTP 200 with a Checkout client secret.