### PR TITLE
fix(payments): sunset SEPA checkout sessions

### DIFF
--- a/docs/stripe-sepa-renewal-migration.md
+++ b/docs/stripe-sepa-renewal-migration.md
@@ -1,0 +1,55 @@
+# Stripe SEPA Renewal Migration
+
+## Current Policy
+
+New Stripe Checkout Sessions exclude SEPA Debit in code with `excluded_payment_method_types: ["sepa_debit"]`. This prevents new purchases from choosing SEPA while leaving Stripe Dashboard payment method settings unchanged for now.
+
+Existing active SEPA subscriptions are grandfathered temporarily. They should continue through normal renewal behavior while we audit the affected subscription set and decide whether each subscription should be migrated, grandfathered, or canceled after a deadline.
+
+Do not globally disable SEPA in the Stripe Dashboard until the audit confirms that existing SEPA subscriptions have either been migrated to a non-SEPA payment method or are intentionally grandfathered.
+
+Renewal failures for existing SEPA subscriptions should use the normal failed-payment path. No special access behavior is needed solely because the renewal payment method is SEPA.
+
+## Audit Fields
+
+For each potentially affected Stripe subscription, collect:
+
+- Stripe customer ID
+- Stripe subscription ID
+- Customer email
+- Subscription status
+- Current period end
+- Whether `subscription.default_payment_method` is SEPA Debit
+- Whether `customer.invoice_settings.default_payment_method` is SEPA Debit
+
+The audit must distinguish subscription-level payment methods from customer-level invoice defaults because Stripe payment method priority can cause a SEPA subscription default to keep taking precedence even after the customer invoice default is updated.
+
+## Migration Choice
+
+If `subscription.default_payment_method` is SEPA Debit, prefer a subscription-specific payment update link or a setup-mode card flow that updates `subscription.default_payment_method`. Updating only `customer.invoice_settings.default_payment_method` may not change the payment method used for that subscription.
+
+If only `customer.invoice_settings.default_payment_method` is SEPA Debit, and the subscription does not have a SEPA `subscription.default_payment_method`, a generic Customer Portal `payment_method_update` flow may be sufficient.
+
+For a small number of affected users, use Stripe Dashboard links or manual Dashboard-assisted migration. For larger numbers, build or use a setup-mode card collection flow that explicitly attaches the new card and updates the correct Stripe default based on the audit result.
+
+## Recommended Rollout
+
+Keep existing renewals active while auditing. Do not contact every user preemptively; contact affected users only when the audit shows that migration is needed or when a renewal failure requires normal failed-payment recovery.
+
+Recommended sequence:
+
+1. Audit active and relevant past-due subscriptions for SEPA defaults.
+2. Classify each subscription by whether SEPA is set at `subscription.default_payment_method`, `customer.invoice_settings.default_payment_method`, or both.
+3. Choose the migration path based on Stripe payment method priority.
+4. Contact affected users only when a payment method update is needed.
+5. Use Dashboard links for small affected groups, or a setup-mode card flow for larger groups.
+6. Set an operational deadline for deciding whether remaining SEPA subscriptions are grandfathered, canceled, or required to migrate.
+7. Re-audit before changing global Stripe Dashboard payment method settings.
+
+## Do Not Do Yet
+
+Do not globally disable SEPA in the Stripe Dashboard until the audit confirms that existing SEPA subscriptions are migrated or intentionally grandfathered.
+
+Do not assume a generic customer-level payment method update fixes subscriptions that have `subscription.default_payment_method` set to SEPA Debit.
+
+Do not add special renewal failure handling for SEPA-only failures unless a separate product decision requires it. Existing SEPA renewal failures should continue through the normal failed-payment path.

--- a/docs/superpowers/specs/2026-06-02-stripe-sepa-sunset-containment-design.md
+++ b/docs/superpowers/specs/2026-06-02-stripe-sepa-sunset-containment-design.md
@@ -1,0 +1,72 @@
+# Stripe SEPA Sunset Containment Design
+
+## Reader Line
+
+This spec replaces the earlier SEPA immediate-access architecture plan. It defines the smaller containment path for sunsetting SEPA Direct Debit in new Stripe Checkout Sessions while preserving renewal safety for users who already have active SEPA subscriptions.
+
+## User Situation
+
+Chaarlie no longer wants to offer SEPA for new purchases because delayed settlement, pending payment states, possible reversals, and renewal uncertainty add too much operational risk. Users who have not already received app access through an active subscription should switch to another payment method.
+
+## Promised End State
+
+- New Stripe subscription Checkout Sessions do not offer SEPA Direct Debit.
+- Completed unpaid SEPA Checkout Sessions do not grant new access in this release.
+- Existing active SEPA subscriptions are not broken by a global Stripe Dashboard change during this release.
+- Normal failed-payment/dispute paths remain active for existing subscriptions.
+- Card Checkout continues to work.
+- Existing SEPA subscriptions are audited and handled as a migration/renewal decision, not silently broken.
+
+## Stripe Evidence
+
+- Checkout Sessions in this codebase rely on Dashboard-managed payment methods because `payment_method_types` is omitted from `stripe.checkout.sessions.create`.
+- Stripe documents `excluded_payment_method_types` on Checkout Sessions as the per-session way to exclude methods when payment methods are managed through the Dashboard: https://docs.stripe.com/api/checkout/sessions/create
+- Stripe documents SEPA as a delayed-notification method; a completed Checkout can mean the debit is authorized but funds are not yet available: https://docs.stripe.com/billing/subscriptions/sepa-debit
+- Stripe subscription renewal invoices use invoice, subscription, customer invoice default, and legacy source payment-method priority. Subscription payment method availability can affect renewal success: https://docs.stripe.com/billing/invoices/subscription and https://docs.stripe.com/billing/subscriptions/payment-methods-setting
+- Stripe Customer Portal supports a `payment_method_update` flow that lets customers add a new payment method and sets it as the customer invoice default payment method: https://docs.stripe.com/customer-management/portal-deep-links
+- Stripe also documents a Checkout setup-mode path to collect a new payment method and update the subscription's `default_payment_method`: https://docs.stripe.com/payments/checkout/subscriptions/update-payment-details
+
+## Scope
+
+In scope:
+
+- Code-level SEPA exclusion for new Stripe Checkout Sessions.
+- Rejection of unpaid Checkout Sessions, including SEPA, for new access.
+- Existing async failure/dispute revocation behavior.
+- Removal of the local `stripe_checkout_intents` WIP from this release because the remote migration was never applied and SEPA is being sunset.
+- Tests proving SEPA is excluded from new Checkout creation.
+- Tests proving completed unpaid SEPA does not grant access.
+- An operational audit plan for existing SEPA subscribers and renewals.
+
+Out of scope:
+
+- Global Stripe Dashboard disabling of SEPA during this release.
+- Large checkout-attempt/table rename or webhook file split.
+- A new Stripe checkout-intents table or migration.
+- Migration of all existing SEPA subscribers in code.
+- Customer-facing email copy implementation for renewal migration.
+- Cleanup of already duplicated live Stripe subscriptions.
+
+## Chosen Approach
+
+Use a small server-side containment patch:
+
+1. Add `excluded_payment_method_types: ["sepa_debit"]` to new Stripe subscription Checkout Session creation.
+2. Reject completed unpaid Checkout Sessions for new access, including SEPA.
+3. Keep normal failure/dispute handling for existing subscriptions.
+4. Fulfill delayed non-SEPA Checkout success from `checkout.session.async_payment_succeeded`, while skipping SEPA async success during the sunset.
+5. Remove the local `stripe_checkout_intents` WIP from the final release.
+6. Do not globally disable SEPA in Stripe until existing SEPA subscriptions are audited.
+7. Handle renewals with a separate operational migration path.
+
+## Renewal Handling Recommendation
+
+For existing SEPA subscribers, use a temporary grandfathering approach:
+
+- Let existing SEPA subscriptions continue charging while the subscriber is migrated.
+- Audit active subscriptions with `default_payment_method.type === "sepa_debit"`.
+- Ask affected users to update to card through Stripe Customer Portal or a subscription-specific payment update link.
+- Prefer subscription-specific update where possible so the new card becomes `subscription.default_payment_method` for that subscription.
+- After a deadline, choose one policy: keep grandfathering, cancel at period end, or enforce card-only renewal.
+
+Do not globally disable SEPA until this audit confirms whether disabling it affects renewal collection for active SEPA subscriptions.

