### PR TITLE
Fix PayPal checkout email identity

### DIFF
--- a/docs/superpowers/specs/2026-06-03-paypal-email-identity-design.md
+++ b/docs/superpowers/specs/2026-06-03-paypal-email-identity-design.md
@@ -1,0 +1,234 @@
+# PayPal Email Identity Design
+
+## Reader Line
+
+This spec defines how Chaarlie should separate the user's Chaarlie login email from the PayPal subscriber email, prevent duplicate subscriptions by Chaarlie account identity, and make the PayPal welcome flow understandable when the two emails differ.
+
+## User Situation
+
+A user can complete the Chaarlie quiz with one email and pay through PayPal with another email. Today the PayPal activation path creates or finds the app account by the PayPal subscriber email, even when the checkout intent already has the quiz/lead email. That can leave the user expecting access under the quiz email while the actual account exists under the PayPal email.
+
+The concrete support case was:
+
+- Quiz/lead email: `rikku-07@web.de`
+- PayPal/app profile email created today: `scheer_stefanie@gmx.de`
+- Billing subscription: active
+- Lead and hair profile: linked
+- Auth sign-in: never completed
+- Onboarding: not completed
+
+## Promised End-State
+
+For future PayPal purchases, the Chaarlie account/login/contact email is the email Chaarlie already knows from the quiz lead or authenticated account. The PayPal subscriber email is stored only as payment-provider metadata for support/admin visibility. Normal checkout remains visually unchanged. If a duplicate active subscription is detected for the Chaarlie email, checkout is interrupted with a modal and a direct login link. If PayPal and Chaarlie emails differ, the welcome page shows the distinction briefly and uses the Chaarlie email for password creation and magic links.
+
+## Terms
+
+- **Chaarlie-E-Mail**: the app login, account, and Chaarlie communication email. Stored on `profiles.email` and in Supabase Auth.
+- **PayPal-E-Mail**: the PayPal subscriber/account email returned by PayPal. Stored for support/billing reference only.
+- **Chaarlie checkout email**: the checkout-context email, usually `paypal_checkout_intents.email` from the quiz lead or authenticated account.
+- **Provider subscriber email**: provider-neutral storage field for payment-provider account email, planned as `billing_subscriptions.provider_subscriber_email`.
+
+## Locked Decisions
+
+- `profiles.email` remains the Chaarlie login/contact email.
+- For PayPal checkout from a quiz lead, `paypal_checkout_intents.email` remains the Chaarlie/lead email.
+- PayPal subscriber email is stored on `billing_subscriptions.provider_subscriber_email`.
+- Chaarlie sends login, onboarding, support, and subscription emails only to the Chaarlie email.
+- PayPal can send its own automatic receipts/subscription emails to the PayPal email; Chaarlie does not contact that email separately.
+- PayPal email alone must not block checkout. One PayPal account may pay for multiple Chaarlie accounts.
+- Duplicate active-subscription blocking is provider-neutral and based on the Chaarlie email/account, not PayPal email.
+- If the same Chaarlie email somehow creates a second active PayPal subscription after approval, the duplicate can be canceled/marked duplicate.
+- PayPal activation must use Chaarlie identity on both activation paths: the `/welcome` token path and the PayPal webhook-first path.
+- Normal checkout/payment UI should not gain explanatory copy.
+- The duplicate interruption is a modal/dialog overlay.
+- `/auth?email=...` should prefill the auth email field but never auto-send a login link.
+- The welcome page shows PayPal email only when it differs from the Chaarlie email.
+- Users cannot edit the login email on the PayPal success/welcome page. Wrong-email cases route to support.
+- Existing completed/onboarded users are not silently migrated. Support can manually fix users like Stefanie if needed.
+
+## Current-State Audit Notes
+
+Canceled PayPal rows with `cancel_at_period_end = true` and future `current_period_end` still have paid-through access. The real canceled users inspected had signed in, created passwords, completed onboarding, added routine products, and used conversations. They should not be bulk-migrated just because their subscription renewal was canceled.
+
+Stefanie is the clear paid-but-not-activated case: no sign-in, no password, onboarding still at `welcome`, no routine products, and no conversations.
+
+## Scope
+
+In scope:
+
+- Add provider subscriber email storage.
+- Use Chaarlie/lead email for PayPal account activation when available, including webhook-first activation.
+- Store PayPal subscriber email separately.
+- Remove duplicate blocking/cancellation based only on PayPal subscriber email.
+- Keep duplicate blocking by Chaarlie account/email.
+- Add provider-neutral duplicate modal with login link.
+- Preserve existing `/auth?email=` prefill and add regression coverage.
+- Add minimal welcome page email distinction for PayPal mismatch cases.
+- Add admin/support display for Chaarlie email and PayPal email.
+- Include tests for duplicate guards, activation identity choice, and welcome/auth UI behavior.
+
+Out of scope:
+
+- Bulk migration of existing onboarded users.
+- Allowing users to edit login email during PayPal welcome.
+- Sending Chaarlie emails to PayPal subscriber email.
+- New refund tooling beyond existing duplicate PayPal cancellation behavior for true same-Chaarlie-email duplicates.
+- Rebuilding the full checkout/payment layout.
+
+## UX Mockups
+
+### Normal Checkout
+
+No added explanatory copy.
+
+```text
+[ PayPal Button ]
+
+[ Karte / SEPA anzeigen ]
+```
+
+### Provider-Neutral Duplicate Modal
+
+Shown when the Chaarlie email/account already has active or paid-through access. Applies to Stripe, PayPal, and future providers.
+
+```text
+┌──────────────────────────────────────────────┐
+│ Aktives Abo gefunden                         │
+│                                              │
+│ Für diese Chaarlie-E-Mail gibt es bereits    │
+│ ein aktives Abo.                             │
+│                                              │
+│ rikku-07@web.de                              │
+│                                              │
+│ Bitte melde dich mit dieser E-Mail an,       │
+│ um dein Abo zu nutzen.                       │
+│                                              │
+│ [Einloggen]                       [Schließen]│
+└──────────────────────────────────────────────┘
+```
+
+Primary button:
+
+```text
+Einloggen -> /auth?email=rikku-07%40web.de
+```
+
+Fallback when email is unknown:
+
+```text
+┌──────────────────────────────────────────────┐
+│ Aktives Abo gefunden                         │
+│                                              │
+│ Für dieses Konto gibt es bereits ein         │
+│ aktives Abo.                                 │
+│                                              │
+│ Bitte melde dich an, um dein Abo zu nutzen.  │
+│                                              │
+│ [Einloggen]                       [Schließen]│
+└──────────────────────────────────────────────┘
+```
+
+Primary button:
+
+```text
+Einloggen -> /auth
+```
+
+### PayPal Welcome, Same Email
+
+```text
+Zahlung erfolgreich
+
+Konto aktivieren
+
+Chaarlie-E-Mail
+rikku-07@web.de
+
+[ Passwort erstellen ]
+
+[ Login-Link senden ]
+```
+
+### PayPal Welcome, Different Emails
+
+```text
+Zahlung erfolgreich
+
+Konto aktivieren
+
+Chaarlie-E-Mail
+rikku-07@web.de
+
+PayPal-E-Mail
+scheer_stefanie@gmx.de
+
+[ Passwort erstellen ]
+
+[ Login-Link senden ]
+```
+
+No extra paragraph is required in the normal state. If the design needs a tiny clarification below the PayPal line, keep it restrained:
+
+```text
+Die PayPal-E-Mail nutzen wir nur zur Zahlungszuordnung.
+```
+
+### Auth Page With Prefill
+
+```text
+Einloggen
+
+E-Mail
+rikku-07@web.de
+
+[ Passwort ]
+
+[ Einloggen ]
+
+[ Login-Link per E-Mail senden ]
+```
+
+The page must not auto-send a link.
+
+### Admin/Support Display
+
+```text
+Chaarlie-E-Mail
+rikku-07@web.de
+
+PayPal-E-Mail
+scheer_stefanie@gmx.de
+
+Abo
+Aktiv bis 02.09.2026
+```
+
+For paid-through canceled access, do not show only `canceled`. Use:
+
+```text
+Verlängerung gekündigt, Zugang bis 03.07.2026
+```
+
+## Source Of Truth
+
+- Account/login/contact identity: `profiles.email` plus Supabase Auth user email.
+- Checkout-context identity before payment: `paypal_checkout_intents.email`.
+- Payment-provider identity after payment: `billing_subscriptions.provider_subscriber_email`.
+- Entitlement/access: `billing_subscriptions` current access logic plus `profiles` mirror.
+- Quiz linkage: `paypal_checkout_intents.lead_id` and `leads.user_id`.
+
+## Edge Cases
+
+- Missing lead email: fallback to authenticated user email, then PayPal subscriber email only if no Chaarlie-side email exists.
+- Existing Chaarlie email has active access: block checkout before provider opens where possible, show modal.
+- Existing PayPal email has active access on another Chaarlie account: allow checkout; store/flag only for support.
+- Same Chaarlie email races through two PayPal approvals: keep one entitlement and cancel/mark duplicate for the later true duplicate.
+- PayPal webhook arrives before `/welcome`: use the bound checkout intent email as Chaarlie account email; do not create the account under PayPal email just because the webhook won the race.
+- Existing onboarded mismatch users: leave login unchanged unless support explicitly decides to migrate.
+
+## Open Risks
+
+- Supabase Auth email updates for one-off support fixes need careful handling and should not be part of this feature's automatic runtime path.
+- `provider_subscriber_email` backfill for existing PayPal subscriptions may require PayPal API retrieval if the email is not already present in current local records.
+- Stripe may later want its own provider subscriber email semantics, but this plan only needs PayPal now.
+- Later PayPal webhook payloads may omit `subscriber.email_address`; implementation must preserve an already stored `provider_subscriber_email` instead of overwriting it with null.