--- a/plans/2026-06-02-stripe-sepa-sunset-containment.md
+++ b/plans/2026-06-02-stripe-sepa-sunset-containment.md
@@ -1,0 +1,449 @@
+# Stripe SEPA Sunset Containment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-stripe-sepa-sunset-containment-design.md`
+
+**User Situation:** Chaarlie wants to stop offering SEPA for new purchases because delayed settlement, pending states, possible reversals, and renewal uncertainty add too much operational risk. Users who have not already received app access through an active subscription should switch to another payment method.
+
+**Promised End State:** New Stripe Checkout Sessions do not offer SEPA; completed unpaid SEPA Checkout Sessions do not grant new access; card Checkout still works; existing active SEPA subscriptions keep running under normal renewal/failure behavior; existing SEPA subscriptions are audited before any global Stripe/Dashboard disablement.
+
+**Goal:** Ship a small SEPA containment patch instead of the larger checkout-attempt architecture refactor.
+
+**Architecture:** Remove the local `stripe_checkout_intents` WIP from this release because the remote migration was never applied and SEPA is being sunset. Keep Stripe Dashboard payment methods for general configuration, but use server-side `excluded_payment_method_types: ["sepa_debit"]` on new Checkout Sessions to block SEPA at code level. Keep activation strict: completed unpaid Checkout Sessions do not grant new access. Treat existing SEPA renewals as an operational migration path rather than a checkout-flow refactor.
+
+**Tech Stack:** Next.js App Router API routes, Stripe Node SDK (`apiVersion: "2026-04-22.dahlia"`), Supabase, Playwright tests, Node `tsx --test` tests.
+
+---
+
+## Locked Decisions
+
+- Do not globally disable SEPA in Stripe Dashboard during this release.
+- Do not rely on hiding SEPA in the frontend. Checkout methods are determined server-side by Stripe from Dashboard-managed methods.
+- Stop new SEPA checkouts with `excluded_payment_method_types: ["sepa_debit"]` in `stripe.checkout.sessions.create`.
+- Do not ship the larger `stripe_checkout_attempts` rename/service/webhook split for this release.
+- Do not ship the current WIP `stripe_checkout_intents` duplicate guard in this release. The migration was not applied remotely, and the SEPA sunset patch does not need a new local lock table.
+- Do not grant new access for completed unpaid SEPA Checkout. Users who hit this state should switch to another payment method.
+- Existing SEPA renewals are grandfathered temporarily until audited and migrated.
+- Existing SEPA renewal failures use the normal failed-payment path.
+- Renewal migration must account for Stripe payment-method priority: if `subscription.default_payment_method` is SEPA, changing only `customer.invoice_settings.default_payment_method` may not be enough.
+
+## Target File Map
+
+- Modify: `src/app/api/stripe/create-checkout-session/route.ts`
+- Create small helper for testability: `src/lib/stripe/checkout-session-params.ts`
+- Modify: `src/lib/stripe/checkout-activation.ts`
+- Modify/keep: `src/lib/stripe/webhook-handlers.ts`
+- Modify/keep: `src/app/api/stripe/webhook/route.ts`
+- Delete from final diff: `src/lib/stripe/checkout-intents.ts`
+- Delete from final diff: `supabase/migrations/20260602_add_stripe_checkout_intents.sql`
+- Modify tests:
+  - `tests/billing-paypal-server.test.ts`
+  - `tests/checkout-activation.spec.ts`
+  - `tests/stripe-webhook-handlers.spec.ts`
+  - `tests/customerio-stripe-webhook.test.ts`
+  - `tests/stripe-purchase-analytics.spec.ts`
+- Add operational doc: `docs/stripe-sepa-renewal-migration.md`
+
+## Non-Goals
+
+- No new checkout-attempt table.
+- No new Stripe checkout-intents table.
+- No `stripe_checkout_intents` to `stripe_checkout_attempts` rename.
+- No broad webhook file split.
+- No automatic migration of existing SEPA subscriptions in this release.
+- No customer-facing email/copy implementation in this release.
+- No cleanup of already duplicated live Stripe subscriptions in this release.
+
+## Task 0: Remove Prior Stripe Checkout-Intents WIP From This Release
+
+**Files:**
+
+- Inspect: `git status --short`
+- Delete: `src/lib/stripe/checkout-intents.ts`
+- Delete: `supabase/migrations/20260602_add_stripe_checkout_intents.sql`
+- Modify: `src/app/api/stripe/create-checkout-session/route.ts`
+- Modify: `src/lib/stripe/webhook-handlers.ts`
+- Modify: `tests/billing-paypal-server.test.ts`
+- Modify: `tests/stripe-webhook-handlers.spec.ts`
+- Modify: `tests/customerio-stripe-webhook.test.ts`
+
+- [ ] **Step 1: Confirm the implementation starts from the containment scope**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: identify the current WIP references to `stripe_checkout_intents` so they can be removed cleanly.
+
+- [ ] **Step 2: Delete the local checkout-intents files**
+
+Remove these files from the final diff:
+
+```text
+src/lib/stripe/checkout-intents.ts
+supabase/migrations/20260602_add_stripe_checkout_intents.sql
+```
+
+Expected: no production code depends on a local Stripe checkout-intents table.
+
+- [ ] **Step 3: Remove checkout-intents from the Stripe checkout route**
+
+In `src/app/api/stripe/create-checkout-session/route.ts`, remove:
+
+- imports from `@/lib/stripe/checkout-intents`
+- `findReusableStripeCheckoutIntent`
+- `createStripeCheckoutIntent`
+- `bindStripeCheckoutIntentToSession`
+- `markStripeCheckoutIntentFailedById`
+- `StripeCheckoutIntentConflictError`
+- `StripeCheckoutIntentRow`
+- `createStripeCheckoutIntentConflictResponse`
+- `markStripeCheckoutIntentFailedBestEffort`
+- `expireStripeCheckoutSessionBestEffort` if it only exists for checkout-intent bind failure compensation
+
+Expected: the route creates a Stripe Checkout Session directly after existing identity/access checks, then returns `{ client_secret: session.client_secret }`.
+
+- [ ] **Step 4: Remove checkout-intents from webhook handlers**
+
+In `src/lib/stripe/webhook-handlers.ts`, remove:
+
+- imports from `@/lib/stripe/checkout-intents`
+- calls to `markStripeCheckoutIntentActivated`
+- calls to `markStripeCheckoutIntentExpired`
+- calls to `markStripeCheckoutIntentFailed`
+
+Expected: existing subscription behavior, async failure revocation, dispute revocation, subscription updated/deleted, and `invoice.payment_failed` behavior remain intact.
+
+- [ ] **Step 5: Remove checkout-intents tests and stubs**
+
+In `tests/billing-paypal-server.test.ts`, remove:
+
+- imports from `../src/lib/stripe/checkout-intents`
+- the `stripe_checkout_intents` table stub branches
+- tests for Stripe checkout-intent creation/bind/fail/expire
+- tests for `createStripeCheckoutIntentConflictResponse`
+
+In `tests/stripe-webhook-handlers.spec.ts` and `tests/customerio-stripe-webhook.test.ts`, remove `stripe_checkout_intents` table stub branches and assertions that only exist to verify intent marking.
+
+Delete these whole intent-only webhook tests, because they have no remaining behavior once local checkout-intent marking is removed:
+
+- `tests/stripe-webhook-handlers.spec.ts`: `checkout.session.expired releases a Stripe checkout intent lock`
+- `tests/stripe-webhook-handlers.spec.ts`: `checkout.session.async_payment_succeeded marks Stripe checkout intent activated without changing access`
+- `tests/customerio-stripe-webhook.test.ts`: `checkout.session.expired releases a Stripe checkout intent lock`
+- `tests/customerio-stripe-webhook.test.ts`: `checkout.session.async_payment_succeeded marks Stripe checkout intent activated without changing access`
+
+Preserve async-failed, dispute, subscription updated/deleted, and `invoice.payment_failed` tests. Those verify real subscription/access behavior, not local intent bookkeeping.
+
+Expected: tests still cover PayPal checkout intents, Stripe access activation, Stripe async failure revocation, disputes, and Customer.io lifecycle behavior.
+
+- [ ] **Step 6: Confirm abandoned architecture files are absent**
+
+The following files should not exist in the final diff:
+
+```text
+supabase/migrations/20260602160000_add_stripe_checkout_attempts.sql
+src/lib/stripe/checkout-attempts.ts
+src/lib/stripe/checkout-session-service.ts
+```
+
+Expected: absent. If they exist only because of the abandoned architecture plan, remove them.
+
+## Task 1: Block SEPA for New Stripe Checkout Sessions
+
+**Files:**
+
+- Modify: `src/app/api/stripe/create-checkout-session/route.ts`
+- Create: `src/lib/stripe/checkout-session-params.ts`
+- Test: `tests/billing-paypal-server.test.ts`
+
+- [ ] **Step 1: Extract a small Checkout params helper and write a failing test**
+
+Extract the Checkout Session params from `create-checkout-session/route.ts` into `src/lib/stripe/checkout-session-params.ts` so the SEPA exclusion can be tested without constructing a full Next request. Add a test equivalent to:
+
+```ts
+test("Stripe subscription checkout excludes SEPA for new sessions", () => {
+  const params = buildStripeSubscriptionCheckoutSessionParams({
+    priceId: "price_month",
+    interval: "month",
+    customerId: null,
+    customerEmail: "buyer@example.com",
+    origin: "https://chaarlie.de",
+    discountCouponId: "coupon_50",
+    leadId: "11111111-1111-4111-8111-111111111111",
+  })
+
+  assert.deepEqual(params.excluded_payment_method_types, ["sepa_debit"])
+  assert.equal(params.mode, "subscription")
+  assert.equal(params.ui_mode, "embedded_page")
+  assert.deepEqual(params.line_items, [{ price: "price_month", quantity: 1 }])
+})
+```
+
+- [ ] **Step 2: Preserve existing Checkout params while adding exclusion**
+
+Update `stripe.checkout.sessions.create` so the created session includes:
+
+```ts
+excluded_payment_method_types: ["sepa_debit"],
+```
+
+Preserve the current params:
+
+- `mode: "subscription"`
+- `ui_mode: "embedded_page"`
+- `line_items`
+- `customer` or `customer_email`, never both
+- `return_url`
+- `automatic_tax`
+- `consent_collection`
+- existing German terms custom text
+- discount coupon when configured
+- lead metadata
+
+- [ ] **Step 3: Run the focused test**
+
+Run:
+
+```bash
+npx tsx --test tests/billing-paypal-server.test.ts
+```
+
+Expected: PASS.
+
+## Task 2: Reject Unpaid SEPA Checkout for New Access
+
+**Files:**
+
+- Modify: `src/lib/stripe/checkout-activation.ts`
+- Verify: `src/lib/stripe/purchase-analytics.ts`
+- Test: `tests/checkout-activation.spec.ts`
+- Test: `tests/stripe-purchase-analytics.spec.ts`
+
+- [ ] **Step 1: Remove unpaid-SEPA activation**
+
+In `src/lib/stripe/checkout-activation.ts`, `assertCheckoutPaymentAuthorized` must not return for `payment_status === "unpaid"` even when `subscription.default_payment_method.type === "sepa_debit"`.
+
+The authorization rule for this release is:
+
+```ts
+session.status === "complete"
+session.payment_status === "paid"
+```
+
+Any completed unpaid Checkout Session throws `checkout_session_unpaid`, including SEPA. This intentionally forces users who reached unpaid SEPA Checkout without existing access to use another payment method.
+
+After removing the SEPA branch, drop the unused `sub` parameter from `assertCheckoutPaymentAuthorized` and update both call sites in `verifyCheckoutSessionForActivation` and `ensureCheckoutAccount`. The `session.status === "complete"` check remains in the existing session-shape validation; `assertCheckoutPaymentAuthorized` only needs to check `payment_status`.
+
+- [ ] **Step 2: Update activation tests**
+
+In `tests/checkout-activation.spec.ts`, replace the previous unpaid-SEPA-grants test with a rejection test:
+
+```ts
+test("verifyCheckoutSessionForActivation rejects complete unpaid SEPA sessions during SEPA sunset", async () => {
+  const stripe = stripeForCheckoutActivation({
+    default_payment_method: { id: "pm_sepa", type: "sepa_debit" },
+  })
+
+  await expect(verifyCheckoutSessionForActivation("cs_unpaid_sepa", stripe)).rejects.toMatchObject({
+    code: "checkout_session_unpaid",
+  })
+})
+```
+
+- [ ] **Step 3: Verify analytics selected-method parsing**
+
+`purchase-analytics.ts` may keep its existing local `default_payment_method` parser for this release. Analytics does not gate access, and a shared selected-payment helper is outside this containment patch.
+
+Expected: analytics still reports `paymentMethodType` from the retrieved Subscription default payment method when available.
+
+- [ ] **Step 4: Run activation tests**
+
+Run:
+
+```bash
+npx playwright test tests/checkout-activation.spec.ts tests/auth-post-checkout-routes.spec.ts --project=chromium
+npx tsx --test tests/stripe-purchase-analytics.spec.ts
+```
+
+Expected: PASS, including:
+
+- unpaid SEPA rejects access
+- unpaid card/non-SEPA rejects access
+- SEPA offered but not selected rejects access
+
+## Task 3: Preserve Existing Subscription Failure and Dispute Handling
+
+**Files:**
+
+- Modify/keep: `src/lib/stripe/webhook-handlers.ts`
+- Modify/keep: `src/app/api/stripe/webhook/route.ts`
+- Test: `tests/stripe-webhook-handlers.spec.ts`
+- Test: `tests/customerio-stripe-webhook.test.ts`
+
+- [ ] **Step 1: Verify only: keep webhook dispatch for delayed-payment events**
+
+Ensure `src/app/api/stripe/webhook/route.ts` handles:
+
+```text
+checkout.session.completed
+checkout.session.async_payment_failed
+charge.dispute.created
+customer.subscription.updated
+customer.subscription.deleted
+invoice.payment_failed
+```
+
+After removing local checkout-intent marking:
+
+- keep `checkout.session.expired` routed to an explicit no-op/logging handler, or remove the case and handler together
+- handle `checkout.session.async_payment_succeeded` as fulfillment for delayed non-SEPA payment methods, while explicitly skipping SEPA async success during the SEPA sunset
+
+Recommended: keep `checkout.session.expired` as explicit no-op/logging, and keep `checkout.session.async_payment_succeeded` routed so Dashboard-managed delayed non-SEPA methods do not dead-end.
+
+Expected in the current WIP: these events are already dispatched. Do not rewrite the dispatcher unless verification shows a missing case.
+
+- [ ] **Step 2: Verify only: async failure revokes only the relevant subscription**
+
+`checkout.session.async_payment_failed`, when received for an existing subscription/customer, should:
+
+- identify the Stripe customer and subscription from the Checkout Session
+- downgrade the matching profile if it still points at that subscription
+- mark the matching Stripe billing row canceled/payment failed
+- best-effort cancel the matching Stripe subscription if cancellable
+- avoid clobbering a newer active subscription on the same profile
+
+- [ ] **Step 3: Verify only: dispute revocation resolves the disputed subscription**
+
+`charge.dispute.created` should:
+
+- resolve the disputed charge's subscription when possible
+- revoke/cancel that subscription
+- avoid canceling a newer unrelated subscription when the disputed subscription cannot be resolved
+- log a warning when resolution fails
+
+- [ ] **Step 4: Run webhook tests**
+
+Run:
+
+```bash
+npx playwright test tests/stripe-webhook-handlers.spec.ts --project=chromium
+npx tsx --test tests/customerio-stripe-webhook.test.ts
+```
+
+Expected: PASS.
+
+## Task 4: Document Existing SEPA Renewal Handling
+
+**Files:**
+
+- Create: `docs/stripe-sepa-renewal-migration.md`
+
+- [ ] **Step 1: Write the operational migration doc**
+
+Create `docs/stripe-sepa-renewal-migration.md` with:
+
+```md
+# Stripe SEPA Renewal Migration
+
+## Current Policy
+
+New Checkout Sessions exclude SEPA Direct Debit in code. Existing SEPA subscriptions are grandfathered temporarily and must be audited before any global Stripe Dashboard disablement.
+
+## Audit
+
+Find active/trialing/past_due Stripe subscriptions where the actual selected/default payment method is `sepa_debit`.
+
+Record:
+
+- Stripe customer ID
+- Stripe subscription ID
+- customer email
+- subscription status
+- current period end
+- whether `subscription.default_payment_method` is SEPA
+- whether `customer.invoice_settings.default_payment_method` is SEPA
+
+## Migration Choice
+
+If `subscription.default_payment_method` is SEPA, prefer a subscription-specific payment update link or a setup-mode card flow that updates `subscription.default_payment_method`.
+
+If only `customer.invoice_settings.default_payment_method` is SEPA, a Customer Portal `payment_method_update` flow may be sufficient because it sets the customer invoice default payment method.
+
+## Recommended Rollout
+
+1. Keep existing SEPA renewals active while auditing.
+2. Send affected users a card update request.
+3. For small numbers, use Stripe Dashboard subscription payment update links.
+4. For larger numbers, build a card-only setup Checkout flow and update `subscription.default_payment_method`.
+5. After a deadline, decide whether to keep grandfathering, cancel at period end, or enforce card-only renewal.
+
+## Do Not Do Yet
+
+Do not globally disable SEPA in Stripe Dashboard until the audit confirms existing SEPA subscriptions have been migrated or intentionally grandfathered.
+```
+
+- [ ] **Step 2: Verify current Stripe Portal route**
+
+Confirm `src/app/api/stripe/portal-session/route.ts` still creates a generic Billing Portal session. This can be used for users who only need to update the customer invoice default payment method, but it may not override a subscription-level SEPA default.
+
+## Task 5: Final Verification
+
+**Files:**
+
+- All files touched above.
+
+- [ ] **Step 1: Run focused payment tests**
+
+Run:
+
+```bash
+npx tsx --test tests/billing-paypal-server.test.ts tests/customerio-stripe-webhook.test.ts tests/stripe-purchase-analytics.spec.ts
+npx playwright test tests/checkout-activation.spec.ts tests/auth-post-checkout-routes.spec.ts tests/stripe-webhook-handlers.spec.ts --project=chromium
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run repo quality gates**
+
+Run:
+
+```bash
+npm run ci:verify
+npm run test:playwright:contracts
+git diff --check
+```
+
+Expected: PASS. Existing unrelated lint warnings may remain only if `npm run ci:verify` already tolerates them.
+
+- [ ] **Step 3: Manual Stripe smoke**
+
+In test mode:
+
+- Start a new Checkout Session and confirm SEPA is not displayed.
+- Complete a card Checkout and confirm `/welcome` still works.
+- Replay or simulate a completed unpaid SEPA Checkout and confirm `/welcome` does not grant access.
+- Replay or simulate a non-SEPA `checkout.session.async_payment_succeeded` and confirm it grants access.
+- Replay or simulate a SEPA `checkout.session.async_payment_succeeded` and confirm it remains no-grant during the sunset.
+- Simulate `checkout.session.async_payment_failed` and confirm access is revoked for the relevant subscription.
+
+Rollback path: if excluding SEPA causes an unexpected Checkout issue, remove the single `excluded_payment_method_types: ["sepa_debit"]` param and redeploy. Stripe Dashboard payment-method settings are intentionally left unchanged in this release.
+
+- [ ] **Step 4: Review gate**
+
+Before shipping:
+
+- request code review
+- run Claude code review
+- request the Codex `ready-check` skill because this touches payment trust and onboarding access
+
+## Self-Review Checklist
+
+- The plan blocks SEPA for new Checkout at server level, not frontend level.
+- The plan does not globally disable SEPA before renewal audit.
+- Completed unpaid SEPA Checkout does not grant new access.
+- SEPA delayed failure/dispute revocation remains active.
+- Renewal migration notes distinguish customer default payment method from subscription default payment method.
+- The abandoned checkout-attempt architecture is not part of this release.

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -5,6 +5,7 @@ import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import { assertCanStartCheckout, assertCanStartCheckoutForEmail } from "@/lib/billing/subscriptions"
 import { getStripe, PRICE_IDS } from "@/lib/stripe/client"
+import { buildStripeCheckoutSessionParams } from "@/lib/stripe/checkout-session-params"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 
 export const runtime = "nodejs"
@@ -49,8 +50,14 @@ export async function POST(req: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
   const authenticatedUserId = user?.id
+  let adminSupabase: ReturnType<typeof createBillingAdminClient> | null = null
+  const getAdminSupabase = () => {
+    adminSupabase ??= createBillingAdminClient()
+    return adminSupabase
+  }
+
   if (authenticatedUserId) {
-    const adminSupabase = createBillingAdminClient()
+    const adminSupabase = getAdminSupabase()
     const conflictResponse = await createStripeCheckoutAccessConflictResponse(
       adminSupabase,
       authenticatedUserId,
@@ -67,13 +74,19 @@ export async function POST(req: NextRequest) {
   }
 
   if (leadId) {
-    const adminSupabase = createBillingAdminClient()
+    const adminSupabase = getAdminSupabase()
     const { data, error } = await adminSupabase
       .from("leads")
       .select("email")
       .eq("id", leadId)
       .maybeSingle()
-    if (error) throw error
+    if (error) {
+      console.error("[stripe] lead lookup failed before Checkout creation", {
+        leadId,
+        error,
+      })
+      return NextResponse.json({ error: "lead lookup failed" }, { status: 500 })
+    }
     customerEmail = data?.email ?? undefined
     if (customerEmail) {
       resolvedLeadId = leadId
@@ -116,24 +129,16 @@ export async function POST(req: NextRequest) {
       "[stripe] STRIPE_DISCOUNT_COUPON_ID is not set — checkout will charge the full anchor price. Configure the discount coupon in Stripe + env to match the UI.",
     )
   }
-  const session = await stripe.checkout.sessions.create({
-    mode: "subscription",
-    ui_mode: "embedded_page",
-    line_items: [{ price: priceId, quantity: 1 }],
-    // Pass customer OR customer_email — never both (Stripe rejects that combination)
-    ...(customerId ? { customer: customerId } : { customer_email: customerEmail }),
-    return_url: `${origin}/welcome?session_id={CHECKOUT_SESSION_ID}`,
-    automatic_tax: { enabled: true },
-    consent_collection: { terms_of_service: "required" },
-    custom_text: {
-      terms_of_service_acceptance: {
-        message:
-          "Ich stimme zu, dass der Zugriff auf das Abo sofort beginnt und ich damit mein 14-tägiges Widerrufsrecht verliere (§ 356 Abs. 4 BGB).",
-      },
-    },
-    ...(discountCouponId ? { discounts: [{ coupon: discountCouponId }] } : {}),
-    metadata: resolvedLeadId ? { lead_id: resolvedLeadId } : undefined,
+
+  const params = buildStripeCheckoutSessionParams({
+    origin,
+    priceId,
+    customerId,
+    customerEmail,
+    discountCouponId,
+    leadId: resolvedLeadId,
   })
+  const session = await stripe.checkout.sessions.create(params)
 
   return NextResponse.json({ client_secret: session.client_secret })
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -2,7 +2,15 @@ import { after, NextResponse, type NextRequest } from "next/server"
 import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 import { getStripe } from "@/lib/stripe/client"
 import {
+  CheckoutActivationError,
+  type CheckoutAccountResult,
+} from "@/lib/stripe/checkout-activation"
+import {
   handleCheckoutSessionCompleted,
+  handleCheckoutSessionExpired,
+  handleCheckoutSessionAsyncPaymentSucceeded,
+  handleCheckoutSessionAsyncPaymentFailed,
+  handleChargeDisputeCreated,
   handleSubscriptionUpdated,
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
@@ -23,6 +31,7 @@ import {
   buildCustomerIoSubscriptionLifecycleSync,
   type CustomerIoLifecycleEvent,
 } from "@/lib/customerio/stripe-lifecycle"
+import { claimWebhookEvent, releaseWebhookEventClaim } from "@/lib/billing/webhook-events"
 
 export const runtime = "nodejs" // raw body required; edge runtime buffers differently
 
@@ -87,6 +96,37 @@ async function dispatchCustomerIoLifecycle(sync: {
   }
 }
 
+function scheduleCheckoutCompletedSync(input: {
+  activation: CheckoutAccountResult
+  defer: (work: () => void | Promise<void>) => void
+  eventId: string
+  session: Stripe.Checkout.Session
+  timestamp: string
+}) {
+  const { activation, defer, eventId, session, timestamp } = input
+  scheduleCustomerIoLifecycle(defer, `checkout ${session.id}`, async () => {
+    if (
+      !activation.subscriptionInterval ||
+      !activation.stripeCustomerId ||
+      !activation.stripeSubscriptionId ||
+      !activation.subscriptionStatus
+    ) {
+      return
+    }
+    const sync = buildCustomerIoCheckoutCompletedSync({
+      email: activation.email,
+      interval: activation.subscriptionInterval,
+      planId: `premium_${activation.subscriptionInterval}`,
+      session,
+      stripeEventId: eventId,
+      subscriptionStatus: activation.subscriptionStatus,
+      timestamp,
+      userId: activation.userId,
+    })
+    await dispatchCustomerIoLifecycle(sync)
+  })
+}
+
 type StripeWebhookEventDeps = {
   supabase: SupabaseClient
   stripe: Stripe
@@ -110,7 +150,37 @@ export async function handleStripeWebhookEvent(event: Stripe.Event, deps: Stripe
   switch (event.type) {
     case "checkout.session.completed": {
       const session = event.data.object as unknown as Stripe.Checkout.Session
-      const activation = await handleCheckoutSessionCompleted(session, {
+      let activation
+      try {
+        activation = await handleCheckoutSessionCompleted(session, {
+          supabase,
+          stripe,
+          premiumTierId: await resolvePremiumTierId(supabase),
+          linkQuizToProfile,
+          profileLinkMode: "defer",
+          defer,
+        })
+      } catch (err) {
+        if (err instanceof CheckoutActivationError && err.code === "checkout_session_unpaid") {
+          console.info("[stripe] checkout.session.completed not activated", {
+            checkoutSessionId: session.id,
+            paymentStatus: session.payment_status,
+          })
+          break
+        }
+        throw err
+      }
+      scheduleCheckoutCompletedSync({ activation, defer, eventId: event.id, session, timestamp })
+      break
+    }
+    case "checkout.session.expired": {
+      const session = event.data.object as unknown as Stripe.Checkout.Session
+      await handleCheckoutSessionExpired(session, { supabase })
+      break
+    }
+    case "checkout.session.async_payment_succeeded": {
+      const session = event.data.object as unknown as Stripe.Checkout.Session
+      const activation = await handleCheckoutSessionAsyncPaymentSucceeded(session, {
         supabase,
         stripe,
         premiumTierId: await resolvePremiumTierId(supabase),
@@ -118,34 +188,35 @@ export async function handleStripeWebhookEvent(event: Stripe.Event, deps: Stripe
         profileLinkMode: "defer",
         defer,
       })
-      scheduleCustomerIoLifecycle(defer, `checkout ${session.id}`, async () => {
-        if (
-          !activation.subscriptionInterval ||
-          !activation.stripeCustomerId ||
-          !activation.stripeSubscriptionId ||
-          !activation.subscriptionStatus
-        ) {
-          return
-        }
-        const sync = buildCustomerIoCheckoutCompletedSync({
-          email: activation.email,
-          interval: activation.subscriptionInterval,
-          planId: `premium_${activation.subscriptionInterval}`,
-          session,
-          stripeEventId: event.id,
-          subscriptionStatus: activation.subscriptionStatus,
-          timestamp,
-          userId: activation.userId,
-        })
-        await dispatchCustomerIoLifecycle(sync)
+      if (activation) {
+        scheduleCheckoutCompletedSync({ activation, defer, eventId: event.id, session, timestamp })
+      }
+      break
+    }
+    case "checkout.session.async_payment_failed": {
+      const session = event.data.object as unknown as Stripe.Checkout.Session
+      await handleCheckoutSessionAsyncPaymentFailed(session, {
+        supabase,
+        stripe,
+        freeTierId: await resolveFreeTierId(supabase),
+      })
+      break
+    }
+    case "charge.dispute.created": {
+      const dispute = event.data.object as unknown as Stripe.Dispute
+      await handleChargeDisputeCreated(dispute, {
+        supabase,
+        stripe,
+        freeTierId: await resolveFreeTierId(supabase),
       })
       break
     }
     case "customer.subscription.updated": {
       const subscription = event.data.object as unknown as Stripe.Subscription
-      await handleSubscriptionUpdated(subscription, {
+      const result = await handleSubscriptionUpdated(subscription, {
         supabase,
       })
+      if (!result.matchedCurrentSubscription) break
       scheduleCustomerIoLifecycle(defer, `subscription updated ${subscription.id}`, async () => {
         const customerId = stripeId(subscription.customer)
         if (!customerId) return
@@ -173,10 +244,11 @@ export async function handleStripeWebhookEvent(event: Stripe.Event, deps: Stripe
     }
     case "customer.subscription.deleted": {
       const subscription = event.data.object as unknown as Stripe.Subscription
-      await handleSubscriptionDeleted(subscription, {
+      const result = await handleSubscriptionDeleted(subscription, {
         supabase,
         freeTierId: await resolveFreeTierId(supabase),
       })
+      if (!result.matchedCurrentSubscription) break
       scheduleCustomerIoLifecycle(defer, `subscription deleted ${subscription.id}`, async () => {
         const customerId = stripeId(subscription.customer)
         if (!customerId) return
@@ -255,10 +327,21 @@ export async function POST(req: NextRequest) {
     { auth: { persistSession: false } },
   )
 
+  const claimed = await claimWebhookEvent(supabase, "stripe", event.id, event.type)
+  if (!claimed) {
+    console.info("[stripe:webhook] duplicate skipped", {
+      eventId: event.id,
+      type: event.type,
+      durationMs: Date.now() - startedAt,
+    })
+    return NextResponse.json({ received: true, duplicate: true })
+  }
+
   try {
     await handleStripeWebhookEvent(event, { supabase, stripe })
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown"
+    await releaseWebhookEventClaim(supabase, "stripe", event.id)
     console.error("[stripe] handler error:", err)
     return new NextResponse(`handler error: ${message}`, { status: 500 })
   }

--- a/src/components/checkout/payment-method-checkout.tsx
+++ b/src/components/checkout/payment-method-checkout.tsx
@@ -95,7 +95,7 @@ export function PaymentMethodCheckout({
           <div>
             <button
               type="button"
-              aria-controls="card-sepa-checkout"
+              aria-controls="card-checkout"
               aria-describedby={!cardCheckoutOpen ? "payment-method-helper" : undefined}
               aria-expanded={cardCheckoutOpen}
               onClick={() => setCardCheckoutOpen(true)}
@@ -105,7 +105,7 @@ export function PaymentMethodCheckout({
                   : "border-border hover:border-[var(--brand-plum-light)]"
               }`}
             >