--- a/plans/2026-06-03-paypal-email-identity.claude-review.md
+++ b/plans/2026-06-03-paypal-email-identity.claude-review.md
@@ -1,0 +1,52 @@
+I have enough grounding across all 8 tasks. Memory pre-check: `MEMORY.md` records the hard-paywall/subscription direction and the just-shipped manual access grants, but nothing that settles or contradicts PayPal identity decisions — no conflict. Here is the verdict.
+
+---
+
+**Verdict:** Approve with revisions — the architecture is correctly shaped, but **3 blockers must be fixed before this goes to a subagent**. Executed verbatim today it would (a) leave a real activation path on the wrong identity, (b) fail `npm run test:node`, and (c) write a conflicting auth prop against code that already does the job.
+
+---
+
+**Lean shape**
+
+- **Irreducible goal:** PayPal activation creates/links the app account under the *Chaarlie* email (intent/lead), stores the PayPal email as provider metadata only, and blocks duplicate checkout by Chaarlie identity (not PayPal email) with a modal + login link.
+- **Cut or defer:**
+  - **Task 4 (Auth Prefill) is ~90% already built.** `AuthForm` already accepts `defaultEmail` (`src/components/auth/auth-form.tsx:11,75`) and `src/app/auth/page.tsx:130` already passes `defaultEmail={searchParams.get("email") ?? undefined}` with no auto-send (magic link requires a button click, `auth-form.tsx:309-315`). Collapse Task 4 to "add a regression test" — do **not** add the new `initialEmail` prop or a server `searchParams` read (the page is a `"use client"` component using `useSearchParams()`, so the plan's Step 2/3 are wrong and would create a duplicate, conflicting prop).
+  - **Task 7 (audit/backfill scripts)** is already marked optional and is off the critical path — defer to a fast-follow.
+  - **Task 6 (admin visibility)** is a support nice-to-have and is under-specified ("Decide display surface during implementation") — trim or defer; it shouldn't gate the identity fix.
+- **Hard tradeoff the plan is avoiding:** PayPal activation has **two** entry points — the token path (`ensurePayPalCheckoutAccountForToken`) *and* the webhook (`webhook-handlers.ts:206`). The plan only addresses the token path. Threading the Chaarlie email through both callers is the actual hard part, and it's silently skipped.
+
+**Prior art**
+
+- **Provider-identity separation** (app identity vs payment-provider identity): matches the canonical shape — keep app login on `profiles.email`/Auth, store provider email as separate metadata. Grounded and correct.
+- **Duplicate prevention keyed on stable app identity, not provider-supplied identifier:** correct direction. **Missing invariant:** the key must be applied *consistently* across all three guard sites — `findPayPalCheckoutDuplicateReason` (`duplicate-guard.ts:32`), the activation-time guard `assertNoDifferentCurrentSubscription` (`checkout-activation.ts:175`), and the webhook (`webhook-handlers.ts:186`). The plan only names the first.
+- **Schema migration = additive expand:** nullable column, no backfill-then-contract needed, reversible. No feature flag required for an additive nullable column. Migration filename `20260603120000_…` correctly sorts after the latest (`20260602120000_…`). Good.
+- **Controlled dialog overlay:** `src/components/ui/dialog.tsx` exports `Dialog/DialogContent/DialogFooter/DialogTitle/DialogClose` with `open`/`onOpenChange` — the plan's `ActiveSubscriptionDialogProps` matches exactly. Grounded.
+
+**Blockers** (will fail or regress as written)
+
+1. **Webhook activation path is omitted — defeats the core goal on a real path.** `webhook-handlers.ts:206` calls `ensurePayPalCheckoutAccount(subscription, …)` directly (not the token wrapper) and can be the *first* to create the account if `BILLING.SUBSCRIPTION.ACTIVATED` lands before the user returns to `/welcome`. The plan's Target File Map and Tasks 2/3 never list `src/lib/paypal/webhook-handlers.ts`, so webhook-activated accounts would still be created under the PayPal email. **Fix:** add `src/lib/paypal/webhook-handlers.ts` to scope; set the Chaarlie account email from `boundIntent?.email` at the `:206` call site.
+
+2. **The identity snippet references a variable that isn't in scope.** Plan Task 2 Step 3 shows `const accountEmail = intent.email ?? valid.email` placed inside `ensurePayPalCheckoutAccount` — but `intent` does not exist there; only `subscription` + `deps` (`PayPalCheckoutActivationDeps`, `checkout-activation.ts:19-28`) are in scope. A subagent pasting this gets a compile error, or "fixes" it by only editing the token wrapper. **Fix:** add `accountEmail?: string | null` to `PayPalCheckoutActivationDeps`, set it in *both* `ensurePayPalCheckoutAccountForToken` (from `intent.email`, `:92`) and the webhook (from `boundIntent?.email`), then `const accountEmail = deps.accountEmail ?? valid.email` inside `ensurePayPalCheckoutAccount`.
+
+3. **Removing the PayPal-email duplicate branch breaks existing passing tests, and the plan never updates them.** Task 3 Step 2 deletes the `paypal_email_already_has_access` branch (`duplicate-guard.ts:46-53`), but `tests/billing-paypal-server.test.ts:809-816` explicitly asserts that reason (`"PayPal duplicate guard checks intent user, intent email, and provider email"`), with the literal reused at lines 839/854/868/875/882/888. Task 8 runs `npm run test:node`, which will fail. **Fix:** add `tests/billing-paypal-server.test.ts` to Task 3's file list and update/remove those assertions.
+
+**High-confidence issues** (correctness, not preference)
+
+- **The Stripe-side modal is in the wrong owner and is "Possibly edit," not optional.** The Stripe 409 is detected inside `fetchClientSecret`, which lives in **both** parents — `pricing-cards.tsx:76-79` and `result-offer-pricing.tsx:87-90` — each currently does `setCheckoutError(generic); throw`. `PaymentMethodCheckout` only receives `fetchClientSecret` as a prop and can't see the 409. So "prefer owning modal state in `PaymentMethodCheckout`" (Task 3 Step 5) can't capture the Stripe path without new callback plumbing from both parents. Both files are **required** edits, not "possibly," and each needs to parse `409 + body.email` and lift modal state. Also: with PayPal enabled the embedded card checkout is collapsed by default (`payment-method-checkout.tsx:55-56`), so the Stripe modal only fires after the user expands "Karte, SEPA & weitere" — call out that trigger timing.
+- **PayPal duplicate has two UX outcomes that the plan doesn't reconcile.** On approval-time duplicate, `paypal-subscription-button.tsx:89` currently `window.location.assign(buildPayPalWelcomeUrl(token))` → the full-page "Abo bereits aktiv" screen (`welcome-client.tsx:210-227`). Task 3 wants a modal instead. The plan must say whether the approval-duplicate redirect is replaced by the modal or kept; otherwise you ship two conflicting duplicate UIs. Also, neither `createSubscriptionIntent` (throws on 409, `:127`) nor `approveSubscriptionIntent` (`:151`) surfaces `body.email` today — both must parse it for the modal's `/auth?email=` link.
+- **Stripe 409 body has no `email` and the route exposes it inconsistently.** `create-checkout-session/route.ts` returns `{ error: "checkout_access_already_exists" }` with no email (`:143,:168`). To honor the mockup's email link you must add email at both conflict sites — but the user-id conflict (`:53`) only has `user.email`, while the lead conflict (`:76`) has `customerEmail`. Spell out which email each branch returns (matches the plan's "only context-known email" rule, but the code split isn't noted).
+- **`assertNoDifferentCurrentSubscription` already enforces Chaarlie-identity blocking but is never mentioned and is now mislabeled.** After the identity change it keys on the Chaarlie-email account's `userId` (`checkout-activation.ts:144,148,180`) — which is exactly the desired semantics — yet its error text says "PayPal subscriber email already has a current subscription" (`:186`). Note it in scope and fix the message, or the plan's claim that duplicate semantics move to Chaarlie identity is only half-true.
+
+**Smaller / nice-to-haves**
+
+- **`provider_subscriber_email` can be nulled out by later webhooks.** Task 2 Step 2 always emits `… ?? null`, so a `CANCELLED`/`EXPIRED` webhook whose payload lacks `subscriber.email_address` would overwrite a stored value (the merge-preserve in `upsertBillingSubscription:36-45` only helps when the *key is absent*, and it never will be). Either omit the key when null, or preserve `existing?.provider_subscriber_email` explicitly.
+- **`assertActivePayPalSubscription` hard-requires the PayPal email** (`checkout-activation.ts:211-217`), which contradicts the plan framing PayPal email as an optional "last fallback." Fine in practice (PayPal always sends it), but note the inconsistency so no one designs around an optional PayPal email.
+- **Task 6 admin query** currently selects `profiles, hair_profiles(*)` only (`api/admin/users/route.ts:32-34`); embedding `billing_subscriptions(...)` requires the PostgREST relationship to resolve. Specify the embed rather than "extend admin query."
+- **Task 1 Step 4 is accurate but worth pinning:** `findVisibleBillingSubscriptionForUser` uses an *explicit* select string (`subscriptions.ts:105-107`) so the new column must be added there; `findCurrentBillingSubscriptionForUser` uses `select("*")` (`:79`) and needs no change. The plan gets this right — keep it.
+- **i18n:** all new copy (modal, `Chaarlie-E-Mail`/`PayPal-E-Mail`, "Verlängerung gekündigt, Zugang bis …") is German and consistent with existing strings. Good.
+
+**Bottom line**
+
+The shape is right and most claims are well-grounded — but don't hand it to a subagent yet. Fix the three blockers first: (1) bring `webhook-handlers.ts` into scope and thread the Chaarlie email through it, (2) rewrite the identity snippet to pass `accountEmail` via `deps` from both callers instead of referencing an out-of-scope `intent`, and (3) add `tests/billing-paypal-server.test.ts` to the duplicate-guard task so `npm run test:node` stays green. Then tighten the Stripe/PayPal modal wiring (both parent components are required, reconcile the approval-duplicate redirect vs modal, add `email` to the 409 bodies) and collapse Task 4 to a verify-plus-test since the prefill already exists. With those, it's ready.
+
+Want me to spec the leaner Task 2/Task 4 counter-proposal (deps-threaded `accountEmail` across both activation callers, and the reduced auth-prefill task) so you can drop it straight into the plan?

--- a/plans/2026-06-03-paypal-email-identity.md
+++ b/plans/2026-06-03-paypal-email-identity.md
@@ -1,0 +1,722 @@
+# PayPal Email Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make PayPal checkout preserve the user's Chaarlie email as the login/contact identity, store the PayPal email only as support-visible provider metadata, and prevent duplicate subscriptions by Chaarlie account email across payment providers.
+
+**Architecture:** Keep `profiles.email`, Supabase Auth email, and checkout-intent email as the Chaarlie identity. Add `billing_subscriptions.provider_subscriber_email` for PayPal's subscriber email. Update PayPal activation to choose the Chaarlie email from the checkout intent/lead when available, while still storing the PayPal email on the billing row. Move duplicate-prevention semantics to Chaarlie identity only and surface duplicate access through a reusable checkout modal that links to `/auth?email=...`.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, Supabase Postgres/Auth, existing provider-neutral billing helpers, Stripe checkout, PayPal JS SDK and PayPal REST activation, existing `Dialog` UI component, node:test via `tsx`, existing Playwright/component test patterns where available.
+
+**Spec link:** `docs/superpowers/specs/2026-06-03-paypal-email-identity-design.md`
+
+**User situation:** A user can enter one email in the Chaarlie quiz and pay with a PayPal account that uses another email. Today PayPal activation can create the app login under the PayPal email, which surprises users and can block them from completing onboarding after payment.
+
+**Promised end-state:** A future PayPal buyer logs in with the email they gave Chaarlie. If PayPal uses another email, support can see it, but the user receives Chaarlie access and communication only through the Chaarlie email. If a Chaarlie email already has active or paid-through access, Stripe/PayPal checkout is blocked with a modal and a direct login link.
+
+**Branch:** `codex/paypal-email-identity-plan` in `.worktrees/paypal-email-identity-plan`.
+
+---
+
+## Locked Decisions
+
+- Chaarlie login/contact email is `profiles.email` and Supabase Auth email.
+- PayPal email is stored as `billing_subscriptions.provider_subscriber_email`.
+- `paypal_checkout_intents.email` remains the Chaarlie/lead email.
+- PayPal email never receives Chaarlie login, onboarding, or subscription communication.
+- PayPal email alone does not block checkout and can pay for multiple Chaarlie accounts.
+- Chaarlie email/account duplicate access blocks checkout across Stripe and PayPal.
+- The duplicate interruption is a modal/dialog overlay with a login link.
+- `/auth?email=...` pre-fills email only; it does not auto-send a login link.
+- The normal checkout payment area gets no new explanatory copy.
+- PayPal welcome shows PayPal email only when it differs from Chaarlie email.
+- Users cannot edit login email on PayPal welcome. Wrong-email cases go to support.
+- Existing onboarded users are not bulk-migrated.
+
+## Scope Boundaries
+
+In scope:
+
+- Schema migration for provider subscriber email.
+- PayPal activation identity selection.
+- PayPal subscriber email persistence.
+- Duplicate guard change to ignore PayPal email as a blocker.
+- Provider-neutral duplicate modal and login redirect.
+- Auth email query prefill.
+- Minimal PayPal welcome email display.
+- Admin/support display of Chaarlie email and PayPal email.
+- Tests for the core identity and duplicate behavior.
+
+Out of scope:
+
+- Automatic migration of existing completed/onboarded users.
+- User-editable login email on welcome.
+- Email sends to PayPal subscriber email.
+- New refund tooling beyond existing duplicate PayPal subscription cancellation.
+- Full checkout redesign.
+
+## Target File Map
+
+```
+supabase/migrations/20260603120000_add_provider_subscriber_email.sql
+  Add billing_subscriptions.provider_subscriber_email and optional comments.
+
+src/lib/billing/types.ts
+  Add provider_subscriber_email to billing input/row types.
+
+src/lib/billing/subscriptions.ts
+  Preserve/upsert provider_subscriber_email and return it in visible/current row helpers.
+
+src/lib/paypal/subscription-shapes.ts
+  Map PayPal subscriber.email_address into BillingSubscriptionInput.provider_subscriber_email.
+
+src/lib/paypal/checkout-activation.ts
+  Resolve Chaarlie account email from deps.accountEmail when available; store PayPal email separately.
+
+src/lib/paypal/webhook-handlers.ts
+  Pass bound PayPal checkout intent email into PayPal activation so webhook-first activation uses Chaarlie identity too.
+
+src/lib/paypal/duplicate-guard.ts
+src/app/api/paypal/approve-subscription/route.ts
+src/app/api/paypal/create-subscription-intent/route.ts
+  Keep duplicate checks by intent/user Chaarlie email; remove PayPal subscriber email as a blocker.
+
+src/app/api/stripe/create-checkout-session/route.ts
+src/components/checkout/payment-method-checkout.tsx
+src/components/checkout/paypal-subscription-button.tsx
+src/components/checkout/active-subscription-dialog.tsx
+src/app/pricing/pricing-cards.tsx
+src/components/quiz/result-offer-pricing.tsx
+  Return/display provider-neutral duplicate modal with login link.
+
+src/components/auth/auth-form.tsx
+src/app/auth/page.tsx
+  Existing /auth?email=... prefill is already implemented via defaultEmail; add regression coverage only.
+
+src/app/welcome/page.tsx
+src/app/welcome/welcome-client.tsx
+  Pass Chaarlie email and PayPal email separately; show minimal mismatch display.
+
+src/app/profile/page.tsx
+src/app/admin/users/page.tsx
+src/app/api/admin/users/route.ts
+  Display provider subscriber email for support/admin where billing context is already shown.
+
+tests/paypal-email-identity.test.ts
+tests/billing-paypal-server.test.ts
+tests/payment-duplicate-dialog.test.tsx
+tests/auth-email-prefill.test.tsx
+  Add focused coverage for identity choice, duplicate behavior, and UI states.
+```
+
+---
+
+## UX Mockups
+
+### Normal Checkout
+
+No new copy.
+
+```text
+[ PayPal Button ]
+
+[ Karte / SEPA anzeigen ]
+```
+
+### Duplicate Active Subscription Modal
+
+Use existing `src/components/ui/dialog.tsx`.
+
+```text
+┌──────────────────────────────────────────────┐
+│ Aktives Abo gefunden                         │
+│                                              │
+│ Für diese Chaarlie-E-Mail gibt es bereits    │
+│ ein aktives Abo.                             │
+│                                              │
+│ rikku-07@web.de                              │
+│                                              │
+│ Bitte melde dich mit dieser E-Mail an,       │
+│ um dein Abo zu nutzen.                       │
+│                                              │
+│ [Einloggen]                       [Schließen]│
+└──────────────────────────────────────────────┘
+```
+
+Button target:
+
+```text
+/auth?email=rikku-07%40web.de
+```
+
+Fallback if the email is not known:
+
+```text
+┌──────────────────────────────────────────────┐
+│ Aktives Abo gefunden                         │
+│                                              │
+│ Für dieses Konto gibt es bereits ein         │
+│ aktives Abo.                                 │
+│                                              │
+│ Bitte melde dich an, um dein Abo zu nutzen.  │
+│                                              │
+│ [Einloggen]                       [Schließen]│
+└──────────────────────────────────────────────┘
+```
+
+Button target:
+
+```text
+/auth
+```
+
+### PayPal Welcome, Same Email
+
+```text
+Zahlung erfolgreich
+
+Konto aktivieren
+
+Chaarlie-E-Mail
+rikku-07@web.de
+
+[ Passwort erstellen ]
+
+[ Login-Link senden ]
+```
+
+### PayPal Welcome, Different Emails
+
+```text
+Zahlung erfolgreich
+
+Konto aktivieren
+
+Chaarlie-E-Mail
+rikku-07@web.de
+
+PayPal-E-Mail
+scheer_stefanie@gmx.de
+
+[ Passwort erstellen ]
+
+[ Login-Link senden ]
+```
+
+Optional tiny helper only if needed after design review:
+
+```text
+Die PayPal-E-Mail nutzen wir nur zur Zahlungszuordnung.
+```
+
+### Auth Prefill
+
+```text
+Einloggen
+
+E-Mail
+rikku-07@web.de
+
+[ Passwort ]
+
+[ Einloggen ]
+
+[ Login-Link per E-Mail senden ]
+```
+
+No auto-send.
+
+### Admin/Support Email Display
+
+```text
+Chaarlie-E-Mail
+rikku-07@web.de
+
+PayPal-E-Mail
+scheer_stefanie@gmx.de
+
+Abo
+Aktiv bis 02.09.2026
+```
+
+Paid-through canceled wording:
+
+```text
+Verlängerung gekündigt, Zugang bis 03.07.2026
+```
+
+---
+
+## Task 1: Schema And Billing Types
+
+**Files:**
+- Create: `supabase/migrations/20260603120000_add_provider_subscriber_email.sql`
+- Edit: `src/lib/billing/types.ts`
+- Edit: `src/lib/billing/subscriptions.ts`
+- Test: `tests/paypal-email-identity.test.ts`
+
+- [ ] **Step 1: Add failing billing type/upsert tests**
+
+Create a focused server test for `upsertBillingSubscription` proving:
+
+- `provider_subscriber_email` is written on first insert.
+- `provider_subscriber_email` is updated when provider data changes.
+- Existing rows with no subscriber email remain valid.
+- `findVisibleBillingSubscriptionForUser` returns `provider_subscriber_email`.
+
+- [ ] **Step 2: Add migration**
+
+Create the migration:
+
+```sql
+ALTER TABLE billing_subscriptions
+  ADD COLUMN IF NOT EXISTS provider_subscriber_email text;
+
+COMMENT ON COLUMN billing_subscriptions.provider_subscriber_email IS
+  'Payment-provider subscriber/customer email for support reference only. Chaarlie login/contact email remains profiles.email.';
+```
+
+No index is required for V1 unless implementation later needs admin search by PayPal email.
+
+- [ ] **Step 3: Update billing types**
+
+Add `provider_subscriber_email: string | null` to `BillingSubscriptionRow`.
+
+Add optional `provider_subscriber_email?: string | null` to `BillingSubscriptionInput`.
+
+- [ ] **Step 4: Update billing helper upsert/selects**
+
+In `src/lib/billing/subscriptions.ts`:
+
+- Include `provider_subscriber_email` in the default row merge.
+- Ensure it does not get dropped by `upsertBillingSubscription`.
+- Add it to explicit select strings such as `findVisibleBillingSubscriptionForUser`.
+
+- [ ] **Step 5: Run focused tests**
+
+```bash
+npx tsx --test tests/paypal-email-identity.test.ts
+```
+
+Expected: new billing tests pass.
+
+---
+
+## Task 2: PayPal Identity Selection And Subscriber Email Storage
+
+**Files:**
+- Edit: `src/lib/paypal/subscription-shapes.ts`
+- Edit: `src/lib/paypal/checkout-activation.ts`
+- Edit: `src/lib/paypal/webhook-handlers.ts`
+- Edit: `src/lib/paypal/checkout-intents.ts` only if type naming needs clarification
+- Test: `tests/paypal-email-identity.test.ts`
+
+- [ ] **Step 1: Add failing activation tests**
+
+Cover these cases:
+
+- PayPal subscription email differs from checkout intent email.
+- The auth/profile account is created or found using the checkout intent email.
+- Webhook-first activation also creates/finds the auth/profile account using the checkout intent email.
+- The billing row stores PayPal email as `provider_subscriber_email`.
+- `paypal_checkout_intents.email` remains the Chaarlie/lead email.
+- Missing checkout intent email falls back to any caller-supplied Chaarlie account email if available, then PayPal subscriber email.
+
+- [ ] **Step 2: Map PayPal subscriber email into billing input**
+
+In `toBillingSubscriptionInputFromPayPal`, set:
+
+```ts
+provider_subscriber_email: subscription.subscriber?.email_address?.toLowerCase() ?? null
+```
+
+Preserve existing `provider_customer_id`, status, interval, and metadata behavior.
+
+Important: do not let later PayPal webhook payloads with no `subscriber.email_address` erase an existing stored subscriber email. Either omit `provider_subscriber_email` from the input when PayPal does not provide it, or preserve `existing.provider_subscriber_email` in `upsertBillingSubscription`.
+
+- [ ] **Step 3: Resolve Chaarlie email inside PayPal activation**
+
+Change `ensurePayPalCheckoutAccountForToken`, `ensurePayPalCheckoutAccount`, and the PayPal webhook caller so account lookup/creation uses a Chaarlie email resolved from:
+
+1. `deps.accountEmail` when present.
+2. PayPal subscriber email as last fallback.
+
+Keep PayPal subscriber email for provider data only.
+
+Add `accountEmail?: string | null` to `PayPalCheckoutActivationDeps`.
+
+Token-return path:
+
+```ts
+const result = await ensurePayPalCheckoutAccount(subscription, {
+  ...deps,
+  activationKey: token,
+  interval: intent.interval,
+  leadId: intent.lead_id,
+  accountEmail: intent.email ?? null,
+})
+```
+
+Webhook-first path:
+
+```ts
+const activation = await ensurePayPalCheckoutAccount(subscription, {
+  supabase: deps.supabase,
+  premiumTierId: deps.premiumTierId,
+  activationKey: boundIntent?.token,
+  interval: boundIntent?.interval ?? intervalFromMetadata(subscription),
+  leadId: boundIntent?.lead_id ?? null,
+  accountEmail: boundIntent?.email ?? null,
+  linkQuizToProfile: deps.linkQuizToProfile,
+})
+```
+
+Inside `ensurePayPalCheckoutAccount`, after validating the PayPal subscription:
+
+```ts
+const accountEmail = deps.accountEmail?.trim().toLowerCase() || valid.email
+```
+
+Use `accountEmail` for:
+
+- `findProfileByEmail`
+- `createPayPalCheckoutUser`
+- `upsertSubscriptionProfile(... email: accountEmail ...)`
+- returned activation `email`
+- `linkQuizToProfile(userId, accountEmail, leadId)`
+
+Use PayPal subscriber email only through `toBillingSubscriptionInputFromPayPal` and `provider_subscriber_email`.
+
+Also update the message in `assertNoDifferentCurrentSubscription`; after this change it is guarding the Chaarlie account, not the PayPal subscriber email.
+
+- [ ] **Step 4: Keep password activation tied to token**
+
+Ensure `canSetPasswordForPayPalSubscription` still validates `checkout_activation_session_hash` by token, not by email.
+
+- [ ] **Step 5: Run focused tests**
+
+```bash
+npx tsx --test tests/paypal-email-identity.test.ts
+```
+
+---
+
+## Task 3: Provider-Neutral Duplicate Blocking And Modal
+
+**Files:**
+- Edit: `src/lib/paypal/duplicate-guard.ts`
+- Edit: `src/app/api/paypal/create-subscription-intent/route.ts`
+- Edit: `src/app/api/paypal/approve-subscription/route.ts`
+- Edit: `src/app/api/stripe/create-checkout-session/route.ts`
+- Edit: `src/components/checkout/payment-method-checkout.tsx`
+- Edit: `src/components/checkout/paypal-subscription-button.tsx`
+- Create: `src/components/checkout/active-subscription-dialog.tsx`
+- Edit: `src/app/pricing/pricing-cards.tsx`
+- Edit: `src/components/quiz/result-offer-pricing.tsx`
+- Test: `tests/paypal-email-identity.test.ts`
+- Test: `tests/billing-paypal-server.test.ts`
+- Test: `tests/payment-duplicate-dialog.test.tsx`
+
+- [ ] **Step 1: Add duplicate guard tests**
+
+Cover:
+
+- Existing Chaarlie intent email access blocks PayPal checkout intent creation.
+- Existing PayPal subscriber email access does not block.
+- Post-approval duplicate for the same Chaarlie email can mark/cancel duplicate.
+- Post-approval same PayPal email with different Chaarlie email is allowed.
+
+- [ ] **Step 2: Remove PayPal subscriber email blocker**
+
+In `src/lib/paypal/duplicate-guard.ts`, remove the branch that returns duplicate solely because `subscription.subscriber.email_address` already has access.
+
+Keep:
+
+- `intent.user_id` already has access.
+- `intent.email` already has access.
+
+Update `tests/billing-paypal-server.test.ts` at the existing PayPal duplicate guard coverage so it no longer expects `paypal_email_already_has_access`. Add the inverse assertion: same PayPal email plus different Chaarlie intent email is allowed unless the Chaarlie email/user already has current access.
+
+- [ ] **Step 3: Return duplicate error with context email**
+
+For provider-neutral checkout-start endpoints, return a structured `409` body:
+
+```json
+{
+  "error": "checkout_access_already_exists",
+  "email": "rikku-07@web.de"
+}
+```
+
+Only include email that is already in checkout context:
+
+- authenticated user's email
+- lead/intent email
+
+Do not disclose a broad lookup result that the browser did not already know.
+
+Concrete route expectations:
+
+- `src/app/api/paypal/create-subscription-intent/route.ts`: return the authenticated user email or lead email already used to create/check the intent.
+- `src/app/api/stripe/create-checkout-session/route.ts`: return `user.email` for authenticated-user conflicts and `customerEmail` for lead/customer-email conflicts.
+- `src/app/api/paypal/approve-subscription/route.ts`: for same-Chaarlie-email duplicate after approval, return the bound intent email when available.
+
+- [ ] **Step 4: Create active subscription dialog**
+
+Create `src/components/checkout/active-subscription-dialog.tsx` using existing `Dialog` and `Button`.
+
+Props:
+
+```ts
+type ActiveSubscriptionDialogProps = {
+  open: boolean
+  email?: string | null
+  onOpenChange: (open: boolean) => void
+}
+```
+
+Dialog behavior:
+
+- If `email` exists, show the known-email copy and link to `/auth?email=${encodeURIComponent(email)}`.
+- Else show fallback copy and link to `/auth`.
+- Secondary action closes the dialog.
+
+- [ ] **Step 5: Wire modal into checkout UI**
+
+In PayPal and Stripe checkout start handlers:
+
+- If response status is `409` with `checkout_access_already_exists`, open modal instead of showing inline error.
+- Preserve existing non-duplicate errors.
+- Keep normal checkout UI unchanged.
+
+Required wiring:
+
+- PayPal: `PayPalSubscriptionButton` must parse `409` bodies from both create-intent and approve-subscription responses, surface the known context email, and open the modal instead of redirecting to the old duplicate welcome screen.
+- Stripe: the `fetchClientSecret` callbacks in `src/app/pricing/pricing-cards.tsx` and `src/components/quiz/result-offer-pricing.tsx` must parse `409` bodies and lift duplicate modal state. `PaymentMethodCheckout` receives `fetchClientSecret`, so it cannot see Stripe 409s without callback plumbing from both parents.
+- The Stripe modal triggers only after the user opens the collapsed card/SEPA checkout when PayPal is enabled; document that in manual verification.
+- The old PayPal approval duplicate redirect to `/welcome?provider=paypal&token=...` should be replaced by the modal for true same-Chaarlie-email duplicates. Keep the full-page duplicate welcome only as a defensive fallback for direct stale duplicate links.
+
+- [ ] **Step 6: Run duplicate/modal tests**
+
+```bash
+npx tsx --test tests/paypal-email-identity.test.ts tests/payment-duplicate-dialog.test.tsx
+```
+
+---
+
+## Task 4: Auth Prefill Regression Coverage
+
+**Files:**
+- Test: `tests/auth-email-prefill.test.tsx`
+
+- [ ] **Step 1: Confirm existing implementation**
+
+`/auth?email=...` is already implemented:
+
+- `src/app/auth/page.tsx` reads `useSearchParams()` client-side and passes `defaultEmail={searchParams.get("email") ?? undefined}`.
+- `src/components/auth/auth-form.tsx` accepts `defaultEmail?: string` and initializes local email state from it.
+- Magic link sending still requires an explicit button click.
+
+Do not add a second prop such as `initialEmail`.
+
+- [ ] **Step 2: Add auth prefill regression tests**
+
+Cover:
+
+- `/auth?email=rikku-07%40web.de` renders email input prefilled.
+- No magic link request is sent automatically.
+- User can still edit the email.
+
+- [ ] **Step 3: Run auth prefill tests**
+
+```bash
+npx tsx --test tests/auth-email-prefill.test.tsx
+```
+
+---
+
+## Task 5: PayPal Welcome Email Display
+
+**Files:**
+- Edit: `src/app/welcome/page.tsx`
+- Edit: `src/app/welcome/welcome-client.tsx`
+- Test: `tests/paypal-email-identity.test.ts`
+- Optional UI/component test if welcome already has a test harness
+
+- [ ] **Step 1: Add failing welcome tests**
+
+Cover:
+
+- Same Chaarlie/PayPal email: only Chaarlie email is shown.
+- Different emails: Chaarlie email and PayPal email are shown.
+- Password creation and login link requests still send to Chaarlie email only.
+
+- [ ] **Step 2: Pass both emails from server welcome**
+
+From PayPal activation, pass:
+
+```ts
+email={activation.email} // Chaarlie email
+providerSubscriberEmail={activation.providerSubscriberEmail}
+```
+
+If the activation result does not currently expose provider subscriber email, extend the result type.
+
+- [ ] **Step 3: Update welcome client display**
+
+Replace the single "E-Mail aus deinem Checkout" label with:
+
+```text
+Chaarlie-E-Mail
+```
+
+Show a second read-only field only if normalized emails differ:
+
+```text
+PayPal-E-Mail
+```
+
+Keep layout compact and avoid adding normal-checkout explanatory copy.
+
+- [ ] **Step 4: Keep account actions Chaarlie-email-only**
+
+Ensure `handleCreatePassword` signs in using the Chaarlie email returned by `/api/auth/set-checkout-password`.
+
+Ensure `handleMagicLink` calls `/api/auth/send-magic-link` with token/session only, and that the route resolves to the Chaarlie email.
+
+- [ ] **Step 5: Run welcome tests**
+
+```bash
+npx tsx --test tests/paypal-email-identity.test.ts
+```
+
+---
+
+## Task 6: Admin And Support Visibility
+
+**Files:**
+- Edit: `src/app/api/admin/users/route.ts`
+- Edit: `src/app/admin/users/page.tsx`
+- Edit: `src/app/profile/page.tsx` if billing section should show provider email for admins/users
+- Test: existing admin/user tests if present, otherwise add focused component/server tests
+
+- [ ] **Step 1: Decide display surface during implementation**
+
+Minimum required: admin/support user list or detail surface should show both:
+
+```text
+Chaarlie-E-Mail
+PayPal-E-Mail
+```
+
+If `src/app/admin/users/page.tsx` remains list-only, keep the list compact and add PayPal email only where a billing detail surface already exists. Do not make the user table unreadably wide.
+
+- [ ] **Step 2: Include billing subscription data in admin response**
+
+Extend admin query to include current/visible billing subscription rows, including `provider_subscriber_email`.
+
+Be explicit about PostgREST embedding. If `profiles` cannot embed `billing_subscriptions` cleanly in `src/app/api/admin/users/route.ts`, fetch current/visible billing rows separately by user IDs and merge them in the route response.
+
+- [ ] **Step 3: Show paid-through canceled wording**
+
+Where subscription status appears, display:
+
+```text
+Verlängerung gekündigt, Zugang bis {date}
+```
+
+when `entitlement_status = canceled`, `cancel_at_period_end = true`, and `current_period_end` is future.
+
+- [ ] **Step 4: Run admin/profile tests or manual checks**
+
+Use tests if available; otherwise include browser/manual verification in Task 8.
+
+---
+
+## Task 7: Existing Data Backfill And Support Handling
+
+**Files:**
+- Create optional: `scripts/paypal/audit-email-identity.ts`
+- Create optional: `supabase/manual-test-backfills/20260603_provider_subscriber_email_backfill.sql`
+- Do not modify production data automatically from application runtime.
+
+- [ ] **Step 1: Add audit script or documented SQL**
+
+Produce a dry-run report for PayPal rows:
+
+```text
+user_id
+profile.email
+linked lead email
+provider_subscription_id
+provider_subscriber_email
+onboarding_completed
+last_sign_in_at
+current_access
+recommended action
+```
+
+- [ ] **Step 2: Backfill provider_subscriber_email where safely known**
+
+For newly processed PayPal subscriptions, runtime writes the field.
+
+For existing rows, either:
+
+- retrieve PayPal subscription details and write `subscriber.email_address`, or
+- leave null until the next webhook/activation touch if API backfill is not worth the risk.
+
+Do not infer PayPal email from `profiles.email` for mismatched rows without a PayPal API confirmation.
+
+- [ ] **Step 3: Document support handling for Stefanie-like cases**
+
+Support/manual fix path:
+
+- If user never signed in and lead email has no existing auth/profile conflict, support may change Supabase Auth email and `profiles.email` to the lead email.
+- Preserve billing subscription, hair profile, lead link, and access state.
+- Send magic login link to the Chaarlie email.
+
+No automatic migration for completed/onboarded users.
+
+---
+
+## Task 8: Verification
+
+**Automated checks:**
+
+- [ ] Run focused tests:
+
+```bash
+npx tsx --test tests/paypal-email-identity.test.ts tests/payment-duplicate-dialog.test.tsx tests/auth-email-prefill.test.tsx
+```
+
+- [ ] Run broader payment/auth tests relevant to touched files:
+
+```bash
+npm run test:node
+npm run test:playwright:contracts
+```
+
+If full contract suite is too broad for the execution branch, at minimum run existing Stripe/PayPal/billing/auth focused tests and document skipped suites.
+
+**Manual/browser checks:**
+
+- [ ] Quiz lead email equals PayPal email: PayPal welcome shows only Chaarlie-E-Mail and activation works.
+- [ ] Quiz lead email differs from PayPal email: account is created under lead email, PayPal email is shown only on welcome, and login link/password activation uses lead email.
+- [ ] Existing Chaarlie email has active access: PayPal checkout start shows modal and does not open PayPal.
+- [ ] Existing Chaarlie email has active access: Stripe checkout start shows the same modal and does not start Stripe checkout.
+- [ ] `/auth?email=rikku-07%40web.de` pre-fills email and does not auto-send.
+- [ ] Admin/support can see Chaarlie email and PayPal email.
+- [ ] Paid-through canceled subscription displays "Verlängerung gekündigt, Zugang bis ..." instead of a bare canceled state.
+
+**Readiness gate:**
+
+- [ ] Run `ready-check` before shipping because this touches checkout, auth, onboarding, copy, and trust.
+- [ ] Request Claude review against this plan and the mockups before implementation or before PR, per user request.
+
+## Implementation Notes
+
+- Keep the normal checkout page visually unchanged.
+- Do not add an email chooser on welcome.
+- Do not disclose broad matched-account emails in duplicate responses.
+- Do not block checkout merely because PayPal subscriber email has access elsewhere.
+- Treat `billing_subscriptions` as the entitlement source of truth; `profiles` remains the access mirror.

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useState } from "react"
 import { useToast } from "@/providers/toast-provider"
 import type { Profile, HairProfile } from "@/lib/types"
+import type { BillingSubscriptionRow } from "@/lib/billing/types"
 import { fehler, HAIR_TEXTURE_LABELS } from "@/lib/vocabulary"
 
 interface UserWithHairProfile extends Profile {
   hair_profiles?: HairProfile[]
+  current_billing_subscription?: BillingSubscriptionRow | null
 }
 
 export default function AdminUsersPage() {
@@ -56,6 +58,13 @@ export default function AdminUsersPage() {
     return parts.length > 0 ? parts.join(" / ") : null
   }
 
+  function getPayPalEmail(user: UserWithHairProfile): string | null {
+    const subscriberEmail = user.current_billing_subscription?.provider_subscriber_email?.trim()
+    if (!subscriberEmail) return null
+    if (subscriberEmail.toLowerCase() === user.email?.trim().toLowerCase()) return null
+    return subscriberEmail
+  }
+
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
@@ -79,7 +88,7 @@ export default function AdminUsersPage() {
             <thead>
               <tr className="border-b bg-muted/50">
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">Name</th>
-                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Email</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Kontakt</th>
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">Admin</th>
                 <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                   Haarprofil
@@ -92,6 +101,7 @@ export default function AdminUsersPage() {
             <tbody>
               {users.map((user) => {
                 const hairSummary = getHairSummary(user)
+                const paypalEmail = getPayPalEmail(user)
                 return (
                   <tr
                     key={user.id}
@@ -100,7 +110,24 @@ export default function AdminUsersPage() {
                     <td className="px-4 py-3 font-medium text-foreground">
                       {user.full_name || "—"}
                     </td>
-                    <td className="px-4 py-3 text-muted-foreground">{user.email}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      <div className="space-y-1">
+                        <div>
+                          <p className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground/70">
+                            Chaarlie-E-Mail
+                          </p>
+                          <p>{user.email}</p>
+                        </div>
+                        {paypalEmail ? (
+                          <div>
+                            <p className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground/70">
+                              PayPal-E-Mail
+                            </p>
+                            <p>{paypalEmail}</p>
+                          </div>
+                        ) : null}
+                      </div>
+                    </td>
                     <td className="px-4 py-3">
                       <span
                         className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,6 +1,12 @@
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { hasCurrentBillingAccess } from "@/lib/billing/subscriptions"
+import type { BillingSubscriptionRow } from "@/lib/billing/types"
 import { ERR_UNAUTHORIZED, ERR_FORBIDDEN, fehler } from "@/lib/vocabulary"
 import { NextResponse } from "next/server"
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
 
 export async function GET(request: Request) {
   const supabase = await createClient()
@@ -19,28 +25,79 @@ export async function GET(request: Request) {
     .single()
 
   if (!profile?.is_admin) {
-    return NextResponse.json(
-      { error: ERR_FORBIDDEN },
-      { status: 403 }
-    )
+    return NextResponse.json({ error: ERR_FORBIDDEN }, { status: 403 })
   }
 
   const { searchParams } = new URL(request.url)
-  const limit = parseInt(searchParams.get("limit") || "50")
-  const offset = parseInt(searchParams.get("offset") || "0")
+  const limit = parseBoundedInteger(searchParams.get("limit"), DEFAULT_LIMIT, 1, MAX_LIMIT)
+  const offset = parseBoundedInteger(searchParams.get("offset"), 0, 0)
 
-  const { data: users, count, error } = await supabase
+  const {
+    data: users,
+    count,
+    error,
+  } = await supabase
     .from("profiles")
     .select("*, hair_profiles(*)", { count: "exact" })
     .order("created_at", { ascending: false })
     .range(offset, offset + limit - 1)
 
   if (error) {
-    return NextResponse.json(
-      { error: fehler("Laden", "der Benutzer") },
-      { status: 500 }
-    )
+    return NextResponse.json({ error: fehler("Laden", "der Benutzer") }, { status: 500 })
   }
 
-  return NextResponse.json({ users: users || [], total: count || 0 })
+  const userRows = users || []
+  let billingByUserId: Map<string, BillingSubscriptionRow>
+  try {
+    billingByUserId = await loadVisibleBillingByUserId(userRows.map((row) => row.id))
+  } catch (billingError) {
+    console.error("[admin.users] billing lookup failed:", billingError)
+    return NextResponse.json({ error: fehler("Laden", "der Abo-Daten") }, { status: 500 })
+  }
+
+  return NextResponse.json({
+    users: userRows.map((row) => ({
+      ...row,
+      current_billing_subscription: billingByUserId.get(row.id) ?? null,
+    })),
+    total: count || 0,
+  })
+}
+
+async function loadVisibleBillingByUserId(userIds: string[]) {
+  const billingByUserId = new Map<string, BillingSubscriptionRow>()
+  if (userIds.length === 0) return billingByUserId
+
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from("billing_subscriptions")
+    .select(
+      "id, user_id, provider, provider_customer_id, provider_subscriber_email, provider_subscription_id, provider_status, entitlement_status, interval, current_period_end, cancel_at_period_end, cancelled_at, metadata, created_at, updated_at",
+    )
+    .in("user_id", userIds)
+    .in("entitlement_status", ["active", "past_due", "canceled"])
+    .order("current_period_end", { ascending: false })
+
+  if (error) throw error
+
+  for (const row of ((data as BillingSubscriptionRow[] | null) ?? []).filter((candidate) =>
+    hasCurrentBillingAccess(candidate),
+  )) {
+    if (!billingByUserId.has(row.user_id)) {
+      billingByUserId.set(row.user_id, row)
+    }
+  }
+
+  return billingByUserId
+}
+
+function parseBoundedInteger(
+  value: string | null,
+  fallback: number,
+  min: number,
+  max?: number,
+): number {
+  const parsed = value === null ? fallback : Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.min(Math.max(parsed, min), max ?? parsed)
 }

--- a/src/app/api/paypal/approve-subscription/route.ts
+++ b/src/app/api/paypal/approve-subscription/route.ts
@@ -16,8 +16,8 @@ import {
 } from "@/lib/paypal/subscriptions"
 import {
   cancelAndMarkPayPalDuplicate,
+  buildPayPalDuplicateCheckoutBody,
   findPayPalCheckoutDuplicateReason,
-  PAYPAL_DUPLICATE_CHECKOUT_COPY,
   PayPalDuplicateCancellationError,
 } from "@/lib/paypal/duplicate-guard"
 
@@ -49,10 +49,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "paypal token mismatch" }, { status: 400 })
   }
   if (intent.status === "duplicate") {
-    return NextResponse.json(
-      { error: "checkout_access_already_exists", message: PAYPAL_DUPLICATE_CHECKOUT_COPY },
-      { status: 409 },
-    )
+    return createPayPalDuplicateCheckoutResponse(intent)
   }
   if (intent.provider_subscription_id && intent.provider_subscription_id !== subscription.id) {
     return NextResponse.json({ error: "paypal subscription mismatch" }, { status: 400 })
@@ -67,7 +64,7 @@ export async function POST(request: Request) {
       admin,
       token,
       subscription.id,
-      getPayPalSubscriberEmail(subscription),
+      intent.email ?? getPayPalSubscriberEmail(subscription),
     )
     return NextResponse.json({ ok: true, token })
   }
@@ -112,13 +109,16 @@ export async function POST(request: Request) {
       }
       throw error
     }
-    return NextResponse.json(
-      { error: "checkout_access_already_exists", message: PAYPAL_DUPLICATE_CHECKOUT_COPY },
-      { status: 409 },
-    )
+    return createPayPalDuplicateCheckoutResponse(boundIntent)
   }
 
   return NextResponse.json({ ok: true, token })
+}
+
+export function createPayPalDuplicateCheckoutResponse(
+  intent: Pick<PayPalCheckoutIntentRow, "email" | "lead_id">,
+): NextResponse<ReturnType<typeof buildPayPalDuplicateCheckoutBody>> {
+  return NextResponse.json(buildPayPalDuplicateCheckoutBody(intent), { status: 409 })
 }
 
 function getPayPalSubscriberEmail(subscription: PayPalSubscription): string | null {

--- a/src/app/api/paypal/create-subscription-intent/route.ts
+++ b/src/app/api/paypal/create-subscription-intent/route.ts
@@ -45,26 +45,35 @@ export async function POST(request: Request) {
   } = await supabase.auth.getUser()
 
   if (user?.id) {
-    const conflict = await toConflictResponse(assertCanStartCheckout(admin, user.id))
+    const conflict = await toConflictResponse(assertCanStartCheckout(admin, user.id), user.email)
     if (conflict) return conflict
   }
 
   let email = user?.email ?? null
+  let resolvedLeadId: string | null = null
+  let canExposeConflictEmail = Boolean(user?.email)
   if (leadId) {
     const { data, error } = await admin.from("leads").select("email").eq("id", leadId).maybeSingle()
     if (error) throw error
-    email = typeof data?.email === "string" ? data.email : email
+    if (typeof data?.email === "string") {
+      email = data.email
+      resolvedLeadId = leadId
+    }
+    canExposeConflictEmail = false
   }
 
   if (email) {
-    const conflict = await toConflictResponse(assertCanStartCheckoutForEmail(admin, email))
+    const conflict = await toConflictResponse(
+      assertCanStartCheckoutForEmail(admin, email),
+      canExposeConflictEmail ? email : null,
+    )
     if (conflict) return conflict
   }
 
   const intent = await createPayPalCheckoutIntent(admin, {
     interval: interval as BillingInterval,
     source: source as PayPalCheckoutSource,
-    leadId: leadId ?? null,
+    leadId: resolvedLeadId,
     email,
     userId: user?.id ?? null,
   })
@@ -74,13 +83,17 @@ export async function POST(request: Request) {
 
 async function toConflictResponse(
   promise: Promise<void>,
-): Promise<NextResponse<{ error: typeof ACCESS_CONFLICT_ERROR }> | null> {
+  email?: string | null,
+): Promise<NextResponse<{ error: typeof ACCESS_CONFLICT_ERROR; email?: string }> | null> {
   try {
     await promise
     return null
   } catch (error) {
     if (error instanceof Error && error.message.includes("already has access")) {
-      return NextResponse.json({ error: ACCESS_CONFLICT_ERROR }, { status: 409 })
+      return NextResponse.json(
+        { error: ACCESS_CONFLICT_ERROR, ...(email ? { email } : {}) },
+        { status: 409 },
+      )
     }
     throw error
   }

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -17,7 +17,7 @@ const BodySchema = z.object({
 })
 
 export async function POST(req: NextRequest) {
-  const parsed = BodySchema.safeParse(await req.json())
+  const parsed = BodySchema.safeParse(await req.json().catch(() => null))
   if (!parsed.success) {
     return NextResponse.json({ error: "bad request" }, { status: 400 })
   }
@@ -32,6 +32,7 @@ export async function POST(req: NextRequest) {
   // Priority: leadId email → authed user's stripe_customer_id → authed user's email → 400
   let customerId: string | undefined
   let customerEmail: string | undefined
+  let resolvedLeadId: string | null = null
 
   const cookieStore = await cookies()
   const supabase = createServerClient(
@@ -53,6 +54,7 @@ export async function POST(req: NextRequest) {
     const conflictResponse = await createStripeCheckoutAccessConflictResponse(
       adminSupabase,
       authenticatedUserId,
+      user.email,
     )
     if (conflictResponse) return conflictResponse
     if (user?.email) {
@@ -66,22 +68,27 @@ export async function POST(req: NextRequest) {
 
   if (leadId) {
     const adminSupabase = createBillingAdminClient()
-    const { data } = await adminSupabase
+    const { data, error } = await adminSupabase
       .from("leads")
       .select("email")
       .eq("id", leadId)
       .maybeSingle()
+    if (error) throw error
     customerEmail = data?.email ?? undefined
     if (customerEmail) {
+      resolvedLeadId = leadId
       const conflictResponse = await createStripeCheckoutEmailAccessConflictResponse(
         adminSupabase,
         customerEmail,
+        { includeEmail: false },
       )
       if (conflictResponse) return conflictResponse
     }
-  } else {
-    // Resubscribe / direct-entry path — lock to the authenticated user's identity
-    if (user) {
+  }
+
+  if (!customerId && !customerEmail) {
+    // Resubscribe, direct-entry, or stale lead path — lock to the authenticated user's identity.
+    if (user?.id) {
       const { data: profile } = await supabase
         .from("profiles")
         .select("stripe_customer_id")
@@ -125,7 +132,7 @@ export async function POST(req: NextRequest) {
       },
     },
     ...(discountCouponId ? { discounts: [{ coupon: discountCouponId }] } : {}),
-    metadata: leadId ? { lead_id: leadId } : undefined,
+    metadata: resolvedLeadId ? { lead_id: resolvedLeadId } : undefined,
   })
 
   return NextResponse.json({ client_secret: session.client_secret })
@@ -134,13 +141,20 @@ export async function POST(req: NextRequest) {
 export async function createStripeCheckoutEmailAccessConflictResponse(
   supabase: Parameters<typeof assertCanStartCheckoutForEmail>[0],
   email: string,
-): Promise<NextResponse<{ error: "checkout_access_already_exists" }> | null> {
+  options: { includeEmail?: boolean } = {},
+): Promise<NextResponse<{ error: "checkout_access_already_exists"; email?: string }> | null> {
   try {
     await assertCanStartCheckoutForEmail(supabase, email)
     return null
   } catch (error) {
     if (error instanceof Error && error.message.includes("already has access")) {
-      return NextResponse.json({ error: "checkout_access_already_exists" }, { status: 409 })
+      return NextResponse.json(
+        {
+          error: "checkout_access_already_exists",
+          ...(options.includeEmail === false ? {} : { email }),
+        },
+        { status: 409 },
+      )
     }
     throw error
   }
@@ -159,13 +173,17 @@ function createBillingAdminClient() {
 export async function createStripeCheckoutAccessConflictResponse(
   supabase: Parameters<typeof assertCanStartCheckout>[0],
   userId: string,
-): Promise<NextResponse<{ error: "checkout_access_already_exists" }> | null> {
+  email?: string | null,
+): Promise<NextResponse<{ error: "checkout_access_already_exists"; email?: string }> | null> {
   try {
     await assertCanStartCheckout(supabase, userId)
     return null
   } catch (error) {
     if (error instanceof Error && error.message.includes("already has access")) {
-      return NextResponse.json({ error: "checkout_access_already_exists" }, { status: 409 })
+      return NextResponse.json(
+        { error: "checkout_access_already_exists", ...(email ? { email } : {}) },
+        { status: 409 },
+      )
     }
     throw error
   }

--- a/src/app/pricing/pricing-cards.tsx
+++ b/src/app/pricing/pricing-cards.tsx
@@ -7,6 +7,11 @@ import {
   isPayPalCheckoutEnabled,
   PaymentMethodCheckout,
 } from "@/components/checkout/payment-method-checkout"
+import {
+  ActiveSubscriptionDialog,
+  isCheckoutAccessAlreadyExistsResponse,
+  readCheckoutAccessAlreadyExistsEmail,
+} from "@/components/checkout/active-subscription-dialog"
 import { trackAppEvent } from "@/lib/analytics/track-app-event"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 import { getStripePricingPlan, STRIPE_PRICING_PLANS } from "@/lib/stripe/pricing-plans"
@@ -35,6 +40,8 @@ export function PricingCards({
       ? checkoutStartError
       : null,
   )
+  const [duplicateEmail, setDuplicateEmail] = useState<string | null>(null)
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
 
   useEffect(() => {
     trackAppEvent("pricing_viewed", {
@@ -74,6 +81,13 @@ export function PricingCards({
       }),
     })
     if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      if (isCheckoutAccessAlreadyExistsResponse(res, body)) {
+        setCheckoutError(null)
+        setDuplicateEmail(readCheckoutAccessAlreadyExistsEmail(body))
+        setDuplicateDialogOpen(true)
+        throw new Error("checkout access already exists")
+      }
       setCheckoutError(checkoutStartError)
       throw new Error("failed to create checkout session")
     }
@@ -103,6 +117,11 @@ export function PricingCards({
 
   return (
     <div className="space-y-8">
+      <ActiveSubscriptionDialog
+        email={duplicateEmail}
+        onOpenChange={setDuplicateDialogOpen}
+        open={duplicateDialogOpen}
+      />
       {/* Plan cards always visible; selected card is visually emphasised */}
       <div className="grid gap-6 md:grid-cols-3">
         {PLANS.map((plan) => {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { ManageSubscriptionButton } from "@/components/profile/manage-subscription-button"
+import { formatBillingDate, formatBillingMembershipStatus } from "@/lib/billing/display"
 import { findVisibleBillingSubscriptionForUser } from "@/lib/billing/subscriptions"
 import type { BillingSubscriptionRow } from "@/lib/billing/types"
 import { PRODUCT_CATEGORY_LABELS, PRODUCT_CATEGORY_ORDER } from "@/lib/onboarding/product-options"
@@ -252,7 +253,7 @@ function toggleConcern(currentValues: ProfileConcern[], concern: ProfileConcern)
 }
 
 function formatNullableDate(value: string | null | undefined): string {
-  return value ? new Date(value).toLocaleDateString("de-DE") : "—"
+  return formatBillingDate(value)
 }
 
 function createProductRows(rows: UserProductUsageRow[]): ProductDetailRow[] {
@@ -1912,7 +1913,10 @@ export default function ProfilePage() {
                 <p className="mb-1 text-sm text-muted-foreground">
                   Status:{" "}
                   <strong className="text-foreground">
-                    {billingSubscription?.entitlement_status ?? profile?.subscription_status ?? "—"}
+                    {formatBillingMembershipStatus(
+                      billingSubscription,
+                      profile?.subscription_status,
+                    )}
                   </strong>
                 </p>
                 <p className="mb-4 text-sm text-muted-foreground">

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation"
+import { createHash } from "node:crypto"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
@@ -99,6 +100,7 @@ async function renderPayPalWelcome(token: string | undefined) {
     return (
       <WelcomeClient
         activationSource={{ provider: "paypal", token }}
+        analyticsId={paypalCheckoutAnalyticsId(token)}
         mode="duplicate"
         purchase={null}
       />
@@ -109,6 +111,7 @@ async function renderPayPalWelcome(token: string | undefined) {
     return (
       <WelcomeClient
         activationSource={{ provider: "paypal", token }}
+        analyticsId={paypalCheckoutAnalyticsId(token)}
         mode="pending"
         purchase={null}
       />
@@ -124,7 +127,9 @@ async function renderPayPalWelcome(token: string | undefined) {
     return (
       <WelcomeClient
         activationSource={{ provider: "paypal", token }}
+        analyticsId={paypalCheckoutAnalyticsId(token)}
         email={activation.email}
+        providerSubscriberEmail={activation.providerSubscriberEmail}
         purchase={null}
         redirectTo="/onboarding"
       />
@@ -134,8 +139,14 @@ async function renderPayPalWelcome(token: string | undefined) {
   return (
     <WelcomeClient
       activationSource={{ provider: "paypal", token }}
+      analyticsId={paypalCheckoutAnalyticsId(token)}
       email={activation.email}
+      providerSubscriberEmail={activation.providerSubscriberEmail}
       purchase={null}
     />
   )
+}
+
+function paypalCheckoutAnalyticsId(token: string): string {
+  return `paypal:${createHash("sha256").update(token).digest("hex").slice(0, 16)}`
 }

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -11,7 +11,9 @@ import { createClient } from "@/lib/supabase/client"
 import { CheckoutReturnAnalytics } from "./checkout-return-analytics"
 
 interface WelcomeClientProps {
+  analyticsId?: string
   email?: string
+  providerSubscriberEmail?: string | null
   purchase: CheckoutPurchaseAnalytics | null
   redirectTo?: string
   sessionId?: string
@@ -35,7 +37,9 @@ const MAGIC_LINK_BODY =
   "Wir senden dir einen sicheren Login-Link. Du klickst ihn im Postfach an und bist direkt angemeldet."
 
 export function WelcomeClient({
+  analyticsId: providedAnalyticsId,
   email,
+  providerSubscriberEmail,
   purchase,
   redirectTo,
   sessionId,
@@ -44,8 +48,13 @@ export function WelcomeClient({
 }: WelcomeClientProps) {
   const router = useRouter()
   const supabase = createClient()
-  const analyticsId = sessionId ?? activationSourceId(activationSource)
+  const analyticsId = providedAnalyticsId ?? sessionId ?? activationSourceId(activationSource)
   const requestBody = useMemo(() => activationRequestBody(activationSource), [activationSource])
+  const paypalActivationToken =
+    activationSource.provider === "paypal" ? activationSource.token : null
+  const showProviderSubscriberEmail =
+    Boolean(providerSubscriberEmail?.trim()) &&
+    providerSubscriberEmail?.trim().toLowerCase() !== email?.trim().toLowerCase()
 
   const [state, setState] = useState<ScreenState>({ view: "choice" })
   const [loading, setLoading] = useState<LoadingState>(null)
@@ -55,8 +64,8 @@ export function WelcomeClient({
   const [highlightMagicLink, setHighlightMagicLink] = useState(false)
 
   useEffect(() => {
-    if (mode !== "pending" || activationSource.provider !== "paypal") return
-    const { token } = activationSource
+    if (mode !== "pending" || !paypalActivationToken) return
+    const token = paypalActivationToken
 
     let cancelled = false
     let attempts = 0
@@ -94,7 +103,7 @@ export function WelcomeClient({
       cancelled = true
       if (timer) clearTimeout(timer)
     }
-  }, [activationSource, mode])
+  }, [mode, paypalActivationToken])
 
   async function handleCreatePassword(e: FormEvent) {
     e.preventDefault()
@@ -266,17 +275,36 @@ export function WelcomeClient({
             </div>
           </div>
 
-          <div className="mx-auto w-full max-w-md space-y-2">
-            <label htmlFor="checkout-email" className="text-sm font-medium text-foreground">
-              E-Mail aus deinem Checkout
-            </label>
-            <Input
-              id="checkout-email"
-              value={email ?? ""}
-              readOnly
-              aria-readonly="true"
-              className="h-11 bg-muted/60 text-center"
-            />
+          <div className="mx-auto w-full max-w-md space-y-3">
+            <div className="space-y-2">
+              <label htmlFor="checkout-email" className="text-sm font-medium text-foreground">
+                Chaarlie-E-Mail
+              </label>
+              <Input
+                id="checkout-email"
+                value={email ?? ""}
+                readOnly
+                aria-readonly="true"
+                className="h-11 bg-muted/60 text-center"
+              />
+            </div>
+            {showProviderSubscriberEmail ? (
+              <div className="space-y-2">
+                <label
+                  htmlFor="provider-subscriber-email"
+                  className="text-sm font-medium text-foreground"
+                >
+                  PayPal-E-Mail
+                </label>
+                <Input
+                  id="provider-subscriber-email"
+                  value={providerSubscriberEmail?.trim() ?? ""}
+                  readOnly
+                  aria-readonly="true"
+                  className="h-11 bg-muted/60 text-center"
+                />
+              </div>
+            ) : null}
           </div>
 
           {message && (
@@ -387,7 +415,7 @@ function activationRequestBody(source: CheckoutActivationSource): Record<string,
 }
 
 function activationSourceId(source: CheckoutActivationSource): string {
-  if (source.provider === "paypal") return `paypal:${source.token}`
+  if (source.provider === "paypal") return "paypal:checkout"
   return source.sessionId
 }
 

--- a/src/components/checkout/active-subscription-dialog.tsx
+++ b/src/components/checkout/active-subscription-dialog.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import Link from "next/link"
+
+import { Button, buttonVariants } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+export type ActiveSubscriptionDialogProps = {
+  open: boolean
+  email?: string | null
+  onOpenChange: (open: boolean) => void
+}
+
+export const checkoutAccessAlreadyExistsError = "checkout_access_already_exists"
+
+export function isCheckoutAccessAlreadyExistsResponse(response: Response, body: unknown): boolean {
+  return (
+    response.status === 409 &&
+    typeof body === "object" &&
+    body !== null &&
+    (body as { error?: unknown }).error === checkoutAccessAlreadyExistsError
+  )
+}
+
+export function readCheckoutAccessAlreadyExistsEmail(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null
+  const email = (body as { email?: unknown }).email
+  return typeof email === "string" && email.trim() ? email.trim() : null
+}
+
+export function ActiveSubscriptionDialog({
+  open,
+  email,
+  onOpenChange,
+}: ActiveSubscriptionDialogProps) {
+  const normalizedEmail = email?.trim() || null
+  const loginHref = normalizedEmail ? `/auth?email=${encodeURIComponent(normalizedEmail)}` : "/auth"
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="mx-4 max-w-md rounded-[8px]">
+        <DialogHeader>
+          <DialogTitle>Aktives Abo gefunden</DialogTitle>
+          <DialogDescription>
+            {normalizedEmail
+              ? "Für diese Chaarlie-E-Mail gibt es bereits ein aktives Abo."
+              : "Für dieses Konto gibt es bereits ein aktives Abo."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {normalizedEmail ? (
+          <p className="rounded-[8px] border border-border bg-muted/60 px-3 py-2 text-center text-sm font-semibold text-foreground">
+            {normalizedEmail}
+          </p>
+        ) : null}
+
+        <p className="text-sm leading-6 text-muted-foreground">
+          {normalizedEmail
+            ? "Bitte melde dich mit dieser E-Mail an, um dein Abo zu nutzen."
+            : "Bitte melde dich an, um dein Abo zu nutzen."}
+        </p>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Schließen
+          </Button>
+          <Link className={buttonVariants()} href={loginHref}>
+            Einloggen
+          </Link>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/checkout/paypal-subscription-button.tsx
+++ b/src/components/checkout/paypal-subscription-button.tsx
@@ -6,10 +6,21 @@ import type { CreateSubscriptionActions, OnApproveData } from "@paypal/paypal-js
 
 import type { BillingInterval } from "@/lib/stripe/intervals"
 import type { PayPalCheckoutSource } from "@/lib/paypal/checkout-intents"
+import {
+  ActiveSubscriptionDialog,
+  checkoutAccessAlreadyExistsError,
+  isCheckoutAccessAlreadyExistsResponse,
+  readCheckoutAccessAlreadyExistsEmail,
+} from "./active-subscription-dialog"
 
 const paypalStartError = "PayPal-Zahlung konnte nicht gestartet werden. Bitte versuche es erneut."
-const duplicateAccessError =
-  "Für diese E-Mail gibt es bereits ein aktives Abo. Bitte melde dich mit deinem bestehenden Konto an."
+
+class CheckoutAccessAlreadyExistsError extends Error {
+  constructor(readonly email?: string | null) {
+    super(checkoutAccessAlreadyExistsError)
+    this.name = "CheckoutAccessAlreadyExistsError"
+  }
+}
 
 export function buildPayPalWelcomeUrl(token: string) {
   const params = new URLSearchParams({
@@ -31,7 +42,10 @@ export function PayPalSubscriptionButton({
   source: PayPalCheckoutSource
 }) {
   const [error, setError] = useState<string | null>(null)
+  const [duplicateEmail, setDuplicateEmail] = useState<string | null>(null)
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const intentTokenRef = useRef<string | null>(null)
+  const suppressNextPayPalErrorRef = useRef(false)
   const clientId = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID?.trim()
 
   if (!clientId) {
@@ -44,6 +58,11 @@ export function PayPalSubscriptionButton({
 
   return (
     <div>
+      <ActiveSubscriptionDialog
+        email={duplicateEmail}
+        onOpenChange={setDuplicateDialogOpen}
+        open={duplicateDialogOpen}
+      />
       <PayPalScriptProvider
         options={{
           clientId,
@@ -73,6 +92,12 @@ export function PayPalSubscriptionButton({
                 },
               } as Parameters<CreateSubscriptionActions["subscription"]["create"]>[0])
             } catch (err) {
+              if (err instanceof CheckoutAccessAlreadyExistsError) {
+                suppressNextPayPalErrorRef.current = true
+                setDuplicateEmail(err.email ?? null)
+                setDuplicateDialogOpen(true)
+                throw err
+              }
               setError(err instanceof Error ? err.message : paypalStartError)
               throw err
             }
@@ -85,13 +110,24 @@ export function PayPalSubscriptionButton({
             }
             const approved = await approveSubscriptionIntent(token, data.subscriptionID)
             if (!approved.ok) {
+              if (approved.duplicate) {
+                setError(null)
+                setDuplicateEmail(approved.email ?? null)
+                setDuplicateDialogOpen(true)
+                return
+              }
               setError(approved.message)
-              if (approved.duplicate) window.location.assign(buildPayPalWelcomeUrl(token))
               return
             }
             window.location.assign(buildPayPalWelcomeUrl(token))
           }}
-          onError={() => setError(paypalStartError)}
+          onError={() => {
+            if (suppressNextPayPalErrorRef.current) {
+              suppressNextPayPalErrorRef.current = false
+              return
+            }
+            setError(paypalStartError)
+          }}
           style={{
             borderRadius: 999,
             color: "gold",
@@ -124,7 +160,9 @@ async function createSubscriptionIntent({
   })
   const body = await response.json().catch(() => ({}))
   if (!response.ok) {
-    if (response.status === 409) throw new Error(duplicateAccessError)
+    if (isCheckoutAccessAlreadyExistsResponse(response, body)) {
+      throw new CheckoutAccessAlreadyExistsError(readCheckoutAccessAlreadyExistsEmail(body))
+    }
     throw new Error(paypalStartError)
   }
 
@@ -138,7 +176,9 @@ async function createSubscriptionIntent({
 async function approveSubscriptionIntent(
   token: string,
   subscriptionId: string,
-): Promise<{ ok: true } | { ok: false; duplicate: boolean; message: string }> {
+): Promise<
+  { ok: true } | { ok: false; duplicate: boolean; email?: string | null; message: string }
+> {
   const response = await fetch("/api/paypal/approve-subscription", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -148,5 +188,10 @@ async function approveSubscriptionIntent(
 
   const body = await response.json().catch(() => ({}))
   const message = typeof body.message === "string" ? body.message : paypalStartError
-  return { ok: false, duplicate: response.status === 409, message }
+  return {
+    ok: false,
+    duplicate: isCheckoutAccessAlreadyExistsResponse(response, body),
+    email: readCheckoutAccessAlreadyExistsEmail(body),
+    message,
+  }
 }

--- a/src/components/quiz/result-offer-pricing.tsx
+++ b/src/components/quiz/result-offer-pricing.tsx
@@ -7,6 +7,11 @@ import {
   isPayPalCheckoutEnabled,
   PaymentMethodCheckout,
 } from "@/components/checkout/payment-method-checkout"
+import {
+  ActiveSubscriptionDialog,
+  isCheckoutAccessAlreadyExistsResponse,
+  readCheckoutAccessAlreadyExistsEmail,
+} from "@/components/checkout/active-subscription-dialog"
 import { Button } from "@/components/ui/button"
 import { trackAppEvent } from "@/lib/analytics/track-app-event"
 import type { BillingInterval } from "@/lib/stripe/intervals"
@@ -38,6 +43,8 @@ export function ResultOfferPricing({
     useState<BillingInterval>(DEFAULT_PRICING_INTERVAL)
   const [checkoutInterval, setCheckoutInterval] = useState<BillingInterval | null>(null)
   const [checkoutError, setCheckoutError] = useState<string | null>(null)
+  const [duplicateEmail, setDuplicateEmail] = useState<string | null>(null)
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const selectedPlan = getStripePricingPlan(selectedInterval)
 
   useEffect(() => {
@@ -85,6 +92,13 @@ export function ResultOfferPricing({
     })
 
     if (!response.ok) {
+      const body = await response.json().catch(() => ({}))
+      if (isCheckoutAccessAlreadyExistsResponse(response, body)) {
+        setCheckoutError(null)
+        setDuplicateEmail(readCheckoutAccessAlreadyExistsEmail(body))
+        setDuplicateDialogOpen(true)
+        throw new Error("checkout access already exists")
+      }
       setCheckoutError(checkoutStartError)
       throw new Error("failed to create checkout session")
     }
@@ -117,6 +131,11 @@ export function ResultOfferPricing({
 
   return (
     <div className="space-y-4">
+      <ActiveSubscriptionDialog
+        email={duplicateEmail}
+        onOpenChange={setDuplicateDialogOpen}
+        open={duplicateDialogOpen}
+      />
       <div className="grid gap-2.5">
         {STRIPE_PRICING_PLANS.map((plan) => {
           const isSelected = plan.interval === selectedInterval

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -22,27 +22,35 @@ interface DialogProps {
   children: React.ReactNode
 }
 
-function Dialog({ open: controlledOpen, onOpenChange: controlledOnOpenChange, children }: DialogProps) {
+function Dialog({
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+  children,
+}: DialogProps) {
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false)
 
   const open = controlledOpen !== undefined ? controlledOpen : uncontrolledOpen
   const onOpenChange = controlledOnOpenChange || setUncontrolledOpen
 
-  return (
-    <DialogContext.Provider value={{ open, onOpenChange }}>
-      {children}
-    </DialogContext.Provider>
-  )
+  return <DialogContext.Provider value={{ open, onOpenChange }}>{children}</DialogContext.Provider>
 }
 
-function DialogTrigger({ children, className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+function DialogTrigger({
+  children,
+  className,
+  onClick,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
   const { onOpenChange } = React.useContext(DialogContext)
 
   return (
     <button
       type="button"
       className={className}
-      onClick={() => onOpenChange(true)}
+      onClick={(event) => {
+        onClick?.(event)
+        if (!event.defaultPrevented) onOpenChange(true)
+      }}
       {...props}
     >
       {children}
@@ -50,14 +58,22 @@ function DialogTrigger({ children, className, ...props }: React.ButtonHTMLAttrib
   )
 }
 
-function DialogClose({ children, className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+function DialogClose({
+  children,
+  className,
+  onClick,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
   const { onOpenChange } = React.useContext(DialogContext)
 
   return (
     <button
       type="button"
       className={className}
-      onClick={() => onOpenChange(false)}
+      onClick={(event) => {
+        onClick?.(event)
+        if (!event.defaultPrevented) onOpenChange(false)
+      }}
       {...props}
     >
       {children}
@@ -102,7 +118,7 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
     if (!mounted || !open) return null
 
     return createPortal(
-      <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 z-[120] flex items-center justify-center">
         {/* Overlay */}
         <div
           className="fixed inset-0 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out"
@@ -113,23 +129,24 @@ const DialogContent = React.forwardRef<HTMLDivElement, DialogContentProps>(
           ref={ref}
           className={cn(
             "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
-            className
+            className,
           )}
           {...props}
         >
           {children}
           <button
+            type="button"
             className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
             onClick={() => onOpenChange(false)}
           >
             <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">Schließen</span>
           </button>
         </div>
       </div>,
-      document.body
+      document.body,
     )
-  }
+  },
 )
 DialogContent.displayName = "DialogContent"
 
@@ -153,20 +170,12 @@ function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 
 function DialogTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h2
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
-      {...props}
-    />
+    <h2 className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
   )
 }
 
 function DialogDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return (
-    <p
-      className={cn("text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />
 }
 
 export {

--- a/src/lib/billing/display.ts
+++ b/src/lib/billing/display.ts
@@ -1,0 +1,33 @@
+import type { BillingSubscriptionRow } from "./types"
+
+export function formatBillingDate(value: string | null | undefined): string {
+  return value ? new Date(value).toLocaleDateString("de-DE") : "—"
+}
+
+export function formatBillingMembershipStatus(
+  subscription:
+    | Pick<
+        BillingSubscriptionRow,
+        "entitlement_status" | "cancel_at_period_end" | "current_period_end"
+      >
+    | null
+    | undefined,
+  fallbackStatus?: string | null,
+  now = new Date(),
+): string {
+  if (
+    subscription?.entitlement_status === "canceled" &&
+    subscription.cancel_at_period_end &&
+    isFutureDate(subscription.current_period_end, now)
+  ) {
+    return `Verlängerung gekündigt, Zugang bis ${formatBillingDate(subscription.current_period_end)}`
+  }
+
+  return subscription?.entitlement_status ?? fallbackStatus ?? "—"
+}
+
+function isFutureDate(value: string | null | undefined, now: Date): boolean {
+  if (!value) return false
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) && timestamp > now.getTime()
+}

--- a/src/lib/billing/subscriptions.ts
+++ b/src/lib/billing/subscriptions.ts
@@ -33,14 +33,19 @@ export async function upsertBillingSubscription(
     input.provider,
     input.provider_subscription_id,
   )
+  const { provider_subscriber_email, ...subscriptionInput } = input
   const row = {
     provider_customer_id: existing?.provider_customer_id ?? null,
+    provider_subscriber_email:
+      provider_subscriber_email !== undefined
+        ? provider_subscriber_email
+        : (existing?.provider_subscriber_email ?? null),
     interval: existing?.interval ?? null,
     current_period_end: existing?.current_period_end ?? null,
     cancel_at_period_end: existing?.cancel_at_period_end ?? false,
     cancelled_at: existing?.cancelled_at ?? null,
     metadata: existing?.metadata ?? {},
-    ...input,
+    ...subscriptionInput,
     updated_at: now,
   }
 
@@ -103,7 +108,7 @@ export async function findVisibleBillingSubscriptionForUser(
   const { data, error } = await supabase
     .from("billing_subscriptions")
     .select(
-      "id, user_id, provider, provider_customer_id, provider_subscription_id, provider_status, entitlement_status, interval, current_period_end, cancel_at_period_end, cancelled_at, metadata, created_at, updated_at",
+      "id, user_id, provider, provider_customer_id, provider_subscriber_email, provider_subscription_id, provider_status, entitlement_status, interval, current_period_end, cancel_at_period_end, cancelled_at, metadata, created_at, updated_at",
     )
     .eq("user_id", userId)
     .in("entitlement_status", ["active", "past_due", "canceled"])

--- a/src/lib/billing/types.ts
+++ b/src/lib/billing/types.ts
@@ -9,6 +9,7 @@ export interface BillingSubscriptionRow {
   user_id: string
   provider: BillingProvider
   provider_customer_id: string | null
+  provider_subscriber_email: string | null
   provider_subscription_id: string
   provider_status: string
   entitlement_status: BillingEntitlementStatus
@@ -28,6 +29,7 @@ export type BillingSubscriptionInput = {
   provider_status: string
   entitlement_status: BillingEntitlementStatus
   provider_customer_id?: string | null
+  provider_subscriber_email?: string | null
   interval?: BillingInterval | null
   current_period_end?: string | null
   cancel_at_period_end?: boolean

--- a/src/lib/paypal/checkout-activation.ts
+++ b/src/lib/paypal/checkout-activation.ts
@@ -20,6 +20,7 @@ export interface PayPalCheckoutActivationDeps {
   supabase: SupabaseClient
   premiumTierId: string
   activationKey?: string
+  accountEmail?: string | null
   interval?: BillingInterval
   leadId?: string | null
   linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
@@ -54,6 +55,7 @@ export type PayPalCheckoutAccountResult =
       status: "active"
       userId: string
       email: string
+      providerSubscriberEmail: string | null
       canSetInitialPassword: boolean
     }
   | { status: "pending" }
@@ -109,6 +111,7 @@ export async function ensurePayPalCheckoutAccountForToken(
   const result = await ensurePayPalCheckoutAccount(subscription, {
     ...deps,
     activationKey: token,
+    accountEmail: intent.email ?? null,
     interval: intent.interval,
     leadId: intent.lead_id,
   })
@@ -131,10 +134,11 @@ export async function ensurePayPalCheckoutAccount(
     )
   }
 
-  const valid = assertActivePayPalSubscription(subscription)
+  const valid = assertActivePayPalSubscription(subscription, deps.accountEmail)
+  const accountEmail = deps.accountEmail?.trim().toLowerCase() || valid.email.toLowerCase()
   const interval = deps.interval ?? intervalFromPlanId(valid.planId)
   const activationKey = deps.activationKey ?? valid.id
-  const existingProfile = await findProfileByEmail(deps, valid.email)
+  const existingProfile = await findProfileByEmail(deps, accountEmail)
 
   let userId: string
   let canSetInitialPassword = false
@@ -144,7 +148,7 @@ export async function ensurePayPalCheckoutAccount(
     await assertNoDifferentCurrentSubscription(deps, userId, valid.id)
     canSetInitialPassword = await canSetPasswordForPayPalSubscription(deps, userId, activationKey)
   } else {
-    const created = await createPayPalCheckoutUser(deps, valid.email, activationKey)
+    const created = await createPayPalCheckoutUser(deps, accountEmail, activationKey)
     if (!created.created) await assertNoDifferentCurrentSubscription(deps, created.userId, valid.id)
     if (created.created) {
       userId = created.userId
@@ -155,7 +159,7 @@ export async function ensurePayPalCheckoutAccount(
   }
 
   await upsertSubscriptionProfile(deps, userId, {
-    email: valid.email,
+    email: accountEmail,
     subscription_status: "active",
     subscription_interval: interval,
     current_period_end: valid.periodEnd,
@@ -167,9 +171,15 @@ export async function ensurePayPalCheckoutAccount(
     toBillingSubscriptionInputFromPayPal(subscription, userId, interval),
   )
   await mirrorBillingSubscriptionToProfile(deps.supabase, billingRow, deps.premiumTierId)
-  await linkPayPalQuizProfile(subscription, deps, userId, valid.email)
+  await linkPayPalQuizProfile(subscription, deps, userId, accountEmail)
 
-  return { status: "active", userId, email: valid.email, canSetInitialPassword }
+  return {
+    status: "active",
+    userId,
+    email: accountEmail,
+    providerSubscriberEmail: billingRow.provider_subscriber_email,
+    canSetInitialPassword,
+  }
 }
 
 async function assertNoDifferentCurrentSubscription(
@@ -183,7 +193,7 @@ async function assertNoDifferentCurrentSubscription(
     return
   throw new PayPalCheckoutActivationError(
     "paypal_existing_access",
-    "PayPal subscriber email already has a current subscription",
+    "Chaarlie account already has current subscription access",
   )
 }
 
@@ -195,7 +205,10 @@ export function paypalCheckoutActivationHash(subscriptionId: string): string {
   return createHash("sha256").update(paypalCheckoutActivationId(subscriptionId)).digest("hex")
 }
 
-function assertActivePayPalSubscription(subscription: PayPalSubscription): {
+function assertActivePayPalSubscription(
+  subscription: PayPalSubscription,
+  accountEmail?: string | null,
+): {
   id: string
   email: string
   planId: string
@@ -208,11 +221,13 @@ function assertActivePayPalSubscription(subscription: PayPalSubscription): {
     )
   }
 
-  const email = subscription.subscriber?.email_address
+  const email =
+    accountEmail?.trim().toLowerCase() ||
+    subscription.subscriber?.email_address?.trim().toLowerCase()
   if (!email) {
     throw new PayPalCheckoutActivationError(
       "paypal_subscription_email_missing",
-      "PayPal subscription has no subscriber email",
+      "PayPal checkout activation has no Chaarlie or subscriber email",
     )
   }
 
@@ -249,7 +264,7 @@ async function findProfileByEmail(
   const { data, error } = await deps.supabase
     .from("profiles")
     .select("id, email")
-    .ilike("email", email)
+    .eq("email", email.toLowerCase())
     .maybeSingle()
   if (error) throw new Error(`profile lookup failed: ${error.message}`)
   return data as ProfileRow | null

--- a/src/lib/paypal/checkout-intents.ts
+++ b/src/lib/paypal/checkout-intents.ts
@@ -174,6 +174,21 @@ export async function markPayPalCheckoutIntentActivated(
   if (error) throw error
 }
 
+export async function markPayPalCheckoutIntentExpired(
+  supabase: PayPalCheckoutIntentClient,
+  token: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from("paypal_checkout_intents")
+    .update({
+      status: "expired",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("token", token)
+
+  if (error) throw error
+}
+
 export function isPayPalCheckoutIntentExpired(
   intent: Pick<PayPalCheckoutIntentRow, "expires_at">,
   now: Date = new Date(),

--- a/src/lib/paypal/duplicate-guard.ts
+++ b/src/lib/paypal/duplicate-guard.ts
@@ -9,6 +9,20 @@ import type { PayPalSubscription } from "@/lib/paypal/subscription-shapes"
 export const PAYPAL_DUPLICATE_CHECKOUT_COPY =
   "Für diese E-Mail gibt es bereits ein aktives Abo. Wir haben die neue PayPal-Zahlung gestoppt. Bitte melde dich mit deinem bestehenden Konto an."
 
+export function buildPayPalDuplicateCheckoutBody(
+  intent: Pick<PayPalCheckoutIntentRow, "email" | "lead_id">,
+): {
+  error: "checkout_access_already_exists"
+  email?: string
+  message: typeof PAYPAL_DUPLICATE_CHECKOUT_COPY
+} {
+  return {
+    error: "checkout_access_already_exists",
+    ...(canExposePayPalDuplicateEmail(intent) ? { email: intent.email } : {}),
+    message: PAYPAL_DUPLICATE_CHECKOUT_COPY,
+  }
+}
+
 export class PayPalDuplicateCancellationError extends Error {
   constructor(
     message: string,
@@ -19,10 +33,7 @@ export class PayPalDuplicateCancellationError extends Error {
   }
 }
 
-type DuplicateReason =
-  | "user_already_has_access"
-  | "intent_email_already_has_access"
-  | "paypal_email_already_has_access"
+type DuplicateReason = "user_already_has_access" | "intent_email_already_has_access"
 
 type CancelPayPalSubscription = (subscriptionId: string, reason: string) => Promise<void>
 type RetrievePayPalSubscription = (
@@ -33,6 +44,7 @@ export async function findPayPalCheckoutDuplicateReason(
   supabase: Pick<SupabaseClient, "from">,
   intent: Pick<PayPalCheckoutIntentRow, "user_id" | "email">,
   subscription: PayPalSubscription,
+  options: { fallbackAccountEmail?: string | null } = {},
 ): Promise<DuplicateReason | null> {
   if (intent.user_id && (await hasCurrentAccessForUser(supabase, intent.user_id))) {
     return "user_already_has_access"
@@ -43,13 +55,15 @@ export async function findPayPalCheckoutDuplicateReason(
     return "intent_email_already_has_access"
   }
 
+  const fallbackAccountEmail = normalizeEmail(options.fallbackAccountEmail)
   const paypalEmail = normalizeEmail(subscription.subscriber?.email_address)
   if (
-    paypalEmail &&
-    paypalEmail !== intentEmail &&
-    (await hasCurrentAccessForEmail(supabase, paypalEmail))
+    !intentEmail &&
+    fallbackAccountEmail &&
+    fallbackAccountEmail === paypalEmail &&
+    (await hasCurrentAccessForEmail(supabase, fallbackAccountEmail))
   ) {
-    return "paypal_email_already_has_access"
+    return "intent_email_already_has_access"
   }
 
   return null
@@ -146,6 +160,12 @@ async function isTerminalPayPalSubscription(
 function isTerminalPayPalStatus(status: string | null | undefined): boolean {
   const normalized = status?.trim().toUpperCase()
   return normalized === "CANCELLED" || normalized === "CANCELED" || normalized === "EXPIRED"
+}
+
+function canExposePayPalDuplicateEmail(
+  intent: Pick<PayPalCheckoutIntentRow, "email" | "lead_id">,
+): intent is Pick<PayPalCheckoutIntentRow, "email" | "lead_id"> & { email: string } {
+  return Boolean(intent.email && !intent.lead_id)
 }
 
 async function retrievePayPalSubscriptionAfterCancelFailure(subscriptionId: string) {

--- a/src/lib/paypal/subscription-shapes.ts
+++ b/src/lib/paypal/subscription-shapes.ts
@@ -70,11 +70,14 @@ export function toBillingSubscriptionInputFromPayPal(
   const paidThrough = derivePayPalPaidThroughDate(subscription)
   const isProviderCancellation =
     subscription.status === "CANCELLED" || subscription.status === "EXPIRED"
+  const providerSubscriberEmail =
+    subscription.subscriber?.email_address?.trim().toLowerCase() || undefined
 
   return {
     user_id: userId,
     provider: "paypal",
     provider_customer_id: subscription.subscriber?.payer_id ?? null,
+    provider_subscriber_email: providerSubscriberEmail,
     provider_subscription_id: subscription.id,
     provider_status: subscription.status ?? "UNKNOWN",
     entitlement_status: entitlementStatus,

--- a/src/lib/paypal/webhook-handlers.ts
+++ b/src/lib/paypal/webhook-handlers.ts
@@ -10,7 +10,9 @@ import {
   bindPayPalCheckoutIntentToSubscription,
   findPayPalCheckoutIntentByProviderSubscriptionId,
   findPayPalCheckoutIntentByToken,
+  isPayPalCheckoutIntentExpired,
   markPayPalCheckoutIntentActivated,
+  markPayPalCheckoutIntentExpired,
   PayPalCheckoutIntentBindingError,
 } from "@/lib/paypal/checkout-intents"
 import {
@@ -149,6 +151,12 @@ async function activateOrRefreshSubscription(
   if (!existing && !intent) {
     throw new Error(`PayPal subscription ${subscription.id} has no checkout intent or local row`)
   }
+  if (!existing && intent && isPayPalCheckoutIntentExpired(intent)) {
+    await markPayPalCheckoutIntentExpired(deps.supabase, intent.token)
+    const cancel = deps.cancelPayPalSubscription ?? cancelPayPalSubscriptionForWebhook
+    await cancel(subscription.id, "PayPal checkout intent expired before activation")
+    return
+  }
 
   let boundIntent = intent
   if (token && intent && !intent.provider_subscription_id) {
@@ -157,7 +165,7 @@ async function activateOrRefreshSubscription(
         deps.supabase,
         token,
         subscription.id,
-        intent.email ?? subscription.subscriber?.email_address ?? null,
+        intent.email ?? null,
       )
     } catch (error) {
       if (error instanceof PayPalCheckoutIntentBindingError && !existing) {
@@ -183,10 +191,12 @@ async function activateOrRefreshSubscription(
   }
 
   if (!existing && boundIntent) {
+    const fallbackAccountEmail = boundIntent.email ?? subscription.subscriber?.email_address ?? null
     const duplicateReason = await findPayPalCheckoutDuplicateReason(
       deps.supabase,
       boundIntent,
       subscription,
+      { fallbackAccountEmail },
     )
     if (duplicateReason) {
       await cancelAndMarkPayPalDuplicate({
@@ -207,6 +217,7 @@ async function activateOrRefreshSubscription(
     supabase: deps.supabase,
     premiumTierId: deps.premiumTierId,
     activationKey: boundIntent?.token,
+    accountEmail: boundIntent?.email ?? null,
     interval: boundIntent?.interval ?? intervalFromMetadata(subscription),
     leadId: boundIntent?.lead_id ?? null,
     linkQuizToProfile: deps.linkQuizToProfile,

--- a/supabase/manual-test-backfills/20260603_provider_subscriber_email_audit.sql
+++ b/supabase/manual-test-backfills/20260603_provider_subscriber_email_audit.sql
@@ -1,0 +1,43 @@
+-- Dry-run support audit for PayPal identity cleanup.
+-- Do not use this to infer PayPal-E-Mail from profiles.email. Backfill
+-- provider_subscriber_email only from PayPal API-confirmed subscriber data.
+
+select
+  p.id as user_id,
+  p.email as chaarlie_email,
+  l.email as linked_lead_email,
+  bs.provider_subscription_id,
+  bs.provider_subscriber_email as paypal_email,
+  p.onboarding_completed,
+  au.last_sign_in_at,
+  bs.entitlement_status,
+  bs.cancel_at_period_end,
+  bs.current_period_end,
+  case
+    when bs.entitlement_status in ('active', 'past_due') then true
+    when bs.entitlement_status = 'canceled'
+      and bs.cancel_at_period_end = true
+      and bs.current_period_end > now()
+      then true
+    else false
+  end as current_access,
+  case
+    when au.last_sign_in_at is null and coalesce(p.onboarding_completed, false) = false
+      then 'Support prüfen: nie aktiviert; ggf. Auth/profiles.email auf Chaarlie-E-Mail korrigieren'
+    when bs.provider_subscriber_email is null
+      then 'Optional: PayPal API subscriber.email_address prüfen und provider_subscriber_email backfillen'
+    else 'Keine automatische Änderung'
+end as recommended_action
+from billing_subscriptions bs
+join profiles p on p.id = bs.user_id
+left join lateral (
+  select leads.email
+  from leads
+  where leads.user_id = p.id
+     or lower(leads.email) = lower(p.email)
+  order by leads.created_at desc
+  limit 1
+) l on true
+left join auth.users au on au.id = p.id
+where bs.provider = 'paypal'
+order by bs.created_at desc;

--- a/supabase/migrations/20260603120000_add_provider_subscriber_email.sql
+++ b/supabase/migrations/20260603120000_add_provider_subscriber_email.sql
@@ -1,0 +1,5 @@
+ALTER TABLE billing_subscriptions
+  ADD COLUMN IF NOT EXISTS provider_subscriber_email text;
+
+COMMENT ON COLUMN billing_subscriptions.provider_subscriber_email IS
+  'Payment-provider subscriber/customer email for support reference only. Chaarlie login/contact email remains profiles.email.';

--- a/tests/admin-paypal-email-visibility.test.ts
+++ b/tests/admin-paypal-email-visibility.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const adminUsersRouteSource = readFileSync(
+  new URL("../src/app/api/admin/users/route.ts", import.meta.url),
+  "utf8",
+)
+const adminUsersPageSource = readFileSync(
+  new URL("../src/app/admin/users/page.tsx", import.meta.url),
+  "utf8",
+)
+
+test("admin users API merges visible billing subscription data with provider subscriber email", () => {
+  assert.match(adminUsersRouteSource, /createAdminClient/)
+  assert.match(adminUsersRouteSource, /loadVisibleBillingByUserId/)
+  assert.match(adminUsersRouteSource, /provider_subscriber_email/)
+  assert.match(adminUsersRouteSource, /hasCurrentBillingAccess/)
+  assert.match(adminUsersRouteSource, /current_billing_subscription/)
+})
+
+test("admin users API returns a controlled response if billing lookup fails", () => {
+  assert.match(
+    adminUsersRouteSource,
+    /try \{[\s\S]*billingByUserId = await loadVisibleBillingByUserId/,
+  )
+  assert.match(adminUsersRouteSource, /billing lookup failed/)
+  assert.match(adminUsersRouteSource, /fehler\("Laden", "der Abo-Daten"\)/)
+})
+
+test("admin users API clamps pagination before querying profile and billing rows", () => {
+  assert.match(adminUsersRouteSource, /const MAX_LIMIT = 100/)
+  assert.match(adminUsersRouteSource, /parseBoundedInteger\(searchParams\.get\("limit"\)/)
+  assert.match(adminUsersRouteSource, /parseBoundedInteger\(searchParams\.get\("offset"\)/)
+})
+
+test("admin users table shows Chaarlie and PayPal emails in the existing contact column", () => {
+  assert.match(
+    adminUsersPageSource,
+    /current_billing_subscription\?: BillingSubscriptionRow \| null/,
+  )
+  assert.match(adminUsersPageSource, /Chaarlie-E-Mail/)
+  assert.match(adminUsersPageSource, /PayPal-E-Mail/)
+  assert.match(adminUsersPageSource, /const paypalEmail = getPayPalEmail\(user\)/)
+  assert.match(adminUsersPageSource, /Kontakt/)
+})
+
+test("admin users table hides PayPal email when it matches the Chaarlie email", () => {
+  assert.match(
+    adminUsersPageSource,
+    /subscriberEmail\.toLowerCase\(\) === user\.email\?\.trim\(\)\.toLowerCase\(\)/,
+  )
+})

--- a/tests/auth-email-prefill.test.tsx
+++ b/tests/auth-email-prefill.test.tsx
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const authPageSource = readFileSync(new URL("../src/app/auth/page.tsx", import.meta.url), "utf8")
+const authFormSource = readFileSync(
+  new URL("../src/components/auth/auth-form.tsx", import.meta.url),
+  "utf8",
+)
+
+test("/auth passes the email query parameter as the AuthForm defaultEmail", () => {
+  assert.match(authPageSource, /defaultEmail=\{searchParams\.get\("email"\) \?\? undefined\}/)
+})
+
+test("AuthForm initializes the email field from defaultEmail", () => {
+  assert.match(authFormSource, /const \[email, setEmail\] = useState\(defaultEmail \?\? ""\)/)
+  assert.match(authFormSource, /value=\{email\}/)
+})
+
+test("prefilled auth email remains editable", () => {
+  assert.match(authFormSource, /onChange=\{\(e\) => setEmail\(e\.target\.value\)\}/)
+  assert.doesNotMatch(authFormSource, /readOnly/)
+  assert.doesNotMatch(authFormSource, /aria-readonly/)
+})
+
+test("magic link sending still requires the explicit button handler", () => {
+  assert.match(authFormSource, /async function handleMagicLink/)
+  assert.match(authFormSource, /onClick=\{handleMagicLink\}/)
+  assert.doesNotMatch(authPageSource, /signInWithOtp/)
+  assert.doesNotMatch(authPageSource, /send-magic-link/)
+})

--- a/tests/auth-post-checkout-routes.spec.ts
+++ b/tests/auth-post-checkout-routes.spec.ts
@@ -334,6 +334,7 @@ test("password activation accepts PayPal intent tokens and uses provider-owned e
         status: "active",
         userId: "user-paypal",
         email: "paypal-owned@example.com",
+        providerSubscriberEmail: "paypal-owned@example.com",
         canSetInitialPassword: true,
       }
     },
@@ -539,6 +540,7 @@ test("send magic link accepts PayPal intent tokens and consumes the provider mar
         status: "active",
         userId: "user-paypal",
         email: "paypal-owned@example.com",
+        providerSubscriberEmail: "paypal-owned@example.com",
         canSetInitialPassword: true,
       }),
       claimCheckoutActivation: async () => true,

--- a/tests/billing-display.test.ts
+++ b/tests/billing-display.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { formatBillingMembershipStatus } from "../src/lib/billing/display"
+
+test("billing status labels canceled subscriptions with paid-through access", () => {
+  const label = formatBillingMembershipStatus(
+    {
+      entitlement_status: "canceled",
+      cancel_at_period_end: true,
+      current_period_end: "2026-07-03T12:00:00.000Z",
+    },
+    null,
+    new Date("2026-06-03T12:00:00.000Z"),
+  )
+
+  assert.equal(label, "Verlängerung gekündigt, Zugang bis 3.7.2026")
+})
+
+test("billing status falls back to the raw status when canceled access is already expired", () => {
+  const label = formatBillingMembershipStatus(
+    {
+      entitlement_status: "canceled",
+      cancel_at_period_end: true,
+      current_period_end: "2026-05-03T12:00:00.000Z",
+    },
+    "active",
+    new Date("2026-06-03T12:00:00.000Z"),
+  )
+
+  assert.equal(label, "canceled")
+})

--- a/tests/billing-paypal-server.test.ts
+++ b/tests/billing-paypal-server.test.ts
@@ -86,6 +86,7 @@ function createSupabaseStub(seed?: {
     user_id: row.user_id ?? "user-1",
     provider: row.provider ?? "stripe",
     provider_customer_id: row.provider_customer_id ?? null,
+    provider_subscriber_email: row.provider_subscriber_email ?? null,
     provider_subscription_id: row.provider_subscription_id ?? `sub-${index + 1}`,
     provider_status: row.provider_status ?? "active",
     entitlement_status: row.entitlement_status ?? "active",
@@ -782,7 +783,7 @@ test("PayPal checkout intent binding is immutable after the first provider subsc
   assert.equal(paypalIntents[0].email, "first@example.com")
 })
 
-test("PayPal duplicate guard checks intent user, intent email, and provider email", async () => {
+test("PayPal duplicate guard checks Chaarlie user and email, not PayPal subscriber email", async () => {
   const { supabase } = createSupabaseStub({
     billing: [{ user_id: "user-1", entitlement_status: "active" }],
     profiles: {
@@ -812,7 +813,7 @@ test("PayPal duplicate guard checks intent user, intent email, and provider emai
       { user_id: null, email: "other@example.com" },
       { subscriber: { email_address: "Lead@Example.com" } },
     ),
-    "paypal_email_already_has_access",
+    null,
   )
 })
 
@@ -836,7 +837,7 @@ test("PayPal duplicate marker is written only after duplicate cancellation succe
         cancelPayPalSubscription: async () => {
           throw new Error("PayPal outage")
         },
-        reason: "paypal_email_already_has_access",
+        reason: "intent_email_already_has_access",
         subscriptionId: "I-duplicate",
         supabase,
         token: "token-1",
@@ -851,7 +852,7 @@ test("PayPal duplicate marker is written only after duplicate cancellation succe
         cancelPayPalSubscription: async () => {
           throw new Error("SUBSCRIPTION_STATUS_INVALID")
         },
-        reason: "paypal_email_already_has_access",
+        reason: "intent_email_already_has_access",
         retrievePayPalSubscription: async () => ({ status: "ACTIVE" }),
         subscriptionId: "I-duplicate",
         supabase,
@@ -865,27 +866,27 @@ test("PayPal duplicate marker is written only after duplicate cancellation succe
     cancelPayPalSubscription: async () => {
       throw new Error("already cancelled")
     },
-    reason: "paypal_email_already_has_access",
+    reason: "intent_email_already_has_access",
     retrievePayPalSubscription: async () => ({ status: "CANCELLED" }),
     subscriptionId: "I-duplicate",
     supabase,
     token: "token-1",
   })
   assert.equal(paypalIntents[0].status, "duplicate")
-  assert.equal(paypalIntents[0].duplicate_reason, "paypal_email_already_has_access")
+  assert.equal(paypalIntents[0].duplicate_reason, "intent_email_already_has_access")
 
   paypalIntents[0].status = "approved"
   paypalIntents[0].duplicate_reason = null
 
   await cancelAndMarkPayPalDuplicate({
     cancelPayPalSubscription: async () => {},
-    reason: "paypal_email_already_has_access",
+    reason: "intent_email_already_has_access",
     subscriptionId: "I-duplicate",
     supabase,
     token: "token-1",
   })
   assert.equal(paypalIntents[0].status, "duplicate")
-  assert.equal(paypalIntents[0].duplicate_reason, "paypal_email_already_has_access")
+  assert.equal(paypalIntents[0].duplicate_reason, "intent_email_already_has_access")
 })
 
 test("mirrorBillingSubscriptionToProfile keeps future paid-through PayPal cancellations active", async () => {
@@ -1366,6 +1367,53 @@ test("PayPal activation reuses an existing profile with the provider email", asy
   assert.equal(profiles["existing-user"].subscription_status, "active")
 })
 
+test("PayPal activation does not treat wildcard characters as profile email matches", async () => {
+  const { supabase, profiles, authUsers } = createSupabaseStub({
+    profiles: {
+      "existing-user": {
+        id: "existing-user",
+        email: "axb@example.com",
+        subscription_status: null,
+      },
+    },
+    authUsers: {
+      "existing-user": {
+        id: "existing-user",
+        email: "axb@example.com",
+        app_metadata: {},
+      },
+    },
+  })
+
+  const result = await ensurePayPalCheckoutAccount(
+    {
+      id: "I-wildcard-email",
+      status: "ACTIVE",
+      plan_id: "P-month",
+      subscriber: {
+        payer_id: "payer-1",
+        email_address: "a_b@example.com",
+      },
+      billing_info: { next_billing_time: futureIso() },
+    },
+    {
+      supabase,
+      premiumTierId: "tier-premium",
+      interval: "month",
+    },
+  )
+
+  assert.equal(result.status, "active")
+  if (result.status !== "active") throw new Error("expected active PayPal activation result")
+  assert.notEqual(result.userId, "existing-user")
+  assert.equal(profiles["existing-user"].subscription_status, null)
+  assert.equal(profiles[result.userId].email, "a_b@example.com")
+  assert.equal(
+    Object.values(authUsers).some((user) => user.email === "a_b@example.com"),
+    true,
+  )
+})
+
 test("PayPal activation refuses to attach a second current subscription to the same email", async () => {
   const { supabase, profiles, authUsers } = createSupabaseStub({
     billing: [
@@ -1411,7 +1459,7 @@ test("PayPal activation refuses to attach a second current subscription to the s
           interval: "quarter",
         },
       ),
-    /already has a current subscription/,
+    /Chaarlie account already has current subscription access/,
   )
   assert.equal(Object.keys(authUsers).length, 1)
   assert.equal(profiles["existing-user"].subscription_status, "active")
@@ -1572,18 +1620,22 @@ test("Stripe subscription.deleted downgrades profile and marks billing row cance
   assert.equal(billing[0].current_period_end, periodEnd)
 })
 
-test("Stripe checkout route returns a stable conflict key when checkout access already exists", async () => {
+test("Stripe checkout route returns a stable conflict key and known email when checkout access already exists", async () => {
   const active = createSupabaseStub({
     billing: [{ user_id: "user-1", entitlement_status: "active" }],
     profiles: { "user-1": { id: "user-1", subscription_status: null } },
   })
 
-  const response = await createStripeCheckoutAccessConflictResponse(active.supabase, "user-1")
+  const response = await createStripeCheckoutAccessConflictResponse(
+    active.supabase,
+    "user-1",
+    "paid@example.com",
+  )
   if (!response) throw new Error("expected checkout conflict response")
   const body = await response.json()
 
   assert.equal(response.status, 409)
-  assert.deepEqual(body, { error: "checkout_access_already_exists" })
+  assert.deepEqual(body, { error: "checkout_access_already_exists", email: "paid@example.com" })
 })
 
 test("Stripe checkout conflict check uses the provided billing-visible client", async () => {
@@ -1619,6 +1671,10 @@ test("Stripe checkout lead-email conflict uses provider-neutral access guard", a
   )
 
   assert.equal(response?.status, 409)
+  assert.deepEqual(await response?.json(), {
+    error: "checkout_access_already_exists",
+    email: "paid@example.com",
+  })
 })
 
 test("Stripe checkout email conflict blocks email-only manual grants", async () => {
@@ -1640,6 +1696,10 @@ test("Stripe checkout email conflict blocks email-only manual grants", async () 
   )
 
   assert.equal(response?.status, 409)
+  assert.deepEqual(await response?.json(), {
+    error: "checkout_access_already_exists",
+    email: "Friend@Example.com",
+  })
 })
 
 test("Stripe checkout email conflict ignores missing manual grants table", async () => {

--- a/tests/payment-duplicate-dialog.test.tsx
+++ b/tests/payment-duplicate-dialog.test.tsx
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import {
+  buildPayPalDuplicateCheckoutBody,
+  PAYPAL_DUPLICATE_CHECKOUT_COPY,
+} from "../src/lib/paypal/duplicate-guard"
+
+const dialogSource = readFileSync(
+  new URL("../src/components/checkout/active-subscription-dialog.tsx", import.meta.url),
+  "utf8",
+)
+const paypalButtonSource = readFileSync(
+  new URL("../src/components/checkout/paypal-subscription-button.tsx", import.meta.url),
+  "utf8",
+)
+const pricingCardsSource = readFileSync(
+  new URL("../src/app/pricing/pricing-cards.tsx", import.meta.url),
+  "utf8",
+)
+const resultOfferPricingSource = readFileSync(
+  new URL("../src/components/quiz/result-offer-pricing.tsx", import.meta.url),
+  "utf8",
+)
+const paypalCreateRouteSource = readFileSync(
+  new URL("../src/app/api/paypal/create-subscription-intent/route.ts", import.meta.url),
+  "utf8",
+)
+const paypalApproveRouteSource = readFileSync(
+  new URL("../src/app/api/paypal/approve-subscription/route.ts", import.meta.url),
+  "utf8",
+)
+const stripeRouteSource = readFileSync(
+  new URL("../src/app/api/stripe/create-checkout-session/route.ts", import.meta.url),
+  "utf8",
+)
+
+test("active subscription dialog links known emails to prefilled auth", () => {
+  assert.match(dialogSource, /Aktives Abo gefunden/)
+  assert.match(dialogSource, /Für diese Chaarlie-E-Mail gibt es bereits ein aktives Abo\./)
+  assert.match(dialogSource, /Bitte melde dich mit dieser E-Mail an/)
+  assert.ok(dialogSource.includes("`/auth?email=${encodeURIComponent(normalizedEmail)}`"))
+  assert.match(dialogSource, /const loginHref = normalizedEmail/)
+})
+
+test("active subscription dialog has an unknown-email fallback", () => {
+  assert.match(dialogSource, /Für dieses Konto gibt es bereits ein aktives Abo\./)
+  assert.match(dialogSource, /Bitte melde dich an, um dein Abo zu nutzen\./)
+  assert.ok(dialogSource.includes(': "/auth"'))
+})
+
+test("PayPal duplicate responses open the modal instead of redirecting to welcome", () => {
+  assert.match(paypalButtonSource, /ActiveSubscriptionDialog/)
+  assert.match(paypalButtonSource, /setDuplicateDialogOpen\(true\)/)
+  assert.match(paypalButtonSource, /readCheckoutAccessAlreadyExistsEmail/)
+  assert.doesNotMatch(
+    paypalButtonSource,
+    /if \(approved\.duplicate\) window\.location\.assign\(buildPayPalWelcomeUrl\(token\)\)/,
+  )
+})
+
+test("Stripe duplicate responses are handled in both checkout parents", () => {
+  for (const source of [pricingCardsSource, resultOfferPricingSource]) {
+    assert.match(source, /ActiveSubscriptionDialog/)
+    assert.match(source, /isCheckoutAccessAlreadyExistsResponse/)
+    assert.match(source, /readCheckoutAccessAlreadyExistsEmail/)
+    assert.match(source, /setDuplicateDialogOpen\(true\)/)
+  }
+})
+
+test("duplicate checkout API responses include known context email", () => {
+  assert.ok(paypalCreateRouteSource.includes("canExposeConflictEmail ? email : null"))
+  assert.match(paypalApproveRouteSource, /createPayPalDuplicateCheckoutResponse/)
+  assert.match(paypalApproveRouteSource, /buildPayPalDuplicateCheckoutBody/)
+  assert.doesNotMatch(
+    paypalApproveRouteSource,
+    /boundIntent\.email \? \{ email: boundIntent\.email \}/,
+  )
+  assert.ok(stripeRouteSource.includes("...(options.includeEmail === false ? {} : { email })"))
+  assert.ok(stripeRouteSource.includes("...(email ? { email } : {})"))
+})
+
+test("PayPal duplicate approval response hides lead-derived Chaarlie emails", async () => {
+  const body = buildPayPalDuplicateCheckoutBody({
+    email: "lead@example.com",
+    lead_id: "lead-123",
+  })
+
+  assert.deepEqual(body, {
+    error: "checkout_access_already_exists",
+    message: PAYPAL_DUPLICATE_CHECKOUT_COPY,
+  })
+})
+
+test("PayPal duplicate approval response can include non-lead account emails", async () => {
+  const body = buildPayPalDuplicateCheckoutBody({
+    email: "account@example.com",
+    lead_id: null,
+  })
+
+  assert.deepEqual(body, {
+    error: "checkout_access_already_exists",
+    email: "account@example.com",
+    message: PAYPAL_DUPLICATE_CHECKOUT_COPY,
+  })
+})
+
+test("PayPal approval retry keeps the Chaarlie account email bound to the intent", () => {
+  assert.ok(
+    paypalApproveRouteSource.includes("intent.email ?? getPayPalSubscriberEmail(subscription)"),
+  )
+})
+
+test("Stripe lead-derived duplicate conflicts do not expose hidden lead emails", () => {
+  assert.ok(stripeRouteSource.includes("req.json().catch(() => null)"))
+  assert.ok(stripeRouteSource.includes("{ includeEmail: false }"))
+  assert.ok(stripeRouteSource.includes("options.includeEmail === false ? {} : { email }"))
+  assert.ok(stripeRouteSource.includes("let resolvedLeadId: string | null = null"))
+  assert.ok(
+    stripeRouteSource.includes(
+      "metadata: resolvedLeadId ? { lead_id: resolvedLeadId } : undefined",
+    ),
+  )
+})

--- a/tests/paypal-cancel.test.ts
+++ b/tests/paypal-cancel.test.ts
@@ -27,6 +27,7 @@ function createSupabaseStub(options: {
     user_id: row.user_id ?? "user-1",
     provider: row.provider ?? "paypal",
     provider_customer_id: row.provider_customer_id ?? "payer-1",
+    provider_subscriber_email: row.provider_subscriber_email ?? null,
     provider_subscription_id: row.provider_subscription_id ?? `I-${index + 1}`,
     provider_status: row.provider_status ?? "ACTIVE",
     entitlement_status: row.entitlement_status ?? "active",

--- a/tests/paypal-email-identity.test.ts
+++ b/tests/paypal-email-identity.test.ts
@@ -1,0 +1,670 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  findVisibleBillingSubscriptionForUser,
+  upsertBillingSubscription,
+} from "../src/lib/billing/subscriptions"
+import {
+  ensurePayPalCheckoutAccount,
+  ensurePayPalCheckoutAccountForToken,
+  paypalCheckoutActivationHash,
+} from "../src/lib/paypal/checkout-activation"
+import { handlePayPalWebhookEvent } from "../src/lib/paypal/webhook-handlers"
+import { toBillingSubscriptionInputFromPayPal } from "../src/lib/paypal/subscription-shapes"
+import type {
+  BillingSubscriptionInput,
+  BillingSubscriptionRow,
+  SupabaseBillingClient,
+} from "../src/lib/billing/types"
+import type { PayPalSubscription } from "../src/lib/paypal/subscription-shapes"
+
+type BillingSubscriptionWithProviderEmail = BillingSubscriptionRow & {
+  provider_subscriber_email: string | null
+}
+
+type AuthUserStub = {
+  id: string
+  email: string
+  app_metadata?: Record<string, unknown>
+}
+
+function futureIso() {
+  return new Date(Date.now() + 86_400_000).toISOString()
+}
+
+function createBillingRow(
+  row: Partial<BillingSubscriptionWithProviderEmail> = {},
+  index = 0,
+): BillingSubscriptionWithProviderEmail {
+  return {
+    id: row.id ?? `billing-${index + 1}`,
+    user_id: row.user_id ?? "user-1",
+    provider: row.provider ?? "paypal",
+    provider_customer_id: row.provider_customer_id ?? null,
+    provider_subscriber_email: row.provider_subscriber_email ?? null,
+    provider_subscription_id: row.provider_subscription_id ?? `I-${index + 1}`,
+    provider_status: row.provider_status ?? "ACTIVE",
+    entitlement_status: row.entitlement_status ?? "active",
+    interval: row.interval ?? "month",
+    current_period_end: row.current_period_end ?? futureIso(),
+    cancel_at_period_end: row.cancel_at_period_end ?? false,
+    cancelled_at: row.cancelled_at ?? null,
+    metadata: row.metadata ?? {},
+    created_at: row.created_at ?? new Date().toISOString(),
+    updated_at: row.updated_at ?? new Date().toISOString(),
+  }
+}
+
+function createSupabaseStub(seed?: {
+  billing?: Partial<BillingSubscriptionWithProviderEmail>[]
+  profiles?: Record<string, Record<string, unknown>>
+  authUsers?: Record<string, AuthUserStub>
+  paypalIntents?: Array<Record<string, unknown>>
+}) {
+  const billing = (seed?.billing ?? []).map((row, index) => createBillingRow(row, index))
+  const profiles = seed?.profiles ?? {}
+  const authUsers = seed?.authUsers ?? {}
+  const paypalIntents = seed?.paypalIntents ?? []
+  const webhookEvents = new Set<string>()
+
+  function makeQuery(table: string) {
+    const state: {
+      select?: string
+      filters: Array<{ column: string; value: unknown; op: "eq" | "ilike" | "in" | "is" }>
+      order?: { column: string; ascending: boolean }
+    } = { filters: [] }
+
+    function rows() {
+      if (table === "billing_subscriptions") return billing
+      if (table === "profiles") return Object.values(profiles)
+      if (table === "paypal_checkout_intents") return paypalIntents
+      return []
+    }
+
+    function applyFilters(input: Record<string, unknown>[]) {
+      return input.filter((row) =>
+        state.filters.every((filter) => {
+          if (filter.op === "eq") return row[filter.column] === filter.value
+          if (filter.op === "ilike") {
+            return (
+              String(row[filter.column] ?? "").toLowerCase() === String(filter.value).toLowerCase()
+            )
+          }
+          if (filter.op === "is") return row[filter.column] === filter.value
+          if (filter.op === "in") return (filter.value as unknown[]).includes(row[filter.column])
+          return false
+        }),
+      )
+    }
+
+    function applyOrder(input: Record<string, unknown>[]) {
+      if (!state.order) return input
+      return [...input].sort((left, right) => {
+        const leftValue = String(left[state.order!.column] ?? "")
+        const rightValue = String(right[state.order!.column] ?? "")
+        if (leftValue === rightValue) return 0
+        const direction = state.order!.ascending ? 1 : -1
+        return leftValue > rightValue ? direction : -direction
+      })
+    }
+
+    function applySelect(input: Record<string, unknown>) {
+      if (!state.select || state.select === "*") return input
+      const selected = state.select.split(",").map((column) => column.trim())
+      return Object.fromEntries(selected.map((column) => [column, input[column]]))
+    }
+
+    async function resolveRows() {
+      const filtered = applyFilters(rows() as unknown as Record<string, unknown>[])
+      return { data: applyOrder(filtered).map(applySelect), error: null }
+    }
+
+    const builder = {
+      select(columns = "*") {
+        state.select = columns
+        return builder
+      },
+      eq(column: string, value: unknown) {
+        state.filters.push({ column, value, op: "eq" })
+        return builder
+      },
+      ilike(column: string, value: unknown) {
+        state.filters.push({ column, value, op: "ilike" })
+        return builder
+      },
+      is(column: string, value: unknown) {
+        state.filters.push({ column, value, op: "is" })
+        return builder
+      },
+      in(column: string, value: unknown[]) {
+        state.filters.push({ column, value, op: "in" })
+        return builder
+      },
+      order(column: string, options: { ascending?: boolean } = {}) {
+        state.order = { column, ascending: options.ascending !== false }
+        return builder
+      },
+      maybeSingle: async () => {
+        const { data } = await resolveRows()
+        return { data: data[0] ?? null, error: null }
+      },
+      single: async () => {
+        const { data } = await resolveRows()
+        return { data: data[0] ?? null, error: null }
+      },
+      upsert(row: Record<string, unknown>) {
+        if (table === "billing_subscriptions") {
+          const existing = billing.find(
+            (candidate) =>
+              candidate.provider === row.provider &&
+              candidate.provider_subscription_id === row.provider_subscription_id,
+          )
+          if (existing) {
+            Object.assign(existing, row, { updated_at: row.updated_at ?? existing.updated_at })
+          } else {
+            billing.push(
+              createBillingRow(
+                row as Partial<BillingSubscriptionWithProviderEmail>,
+                billing.length,
+              ),
+            )
+          }
+        } else if (table === "profiles") {
+          const id = String(row.id)
+          profiles[id] = {
+            ...(profiles[id] ?? {}),
+            ...row,
+          }
+        }
+        const saved =
+          table === "billing_subscriptions"
+            ? billing.find(
+                (candidate) =>
+                  candidate.provider === row.provider &&
+                  candidate.provider_subscription_id === row.provider_subscription_id,
+              )
+            : row
+        return {
+          select: (columns = "*") => {
+            state.select = columns
+            return {
+              single: async () => ({
+                data: saved ? applySelect(saved as unknown as Record<string, unknown>) : null,
+                error: null,
+              }),
+            }
+          },
+        }
+      },
+      update(patch: Record<string, unknown>) {
+        return {
+          eq(column: string, value: unknown) {
+            state.filters.push({ column, value, op: "eq" })
+            return this
+          },
+          is(column: string, value: unknown) {
+            state.filters.push({ column, value, op: "is" })
+            return this
+          },
+          select(columns = "*") {
+            state.select = columns
+            const matched = applyFilters(rows() as unknown as Record<string, unknown>[])
+            for (const row of matched) Object.assign(row, patch)
+            return {
+              maybeSingle: async () => ({
+                data: matched[0] ? applySelect(matched[0]) : null,
+                error: null,
+              }),
+            }
+          },
+          then(resolve: (value: unknown) => void, reject: (error: unknown) => void) {
+            const matched = applyFilters(rows() as unknown as Record<string, unknown>[])
+            for (const row of matched) Object.assign(row, patch)
+            Promise.resolve({ data: matched, error: null }).then(resolve, reject)
+          },
+        }
+      },
+      insert(row: Record<string, unknown>) {
+        if (table === "billing_webhook_events") {
+          const key = `${row.provider}:${row.provider_event_id}`
+          if (webhookEvents.has(key)) {
+            return Promise.resolve({
+              data: null,
+              error: { code: "23505", message: "duplicate key value violates unique constraint" },
+            })
+          }
+          webhookEvents.add(key)
+        }
+        return Promise.resolve({ data: row, error: null })
+      },
+      delete() {
+        return {
+          eq(column: string, value: unknown) {
+            state.filters.push({ column, value, op: "eq" })
+            return this
+          },
+          then(resolve: (value: unknown) => void, reject: (error: unknown) => void) {
+            Promise.resolve({ data: null, error: null }).then(resolve, reject)
+          },
+        }
+      },
+      then(resolve: (value: unknown) => void, reject: (error: unknown) => void) {
+        resolveRows().then(resolve, reject)
+      },
+    }
+
+    return builder
+  }
+
+  return {
+    billing,
+    profiles,
+    authUsers,
+    paypalIntents,
+    supabase: {
+      from(table: string) {
+        return makeQuery(table)
+      },
+      auth: {
+        admin: {
+          async createUser(args: { email: string; app_metadata?: Record<string, unknown> }) {
+            const existing = Object.values(authUsers).find(
+              (user) => user.email.toLowerCase() === args.email.toLowerCase(),
+            )
+            if (existing) {
+              return { data: { user: null }, error: { status: 422, message: "duplicate" } }
+            }
+            const id = `user-${Object.keys(authUsers).length + 1}`
+            authUsers[id] = { id, email: args.email, app_metadata: args.app_metadata }
+            return { data: { user: { id, email: args.email } }, error: null }
+          },
+          async getUserById(userId: string) {
+            return { data: { user: authUsers[userId] ?? null }, error: null }
+          },
+          async listUsers() {
+            return { data: { users: Object.values(authUsers) }, error: null }
+          },
+        },
+      },
+    } as unknown as SupabaseBillingClient,
+  }
+}
+
+function paypalSubscription(
+  email = "paypal-buyer@example.com",
+  id = "I-active",
+): PayPalSubscription {
+  return {
+    id,
+    status: "ACTIVE",
+    plan_id: "P-month",
+    subscriber: { payer_id: "payer-1", email_address: email },
+    billing_info: { next_billing_time: futureIso() },
+  }
+}
+
+test("upsertBillingSubscription writes provider_subscriber_email on first insert", async () => {
+  const { billing, supabase } = createSupabaseStub()
+
+  const row = await upsertBillingSubscription(supabase, {
+    user_id: "user-1",
+    provider: "paypal",
+    provider_customer_id: "payer-1",
+    provider_subscriber_email: "payer@example.com",
+    provider_subscription_id: "I-123",
+    provider_status: "ACTIVE",
+    entitlement_status: "active",
+  })
+
+  assert.equal(billing.length, 1)
+  assert.equal(billing[0].provider_subscriber_email, "payer@example.com")
+  assert.equal(row.provider_subscriber_email, "payer@example.com")
+})
+
+test("upsertBillingSubscription updates provider_subscriber_email when provider data changes", async () => {
+  const { billing, supabase } = createSupabaseStub({
+    billing: [
+      {
+        provider_subscription_id: "I-123",
+        provider_subscriber_email: "old-payer@example.com",
+      },
+    ],
+  })
+
+  await upsertBillingSubscription(supabase, {
+    user_id: "user-1",
+    provider: "paypal",
+    provider_subscriber_email: "new-payer@example.com",
+    provider_subscription_id: "I-123",
+    provider_status: "ACTIVE",
+    entitlement_status: "active",
+  })
+
+  assert.equal(billing.length, 1)
+  assert.equal(billing[0].provider_subscriber_email, "new-payer@example.com")
+})
+
+test("upsertBillingSubscription preserves provider_subscriber_email when provider payload omits it", async () => {
+  const { billing, supabase } = createSupabaseStub({
+    billing: [
+      {
+        provider_subscription_id: "I-123",
+        provider_subscriber_email: "payer@example.com",
+      },
+    ],
+  })
+  const input: BillingSubscriptionInput = {
+    user_id: "user-1",
+    provider: "paypal",
+    provider_subscription_id: "I-123",
+    provider_status: "SUSPENDED",
+    entitlement_status: "past_due",
+    provider_subscriber_email: undefined,
+  }
+
+  await upsertBillingSubscription(supabase, input)
+
+  assert.equal(billing[0].provider_status, "SUSPENDED")
+  assert.equal(billing[0].provider_subscriber_email, "payer@example.com")
+})
+
+test("upsertBillingSubscription keeps existing rows with no provider_subscriber_email valid", async () => {
+  const { billing, supabase } = createSupabaseStub({
+    billing: [
+      {
+        provider_subscription_id: "I-123",
+        provider_subscriber_email: null,
+      },
+    ],
+  })
+
+  await upsertBillingSubscription(supabase, {
+    user_id: "user-1",
+    provider: "paypal",
+    provider_subscription_id: "I-123",
+    provider_status: "SUSPENDED",
+    entitlement_status: "past_due",
+  })
+
+  assert.equal(billing.length, 1)
+  assert.equal(billing[0].provider_status, "SUSPENDED")
+  assert.equal(billing[0].provider_subscriber_email, null)
+})
+
+test("findVisibleBillingSubscriptionForUser returns provider_subscriber_email", async () => {
+  const { supabase } = createSupabaseStub({
+    billing: [
+      {
+        user_id: "user-1",
+        provider_subscription_id: "I-123",
+        provider_subscriber_email: "payer@example.com",
+      },
+    ],
+  })
+
+  const row = await findVisibleBillingSubscriptionForUser(supabase, "user-1")
+
+  assert.equal(row?.provider_subscriber_email, "payer@example.com")
+})
+
+test("toBillingSubscriptionInputFromPayPal maps subscriber email as lowercase provider metadata", () => {
+  const row = toBillingSubscriptionInputFromPayPal(
+    paypalSubscription("PayPal-Buyer@Example.COM"),
+    "user-1",
+    "month",
+  )
+
+  assert.equal(row.provider_subscriber_email, "paypal-buyer@example.com")
+})
+
+test("PayPal activation uses deps.accountEmail for an existing Chaarlie account", async () => {
+  const { supabase, profiles, billing, authUsers } = createSupabaseStub({
+    profiles: {
+      "existing-user": {
+        id: "existing-user",
+        email: "lead@example.com",
+      },
+    },
+    authUsers: {
+      "existing-user": {
+        id: "existing-user",
+        email: "lead@example.com",
+        app_metadata: {
+          checkout_activation_session_hash: paypalCheckoutActivationHash("checkout-token"),
+        },
+      },
+    },
+  })
+  const linked: unknown[][] = []
+
+  const result = await ensurePayPalCheckoutAccount(paypalSubscription("paypal-buyer@example.com"), {
+    supabase: supabase as any,
+    premiumTierId: "tier-premium",
+    activationKey: "checkout-token",
+    accountEmail: " Lead@Example.COM ",
+    interval: "month",
+    linkQuizToProfile: async (...args) => {
+      linked.push(args)
+    },
+  })
+
+  assert.equal(result.status, "active")
+  if (result.status !== "active") throw new Error("expected active result")
+  assert.equal(result.userId, "existing-user")
+  assert.equal(result.email, "lead@example.com")
+  assert.equal(result.providerSubscriberEmail, "paypal-buyer@example.com")
+  assert.equal(Object.keys(authUsers).length, 1)
+  assert.equal(profiles["existing-user"].email, "lead@example.com")
+  assert.equal(billing[0].provider_subscriber_email, "paypal-buyer@example.com")
+  assert.deepEqual(linked, [["existing-user", "lead@example.com", undefined]])
+})
+
+test("PayPal activation creates Chaarlie account from deps.accountEmail and keeps password setup token based", async () => {
+  const { supabase, profiles, billing, authUsers } = createSupabaseStub()
+
+  const result = await ensurePayPalCheckoutAccount(paypalSubscription("paypal-buyer@example.com"), {
+    supabase: supabase as any,
+    premiumTierId: "tier-premium",
+    activationKey: "checkout-token",
+    accountEmail: "Lead@Example.COM",
+    interval: "month",
+  })
+
+  assert.equal(result.status, "active")
+  if (result.status !== "active") throw new Error("expected active result")
+  assert.equal(result.email, "lead@example.com")
+  assert.equal(result.providerSubscriberEmail, "paypal-buyer@example.com")
+  assert.equal(result.canSetInitialPassword, true)
+  assert.equal(Object.values(authUsers)[0].email, "lead@example.com")
+  assert.equal(
+    Object.values(authUsers)[0].app_metadata?.checkout_activation_session_hash,
+    paypalCheckoutActivationHash("checkout-token"),
+  )
+  assert.equal(Object.values(profiles)[0].email, "lead@example.com")
+  assert.equal(billing[0].provider_subscriber_email, "paypal-buyer@example.com")
+})
+
+test("PayPal activation accepts missing subscriber email when Chaarlie account email is present", async () => {
+  const { supabase, profiles, billing, authUsers } = createSupabaseStub()
+  const subscription = paypalSubscription("paypal-buyer@example.com")
+  subscription.subscriber = { payer_id: "payer-1" }
+
+  const result = await ensurePayPalCheckoutAccount(subscription, {
+    supabase: supabase as any,
+    premiumTierId: "tier-premium",
+    accountEmail: "Lead@Example.COM",
+    interval: "month",
+  })
+
+  assert.equal(result.status, "active")
+  if (result.status !== "active") throw new Error("expected active result")
+  assert.equal(result.email, "lead@example.com")
+  assert.equal(result.providerSubscriberEmail, null)
+  assert.equal(Object.values(authUsers)[0].email, "lead@example.com")
+  assert.equal(Object.values(profiles)[0].email, "lead@example.com")
+  assert.equal(billing[0].provider_subscriber_email, null)
+})
+
+test("PayPal activation falls back to subscriber email when checkout account email is missing", async () => {
+  const { supabase, profiles, authUsers } = createSupabaseStub()
+
+  const result = await ensurePayPalCheckoutAccount(paypalSubscription("PayPal-Buyer@Example.COM"), {
+    supabase: supabase as any,
+    premiumTierId: "tier-premium",
+    accountEmail: null,
+    interval: "month",
+  })
+
+  assert.equal(result.status, "active")
+  if (result.status !== "active") throw new Error("expected active result")
+  assert.equal(result.email, "paypal-buyer@example.com")
+  assert.equal(result.providerSubscriberEmail, "paypal-buyer@example.com")
+  assert.equal(Object.values(authUsers)[0].email, "paypal-buyer@example.com")
+  assert.equal(Object.values(profiles)[0].email, "paypal-buyer@example.com")
+})
+
+test("ensurePayPalCheckoutAccountForToken keeps checkout intent email as Chaarlie account email", async () => {
+  const { supabase, paypalIntents } = createSupabaseStub({
+    paypalIntents: [
+      {
+        id: "intent-1",
+        token: "checkout-token",
+        interval: "month",
+        source: "pricing_page",
+        status: "approved",
+        provider_subscription_id: null,
+        lead_id: null,
+        email: "lead@example.com",
+        user_id: null,
+        expires_at: futureIso(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        metadata: {},
+      },
+    ],
+  })
+
+  const result = await ensurePayPalCheckoutAccountForToken("checkout-token", {
+    supabase: supabase as any,
+    premiumTierId: "tier-premium",
+  })
+
+  assert.deepEqual(result, { status: "pending" })
+  assert.equal(paypalIntents[0].email, "lead@example.com")
+})
+
+test("webhook-first PayPal activation uses bound checkout intent email and keeps PayPal email in provider metadata", async () => {
+  const { supabase, profiles, billing, authUsers, paypalIntents } = createSupabaseStub({
+    paypalIntents: [
+      {
+        id: "intent-1",
+        token: "checkout-token",
+        interval: "month",
+        source: "pricing_page",
+        status: "approved",
+        provider_subscription_id: null,
+        lead_id: "lead-123",
+        email: "lead@example.com",
+        user_id: null,
+        expires_at: futureIso(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        metadata: {},
+      },
+    ],
+  })
+  const linked: unknown[][] = []
+
+  const result = await handlePayPalWebhookEvent(
+    {
+      id: "WH-identity",
+      event_type: "BILLING.SUBSCRIPTION.ACTIVATED",
+      resource: { id: "I-active" },
+    },
+    {
+      supabase: supabase as any,
+      premiumTierId: "tier-premium",
+      freeTierId: "tier-free",
+      retrievePayPalSubscription: async () => ({
+        ...paypalSubscription("paypal-buyer@example.com"),
+        custom_id: "checkout-token",
+      }),
+      linkQuizToProfile: async (...args) => {
+        linked.push(args)
+      },
+    },
+  )
+
+  assert.deepEqual(result, { handled: true })
+  assert.equal(Object.values(authUsers)[0].email, "lead@example.com")
+  assert.equal(Object.values(profiles)[0].email, "lead@example.com")
+  assert.equal(billing[0].provider_subscriber_email, "paypal-buyer@example.com")
+  assert.equal(paypalIntents[0].email, "lead@example.com")
+  assert.equal(paypalIntents[0].provider_subscription_id, "I-active")
+  assert.equal(paypalIntents[0].status, "activated")
+  assert.deepEqual(linked, [[Object.values(authUsers)[0].id, "lead@example.com", "lead-123"]])
+})
+
+test("webhook-first PayPal activation cancels duplicate fallback subscriber email access", async () => {
+  const { supabase, paypalIntents, billing } = createSupabaseStub({
+    billing: [
+      {
+        user_id: "existing-user",
+        provider: "paypal",
+        provider_subscription_id: "I-existing",
+        entitlement_status: "active",
+      },
+    ],
+    profiles: {
+      "existing-user": {
+        id: "existing-user",
+        email: "paypal-buyer@example.com",
+      },
+    },
+    paypalIntents: [
+      {
+        id: "intent-1",
+        token: "checkout-token",
+        interval: "month",
+        source: "pricing_page",
+        status: "approved",
+        provider_subscription_id: null,
+        lead_id: null,
+        email: null,
+        user_id: null,
+        expires_at: futureIso(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        metadata: {},
+      },
+    ],
+  })
+  const cancelled: string[] = []
+
+  const result = await handlePayPalWebhookEvent(
+    {
+      id: "WH-duplicate-fallback",
+      event_type: "BILLING.SUBSCRIPTION.ACTIVATED",
+      resource: { id: "I-duplicate" },
+    },
+    {
+      supabase: supabase as any,
+      premiumTierId: "tier-premium",
+      freeTierId: "tier-free",
+      retrievePayPalSubscription: async () => ({
+        ...paypalSubscription("paypal-buyer@example.com", "I-duplicate"),
+        custom_id: "checkout-token",
+      }),
+      cancelPayPalSubscription: async (subscriptionId) => {
+        cancelled.push(subscriptionId)
+      },
+    },
+  )
+
+  assert.deepEqual(result, { handled: true })
+  assert.deepEqual(cancelled, ["I-duplicate"])
+  assert.equal(paypalIntents[0].provider_subscription_id, "I-duplicate")
+  assert.equal(paypalIntents[0].status, "duplicate")
+  assert.equal(paypalIntents[0].duplicate_reason, "intent_email_already_has_access")
+  assert.equal(billing.length, 1)
+})

--- a/tests/paypal-webhook-handlers.test.ts
+++ b/tests/paypal-webhook-handlers.test.ts
@@ -49,6 +49,7 @@ function createSupabaseStub(seed?: {
     user_id: row.user_id ?? "user-1",
     provider: row.provider ?? "paypal",
     provider_customer_id: row.provider_customer_id ?? "payer-1",
+    provider_subscriber_email: row.provider_subscriber_email ?? null,
     provider_subscription_id: row.provider_subscription_id ?? `I-${index + 1}`,
     provider_status: row.provider_status ?? "ACTIVE",
     entitlement_status: row.entitlement_status ?? "active",
@@ -460,6 +461,43 @@ test("activation webhook does not rebind an intent that already belongs to anoth
   assert.deepEqual(cancelled, ["I-active"])
   assert.equal(paypalIntents[0].provider_subscription_id, "I-original")
   assert.equal(paypalIntents[0].status, "approved")
+  assert.equal(billing.length, 0)
+})
+
+test("activation webhook cancels subscriptions created from expired checkout intents", async () => {
+  const { supabase, billing, paypalIntents } = createSupabaseStub({
+    billing: [],
+    paypalIntents: [
+      {
+        id: "intent-expired",
+        token: "token-active",
+        interval: "month",
+        source: "pricing_page",
+        status: "approved",
+        provider_subscription_id: null,
+        expires_at: pastIso(),
+      },
+    ],
+  })
+  const cancelled: string[] = []
+
+  const result = await handlePayPalWebhookEvent(
+    event("WH-expired-token", "BILLING.SUBSCRIPTION.ACTIVATED"),
+    {
+      supabase,
+      premiumTierId: "tier-premium",
+      freeTierId: "tier-free",
+      retrievePayPalSubscription: async () => subscription("ACTIVE", futureIso()),
+      cancelPayPalSubscription: async (subscriptionId) => {
+        cancelled.push(subscriptionId)
+      },
+    },
+  )
+
+  assert.deepEqual(result, { handled: true })
+  assert.deepEqual(cancelled, ["I-active"])
+  assert.equal(paypalIntents[0].status, "expired")
+  assert.equal(paypalIntents[0].provider_subscription_id, null)
   assert.equal(billing.length, 0)
 })
 

--- a/tests/welcome-email-display.test.tsx
+++ b/tests/welcome-email-display.test.tsx
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const welcomePageSource = readFileSync(
+  new URL("../src/app/welcome/page.tsx", import.meta.url),
+  "utf8",
+)
+const welcomeClientSource = readFileSync(
+  new URL("../src/app/welcome/welcome-client.tsx", import.meta.url),
+  "utf8",
+)
+
+test("PayPal welcome passes Chaarlie and provider subscriber emails separately", () => {
+  assert.match(welcomePageSource, /email=\{activation\.email\}/)
+  assert.match(welcomePageSource, /providerSubscriberEmail=\{activation\.providerSubscriberEmail\}/)
+})
+
+test("PayPal welcome uses a hashed analytics id instead of the activation token", () => {
+  assert.match(welcomePageSource, /function paypalCheckoutAnalyticsId/)
+  assert.match(welcomePageSource, /createHash\("sha256"\)\.update\(token\)/)
+  assert.match(welcomePageSource, /analyticsId=\{paypalCheckoutAnalyticsId\(token\)\}/)
+  assert.doesNotMatch(welcomeClientSource, /`paypal:\$\{source\.token\}`/)
+  assert.match(welcomeClientSource, /return "paypal:checkout"/)
+})
+
+test("PayPal pending polling depends on the stable token instead of the activationSource object", () => {
+  assert.match(welcomeClientSource, /const paypalActivationToken =/)
+  assert.match(welcomeClientSource, /\}, \[mode, paypalActivationToken\]\)/)
+  assert.doesNotMatch(welcomeClientSource, /\}, \[activationSource, mode\]\)/)
+})
+
+test("welcome labels the account email as Chaarlie-E-Mail", () => {
+  assert.match(welcomeClientSource, /Chaarlie-E-Mail/)
+  assert.doesNotMatch(welcomeClientSource, /E-Mail aus deinem Checkout/)
+})
+
+test("welcome only shows PayPal-E-Mail when it differs from Chaarlie email", () => {
+  assert.match(welcomeClientSource, /providerSubscriberEmail\?: string \| null/)
+  assert.match(welcomeClientSource, /const showProviderSubscriberEmail =/)
+  assert.match(
+    welcomeClientSource,
+    /providerSubscriberEmail\?\.trim\(\)\.toLowerCase\(\) !== email\?\.trim\(\)\.toLowerCase\(\)/,
+  )
+  assert.match(welcomeClientSource, /PayPal-E-Mail/)
+})


### PR DESCRIPTION
## Summary

This fixes the PayPal email mismatch flow so the Chaarlie account/login email stays the quiz/contact email, while the PayPal subscriber email is stored only as support-visible provider metadata.

## What changed

- Added `billing_subscriptions.provider_subscriber_email` for payment-provider subscriber/customer email.
- Updated PayPal activation and webhook-first activation to bind access to the Chaarlie/checkout-intent email, not the PayPal account email.
- Kept PayPal subscriber email in billing metadata and displayed it only on welcome/admin when it differs from the Chaarlie email.
- Added provider-neutral duplicate subscription blocking for Stripe and PayPal with a German modal and `/auth?email=...` login prefill when safe.
- Suppressed lead-derived email exposure in duplicate checkout responses.
- Avoided sending raw PayPal activation tokens to checkout analytics.
- Added a dry-run PayPal buyer audit SQL for support/documentation.

## Migration status

Changed migration:

- `20260603120000_add_provider_subscriber_email.sql`

Supabase project `pqdkhefxsxkyeqelqegq`:

- Applied surgically during shipping with `supabase db query --linked --file supabase/migrations/20260603120000_add_provider_subscriber_email.sql`.
- Verified remote column exists as nullable `text` with the intended comment.
- Marked only migration `20260603120000` as applied with `supabase migration repair 20260603120000 --status applied --linked`.
- Verified `supabase_migrations.schema_migrations` contains `20260603120000`.

Note: remote migration history has unrelated existing divergence around late May, so I intentionally did not run a blind `supabase db push`.

## PayPal audit

Ran `supabase/manual-test-backfills/20260603_provider_subscriber_email_audit.sql` after the migration. It found 9 PayPal billing rows; historical `provider_subscriber_email` values are still null and should only be backfilled from PayPal API-confirmed subscriber data. Stefanie's current row remains not onboarded/no last sign-in and should stay a support/manual correction case.

## Verification

- `npm run typecheck` passed
- `npm run lint` passed with 0 errors and 4 pre-existing warnings
- `npm run test:node` passed: 566 tests, 0 failures
- `npm run build` passed
- `git diff --check origin/main` passed
- Targeted Clawpatch/code review run completed; remaining material item is the known follow-up to replace public `lead_id` checkout identity with a signed/owned checkout token.

## Known follow-ups

- Replace public `lead_id` checkout identity with a signed checkout token / ownership proof for Stripe and PayPal.
- Consider separate hardening tickets for existing Stripe session lookup and PayPal cancellation ordering findings surfaced by Clawpatch.