-              Karte, SEPA & weitere
+              Karte & weitere
             </button>
             {!cardCheckoutOpen ? (
               <p
@@ -120,7 +120,7 @@ export function PaymentMethodCheckout({
       ) : null}
 
       {showCardCheckout ? (
-        <div id="card-sepa-checkout" className={paypalEnabled ? "mt-3" : undefined}>
+        <div id="card-checkout" className={paypalEnabled ? "mt-3" : undefined}>
           {checkoutError ? (
             <div className="rounded-[14px] border border-destructive/30 bg-destructive/10 p-5 text-center">
               <p className="mb-3 text-sm text-destructive">{checkoutError}</p>

--- a/src/lib/stripe/checkout-activation.ts
+++ b/src/lib/stripe/checkout-activation.ts
@@ -101,7 +101,8 @@ export async function verifyCheckoutSessionForActivation(
   const session = await measureCheckoutStep("stripe.checkout.sessions.retrieve", () =>
     stripeClient.checkout.sessions.retrieve(sessionId),
   )
-  assertValidCheckoutSession(session)
+  assertCheckoutSessionShape(session)
+  assertCheckoutPaymentAuthorized(session)
   return session
 }
 
@@ -110,13 +111,10 @@ export async function ensureCheckoutAccount(
   deps: CheckoutActivationDeps,
 ): Promise<CheckoutAccountResult> {
   const startedAt = Date.now()
-  const valid = assertValidCheckoutSession(session)
+  const valid = assertCheckoutSessionShape(session)
   const sessionHash = checkoutSessionHash(valid.id).slice(0, 12)
-  const sub = (await measureCheckoutStep("stripe.subscriptions.retrieve", () =>
-    deps.stripe.subscriptions.retrieve(valid.subscriptionId, {
-      expand: ["items.data.price"],
-    }),
-  )) as unknown as RetrievedSub
+  assertCheckoutPaymentAuthorized(session)
+  const sub = await retrieveCheckoutSubscription(deps.stripe, valid.subscriptionId)
   assertCurrentCheckoutSubscription(sub, deps.now?.() ?? new Date())
 
   const existingProfile = await measureCheckoutStep("profiles.findExisting", () =>
@@ -170,7 +168,10 @@ export async function ensureCheckoutAccount(
       interval,
       current_period_end: subPeriodEndIso(sub),
       cancel_at_period_end: false,
-      metadata: { checkout_session_id: valid.id },
+      metadata: {
+        checkout_session_id: valid.id,
+        payment_status: session.payment_status ?? "unknown",
+      },
     }),
   )
 
@@ -276,7 +277,18 @@ export function stripeEntitlementStatus(status: string | undefined) {
   return "active"
 }
 
-function assertValidCheckoutSession(session: Stripe.Checkout.Session): ValidCheckoutSession {
+async function retrieveCheckoutSubscription(
+  stripe: Stripe,
+  subscriptionId: string,
+): Promise<RetrievedSub> {
+  return (await measureCheckoutStep("stripe.subscriptions.retrieve", () =>
+    stripe.subscriptions.retrieve(subscriptionId, {
+      expand: ["items.data.price"],
+    }),
+  )) as unknown as RetrievedSub
+}
+
+function assertCheckoutSessionShape(session: Stripe.Checkout.Session): ValidCheckoutSession {
   if (!session.id) {
     throw new CheckoutActivationError("checkout_session_missing_id", "checkout session has no id")
   }
@@ -299,16 +311,16 @@ function assertValidCheckoutSession(session: Stripe.Checkout.Session): ValidChec
       "checkout session customer is missing",
     )
   }
-  if (typeof session.subscription !== "string") {
+  const subscriptionId =
+    typeof session.subscription === "string"
+      ? session.subscription
+      : isRecord(session.subscription) && typeof session.subscription.id === "string"
+        ? session.subscription.id
+        : null
+  if (!subscriptionId) {
     throw new CheckoutActivationError(
       "checkout_session_subscription_missing",
       "checkout session subscription is missing",
-    )
-  }
-  if (session.payment_status === "unpaid") {
-    throw new CheckoutActivationError(
-      "checkout_session_unpaid",
-      "checkout session payment is unpaid",
     )
   }
 
@@ -316,8 +328,18 @@ function assertValidCheckoutSession(session: Stripe.Checkout.Session): ValidChec
     id: session.id,
     email,
     customerId: session.customer,
-    subscriptionId: session.subscription,
+    subscriptionId,
   }
+}
+
+function assertCheckoutPaymentAuthorized(session: Stripe.Checkout.Session) {
+  if (session.payment_status === "paid") return
+  if (session.payment_status === "no_payment_required") return
+
+  throw new CheckoutActivationError(
+    "checkout_session_unpaid",
+    "checkout session payment is not paid",
+  )
 }
 
 async function findExistingProfile(

--- a/src/lib/stripe/checkout-session-params.ts
+++ b/src/lib/stripe/checkout-session-params.ts
@@ -1,0 +1,39 @@
+import type Stripe from "stripe"
+
+type BuildStripeCheckoutSessionParamsInput = {
+  origin: string
+  priceId: string
+  customerId?: string
+  customerEmail?: string
+  discountCouponId?: string
+  leadId?: string | null
+}
+
+export function buildStripeCheckoutSessionParams({
+  origin,
+  priceId,
+  customerId,
+  customerEmail,
+  discountCouponId,
+  leadId,
+}: BuildStripeCheckoutSessionParamsInput): Stripe.Checkout.SessionCreateParams {
+  return {
+    mode: "subscription",
+    ui_mode: "embedded_page",
+    line_items: [{ price: priceId, quantity: 1 }],
+    // Pass customer OR customer_email — never both (Stripe rejects that combination)
+    ...(customerId ? { customer: customerId } : { customer_email: customerEmail }),
+    return_url: `${origin}/welcome?session_id={CHECKOUT_SESSION_ID}`,
+    automatic_tax: { enabled: true },
+    consent_collection: { terms_of_service: "required" },
+    custom_text: {
+      terms_of_service_acceptance: {
+        message:
+          "Ich stimme zu, dass der Zugriff auf das Abo sofort beginnt und ich damit mein 14-tägiges Widerrufsrecht verliere (§ 356 Abs. 4 BGB).",
+      },
+    },
+    excluded_payment_method_types: ["sepa_debit"],
+    ...(discountCouponId ? { discounts: [{ coupon: discountCouponId }] } : {}),
+    metadata: leadId ? { lead_id: leadId } : undefined,
+  }
+}

--- a/src/lib/stripe/purchase-analytics.ts
+++ b/src/lib/stripe/purchase-analytics.ts
@@ -2,6 +2,7 @@ import type Stripe from "stripe"
 import { intervalFromPrice, type BillingInterval } from "./intervals"
 
 type RetrievedSubscription = {
+  default_payment_method?: string | { id: string; type?: string } | null
   items: {
     data: Array<{
       price: {
@@ -18,10 +19,10 @@ function subscriptionIdFromSession(session: Stripe.Checkout.Session) {
   return session.subscription?.id
 }
 
-function singleAllowedPaymentMethodTypeFromSession(session: Stripe.Checkout.Session) {
-  const methodTypes = session.payment_method_types
-  if (methodTypes?.length !== 1) return undefined
-  return methodTypes[0]
+function selectedPaymentMethodTypeFromSubscription(subscription: RetrievedSubscription) {
+  const paymentMethod = subscription.default_payment_method
+  if (typeof paymentMethod !== "object" || paymentMethod === null) return undefined
+  return paymentMethod.type
 }
 
 function planIdForInterval(interval: BillingInterval) {
@@ -51,7 +52,7 @@ export async function buildCheckoutPurchaseAnalytics(
   }
 
   const subscription = (await stripe.subscriptions.retrieve(subscriptionId, {
-    expand: ["items.data.price"],
+    expand: ["default_payment_method", "items.data.price"],
   })) as unknown as RetrievedSubscription
   const price = subscription.items.data[0]?.price
   if (!price) return null
@@ -65,7 +66,7 @@ export async function buildCheckoutPurchaseAnalytics(
     currency: session.currency.toUpperCase(),
     interval,
     planId: planIdForInterval(interval),
-    paymentMethodType: singleAllowedPaymentMethodTypeFromSession(session),
+    paymentMethodType: selectedPaymentMethodTypeFromSubscription(subscription),
     value: session.amount_total / 100,
   }
 }

--- a/src/lib/stripe/webhook-handlers.ts
+++ b/src/lib/stripe/webhook-handlers.ts
@@ -6,16 +6,216 @@ import {
   subPeriodEndIso,
 } from "./checkout-activation"
 import { intervalFromPrice } from "./intervals"
-import { upsertBillingSubscription } from "@/lib/billing/subscriptions"
+import {
+  findBillingSubscriptionByProviderId,
+  upsertBillingSubscription,
+} from "@/lib/billing/subscriptions"
 
 export type HandlerDeps = CheckoutActivationDeps
 type SubscriptionUpdateDeps = Pick<HandlerDeps, "supabase">
+type SubscriptionLifecycleResult = {
+  matchedCurrentSubscription: boolean
+  profileId?: string
+}
+
+function stripeObjectId(value: string | { id?: string } | null | undefined): string | null {
+  if (typeof value === "string") return value
+  return value?.id ?? null
+}
+
+type InvoiceWithSubscriptionDetails = {
+  id?: string
+  parent?: {
+    subscription_details?: {
+      subscription?: string | { id?: string } | null
+    } | null
+  } | null
+}
+
+function subscriptionIdFromInvoice(invoice: InvoiceWithSubscriptionDetails | null): string | null {
+  return stripeObjectId(invoice?.parent?.subscription_details?.subscription)
+}
+
+async function updateProfileForCurrentSubscription(
+  deps: SubscriptionUpdateDeps,
+  input: {
+    profileId: string
+    subscriptionId: string
+    patch: Record<string, unknown>
+  },
+) {
+  const { data, error } = await deps.supabase
+    .from("profiles")
+    .update(input.patch)
+    .eq("id", input.profileId)
+    .eq("stripe_subscription_id", input.subscriptionId)
+    .select("id")
+    .maybeSingle()
+  if (error) throw error
+  return Boolean(data?.id)
+}
+
+async function subscriptionIdFromCharge(
+  stripe: HandlerDeps["stripe"],
+  charge: Stripe.Charge,
+): Promise<string | null> {
+  const paymentIntentId = stripeObjectId(charge.payment_intent)
+  if (!paymentIntentId) return null
+
+  const invoicePayments = await stripe.invoicePayments.list({
+    payment: {
+      type: "payment_intent",
+      payment_intent: paymentIntentId,
+    },
+    limit: 1,
+    expand: ["data.invoice.parent.subscription_details.subscription"],
+  })
+  const invoice = invoicePayments.data[0]?.invoice
+  if (!invoice) return null
+  if (typeof invoice !== "string") return subscriptionIdFromInvoice(invoice)
+
+  const retrievedInvoice = (await stripe.invoices.retrieve(invoice, {
+    expand: ["parent.subscription_details.subscription"],
+  })) as InvoiceWithSubscriptionDetails
+  return subscriptionIdFromInvoice(retrievedInvoice)
+}
+
+async function selectedSubscriptionPaymentMethodType(
+  stripe: HandlerDeps["stripe"],
+  session: Stripe.Checkout.Session,
+): Promise<string | undefined> {
+  const subscriptionId = stripeObjectId(session.subscription)
+  if (subscriptionId) {
+    const subscription = (await stripe.subscriptions.retrieve(subscriptionId, {
+      expand: ["default_payment_method"],
+    })) as unknown as {
+      default_payment_method?: string | { id: string; type?: string } | null
+    }
+    const paymentMethod = subscription.default_payment_method
+    if (typeof paymentMethod === "object" && paymentMethod !== null && paymentMethod.type) {
+      return paymentMethod.type
+    }
+  }
+
+  // Fallback only when Checkout offered a single method. `payment_method_types`
+  // is an offered-method list, not proof of the method used.
+  return session.payment_method_types?.length === 1 ? session.payment_method_types[0] : undefined
+}
 
 export async function handleCheckoutSessionCompleted(
   session: Stripe.Checkout.Session,
   deps: HandlerDeps,
 ): Promise<CheckoutAccountResult> {
   return ensureCheckoutAccount(session, deps)
+}
+
+export async function handleCheckoutSessionExpired(
+  session: Stripe.Checkout.Session,
+  deps: Pick<HandlerDeps, "supabase">,
+): Promise<void> {
+  void deps
+  if (!session.id) return
+  console.info("[stripe] checkout.session.expired acknowledged", {
+    checkoutSessionId: session.id,
+  })
+}
+
+export async function handleCheckoutSessionAsyncPaymentSucceeded(
+  session: Stripe.Checkout.Session,
+  deps: HandlerDeps,
+): Promise<CheckoutAccountResult | null> {
+  if (!session.id) return null
+  const paymentMethodType = await selectedSubscriptionPaymentMethodType(deps.stripe, session)
+  if (paymentMethodType === "sepa_debit") {
+    console.info("[stripe] checkout.session.async_payment_succeeded skipped for SEPA sunset", {
+      checkoutSessionId: session.id,
+    })
+    const subscriptionId = stripeObjectId(session.subscription)
+    if (subscriptionId) {
+      await cancelStripeSubscriptionBestEffort(
+        deps.stripe,
+        subscriptionId,
+        "sepa_async_payment_succeeded_sunset",
+      )
+    }
+    return null
+  }
+
+  return ensureCheckoutAccount(session, deps)
+}
+
+export async function handleCheckoutSessionAsyncPaymentFailed(
+  session: Stripe.Checkout.Session,
+  deps: Pick<HandlerDeps, "supabase" | "stripe"> & { freeTierId: string },
+): Promise<void> {
+  if (!session.id) return
+
+  const customerId = stripeObjectId(session.customer)
+  const subscriptionId = stripeObjectId(session.subscription)
+  if (!customerId || !subscriptionId) return
+
+  await revokeStripeAccessForCustomer(deps.supabase, {
+    customerId,
+    subscriptionId,
+    freeTierId: deps.freeTierId,
+    providerStatus: "payment_failed",
+    reason: "async_payment_failed",
+  })
+  await cancelStripeSubscriptionBestEffort(deps.stripe, subscriptionId, "async_payment_failed")
+}
+
+export async function handleChargeDisputeCreated(
+  dispute: Stripe.Dispute,
+  deps: Pick<HandlerDeps, "supabase" | "stripe"> & { freeTierId: string },
+): Promise<void> {
+  const chargeId = stripeObjectId(dispute.charge)
+  if (!chargeId) {
+    console.warn("[stripe] charge.dispute.created missing charge", {
+      disputeId: dispute.id,
+    })
+    return
+  }
+
+  const charge = await deps.stripe.charges.retrieve(chargeId)
+  const customerId = stripeObjectId(charge.customer)
+  if (!customerId) {
+    console.warn("[stripe] disputed charge missing customer", {
+      chargeId,
+      disputeId: dispute.id,
+    })
+    return
+  }
+
+  const subscriptionId = await subscriptionIdFromCharge(deps.stripe, charge)
+  if (!subscriptionId) {
+    console.warn("[stripe] disputed charge missing subscription", {
+      chargeId,
+      customerId,
+      disputeId: dispute.id,
+    })
+    return
+  }
+
+  const profile = await findProfileByStripeCustomerId(deps.supabase, customerId)
+  if (!profile) return
+  if (!profile.stripe_subscription_id) {
+    console.warn("[stripe] disputed charge customer has no current subscription", {
+      chargeId,
+      customerId,
+      disputeId: dispute.id,
+      profileId: profile.id,
+      disputedSubscriptionId: subscriptionId,
+    })
+  }
+
+  await revokeStripeAccessForCustomer(deps.supabase, {
+    customerId,
+    subscriptionId,
+    freeTierId: deps.freeTierId,
+    providerStatus: "disputed",
+    reason: "charge_dispute_created",
+  })
+  await cancelStripeSubscriptionBestEffort(deps.stripe, subscriptionId, "charge_dispute_created")
 }
 
 /** Narrow shape we read from a subscription event. */
@@ -40,25 +240,30 @@ interface UpdatedSub {
 export async function handleSubscriptionUpdated(
   sub: Stripe.Subscription,
   deps: SubscriptionUpdateDeps,
-): Promise<void> {
+): Promise<SubscriptionLifecycleResult> {
   const s = sub as unknown as UpdatedSub
   if (typeof s.customer !== "string") throw new Error("sub.customer not a string")
+  const profile = await findProfileByStripeCustomerId(deps.supabase, s.customer)
+  if (!profile) return { matchedCurrentSubscription: false }
   const price = s.items.data[0].price
   const interval = intervalFromPrice({
     interval: price.recurring?.interval ?? price.interval ?? "",
     interval_count: price.recurring?.interval_count ?? price.interval_count ?? 1,
   })
-  await deps.supabase
-    .from("profiles")
-    .update({
-      subscription_status: s.status,
-      subscription_interval: interval,
-      current_period_end: subPeriodEndIso(s),
-    })
-    .eq("stripe_customer_id", s.customer)
-
-  const profile = await findProfileByStripeCustomerId(deps.supabase, s.customer)
-  if (!profile) return
+  const matchedCurrentSubscription =
+    profile.stripe_subscription_id === s.id &&
+    (await updateProfileForCurrentSubscription(deps, {
+      profileId: profile.id,
+      subscriptionId: s.id,
+      patch: {
+        subscription_status: s.status,
+        subscription_interval: interval,
+        current_period_end: subPeriodEndIso(s),
+      },
+    }))
+  const entitlementStatus = matchedCurrentSubscription
+    ? stripeEntitlementStatus(s.status)
+    : "canceled"
 
   await upsertBillingSubscription(deps.supabase, {
     user_id: profile.id,
@@ -66,11 +271,12 @@ export async function handleSubscriptionUpdated(
     provider_customer_id: s.customer,
     provider_subscription_id: s.id,
     provider_status: s.status,
-    entitlement_status: stripeEntitlementStatus(s.status),
+    entitlement_status: entitlementStatus,
     interval,
     current_period_end: subPeriodEndIso(s),
     cancel_at_period_end: s.cancel_at_period_end ?? false,
   })
+  return { matchedCurrentSubscription, profileId: profile.id }
 }
 
 export interface DeleteDeps {
@@ -81,19 +287,24 @@ export interface DeleteDeps {
 export async function handleSubscriptionDeleted(
   sub: Stripe.Subscription,
   deps: DeleteDeps,
-): Promise<void> {
+): Promise<SubscriptionLifecycleResult> {
   const customer = typeof sub.customer === "string" ? sub.customer : null
   if (!customer) throw new Error("sub.customer not a string")
-  await deps.supabase
-    .from("profiles")
-    .update({
-      subscription_status: "canceled",
-      subscription_tier_id: deps.freeTierId,
-    })
-    .eq("stripe_customer_id", customer)
-
   const profile = await findProfileByStripeCustomerId(deps.supabase, customer)
-  if (!profile) return
+  if (!profile) return { matchedCurrentSubscription: false }
+  const matchedCurrentSubscription =
+    profile.stripe_subscription_id === sub.id &&
+    (await updateProfileForCurrentSubscription(deps, {
+      profileId: profile.id,
+      subscriptionId: sub.id,
+      patch: {
+        subscription_status: "canceled",
+        subscription_tier_id: deps.freeTierId,
+        stripe_subscription_id: null,
+        subscription_interval: null,
+        current_period_end: null,
+      },
+    }))
 
   await upsertBillingSubscription(deps.supabase, {
     user_id: profile.id,
@@ -104,6 +315,7 @@ export async function handleSubscriptionDeleted(
     entitlement_status: "canceled",
     cancelled_at: new Date().toISOString(),
   })
+  return { matchedCurrentSubscription, profileId: profile.id }
 }
 
 export async function handleInvoicePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
@@ -112,6 +324,70 @@ export async function handleInvoicePaymentFailed(invoice: Stripe.Invoice): Promi
     customer: invoice.customer,
     attempt: invoice.attempt_count,
   })
+}
+
+export async function revokeStripeAccessForCustomer(
+  supabase: HandlerDeps["supabase"],
+  input: {
+    customerId: string
+    subscriptionId: string
+    freeTierId: string
+    providerStatus: string
+    reason: string
+  },
+): Promise<void> {
+  const profile = await findProfileByStripeCustomerId(supabase, input.customerId)
+  if (!profile) return
+
+  const existingBilling = await findBillingSubscriptionByProviderId(
+    supabase,
+    "stripe",
+    input.subscriptionId,
+  )
+
+  await upsertBillingSubscription(supabase, {
+    user_id: profile.id,
+    provider: "stripe",
+    provider_customer_id: input.customerId,
+    provider_subscription_id: input.subscriptionId,
+    provider_status: input.providerStatus,
+    entitlement_status: "canceled",
+    cancelled_at: new Date().toISOString(),
+    metadata: {
+      ...((existingBilling?.metadata as Record<string, unknown> | null) ?? {}),
+      reason: input.reason,
+    },
+  })
+
+  if (profile.stripe_subscription_id !== input.subscriptionId) return
+
+  await supabase
+    .from("profiles")
+    .update({
+      subscription_status: "canceled",
+      subscription_tier_id: input.freeTierId,
+      stripe_subscription_id: null,
+      subscription_interval: null,
+      current_period_end: null,
+    })
+    .eq("id", profile.id)
+    .eq("stripe_subscription_id", input.subscriptionId)
+}
+
+export async function cancelStripeSubscriptionBestEffort(
+  stripe: HandlerDeps["stripe"],
+  subscriptionId: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await stripe.subscriptions.cancel(subscriptionId)
+  } catch (error) {
+    console.warn("[stripe] failed to cancel subscription", {
+      subscriptionId,
+      reason,
+      error,
+    })
+  }
 }
 
 export type StripeCustomerProfile = {

--- a/tests/billing-paypal-server.test.ts
+++ b/tests/billing-paypal-server.test.ts
@@ -38,8 +38,11 @@ import {
   handleSubscriptionDeleted,
   handleSubscriptionUpdated,
 } from "../src/lib/stripe/webhook-handlers"
-import { createStripeCheckoutAccessConflictResponse } from "../src/app/api/stripe/create-checkout-session/route"
-import { createStripeCheckoutEmailAccessConflictResponse } from "../src/app/api/stripe/create-checkout-session/route"
+import {
+  POST as createStripeCheckoutSession,
+  createStripeCheckoutAccessConflictResponse,
+  createStripeCheckoutEmailAccessConflictResponse,
+} from "../src/app/api/stripe/create-checkout-session/route"
 import { handleBillingReconcile } from "../src/app/api/billing/reconcile/route"
 import { EXPECTED_PAYPAL_PLAN_SHAPES, getPayPalPlanId } from "../src/lib/paypal/plans"
 import {
@@ -111,7 +114,11 @@ function createSupabaseStub(seed?: {
       patch?: Record<string, unknown>
       order?: { column: string; ascending: boolean }[]
       limit?: number
-      filters: Array<{ column: string; value: unknown; op: "eq" | "ilike" | "in" | "lte" | "is" }>
+      filters: Array<{
+        column: string
+        value: unknown
+        op: "eq" | "ilike" | "in" | "lte" | "lt" | "gt" | "is"
+      }>
     } = { filters: [] }
 
     function rows() {
@@ -137,6 +144,14 @@ function createSupabaseStub(seed?: {
             const value = row[filter.column]
             return typeof value === "string" && value <= String(filter.value)
           }
+          if (filter.op === "lt") {
+            const value = row[filter.column]
+            return typeof value === "string" && value < String(filter.value)
+          }
+          if (filter.op === "gt") {
+            const value = row[filter.column]
+            return typeof value === "string" && value > String(filter.value)
+          }
           return false
         }),
       )
@@ -159,12 +174,14 @@ function createSupabaseStub(seed?: {
       const tableError = tableErrors[table]
       if (tableError) return { data: null, error: tableError }
 
+      let updatedRows: Record<string, unknown>[] | null = null
       if (state.op === "update" && state.patch) {
         const matched = applyFilters(rows() as Record<string, unknown>[])
+        updatedRows = [...matched]
         for (const row of matched) Object.assign(row, state.patch)
         calls.push({ table, op: "update", patch: state.patch, filters: state.filters })
       }
-      let result = sorted(applyFilters(rows() as Record<string, unknown>[]))
+      let result = sorted(updatedRows ?? applyFilters(rows() as Record<string, unknown>[]))
       if (typeof state.limit === "number") result = result.slice(0, state.limit)
       return { data: result, error: null }
     }
@@ -270,6 +287,14 @@ function createSupabaseStub(seed?: {
       },
       lte(column: string, value: string) {
         state.filters.push({ column, value, op: "lte" })
+        return builder
+      },
+      lt(column: string, value: string) {
+        state.filters.push({ column, value, op: "lt" })
+        return builder
+      },
+      gt(column: string, value: string) {
+        state.filters.push({ column, value, op: "gt" })
         return builder
       },
       order(column: string, options: { ascending?: boolean } = {}) {
@@ -1247,6 +1272,102 @@ test("checkout.session.completed keeps profile writes and upserts a Stripe billi
   assert.equal(billing[0].current_period_end, new Date(periodEnd * 1000).toISOString())
 })
 
+test("Stripe unpaid SEPA checkout does not grant access on direct activation", async () => {
+  const periodEnd = Math.floor((Date.now() + 172_800_000) / 1000)
+  const { supabase, billing, profiles } = createSupabaseStub()
+  const stripe = {
+    subscriptions: {
+      retrieve: async () => ({
+        id: "sub_sepa",
+        status: "active",
+        default_payment_method: { id: "pm_sepa", type: "sepa_debit" },
+        items: {
+          data: [
+            {
+              current_period_end: periodEnd,
+              price: { recurring: { interval: "month", interval_count: 1 } },
+            },
+          ],
+        },
+      }),
+    },
+  }
+  const linked: unknown[][] = []
+
+  await assert.rejects(
+    () =>
+      ensureCheckoutAccount(
+        {
+          id: "cs_sepa",
+          status: "complete",
+          payment_status: "unpaid",
+          customer: "cus_sepa",
+          customer_details: { email: "sepa@example.com" },
+          subscription: "sub_sepa",
+          metadata: { lead_id: "lead-sepa" },
+        } as any,
+        {
+          supabase: supabase as any,
+          stripe: stripe as any,
+          premiumTierId: "tier-premium",
+          linkQuizToProfile: async (...args) => {
+            linked.push(args)
+          },
+        },
+      ),
+    /checkout session payment is not paid/,
+  )
+
+  assert.equal(Object.keys(profiles).length, 0)
+  assert.equal(billing.length, 0)
+  assert.deepEqual(linked, [])
+})
+
+test("Stripe unpaid non-SEPA checkout does not grant access on direct activation", async () => {
+  const periodEnd = Math.floor((Date.now() + 172_800_000) / 1000)
+  const { supabase, billing, profiles } = createSupabaseStub()
+  const stripe = {
+    subscriptions: {
+      retrieve: async () => ({
+        id: "sub_card_unpaid",
+        status: "active",
+        default_payment_method: { id: "pm_card", type: "card" },
+        items: {
+          data: [
+            {
+              current_period_end: periodEnd,
+              price: { recurring: { interval: "month", interval_count: 1 } },
+            },
+          ],
+        },
+      }),
+    },
+  }
+
+  await assert.rejects(
+    () =>
+      ensureCheckoutAccount(
+        {
+          id: "cs_card_unpaid",
+          status: "complete",
+          payment_status: "unpaid",
+          customer: "cus_card_unpaid",
+          customer_details: { email: "card-unpaid@example.com" },
+          subscription: "sub_card_unpaid",
+        } as any,
+        {
+          supabase: supabase as any,
+          stripe: stripe as any,
+          premiumTierId: "tier-premium",
+        },
+      ),
+    /checkout session payment is not paid/,
+  )
+
+  assert.equal(Object.keys(profiles).length, 0)
+  assert.equal(billing.length, 0)
+})
+
 test("PayPal ACTIVE activation creates a user from provider-verified email and grants Premium", async () => {
   const periodEnd = futureIso()
   const { supabase, profiles, billing, authUsers } = createSupabaseStub()
@@ -1513,6 +1634,7 @@ test("Stripe subscription.updated upserts the billing row when profile resolves 
       "user-1": {
         id: "user-1",
         stripe_customer_id: "cus_update",
+        stripe_subscription_id: "sub_update",
         subscription_status: "active",
       },
     },
@@ -1582,6 +1704,42 @@ test("Stripe unpaid subscription updates do not create open billing access", asy
   assert.equal(await findCurrentBillingSubscriptionForUser(supabase, "user-1"), null)
 })
 
+test("Stripe active non-current subscription updates do not create open billing access", async () => {
+  const periodEnd = Math.floor((Date.now() + 172_800_000) / 1000)
+  const { supabase, billing } = createSupabaseStub({
+    profiles: {
+      "user-1": {
+        id: "user-1",
+        stripe_customer_id: "cus_non_current",
+        stripe_subscription_id: "sub_current",
+        subscription_status: "active",
+      },
+    },
+  })
+
+  await handleSubscriptionUpdated(
+    {
+      id: "sub_old_sepa",
+      customer: "cus_non_current",
+      status: "active",
+      cancel_at_period_end: false,
+      items: {
+        data: [
+          {
+            current_period_end: periodEnd,
+            price: { recurring: { interval: "month", interval_count: 1 } },
+          },
+        ],
+      },
+    } as any,
+    { supabase: supabase as any },
+  )
+
+  assert.equal(billing[0].provider_status, "active")
+  assert.equal(billing[0].entitlement_status, "canceled")
+  assert.equal(await findCurrentBillingSubscriptionForUser(supabase, "user-1"), null)
+})
+
 test("Stripe subscription.deleted downgrades profile and marks billing row canceled", async () => {
   const periodEnd = futureIso()
   const { supabase, billing, profiles } = createSupabaseStub({
@@ -1589,6 +1747,7 @@ test("Stripe subscription.deleted downgrades profile and marks billing row cance
       "user-1": {
         id: "user-1",
         stripe_customer_id: "cus_delete",
+        stripe_subscription_id: "sub_delete",
         subscription_status: "active",
         subscription_tier_id: "tier-premium",
       },
@@ -1636,6 +1795,17 @@ test("Stripe checkout route returns a stable conflict key and known email when c
 
   assert.equal(response.status, 409)
   assert.deepEqual(body, { error: "checkout_access_already_exists", email: "paid@example.com" })
+})
+
+test("Stripe checkout route returns bad request for malformed JSON", async () => {
+  const response = await createStripeCheckoutSession({
+    json: async () => {
+      throw new Error("malformed")
+    },
+  } as any)
+
+  assert.equal(response.status, 400)
+  assert.deepEqual(await response.json(), { error: "bad request" })
 })
 
 test("Stripe checkout conflict check uses the provided billing-visible client", async () => {

--- a/tests/checkout-activation.spec.ts
+++ b/tests/checkout-activation.spec.ts
@@ -23,6 +23,42 @@ function sessionHash(sessionId: string) {
   return createHash("sha256").update(sessionId).digest("hex")
 }
 
+function stripeForCheckoutActivation(options: {
+  session?: Record<string, unknown>
+  default_payment_method?: unknown
+}) {
+  return {
+    checkout: {
+      sessions: {
+        async retrieve(id: string) {
+          return checkoutSession({
+            id,
+            payment_status: "unpaid",
+            ...options.session,
+          })
+        },
+      },
+    },
+    subscriptions: {
+      async retrieve(id: string) {
+        return {
+          id,
+          status: "active",
+          default_payment_method: options.default_payment_method,
+          items: {
+            data: [
+              {
+                price: { recurring: { interval: "month", interval_count: 1 } },
+                current_period_end: 1_800_000_000,
+              },
+            ],
+          },
+        }
+      },
+    },
+  } as any
+}
+
 function stubDeps() {
   const calls: any[] = []
   const users: Record<
@@ -30,6 +66,7 @@ function stubDeps() {
     { id: string; email: string; app_metadata?: Record<string, unknown> }
   > = {}
   const profiles: Record<string, any> = {}
+  const billing: any[] = []
   const duplicateEmails = new Set<string>()
 
   const deps: HandlerDeps = {
@@ -70,15 +107,26 @@ function stubDeps() {
         },
       },
       from(table: string) {
-        return {
+        const filters: Array<[string, string]> = []
+        const rows = () => {
+          if (table === "profiles") return Object.values(profiles)
+          if (table === "billing_subscriptions") return billing
+          return Object.values(users)
+        }
+        const builder = {
           select() {
-            return this
+            return builder
           },
           eq(col: string, val: string) {
             calls.push([`select-${table}-${col}`, val])
-            const rows = table === "profiles" ? Object.values(profiles) : Object.values(users)
-            const row = rows.find((candidate: any) => candidate[col] === val)
-            return { maybeSingle: async () => ({ data: row ?? null, error: null }) }
+            filters.push([col, val])
+            return builder
+          },
+          async maybeSingle() {
+            const row = rows().find((candidate: any) =>
+              filters.every(([col, val]) => candidate[col] === val),
+            )
+            return { data: row ?? null, error: null }
           },
           update(patch: any) {
             return {
@@ -97,10 +145,39 @@ function stubDeps() {
                 ...(profiles[row.id] ?? {}),
                 ...row,
               }
+            } else if (table === "billing_subscriptions") {
+              const existing = billing.find(
+                (candidate) =>
+                  candidate.provider === row.provider &&
+                  candidate.provider_subscription_id === row.provider_subscription_id,
+              )
+              if (existing) Object.assign(existing, row)
+              else billing.push(row)
             }
+            return {
+              error: null,
+              select: () => ({
+                single: async () => ({
+                  data:
+                    table === "billing_subscriptions"
+                      ? billing.find(
+                          (candidate) =>
+                            candidate.provider === row.provider &&
+                            candidate.provider_subscription_id === row.provider_subscription_id,
+                        )
+                      : row,
+                  error: null,
+                }),
+              }),
+            }
+          },
+          insert(row: any) {
+            calls.push([`insert-${table}`, row])
+            if (table === "billing_subscriptions") billing.push(row)
             return Promise.resolve({ error: null })
           },
         }
+        return builder
       },
     } as any,
     stripe: {
@@ -109,6 +186,7 @@ function stubDeps() {
           return {
             id,
             status: "active",
+            default_payment_method: { id: "pm_card", type: "card" },
             items: {
               data: [
                 {
@@ -133,7 +211,7 @@ test("ensureCheckoutAccount creates a fresh paid user with hashed checkout activ
 
   const result = await ensureCheckoutAccount(session, deps)
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-1",
     email: "new@example.com",
     canSetInitialPassword: true,
@@ -183,7 +261,7 @@ test("ensureCheckoutAccount reuses an existing email and denies initial password
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-existing",
     email: "ret@example.com",
     canSetInitialPassword: false,
@@ -221,7 +299,7 @@ test("ensureCheckoutAccount allows password setup for an existing checkout-creat
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-checkout",
     email: "checkout@example.com",
     canSetInitialPassword: true,
@@ -256,7 +334,7 @@ test("ensureCheckoutAccount denies password setup when the matching activation m
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-used",
     email: "used@example.com",
     canSetInitialPassword: false,
@@ -287,7 +365,7 @@ test("ensureCheckoutAccount reuses an existing Stripe customer and does not crea
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-by-customer",
     email: "newer@example.com",
     canSetInitialPassword: false,
@@ -323,7 +401,7 @@ test("ensureCheckoutAccount treats duplicate createUser races as an existing acc
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-race",
     email: "race@example.com",
     canSetInitialPassword: false,
@@ -350,7 +428,7 @@ test("ensureCheckoutAccount creates a missing profile for duplicate auth users",
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-auth-only",
     email: "auth-only@example.com",
     canSetInitialPassword: false,
@@ -385,7 +463,7 @@ test("ensureCheckoutAccount denies password setup for duplicate createUser races
     deps,
   )
 
-  expect(result).toEqual({
+  expect(result).toMatchObject({
     userId: "user-race-match",
     email: "race-match@example.com",
     canSetInitialPassword: false,
@@ -495,14 +573,32 @@ test("verifyCheckoutSessionForActivation returns complete paid sessions", async 
   })
 })
 
-test("verifyCheckoutSessionForActivation rejects incomplete and unpaid sessions", async () => {
+test("verifyCheckoutSessionForActivation accepts complete sessions with no payment required", async () => {
   const stripe = {
     checkout: {
       sessions: {
         async retrieve(id: string) {
-          return id === "cs_unpaid"
-            ? checkoutSession({ id, payment_status: "unpaid" })
-            : checkoutSession({ id, status: "open" })
+          return checkoutSession({
+            id,
+            payment_status: "no_payment_required",
+          })
+        },
+      },
+    },
+  } as any
+
+  await expect(verifyCheckoutSessionForActivation("cs_free", stripe)).resolves.toMatchObject({
+    id: "cs_free",
+    payment_status: "no_payment_required",
+  })
+})
+
+test("verifyCheckoutSessionForActivation rejects incomplete sessions", async () => {
+  const stripe = {
+    checkout: {
+      sessions: {
+        async retrieve(id: string) {
+          return checkoutSession({ id, status: "open" })
         },
       },
     },
@@ -511,7 +607,37 @@ test("verifyCheckoutSessionForActivation rejects incomplete and unpaid sessions"
   await expect(verifyCheckoutSessionForActivation("cs_open", stripe)).rejects.toMatchObject({
     code: "checkout_session_incomplete",
   })
-  await expect(verifyCheckoutSessionForActivation("cs_unpaid", stripe)).rejects.toMatchObject({
+})
+
+test("verifyCheckoutSessionForActivation rejects complete unpaid sessions even if subscription default payment method is SEPA", async () => {
+  const stripe = stripeForCheckoutActivation({
+    default_payment_method: { id: "pm_sepa", type: "sepa_debit" },
+  })
+
+  await expect(verifyCheckoutSessionForActivation("cs_unpaid_sepa", stripe)).rejects.toMatchObject({
+    code: "checkout_session_unpaid",
+  })
+})
+
+test("verifyCheckoutSessionForActivation rejects complete unpaid sessions even if subscription default payment method is card", async () => {
+  const stripe = stripeForCheckoutActivation({
+    default_payment_method: { id: "pm_card", type: "card" },
+  })
+
+  await expect(verifyCheckoutSessionForActivation("cs_unpaid_card", stripe)).rejects.toMatchObject({
+    code: "checkout_session_unpaid",
+  })
+})
+
+test("verifyCheckoutSessionForActivation rejects complete unpaid sessions even if SEPA was offered", async () => {
+  const stripe = stripeForCheckoutActivation({
+    session: { payment_method_types: ["card", "sepa_debit"] },
+    default_payment_method: { id: "pm_card", type: "card" },
+  })
+
+  await expect(
+    verifyCheckoutSessionForActivation("cs_unpaid_offered_sepa", stripe),
+  ).rejects.toMatchObject({
     code: "checkout_session_unpaid",
   })
 })

--- a/tests/customerio-stripe-webhook.test.ts
+++ b/tests/customerio-stripe-webhook.test.ts
@@ -12,6 +12,10 @@ function stubDeps() {
   const users: Record<string, { id: string; email: string }> = {}
   const profiles: Record<string, any> = {}
   const billing: any[] = []
+  const canceledSubscriptions: string[] = []
+  const subscriptionPaymentMethods: Record<string, { id: string; type?: string }> = {
+    sub_123: { id: "pm_card", type: "card" },
+  }
 
   const deps: HandlerDeps = {
     supabase: {
@@ -43,15 +47,37 @@ function stubDeps() {
             return { data: row ?? null, error: null }
           },
           update(patch: any) {
-            return {
+            const updateFilters: Array<[string, string]> = []
+            let appliedRows: any[] | null = null
+            const applyUpdate = () => {
+              if (appliedRows) return appliedRows
+              appliedRows = []
+              for (const row of rowsForTable()) {
+                if (updateFilters.every(([column, value]) => row[column] === value)) {
+                  Object.assign(row, patch)
+                  appliedRows.push(row)
+                }
+              }
+              return appliedRows
+            }
+            const builder = {
               eq(column: string, value: string) {
-                const row = Object.values(profiles).find(
-                  (candidate: any) => candidate[column] === value,
-                )
-                if (row) Object.assign(row, patch)
-                return Promise.resolve({ error: null })
+                updateFilters.push([column, value])
+                return builder
+              },
+              select() {
+                return builder
+              },
+              async maybeSingle() {
+                const row = applyUpdate()[0]
+                return { data: row ?? null, error: null }
+              },
+              then(resolve: (value: { error: null }) => unknown) {
+                applyUpdate()
+                return Promise.resolve({ error: null }).then(resolve)
               },
             }
+            return builder
           },
           upsert(row: any) {
             if (table === "profiles") {
@@ -85,10 +111,14 @@ function stubDeps() {
     } as any,
     stripe: {
       subscriptions: {
-        async retrieve() {
+        async retrieve(id: string) {
           return {
-            id: "sub_123",
+            id,
             status: "active",
+            default_payment_method: subscriptionPaymentMethods[id] ?? {
+              id: "pm_card",
+              type: "card",
+            },
             current_period_end: 1_800_000_000,
             items: {
               data: [
@@ -100,12 +130,16 @@ function stubDeps() {
             },
           }
         },
+        async cancel(id: string) {
+          canceledSubscriptions.push(id)
+          return { id, status: "canceled" }
+        },
       },
     } as any,
     premiumTierId: "tier_premium",
   }
 
-  return { deps, profiles }
+  return { billing, canceledSubscriptions, deps, profiles, subscriptionPaymentMethods }
 }
 
 function withEnv(name: string, value: string, fn: () => Promise<void>) {
@@ -231,4 +265,293 @@ test("webhook event schedules best-effort Customer.io checkout sync after fulfil
   } finally {
     globalThis.fetch = originalFetch
   }
+})
+
+test("webhook event activates non-SEPA async payment success", async () => {
+  const { billing, deps, profiles, subscriptionPaymentMethods } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+  subscriptionPaymentMethods.sub_async_success = { id: "pm_delayed", type: "customer_balance" }
+
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_async_succeeded",
+      type: "checkout.session.async_payment_succeeded",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "cs_async_succeeded",
+          amount_total: 1749,
+          currency: "eur",
+          status: "complete",
+          payment_status: "paid",
+          customer: "cus_async_succeeded",
+          customer_details: { email: "async-success@example.com" },
+          subscription: "sub_async_success",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getPremiumTierId: async () => "tier_premium",
+      linkQuizToProfile: async () => {},
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  const profile = Object.values(profiles).find(
+    (candidate: any) => candidate.email === "async-success@example.com",
+  ) as any
+  assert.equal(profile.subscription_status, "active")
+  assert.equal(profile.stripe_subscription_id, "sub_async_success")
+  assert.equal(billing[0].provider_subscription_id, "sub_async_success")
+  assert.equal(billing[0].entitlement_status, "active")
+  assert.equal(deferred.length, 2)
+})
+
+test("webhook event activates async success when SEPA was offered but a non-SEPA method settled", async () => {
+  const { billing, canceledSubscriptions, deps, profiles, subscriptionPaymentMethods } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+  subscriptionPaymentMethods.sub_mixed_success = { id: "pm_delayed", type: "customer_balance" }
+
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_mixed_async_succeeded",
+      type: "checkout.session.async_payment_succeeded",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "cs_mixed_async_succeeded",
+          amount_total: 1749,
+          currency: "eur",
+          status: "complete",
+          payment_status: "paid",
+          payment_method_types: ["customer_balance", "sepa_debit"],
+          customer: "cus_mixed_async_succeeded",
+          customer_details: { email: "mixed-success@example.com" },
+          subscription: "sub_mixed_success",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getPremiumTierId: async () => "tier_premium",
+      linkQuizToProfile: async () => {},
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  const profile = Object.values(profiles).find(
+    (candidate: any) => candidate.email === "mixed-success@example.com",
+  ) as any
+  assert.equal(profile.subscription_status, "active")
+  assert.equal(profile.stripe_subscription_id, "sub_mixed_success")
+  assert.equal(billing[0].provider_subscription_id, "sub_mixed_success")
+  assert.equal(billing[0].entitlement_status, "active")
+  assert.deepEqual(canceledSubscriptions, [])
+  assert.equal(deferred.length, 2)
+})
+
+test("webhook event skips SEPA async payment success during SEPA sunset", async () => {
+  const { billing, canceledSubscriptions, deps, profiles, subscriptionPaymentMethods } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+  subscriptionPaymentMethods.sub_sepa_success = { id: "pm_sepa", type: "sepa_debit" }
+
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_sepa_async_succeeded",
+      type: "checkout.session.async_payment_succeeded",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "cs_sepa_async_succeeded",
+          amount_total: 749,
+          currency: "eur",
+          status: "complete",
+          payment_status: "paid",
+          customer: "cus_sepa_async_succeeded",
+          customer_details: { email: "sepa-success@example.com" },
+          subscription: "sub_sepa_success",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getPremiumTierId: async () => "tier_premium",
+      linkQuizToProfile: async () => {},
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  assert.deepEqual(Object.values(profiles), [])
+  assert.deepEqual(billing, [])
+  assert.deepEqual(canceledSubscriptions, ["sub_sepa_success"])
+  assert.equal(deferred.length, 0)
+})
+
+test("webhook event skips SEPA async payment success when the session payment method types reveal it", async () => {
+  const { billing, canceledSubscriptions, deps, profiles, subscriptionPaymentMethods } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+  subscriptionPaymentMethods.sub_session_sepa_success = { id: "pm_unknown" }
+
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_session_sepa_async_succeeded",
+      type: "checkout.session.async_payment_succeeded",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "cs_session_sepa_async_succeeded",
+          amount_total: 749,
+          currency: "eur",
+          status: "complete",
+          payment_status: "paid",
+          payment_method_types: ["sepa_debit"],
+          customer: "cus_session_sepa_async_succeeded",
+          customer_details: { email: "session-sepa-success@example.com" },
+          subscription: "sub_session_sepa_success",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getPremiumTierId: async () => "tier_premium",
+      linkQuizToProfile: async () => {},
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  assert.deepEqual(Object.values(profiles), [])
+  assert.deepEqual(billing, [])
+  assert.deepEqual(canceledSubscriptions, ["sub_session_sepa_success"])
+  assert.equal(deferred.length, 0)
+})
+
+test("webhook event acknowledges unpaid checkout completion without granting access", async () => {
+  const { billing, deps, profiles } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_checkout_unpaid",
+      type: "checkout.session.completed",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "cs_unpaid",
+          amount_total: 749,
+          currency: "eur",
+          status: "complete",
+          payment_status: "unpaid",
+          customer: "cus_unpaid",
+          customer_details: { email: "unpaid@example.com" },
+          subscription: "sub_unpaid",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getPremiumTierId: async () => "tier_premium",
+      linkQuizToProfile: async () => {},
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  assert.deepEqual(Object.values(profiles), [])
+  assert.deepEqual(billing, [])
+  assert.equal(deferred.length, 0)
+})
+
+test("webhook event handles checkout.session.async_payment_failed without Customer.io purchase work", async () => {
+  const { billing, canceledSubscriptions, deps, profiles } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+  profiles.user_async_failed = {
+    id: "user_async_failed",
+    email: "async-failed@example.com",
+    stripe_customer_id: "cus_async_failed",
+    stripe_subscription_id: "sub_async_failed",
+    subscription_status: "active",
+    subscription_tier_id: "tier_premium",
+    subscription_interval: "quarter",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_async_failed",
+      type: "checkout.session.async_payment_failed",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "cs_async_failed",
+          customer: "cus_async_failed",
+          subscription: "sub_async_failed",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getFreeTierId: async () => "tier_free",
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  assert.equal(profiles.user_async_failed.subscription_status, "canceled")
+  assert.equal(profiles.user_async_failed.subscription_tier_id, "tier_free")
+  assert.equal(profiles.user_async_failed.stripe_subscription_id, null)
+  assert.equal(profiles.user_async_failed.subscription_interval, null)
+  assert.equal(profiles.user_async_failed.current_period_end, null)
+  assert.equal(billing.length, 1)
+  assert.equal(billing[0].provider_status, "payment_failed")
+  assert.deepEqual(billing[0].metadata, { reason: "async_payment_failed" })
+  assert.deepEqual(canceledSubscriptions, ["sub_async_failed"])
+  assert.equal(deferred.length, 0)
+})
+
+test("stale subscription deletion does not send Customer.io cancellation for a newer active subscription", async () => {
+  const { billing, deps, profiles } = stubDeps()
+  const deferred: Array<() => void | Promise<void>> = []
+  profiles.user_migrated = {
+    id: "user_migrated",
+    email: "migrated@example.com",
+    stripe_customer_id: "cus_migrated",
+    stripe_subscription_id: "sub_new_active",
+    subscription_status: "active",
+    subscription_tier_id: "tier_premium",
+    subscription_interval: "quarter",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+
+  await handleStripeWebhookEvent(
+    {
+      id: "evt_stale_deleted",
+      type: "customer.subscription.deleted",
+      created: 1_800_000_000,
+      data: {
+        object: {
+          id: "sub_old_deleted",
+          customer: "cus_migrated",
+          status: "canceled",
+        },
+      },
+    } as any,
+    {
+      defer: (work) => deferred.push(work),
+      getFreeTierId: async () => "tier_free",
+      stripe: deps.stripe,
+      supabase: deps.supabase,
+    },
+  )
+
+  assert.equal(profiles.user_migrated.stripe_subscription_id, "sub_new_active")
+  assert.equal(profiles.user_migrated.subscription_status, "active")
+  assert.equal(profiles.user_migrated.subscription_tier_id, "tier_premium")
+  assert.equal(billing.length, 1)
+  assert.equal(billing[0].provider_subscription_id, "sub_old_deleted")
+  assert.equal(billing[0].entitlement_status, "canceled")
+  assert.equal(deferred.length, 0)
 })

--- a/tests/payment-duplicate-dialog.test.tsx
+++ b/tests/payment-duplicate-dialog.test.tsx
@@ -34,6 +34,10 @@ const stripeRouteSource = readFileSync(
   new URL("../src/app/api/stripe/create-checkout-session/route.ts", import.meta.url),
   "utf8",
 )
+const stripeCheckoutSessionParamsSource = readFileSync(
+  new URL("../src/lib/stripe/checkout-session-params.ts", import.meta.url),
+  "utf8",
+)
 
 test("active subscription dialog links known emails to prefilled auth", () => {
   assert.match(dialogSource, /Aktives Abo gefunden/)
@@ -116,9 +120,10 @@ test("Stripe lead-derived duplicate conflicts do not expose hidden lead emails",
   assert.ok(stripeRouteSource.includes("{ includeEmail: false }"))
   assert.ok(stripeRouteSource.includes("options.includeEmail === false ? {} : { email }"))
   assert.ok(stripeRouteSource.includes("let resolvedLeadId: string | null = null"))
+  assert.ok(stripeRouteSource.includes("leadId: resolvedLeadId"))
   assert.ok(
-    stripeRouteSource.includes(
-      "metadata: resolvedLeadId ? { lead_id: resolvedLeadId } : undefined",
+    stripeCheckoutSessionParamsSource.includes(
+      "metadata: leadId ? { lead_id: leadId } : undefined",
     ),
   )
 })

--- a/tests/payment-method-checkout.test.tsx
+++ b/tests/payment-method-checkout.test.tsx
@@ -63,8 +63,9 @@ test("PayPal enabled checkout renders express PayPal first and keeps card checko
   assert.match(html, /Jetzt starten — €17,49 im Quartal/)
   assert.match(html, /PayPal öffnet sich zur Bestätigung\. Danach aktivieren wir dein Konto\./)
   assert.match(html, />oder</)
-  assert.match(html, /Karte, SEPA &amp; weitere/)
+  assert.match(html, /Karte &amp; weitere/)
   assert.match(html, /Im sicheren Checkout siehst du alle verfügbaren Zahlungsarten\./)
+  assert.doesNotMatch(html, /SEPA/)
   assert.doesNotMatch(html, /Karte \/ SEPA/)
   assert.match(html, /aria-expanded="false"/)
   assert.doesNotMatch(html, /min-h-\[560px\]|min-h-\[600px\]/)
@@ -72,13 +73,14 @@ test("PayPal enabled checkout renders express PayPal first and keeps card checko
   assert.doesNotMatch(html, /bezahlt bis|paid-through|Kündigung/i)
 })
 
-test("PayPal disabled checkout preserves the immediate card and SEPA checkout surface", () => {
+test("PayPal disabled checkout preserves the immediate Stripe checkout surface", () => {
   const html = renderCheckout(false)
 
   assert.match(html, /Sicher bezahlen/)
   assert.match(html, /Jetzt starten — €17,49 im Quartal/)
   assert.doesNotMatch(html, /PayPal öffnet sich zur Bestätigung/)
   assert.doesNotMatch(html, />oder</)
+  assert.doesNotMatch(html, /SEPA/)
   assert.doesNotMatch(html, /Karte \/ SEPA/)
   assert.doesNotMatch(html, /Im sicheren Checkout siehst du alle verfügbaren Zahlungsarten\./)
   assert.match(html, /min-h-\[560px\]/)

--- a/tests/stripe-checkout-session-params.spec.ts
+++ b/tests/stripe-checkout-session-params.spec.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { buildStripeCheckoutSessionParams } from "../src/lib/stripe/checkout-session-params"
+
+test("excludes only SEPA Direct Debit from new Stripe Checkout Sessions", () => {
+  const params = buildStripeCheckoutSessionParams({
+    origin: "https://chaarlie.example",
+    priceId: "price_month",
+    customerEmail: "lead@example.com",
+  })
+
+  assert.deepEqual(params.excluded_payment_method_types, ["sepa_debit"])
+})
+
+test("preserves lead metadata and coupon discounts", () => {
+  const params = buildStripeCheckoutSessionParams({
+    origin: "https://chaarlie.example",
+    priceId: "price_month",
+    customerEmail: "lead@example.com",
+    discountCouponId: "coupon_half_off",
+    leadId: "8d9675fe-f955-46a2-84dc-0ef5e94009d1",
+  })
+
+  assert.deepEqual(params.metadata, { lead_id: "8d9675fe-f955-46a2-84dc-0ef5e94009d1" })
+  assert.deepEqual(params.discounts, [{ coupon: "coupon_half_off" }])
+})
+
+test("passes customer for customerId input without customer_email", () => {
+  const params = buildStripeCheckoutSessionParams({
+    origin: "https://chaarlie.example",
+    priceId: "price_month",
+    customerId: "cus_123",
+    customerEmail: "customer@example.com",
+  })
+
+  assert.equal(params.customer, "cus_123")
+  assert.equal("customer_email" in params, false)
+})
+
+test("passes customer_email when no customerId is available", () => {
+  const params = buildStripeCheckoutSessionParams({
+    origin: "https://chaarlie.example",
+    priceId: "price_month",
+    customerEmail: "customer@example.com",
+  })
+
+  assert.equal(params.customer_email, "customer@example.com")
+  assert.equal("customer" in params, false)
+})
+
+test("keeps the embedded Checkout return URL on the welcome page", () => {
+  const params = buildStripeCheckoutSessionParams({
+    origin: "https://chaarlie.example",
+    priceId: "price_month",
+    customerEmail: "lead@example.com",
+  })
+
+  assert.equal(
+    params.return_url,
+    "https://chaarlie.example/welcome?session_id={CHECKOUT_SESSION_ID}",
+  )
+})

--- a/tests/stripe-purchase-analytics.spec.ts
+++ b/tests/stripe-purchase-analytics.spec.ts
@@ -11,6 +11,7 @@ test("buildCheckoutPurchaseAnalytics maps Stripe final total, currency, plan, an
         retrieveCalls.push(args)
         return {
           id: "sub_123",
+          default_payment_method: { id: "pm_card", type: "card" },
           items: {
             data: [
               {
@@ -30,7 +31,7 @@ test("buildCheckoutPurchaseAnalytics maps Stripe final total, currency, plan, an
       amount_total: 1749,
       currency: "eur",
       id: "cs_test_123",
-      payment_method_types: ["card"],
+      payment_method_types: ["card", "sepa_debit"],
       subscription: "sub_123",
     } as any,
     stripe as any,
@@ -44,14 +45,19 @@ test("buildCheckoutPurchaseAnalytics maps Stripe final total, currency, plan, an
     value: 17.49,
   })
   assert.equal(retrieveCalls.length, 1)
+  assert.deepEqual(retrieveCalls[0], [
+    "sub_123",
+    { expand: ["default_payment_method", "items.data.price"] },
+  ])
 })
 
-test("buildCheckoutPurchaseAnalytics omits ambiguous payment method lists", async () => {
+test("buildCheckoutPurchaseAnalytics omits payment method when actual method is not expanded", async () => {
   const stripe = {
     subscriptions: {
       async retrieve() {
         return {
           id: "sub_123",
+          default_payment_method: "pm_unexpanded",
           items: {
             data: [
               {
@@ -70,8 +76,8 @@ test("buildCheckoutPurchaseAnalytics omits ambiguous payment method lists", asyn
     {
       amount_total: 749,
       currency: "eur",
-      id: "cs_test_ambiguous",
-      payment_method_types: ["card", "paypal"],
+      id: "cs_test_unexpanded",
+      payment_method_types: ["sepa_debit"],
       subscription: "sub_123",
     } as any,
     stripe as any,

--- a/tests/stripe-webhook-handlers.spec.ts
+++ b/tests/stripe-webhook-handlers.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test"
 import {
   handleCheckoutSessionCompleted,
+  handleCheckoutSessionAsyncPaymentSucceeded,
+  handleCheckoutSessionAsyncPaymentFailed,
+  handleChargeDisputeCreated,
   handleSubscriptionUpdated,
   handleSubscriptionDeleted,
   handleInvoicePaymentFailed,
@@ -12,6 +15,14 @@ function stubDeps() {
   const users: Record<string, { id: string; email: string }> = {}
   const profiles: Record<string, any> = {}
   const billing: any[] = []
+  const charges: Record<string, any> = {}
+  const invoices: Record<string, any> = {}
+  const invoicePayments: any[] = []
+  const retrievedCharges: Array<{ id: string; expand?: string[] }> = []
+  const retrievedInvoices: Array<{ id: string; expand?: string[] }> = []
+  const listedInvoicePayments: any[] = []
+  const canceledSubscriptions: string[] = []
+  const beforeProfileUpdate: Array<() => void> = []
 
   const deps: HandlerDeps = {
     supabase: {
@@ -44,14 +55,41 @@ function stubDeps() {
             return { data: row ?? null, error: null }
           },
           update(patch: any) {
-            return {
+            const updateFilters: Array<[string, string]> = []
+            let appliedRows: any[] | null = null
+            const applyUpdate = () => {
+              if (appliedRows) return appliedRows
+              if (table === "profiles") {
+                for (const hook of beforeProfileUpdate.splice(0)) hook()
+              }
+              appliedRows = []
+              for (const row of rowsForTable()) {
+                if (updateFilters.every(([col, val]) => row[col] === val)) {
+                  Object.assign(row, patch)
+                  appliedRows.push(row)
+                }
+              }
+              return appliedRows
+            }
+            const builder = {
               eq(col: string, val: string) {
-                calls.push([`update-${table}`, val, patch])
-                const row = Object.values(profiles).find((p: any) => p[col] === val)
-                if (row) Object.assign(row, patch)
-                return Promise.resolve({ error: null })
+                calls.push([`update-${table}-${col}`, val, patch])
+                updateFilters.push([col, val])
+                return builder
+              },
+              select() {
+                return builder
+              },
+              async maybeSingle() {
+                const row = applyUpdate()[0]
+                return { data: row ?? null, error: null }
+              },
+              then(resolve: (value: { error: null }) => unknown) {
+                applyUpdate()
+                return Promise.resolve({ error: null }).then(resolve)
               },
             }
+            return builder
           },
           upsert(row: any) {
             calls.push([`upsert-${table}`, row])
@@ -86,6 +124,33 @@ function stubDeps() {
       },
     } as any,
     stripe: {
+      charges: {
+        async retrieve(id: string, params?: { expand?: string[] }) {
+          retrievedCharges.push({ id, expand: params?.expand })
+          return charges[id] ?? { id, customer: null }
+        },
+      },
+      invoicePayments: {
+        async list(params?: any) {
+          listedInvoicePayments.push(params)
+          return {
+            data: invoicePayments.filter((invoicePayment) => {
+              if (!params?.payment) return true
+              const payment = invoicePayment.payment ?? {}
+              return (
+                payment.type === params.payment.type &&
+                payment.payment_intent === params.payment.payment_intent
+              )
+            }),
+          }
+        },
+      },
+      invoices: {
+        async retrieve(id: string, params?: { expand?: string[] }) {
+          retrievedInvoices.push({ id, expand: params?.expand })
+          return invoices[id] ?? { id }
+        },
+      },
       subscriptions: {
         async retrieve(_id: string) {
           return {
@@ -100,12 +165,30 @@ function stubDeps() {
             },
           } as any
         },
+        async cancel(id: string) {
+          canceledSubscriptions.push(id)
+          return { id, status: "canceled" } as any
+        },
       },
     } as any,
     premiumTierId: "tier-premium",
   }
 
-  return { calls, users, profiles, deps }
+  return {
+    beforeProfileUpdate,
+    billing,
+    calls,
+    canceledSubscriptions,
+    charges,
+    invoicePayments,
+    invoices,
+    listedInvoicePayments,
+    retrievedCharges,
+    retrievedInvoices,
+    users,
+    profiles,
+    deps,
+  }
 }
 
 test("checkout.session.completed creates a new Supabase user and activates the sub", async () => {
@@ -161,6 +244,7 @@ test("subscription.updated keeps status=active when cancel_at_period_end flips",
     id: "u",
     email: "x@y",
     stripe_customer_id: "cus_X",
+    stripe_subscription_id: "sub_X",
     subscription_status: "active",
     subscription_interval: "year",
   }
@@ -178,9 +262,91 @@ test("subscription.updated keeps status=active when cancel_at_period_end flips",
       ],
     },
   } as any
-  await handleSubscriptionUpdated(sub, deps)
+  const result = await handleSubscriptionUpdated(sub, deps)
   expect((profiles["u"] as any).subscription_status).toBe("active")
   expect((profiles["u"] as any).current_period_end).toBeTruthy()
+  expect(result.matchedCurrentSubscription).toBe(true)
+})
+
+test("subscription.updated does not overwrite a newer active subscription", async () => {
+  const { billing, deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    email: "x@y",
+    stripe_customer_id: "cus_X",
+    stripe_subscription_id: "sub_new_success",
+    subscription_status: "active",
+    subscription_interval: "month",
+    current_period_end: "2027-02-01T00:00:00.000Z",
+  }
+  const sub = {
+    id: "sub_old_failed",
+    customer: "cus_X",
+    status: "canceled",
+    cancel_at_period_end: false,
+    items: {
+      data: [
+        {
+          price: { interval: "month", interval_count: 3 },
+          current_period_end: 1_900_000_000,
+        },
+      ],
+    },
+  } as any
+
+  const result = await handleSubscriptionUpdated(sub, deps)
+
+  expect((profiles["u"] as any).subscription_status).toBe("active")
+  expect((profiles["u"] as any).subscription_interval).toBe("month")
+  expect((profiles["u"] as any).current_period_end).toBe("2027-02-01T00:00:00.000Z")
+  expect((profiles["u"] as any).stripe_subscription_id).toBe("sub_new_success")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_old_failed",
+    provider_status: "canceled",
+    entitlement_status: "canceled",
+  })
+  expect(result.matchedCurrentSubscription).toBe(false)
+})
+
+test("subscription.updated does not create an open entitlement for an active non-current subscription", async () => {
+  const { billing, deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    email: "x@y",
+    stripe_customer_id: "cus_X",
+    stripe_subscription_id: "sub_new_success",
+    subscription_status: "active",
+    subscription_interval: "month",
+    current_period_end: "2027-02-01T00:00:00.000Z",
+  }
+  const sub = {
+    id: "sub_old_sepa",
+    customer: "cus_X",
+    status: "active",
+    cancel_at_period_end: false,
+    items: {
+      data: [
+        {
+          price: { interval: "month", interval_count: 1 },
+          current_period_end: 1_900_000_000,
+        },
+      ],
+    },
+  } as any
+
+  const result = await handleSubscriptionUpdated(sub, deps)
+
+  expect((profiles["u"] as any).stripe_subscription_id).toBe("sub_new_success")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_old_sepa",
+    provider_status: "active",
+    entitlement_status: "canceled",
+  })
+  expect(result.matchedCurrentSubscription).toBe(false)
 })
 
 test("subscription.deleted flips profile to canceled + Free tier", async () => {
@@ -188,19 +354,543 @@ test("subscription.deleted flips profile to canceled + Free tier", async () => {
   profiles["u"] = {
     id: "u",
     stripe_customer_id: "cus_D",
+    stripe_subscription_id: "sub_D",
     subscription_status: "active",
     subscription_tier_id: "tier-premium",
+    subscription_interval: "month",
+    current_period_end: "2027-01-01T00:00:00.000Z",
   }
   const sub = { id: "sub_D", customer: "cus_D", status: "canceled" } as any
-  await handleSubscriptionDeleted(sub, { ...deps, freeTierId: "tier-free" } as any)
+  const result = await handleSubscriptionDeleted(sub, { ...deps, freeTierId: "tier-free" } as any)
   expect((profiles["u"] as any).subscription_status).toBe("canceled")
   expect((profiles["u"] as any).subscription_tier_id).toBe("tier-free")
+  expect((profiles["u"] as any).stripe_subscription_id).toBeNull()
+  expect((profiles["u"] as any).subscription_interval).toBeNull()
+  expect((profiles["u"] as any).current_period_end).toBeNull()
+  expect(result.matchedCurrentSubscription).toBe(true)
+})
+
+test("subscription.deleted does not downgrade a newer active subscription", async () => {
+  const { billing, deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    stripe_customer_id: "cus_D",
+    stripe_subscription_id: "sub_new_success",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "month",
+    current_period_end: "2027-02-01T00:00:00.000Z",
+  }
+  const sub = { id: "sub_old_failed", customer: "cus_D", status: "canceled" } as any
+
+  const result = await handleSubscriptionDeleted(sub, { ...deps, freeTierId: "tier-free" } as any)
+
+  expect((profiles["u"] as any).subscription_status).toBe("active")
+  expect((profiles["u"] as any).subscription_tier_id).toBe("tier-premium")
+  expect((profiles["u"] as any).stripe_subscription_id).toBe("sub_new_success")
+  expect((profiles["u"] as any).subscription_interval).toBe("month")
+  expect((profiles["u"] as any).current_period_end).toBe("2027-02-01T00:00:00.000Z")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_old_failed",
+    provider_status: "canceled",
+    entitlement_status: "canceled",
+  })
+  expect(result.matchedCurrentSubscription).toBe(false)
+})
+
+test("subscription.deleted reports no match when a concurrent checkout wins the guarded update", async () => {
+  const { beforeProfileUpdate, billing, deps, profiles } = stubDeps()
+  profiles["u"] = {
+    id: "u",
+    stripe_customer_id: "cus_D",
+    stripe_subscription_id: "sub_D",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "month",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+  beforeProfileUpdate.push(() => {
+    profiles["u"].stripe_subscription_id = "sub_new_success"
+    profiles["u"].subscription_status = "active"
+    profiles["u"].subscription_tier_id = "tier-premium"
+  })
+
+  const result = await handleSubscriptionDeleted(
+    { id: "sub_D", customer: "cus_D", status: "canceled" } as any,
+    { ...deps, freeTierId: "tier-free" } as any,
+  )
+
+  expect(result.matchedCurrentSubscription).toBe(false)
+  expect((profiles["u"] as any).subscription_status).toBe("active")
+  expect((profiles["u"] as any).subscription_tier_id).toBe("tier-premium")
+  expect((profiles["u"] as any).stripe_subscription_id).toBe("sub_new_success")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_D",
+    provider_status: "canceled",
+    entitlement_status: "canceled",
+  })
 })
 
 test("invoice.payment_failed logs and returns (no throw)", async () => {
   const invoice = { id: "in_1", customer: "cus_1", attempt_count: 2 } as any
   await handleInvoicePaymentFailed(invoice)
   // no assertion beyond no-throw; log-only for MVP
+})
+
+test("checkout.session.async_payment_failed revokes premium access and cancels subscription", async () => {
+  const { billing, canceledSubscriptions, deps, profiles } = stubDeps()
+  profiles.u = {
+    id: "u",
+    email: "failed@example.com",
+    stripe_customer_id: "cus_async_failed",
+    stripe_subscription_id: "sub_async_failed",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "quarter",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+  billing.push({
+    user_id: "u",
+    provider: "stripe",
+    provider_customer_id: "cus_async_failed",
+    provider_subscription_id: "sub_async_failed",
+    provider_status: "active",
+    entitlement_status: "active",
+    metadata: { checkout_session_id: "cs_async_failed", payment_status: "unpaid" },
+  })
+  await handleCheckoutSessionAsyncPaymentFailed(
+    {
+      id: "cs_async_failed",
+      customer: "cus_async_failed",
+      subscription: "sub_async_failed",
+    } as any,
+    { ...deps, freeTierId: "tier-free" },
+  )
+
+  expect(profiles.u.subscription_status).toBe("canceled")
+  expect(profiles.u.subscription_tier_id).toBe("tier-free")
+  expect(profiles.u.stripe_subscription_id).toBeNull()
+  expect(profiles.u.subscription_interval).toBeNull()
+  expect(profiles.u.current_period_end).toBeNull()
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider: "stripe",
+    provider_customer_id: "cus_async_failed",
+    provider_subscription_id: "sub_async_failed",
+    provider_status: "payment_failed",
+    entitlement_status: "canceled",
+    metadata: {
+      checkout_session_id: "cs_async_failed",
+      payment_status: "unpaid",
+      reason: "async_payment_failed",
+    },
+  })
+  expect(billing[0].cancelled_at).toBeTruthy()
+  expect(canceledSubscriptions).toEqual(["sub_async_failed"])
+})
+
+test("checkout.session.async_payment_succeeded skips SEPA when the session payment method types reveal it", async () => {
+  const { billing, canceledSubscriptions, deps, profiles } = stubDeps()
+  const result = await handleCheckoutSessionAsyncPaymentSucceeded(
+    {
+      id: "cs_async_sepa",
+      status: "complete",
+      payment_status: "paid",
+      customer: "cus_sepa",
+      customer_details: { email: "sepa@example.com" },
+      subscription: "sub_sepa",
+      payment_method_types: ["sepa_debit"],
+    } as any,
+    deps,
+  )
+
+  expect(result).toBeNull()
+  expect(Object.values(profiles)).toHaveLength(0)
+  expect(billing).toHaveLength(0)
+  expect(canceledSubscriptions).toEqual(["sub_sepa"])
+})
+
+test("checkout.session.async_payment_failed does not revoke a newer active subscription", async () => {
+  const { billing, canceledSubscriptions, deps, profiles } = stubDeps()
+  profiles.u = {
+    id: "u",
+    email: "retry@example.com",
+    stripe_customer_id: "cus_retry",
+    stripe_subscription_id: "sub_new_success",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "month",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+  await handleCheckoutSessionAsyncPaymentFailed(
+    {
+      id: "cs_old_failed",
+      customer: "cus_retry",
+      subscription: "sub_old_failed",
+    } as any,
+    { ...deps, freeTierId: "tier-free" },
+  )
+
+  expect(profiles.u.subscription_status).toBe("active")
+  expect(profiles.u.subscription_tier_id).toBe("tier-premium")
+  expect(profiles.u.stripe_subscription_id).toBe("sub_new_success")
+  expect(profiles.u.subscription_interval).toBe("month")
+  expect(profiles.u.current_period_end).toBe("2027-01-01T00:00:00.000Z")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_old_failed",
+    provider_status: "payment_failed",
+    entitlement_status: "canceled",
+    metadata: { reason: "async_payment_failed" },
+  })
+  expect(canceledSubscriptions).toEqual(["sub_old_failed"])
+})
+
+test("checkout.session.async_payment_failed update is guarded against concurrent new subscription", async () => {
+  const { beforeProfileUpdate, billing, deps, profiles } = stubDeps()
+  profiles.u = {
+    id: "u",
+    email: "race@example.com",
+    stripe_customer_id: "cus_race",
+    stripe_subscription_id: "sub_old_failed",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "quarter",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+  beforeProfileUpdate.push(() => {
+    profiles.u.stripe_subscription_id = "sub_new_success"
+    profiles.u.subscription_interval = "month"
+    profiles.u.current_period_end = "2027-02-01T00:00:00.000Z"
+  })
+
+  await handleCheckoutSessionAsyncPaymentFailed(
+    {
+      id: "cs_race",
+      customer: "cus_race",
+      subscription: "sub_old_failed",
+    } as any,
+    { ...deps, freeTierId: "tier-free" },
+  )
+
+  expect(profiles.u.subscription_status).toBe("active")
+  expect(profiles.u.subscription_tier_id).toBe("tier-premium")
+  expect(profiles.u.stripe_subscription_id).toBe("sub_new_success")
+  expect(profiles.u.subscription_interval).toBe("month")
+  expect(profiles.u.current_period_end).toBe("2027-02-01T00:00:00.000Z")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_old_failed",
+    provider_status: "payment_failed",
+    entitlement_status: "canceled",
+  })
+})
+
+test("checkout.session.async_payment_failed still succeeds when subscription cancel fails", async () => {
+  const { billing, canceledSubscriptions, deps, profiles } = stubDeps()
+  profiles.u = {
+    id: "u",
+    email: "cancel-fails@example.com",
+    stripe_customer_id: "cus_cancel_fails",
+    stripe_subscription_id: "sub_cancel_fails",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+  }
+  deps.stripe.subscriptions.cancel = async (id: string) => {
+    canceledSubscriptions.push(id)
+    throw new Error("stripe unavailable")
+  }
+
+  await handleCheckoutSessionAsyncPaymentFailed(
+    {
+      id: "cs_cancel_fails",
+      customer: "cus_cancel_fails",
+      subscription: "sub_cancel_fails",
+    } as any,
+    { ...deps, freeTierId: "tier-free" },
+  )
+
+  expect(profiles.u.subscription_status).toBe("canceled")
+  expect(profiles.u.subscription_tier_id).toBe("tier-free")
+  expect(billing).toHaveLength(1)
+  expect(canceledSubscriptions).toEqual(["sub_cancel_fails"])
+})
+
+test("charge.dispute.created retrieves charge, revokes active profile, and cancels subscription", async () => {
+  const {
+    billing,
+    canceledSubscriptions,
+    charges,
+    deps,
+    invoicePayments,
+    listedInvoicePayments,
+    profiles,
+    retrievedCharges,
+    retrievedInvoices,
+  } = stubDeps()
+  profiles.u = {
+    id: "u",
+    email: "disputed@example.com",
+    stripe_customer_id: "cus_disputed",
+    stripe_subscription_id: "sub_disputed_current",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "year",
+    current_period_end: "2027-01-01T00:00:00.000Z",
+  }
+  billing.push({
+    user_id: "u",
+    provider: "stripe",
+    provider_customer_id: "cus_disputed",
+    provider_subscription_id: "sub_disputed_current",
+    provider_status: "active",
+    entitlement_status: "active",
+    metadata: { source: "checkout" },
+  })
+  charges.ch_disputed = {
+    id: "ch_disputed",
+    customer: { id: "cus_disputed" },
+    payment_intent: { id: "pi_disputed" },
+  }
+  invoicePayments.push({
+    id: "inpay_disputed",
+    payment: { type: "payment_intent", payment_intent: "pi_disputed" },
+    invoice: {
+      id: "in_disputed",
+      parent: {
+        subscription_details: {
+          subscription: { id: "sub_disputed_current" },
+        },
+      },
+    },
+  })
+
+  await handleChargeDisputeCreated(
+    {
+      id: "dp_disputed",
+      charge: { id: "ch_disputed" },
+    } as any,
+    { ...deps, freeTierId: "tier-free" },
+  )
+
+  expect(retrievedCharges).toEqual([{ id: "ch_disputed", expand: undefined }])
+  expect(listedInvoicePayments).toEqual([
+    {
+      payment: { type: "payment_intent", payment_intent: "pi_disputed" },
+      limit: 1,
+      expand: ["data.invoice.parent.subscription_details.subscription"],
+    },
+  ])
+  expect(retrievedInvoices).toHaveLength(0)
+  expect(profiles.u.subscription_status).toBe("canceled")
+  expect(profiles.u.subscription_tier_id).toBe("tier-free")
+  expect(profiles.u.stripe_subscription_id).toBeNull()
+  expect(profiles.u.subscription_interval).toBeNull()
+  expect(profiles.u.current_period_end).toBeNull()
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider: "stripe",
+    provider_customer_id: "cus_disputed",
+    provider_subscription_id: "sub_disputed_current",
+    provider_status: "disputed",
+    entitlement_status: "canceled",
+    metadata: {
+      source: "checkout",
+      reason: "charge_dispute_created",
+    },
+  })
+  expect(billing[0].cancelled_at).toBeTruthy()
+  expect(canceledSubscriptions).toEqual(["sub_disputed_current"])
+})
+
+test("charge.dispute.created does not revoke a newer active subscription for an old disputed charge", async () => {
+  const {
+    billing,
+    canceledSubscriptions,
+    charges,
+    deps,
+    invoicePayments,
+    invoices,
+    listedInvoicePayments,
+    profiles,
+    retrievedCharges,
+    retrievedInvoices,
+  } = stubDeps()
+  profiles.u = {
+    id: "u",
+    email: "retry-dispute@example.com",
+    stripe_customer_id: "cus_retry_dispute",
+    stripe_subscription_id: "sub_new_success",
+    subscription_status: "active",
+    subscription_tier_id: "tier-premium",
+    subscription_interval: "month",
+    current_period_end: "2027-02-01T00:00:00.000Z",
+  }
+  charges.ch_old_disputed = {
+    id: "ch_old_disputed",
+    customer: "cus_retry_dispute",
+    payment_intent: "pi_old_disputed",
+  }
+  invoicePayments.push({
+    id: "inpay_old_disputed",
+    payment: { type: "payment_intent", payment_intent: "pi_old_disputed" },
+    invoice: "in_old_disputed",
+  })
+  invoices.in_old_disputed = {
+    id: "in_old_disputed",
+    parent: {
+      subscription_details: {
+        subscription: "sub_old_disputed",
+      },
+    },
+  }
+
+  await handleChargeDisputeCreated(
+    {
+      id: "dp_old_disputed",
+      charge: "ch_old_disputed",
+    } as any,
+    { ...deps, freeTierId: "tier-free" },
+  )
+
+  expect(retrievedCharges).toEqual([{ id: "ch_old_disputed", expand: undefined }])
+  expect(listedInvoicePayments).toEqual([
+    {
+      payment: { type: "payment_intent", payment_intent: "pi_old_disputed" },
+      limit: 1,
+      expand: ["data.invoice.parent.subscription_details.subscription"],
+    },
+  ])
+  expect(retrievedInvoices).toEqual([
+    { id: "in_old_disputed", expand: ["parent.subscription_details.subscription"] },
+  ])
+  expect(profiles.u.subscription_status).toBe("active")
+  expect(profiles.u.subscription_tier_id).toBe("tier-premium")
+  expect(profiles.u.stripe_subscription_id).toBe("sub_new_success")
+  expect(profiles.u.subscription_interval).toBe("month")
+  expect(profiles.u.current_period_end).toBe("2027-02-01T00:00:00.000Z")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "u",
+    provider_subscription_id: "sub_old_disputed",
+    provider_status: "disputed",
+    entitlement_status: "canceled",
+    metadata: { reason: "charge_dispute_created" },
+  })
+  expect(canceledSubscriptions).toEqual(["sub_old_disputed"])
+})
+
+test("charge.dispute.created without profile skips, but no-current-subscription still cancels disputed sub", async () => {
+  const {
+    billing,
+    canceledSubscriptions,
+    charges,
+    deps,
+    invoicePayments,
+    invoices,
+    listedInvoicePayments,
+    profiles,
+    retrievedCharges,
+    retrievedInvoices,
+  } = stubDeps()
+  profiles.withoutSubscription = {
+    id: "withoutSubscription",
+    email: "former@example.com",
+    stripe_customer_id: "cus_former",
+    stripe_subscription_id: null,
+    subscription_status: "canceled",
+    subscription_tier_id: "tier-free",
+  }
+  charges.ch_no_profile = {
+    id: "ch_no_profile",
+    customer: "cus_missing",
+    payment_intent: "pi_no_profile",
+  }
+  charges.ch_no_subscription = {
+    id: "ch_no_subscription",
+    customer: "cus_former",
+    payment_intent: "pi_no_subscription",
+  }
+  invoicePayments.push(
+    {
+      id: "inpay_no_profile",
+      payment: { type: "payment_intent", payment_intent: "pi_no_profile" },
+      invoice: "in_no_profile",
+    },
+    {
+      id: "inpay_no_subscription",
+      payment: { type: "payment_intent", payment_intent: "pi_no_subscription" },
+      invoice: "in_no_subscription",
+    },
+  )
+  invoices.in_no_profile = {
+    id: "in_no_profile",
+    parent: { subscription_details: { subscription: "sub_no_profile" } },
+  }
+  invoices.in_no_subscription = {
+    id: "in_no_subscription",
+    parent: { subscription_details: { subscription: "sub_former" } },
+  }
+
+  await expect(
+    handleChargeDisputeCreated(
+      {
+        id: "dp_no_profile",
+        charge: "ch_no_profile",
+      } as any,
+      { ...deps, freeTierId: "tier-free" },
+    ),
+  ).resolves.toBeUndefined()
+  await expect(
+    handleChargeDisputeCreated(
+      {
+        id: "dp_no_subscription",
+        charge: "ch_no_subscription",
+      } as any,
+      { ...deps, freeTierId: "tier-free" },
+    ),
+  ).resolves.toBeUndefined()
+
+  expect(retrievedCharges).toEqual([
+    { id: "ch_no_profile", expand: undefined },
+    { id: "ch_no_subscription", expand: undefined },
+  ])
+  expect(listedInvoicePayments).toEqual([
+    {
+      payment: { type: "payment_intent", payment_intent: "pi_no_profile" },
+      limit: 1,
+      expand: ["data.invoice.parent.subscription_details.subscription"],
+    },
+    {
+      payment: { type: "payment_intent", payment_intent: "pi_no_subscription" },
+      limit: 1,
+      expand: ["data.invoice.parent.subscription_details.subscription"],
+    },
+  ])
+  expect(retrievedInvoices).toEqual([
+    { id: "in_no_profile", expand: ["parent.subscription_details.subscription"] },
+    { id: "in_no_subscription", expand: ["parent.subscription_details.subscription"] },
+  ])
+  expect(profiles.withoutSubscription.stripe_subscription_id).toBeNull()
+  expect(profiles.withoutSubscription.subscription_status).toBe("canceled")
+  expect(profiles.withoutSubscription.subscription_tier_id).toBe("tier-free")
+  expect(billing).toHaveLength(1)
+  expect(billing[0]).toMatchObject({
+    user_id: "withoutSubscription",
+    provider_subscription_id: "sub_former",
+    provider_status: "disputed",
+    entitlement_status: "canceled",
+    metadata: { reason: "charge_dispute_created" },
+  })
+  expect(canceledSubscriptions).toEqual(["sub_former"])
 })
 
 test("checkout.session.completed with metadata.lead_id calls linkQuizToProfile with that id", async () => {


### PR DESCRIPTION
## Summary

This PR sunsets SEPA for new Stripe Checkout sessions while keeping the rest of Stripe's dashboard-managed payment methods available and preserving existing active SEPA subscriptions.

The intended behavior is:
- new Checkout Sessions exclude `sepa_debit`
- completed unpaid Checkout Sessions do not activate access
- SEPA `checkout.session.async_payment_succeeded` does not grant access and best-effort cancels the newly settled subscription to avoid renewal without service
- non-SEPA async success still activates normally
- existing active SEPA subscriptions are grandfathered; renewals can continue
- Stripe webhook processing now claims event IDs durably so duplicate deliveries do not double-run business logic
- non-current subscription updates cannot reopen access for a stale subscription
- checkout UI copy no longer advertises SEPA

## Verification

- `npm run ci:verify`
- `npm run test:playwright:contracts`
- `npx tsx --test tests/billing-paypal-server.test.ts tests/customerio-stripe-webhook.test.ts tests/stripe-checkout-session-params.spec.ts`
- `npx playwright test tests/stripe-webhook-handlers.spec.ts --project=chromium`
- `npx tsc --noEmit`
- `git diff --check`

`npm run ci:verify` passed with existing lint warnings in unrelated files:
- `src/components/layout/header.tsx`
- `src/components/ui/avatar.tsx`
- `src/lib/agent/orchestrator/model-client.ts`
- `src/lib/routines/brush-tools.ts`

## Review Notes

- No Supabase migrations changed.
- This branch was 4 commits behind `origin/main` before the local commit. The newer checkout-route access/conflict behavior from current `origin/main` was manually preserved in this implementation, but final review should still be against the latest main before merge.
- Global Stripe Dashboard SEPA disable is intentionally not part of this PR. Existing active SEPA subscriptions remain grandfathered; new app-created Checkout Sessions block SEPA in code.
