### PR TITLE
feat(observability): trace checkout failures in Sentry

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,10 +1,17 @@
 import * as Sentry from "@sentry/nextjs"
+import { scrubSentryBreadcrumb, scrubSentryEvent } from "@/lib/observability/checkout"
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV,
+  sendDefaultPii: false,
   tracesSampleRate: 0.1,
   replaysSessionSampleRate: 0,
-  replaysOnErrorSampleRate: 1.0,
+  // Checkout activation secrets currently live in URLs; keep Replay off until those URLs are secret-free.
+  replaysOnErrorSampleRate: 0,
+  beforeSend: scrubSentryEvent,
+  beforeSendTransaction: scrubSentryEvent,
+  beforeBreadcrumb: scrubSentryBreadcrumb,
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs"
 import { ensureLangfuseTracing, isLangfuseConfigured } from "@/lib/langfuse/client"
+import { scrubSentryBreadcrumb, scrubSentryEvent } from "@/lib/observability/checkout"
 
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "edge" && isLangfuseConfigured()) {
@@ -8,7 +9,13 @@ export async function register() {
 
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment:
+      process.env.VERCEL_ENV ?? process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV,
+    sendDefaultPii: false,
     tracesSampleRate: 0.1,
+    beforeSend: scrubSentryEvent,
+    beforeSendTransaction: scrubSentryEvent,
+    beforeBreadcrumb: scrubSentryBreadcrumb,
   })
 }
 

--- a/src/app/api/auth/send-magic-link/route.ts
+++ b/src/app/api/auth/send-magic-link/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import type Stripe from "stripe"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { createAdminClient } from "@/lib/supabase/admin"
+import { captureCheckoutException, getCheckoutRateLimitReason } from "@/lib/observability/checkout"
 import {
   checkoutSessionHash,
   claimCheckoutActivation,
@@ -57,6 +58,7 @@ export interface SendMagicLinkDeps {
   releaseCheckoutActivationClaim?: typeof releaseCheckoutActivationClaim
   linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
   getPremiumTierId?: (supabase: SupabaseClient) => Promise<string>
+  captureCheckoutException?: typeof captureCheckoutException
   now?: () => Date
 }
 
@@ -89,8 +91,25 @@ export async function handleSendMagicLink(
 
   const rateCheck = await deps.checkRateLimit(parsed.target.activationId, SEND_AUTH_LINK_RATE_LIMIT)
   if (!rateCheck.allowed) {
+    const status = rateCheck.error === "service_unavailable" ? 503 : 429
+    ;(deps.captureCheckoutException ?? captureCheckoutException)(
+      new Error(
+        rateCheck.error === "service_unavailable"
+          ? "Checkout auth-link rate limit unavailable"
+          : "Checkout auth-link rate limited",
+      ),
+      {
+        ...checkoutActivationTargetSentryDetails(parsed.target, "checkout_magic_link_activation"),
+        status,
+        reason:
+          rateCheck.error === "service_unavailable"
+            ? "send_auth_link_rate_limit_unavailable"
+            : "send_auth_link_rate_limited",
+        rateLimitSource: "app",
+      },
+    )
     return {
-      status: rateCheck.error === "service_unavailable" ? 503 : 429,
+      status,
       body: {
         error:
           rateCheck.error === "service_unavailable"
@@ -123,6 +142,14 @@ export async function handleSendMagicLink(
 
     if (error) {
       console.error("[send-magic-link] signInWithOtp failed:", error.message)
+      const rateLimitReason = getCheckoutRateLimitReason(error)
+      ;(deps.captureCheckoutException ?? captureCheckoutException)(error, {
+        ...checkoutActivationTargetSentryDetails(parsed.target, "checkout_magic_link_activation"),
+        // The route still returns 500, but this tags the upstream Supabase Auth throttle.
+        status: rateLimitReason ? 429 : 500,
+        reason: rateLimitReason ?? "sign_in_with_otp_failed",
+        rateLimitSource: rateLimitReason ? "supabase_auth" : undefined,
+      })
       await (deps.releaseCheckoutActivationClaim ?? releaseCheckoutActivationClaim)(
         deps.supabase,
         parsed.target.activationId,
@@ -146,6 +173,10 @@ export async function handleSendMagicLink(
     }
 
     console.error("[send-magic-link] failed:", err)
+    ;(deps.captureCheckoutException ?? captureCheckoutException)(err, {
+      ...checkoutActivationTargetSentryDetails(parsed.target, "checkout_magic_link_activation"),
+      status: 500,
+    })
     return { status: 500, body: { error: SERVER_ERROR } }
   }
 }
@@ -186,6 +217,15 @@ async function consumeCheckoutPasswordMarker(
   })
   if (updateError) {
     console.error("[send-magic-link] activation marker cleanup failed:", updateError.message)
+    ;(deps.captureCheckoutException ?? captureCheckoutException)(updateError, {
+      provider: activationId.startsWith("paypal:") ? "paypal" : "stripe",
+      stage: "checkout_magic_link_activation",
+      source: "welcome",
+      stripeSessionId: activationId.startsWith("paypal:") ? undefined : activationId,
+      paypalTokenPresent: activationId.startsWith("paypal:"),
+      status: 500,
+      reason: "activation_marker_cleanup_failed",
+    })
   }
 }
 
@@ -259,6 +299,26 @@ function isPaymentIncompleteError(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function checkoutActivationTargetSentryDetails(
+  target: CheckoutActivationTarget,
+  stage: "checkout_magic_link_activation",
+) {
+  if (target.provider === "paypal") {
+    return {
+      provider: "paypal" as const,
+      stage,
+      source: "welcome" as const,
+      paypalTokenPresent: true,
+    }
+  }
+  return {
+    provider: "stripe" as const,
+    stage,
+    source: "welcome" as const,
+    stripeSessionId: target.sessionId,
+  }
 }
 
 function toNextResponse(result: RouteResult) {

--- a/src/app/api/auth/set-checkout-password/route.ts
+++ b/src/app/api/auth/set-checkout-password/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import type Stripe from "stripe"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { createAdminClient } from "@/lib/supabase/admin"
+import { captureCheckoutException } from "@/lib/observability/checkout"
 import {
   checkoutSessionHash,
   claimCheckoutActivation,
@@ -59,6 +60,7 @@ export interface SetCheckoutPasswordDeps {
   releaseCheckoutActivationClaim?: typeof releaseCheckoutActivationClaim
   linkQuizToProfile?: (userId: string, email: string | undefined, leadId?: string) => Promise<void>
   getPremiumTierId?: (supabase: SupabaseClient) => Promise<string>
+  captureCheckoutException?: typeof captureCheckoutException
   now?: () => Date
 }
 
@@ -97,8 +99,25 @@ export async function handleSetCheckoutPassword(
 
   const rateCheck = await deps.checkRateLimit(target.activationId, SET_CHECKOUT_PASSWORD_RATE_LIMIT)
   if (!rateCheck.allowed) {
+    const status = rateCheck.error === "service_unavailable" ? 503 : 429
+    ;(deps.captureCheckoutException ?? captureCheckoutException)(
+      new Error(
+        rateCheck.error === "service_unavailable"
+          ? "Checkout password rate limit unavailable"
+          : "Checkout password rate limited",
+      ),
+      {
+        ...checkoutActivationTargetSentryDetails(target, "checkout_password_activation"),
+        status,
+        reason:
+          rateCheck.error === "service_unavailable"
+            ? "set_checkout_password_rate_limit_unavailable"
+            : "set_checkout_password_rate_limited",
+        rateLimitSource: "app",
+      },
+    )
     return {
-      status: rateCheck.error === "service_unavailable" ? 503 : 429,
+      status,
       body: {
         error:
           rateCheck.error === "service_unavailable"
@@ -144,6 +163,11 @@ export async function handleSetCheckoutPassword(
 
     if (updateError) {
       console.error("[set-checkout-password] updateUserById failed:", updateError.message)
+      ;(deps.captureCheckoutException ?? captureCheckoutException)(updateError, {
+        ...checkoutActivationTargetSentryDetails(target, "checkout_password_activation"),
+        status: 500,
+        reason: "update_user_failed",
+      })
       await (deps.releaseCheckoutActivationClaim ?? releaseCheckoutActivationClaim)(
         deps.supabase,
         target.activationId,
@@ -165,6 +189,10 @@ export async function handleSetCheckoutPassword(
     }
 
     console.error("[set-checkout-password] failed:", err)
+    ;(deps.captureCheckoutException ?? captureCheckoutException)(err, {
+      ...checkoutActivationTargetSentryDetails(target, "checkout_password_activation"),
+      status: 500,
+    })
     return { status: 500, body: { error: SERVER_ERROR } }
   }
 }
@@ -276,6 +304,26 @@ function isPaymentIncompleteError(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function checkoutActivationTargetSentryDetails(
+  target: CheckoutActivationTarget,
+  stage: "checkout_password_activation",
+) {
+  if (target.provider === "paypal") {
+    return {
+      provider: "paypal" as const,
+      stage,
+      source: "welcome" as const,
+      paypalTokenPresent: true,
+    }
+  }
+  return {
+    provider: "stripe" as const,
+    stage,
+    source: "welcome" as const,
+    stripeSessionId: target.sessionId,
+  }
 }
 
 function toNextResponse(result: RouteResult) {

--- a/src/app/api/paypal/approve-subscription/route.ts
+++ b/src/app/api/paypal/approve-subscription/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { findBillingSubscriptionByProviderId } from "@/lib/billing/subscriptions"
+import { captureCheckoutException } from "@/lib/observability/checkout"
 import {
   bindPayPalCheckoutIntentToSubscription,
   type PayPalCheckoutIntentRow,
@@ -35,84 +36,110 @@ export async function POST(request: Request) {
   }
 
   const { token, subscription_id } = parsed.data
-  const admin = createAdminClient()
-  const intent = await findPayPalCheckoutIntentByToken(admin, token)
-  if (!intent || isPayPalCheckoutIntentExpired(intent)) {
-    return NextResponse.json({ error: "paypal checkout expired" }, { status: 400 })
-  }
+  let checkoutSource: PayPalCheckoutIntentRow["source"] | undefined
+  try {
+    const admin = createAdminClient()
+    const intent = await findPayPalCheckoutIntentByToken(admin, token)
+    if (!intent || isPayPalCheckoutIntentExpired(intent)) {
+      return NextResponse.json({ error: "paypal checkout expired" }, { status: 400 })
+    }
+    checkoutSource = intent.source
 
-  const subscription = await retrievePayPalSubscription(subscription_id)
-  if (!subscription.id) {
-    return NextResponse.json({ error: "paypal subscription missing" }, { status: 400 })
-  }
-  if (subscription.custom_id?.trim() !== token) {
-    return NextResponse.json({ error: "paypal token mismatch" }, { status: 400 })
-  }
-  if (intent.status === "duplicate") {
-    return createPayPalDuplicateCheckoutResponse(intent)
-  }
-  if (intent.provider_subscription_id && intent.provider_subscription_id !== subscription.id) {
-    return NextResponse.json({ error: "paypal subscription mismatch" }, { status: 400 })
-  }
-  const existingBilling = await findBillingSubscriptionByProviderId(
-    admin,
-    "paypal",
-    subscription.id,
-  )
-  if (existingBilling) {
-    await bindPayPalCheckoutIntentToSubscription(
+    const subscription = await retrievePayPalSubscription(subscription_id)
+    if (!subscription.id) {
+      return NextResponse.json({ error: "paypal subscription missing" }, { status: 400 })
+    }
+    if (subscription.custom_id?.trim() !== token) {
+      return NextResponse.json({ error: "paypal token mismatch" }, { status: 400 })
+    }
+    if (intent.status === "duplicate") {
+      return createPayPalDuplicateCheckoutResponse(intent)
+    }
+    if (intent.provider_subscription_id && intent.provider_subscription_id !== subscription.id) {
+      return NextResponse.json({ error: "paypal subscription mismatch" }, { status: 400 })
+    }
+    const existingBilling = await findBillingSubscriptionByProviderId(
       admin,
-      token,
+      "paypal",
       subscription.id,
-      intent.email ?? getPayPalSubscriberEmail(subscription),
     )
-    return NextResponse.json({ ok: true, token })
-  }
-
-  const email = getPayPalSubscriberEmail(subscription)
-  let boundIntent: PayPalCheckoutIntentRow
-  if (intent.provider_subscription_id === subscription.id) {
-    boundIntent = intent
-  } else {
-    try {
-      boundIntent = await bindPayPalCheckoutIntentToSubscription(
+    if (existingBilling) {
+      await bindPayPalCheckoutIntentToSubscription(
         admin,
         token,
         subscription.id,
-        intent.email ?? email,
+        intent.email ?? getPayPalSubscriberEmail(subscription),
       )
-    } catch (error) {
-      if (error instanceof PayPalCheckoutIntentBindingError) {
-        return NextResponse.json({ error: "paypal subscription mismatch" }, { status: 409 })
-      }
-      throw error
+      return NextResponse.json({ ok: true, token })
     }
-  }
-  const duplicateReason = await findPayPalCheckoutDuplicateReason(admin, boundIntent, subscription)
-  if (duplicateReason) {
-    try {
-      await cancelAndMarkPayPalDuplicate({
-        cancelPayPalSubscription: defaultCancelPayPalSubscription,
-        reason: duplicateReason,
-        retrievePayPalSubscription,
-        subscriptionId: subscription.id,
-        supabase: admin,
-        token,
-      })
-    } catch (error) {
-      if (error instanceof PayPalDuplicateCancellationError) {
-        console.error(
-          "[paypal.approve-subscription] failed to cancel duplicate subscription:",
-          error.cause,
-        )
-        return NextResponse.json({ error: "paypal_duplicate_cancel_failed" }, { status: 502 })
-      }
-      throw error
-    }
-    return createPayPalDuplicateCheckoutResponse(boundIntent)
-  }
 
-  return NextResponse.json({ ok: true, token })
+    const email = getPayPalSubscriberEmail(subscription)
+    let boundIntent: PayPalCheckoutIntentRow
+    if (intent.provider_subscription_id === subscription.id) {
+      boundIntent = intent
+    } else {
+      try {
+        boundIntent = await bindPayPalCheckoutIntentToSubscription(
+          admin,
+          token,
+          subscription.id,
+          intent.email ?? email,
+        )
+      } catch (error) {
+        if (error instanceof PayPalCheckoutIntentBindingError) {
+          return NextResponse.json({ error: "paypal subscription mismatch" }, { status: 409 })
+        }
+        throw error
+      }
+    }
+    const duplicateReason = await findPayPalCheckoutDuplicateReason(
+      admin,
+      boundIntent,
+      subscription,
+    )
+    if (duplicateReason) {
+      try {
+        await cancelAndMarkPayPalDuplicate({
+          cancelPayPalSubscription: defaultCancelPayPalSubscription,
+          reason: duplicateReason,
+          retrievePayPalSubscription,
+          subscriptionId: subscription.id,
+          supabase: admin,
+          token,
+        })
+      } catch (error) {
+        if (error instanceof PayPalDuplicateCancellationError) {
+          console.error(
+            "[paypal.approve-subscription] failed to cancel duplicate subscription:",
+            error.cause,
+          )
+          captureCheckoutException(error, {
+            provider: "paypal",
+            stage: "paypal_approve_subscription",
+            source: checkoutSource,
+            paypalSubscriptionId: subscription.id,
+            paypalTokenPresent: true,
+            status: 502,
+            reason: "duplicate_cancel_failed",
+          })
+          return NextResponse.json({ error: "paypal_duplicate_cancel_failed" }, { status: 502 })
+        }
+        throw error
+      }
+      return createPayPalDuplicateCheckoutResponse(boundIntent)
+    }
+
+    return NextResponse.json({ ok: true, token })
+  } catch (error) {
+    captureCheckoutException(error, {
+      provider: "paypal",
+      stage: "paypal_approve_subscription",
+      source: checkoutSource,
+      paypalSubscriptionId: subscription_id,
+      paypalTokenPresent: true,
+    })
+    throw error
+  }
 }
 
 export function createPayPalDuplicateCheckoutResponse(

--- a/src/app/api/paypal/create-subscription-intent/route.ts
+++ b/src/app/api/paypal/create-subscription-intent/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { createClient } from "@/lib/supabase/server"
 import { assertCanStartCheckout, assertCanStartCheckoutForEmail } from "@/lib/billing/subscriptions"
+import { captureCheckoutException } from "@/lib/observability/checkout"
 import {
   createPayPalCheckoutIntent,
   type PayPalCheckoutSource,
@@ -35,50 +36,74 @@ export async function POST(request: Request) {
   try {
     planId = getPayPalPlanId(interval)
   } catch {
+    captureCheckoutException(new Error("PayPal plan not configured"), {
+      provider: "paypal",
+      stage: "paypal_create_subscription_intent",
+      source,
+      interval,
+      leadId,
+      status: 500,
+      reason: "plan_not_configured",
+    })
     return NextResponse.json({ error: "paypal plan not configured" }, { status: 500 })
   }
 
-  const admin = createAdminClient()
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  try {
+    const admin = createAdminClient()
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
 
-  if (user?.id) {
-    const conflict = await toConflictResponse(assertCanStartCheckout(admin, user.id), user.email)
-    if (conflict) return conflict
-  }
-
-  let email = user?.email ?? null
-  let resolvedLeadId: string | null = null
-  let canExposeConflictEmail = Boolean(user?.email)
-  if (leadId) {
-    const { data, error } = await admin.from("leads").select("email").eq("id", leadId).maybeSingle()
-    if (error) throw error
-    if (typeof data?.email === "string") {
-      email = data.email
-      resolvedLeadId = leadId
+    if (user?.id) {
+      const conflict = await toConflictResponse(assertCanStartCheckout(admin, user.id), user.email)
+      if (conflict) return conflict
     }
-    canExposeConflictEmail = false
+
+    let email = user?.email ?? null
+    let resolvedLeadId: string | null = null
+    let canExposeConflictEmail = Boolean(user?.email)
+    if (leadId) {
+      const { data, error } = await admin
+        .from("leads")
+        .select("email")
+        .eq("id", leadId)
+        .maybeSingle()
+      if (error) throw error
+      if (typeof data?.email === "string") {
+        email = data.email
+        resolvedLeadId = leadId
+      }
+      canExposeConflictEmail = false
+    }
+
+    if (email) {
+      const conflict = await toConflictResponse(
+        assertCanStartCheckoutForEmail(admin, email),
+        canExposeConflictEmail ? email : null,
+      )
+      if (conflict) return conflict
+    }
+
+    const intent = await createPayPalCheckoutIntent(admin, {
+      interval: interval as BillingInterval,
+      source: source as PayPalCheckoutSource,
+      leadId: resolvedLeadId,
+      email,
+      userId: user?.id ?? null,
+    })
+
+    return NextResponse.json({ token: intent.token, planId })
+  } catch (error) {
+    captureCheckoutException(error, {
+      provider: "paypal",
+      stage: "paypal_create_subscription_intent",
+      source,
+      interval,
+      leadId,
+    })
+    throw error
   }
-
-  if (email) {
-    const conflict = await toConflictResponse(
-      assertCanStartCheckoutForEmail(admin, email),
-      canExposeConflictEmail ? email : null,
-    )
-    if (conflict) return conflict
-  }
-
-  const intent = await createPayPalCheckoutIntent(admin, {
-    interval: interval as BillingInterval,
-    source: source as PayPalCheckoutSource,
-    leadId: resolvedLeadId,
-    email,
-    userId: user?.id ?? null,
-  })
-
-  return NextResponse.json({ token: intent.token, planId })
 }
 
 async function toConflictResponse(

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@supabase/supabase-js"
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import { assertCanStartCheckout, assertCanStartCheckoutForEmail } from "@/lib/billing/subscriptions"
+import { captureCheckoutException } from "@/lib/observability/checkout"
 import { getStripe, PRICE_IDS } from "@/lib/stripe/client"
 import { buildStripeCheckoutSessionParams } from "@/lib/stripe/checkout-session-params"
 import type { BillingInterval } from "@/lib/stripe/intervals"
@@ -26,121 +27,150 @@ export async function POST(req: NextRequest) {
 
   const priceId = PRICE_IDS[interval as BillingInterval]
   if (!priceId) {
+    captureCheckoutException(new Error("Stripe price not configured"), {
+      provider: "stripe",
+      stage: "stripe_checkout_session_create",
+      source: "pricing_page",
+      interval,
+      leadId,
+      status: 500,
+      reason: "price_not_configured",
+    })
     return NextResponse.json({ error: "price not configured" }, { status: 500 })
   }
 
-  // Identity resolution: prefer existing Stripe customer > email > 400
-  // Priority: leadId email → authed user's stripe_customer_id → authed user's email → 400
-  let customerId: string | undefined
-  let customerEmail: string | undefined
-  let resolvedLeadId: string | null = null
+  try {
+    // Identity resolution: prefer existing Stripe customer > email > 400
+    // Priority: leadId email → authed user's stripe_customer_id → authed user's email → 400
+    let customerId: string | undefined
+    let customerEmail: string | undefined
+    let resolvedLeadId: string | null = null
 
-  const cookieStore = await cookies()
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll(),
-        setAll: () => {},
+    const cookieStore = await cookies()
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll: () => cookieStore.getAll(),
+          setAll: () => {},
+        },
       },
-    },
-  )
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  const authenticatedUserId = user?.id
-  let adminSupabase: ReturnType<typeof createBillingAdminClient> | null = null
-  const getAdminSupabase = () => {
-    adminSupabase ??= createBillingAdminClient()
-    return adminSupabase
-  }
-
-  if (authenticatedUserId) {
-    const adminSupabase = getAdminSupabase()
-    const conflictResponse = await createStripeCheckoutAccessConflictResponse(
-      adminSupabase,
-      authenticatedUserId,
-      user.email,
     )
-    if (conflictResponse) return conflictResponse
-    if (user?.email) {
-      const emailConflictResponse = await createStripeCheckoutEmailAccessConflictResponse(
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    const authenticatedUserId = user?.id
+    let adminSupabase: ReturnType<typeof createBillingAdminClient> | null = null
+    const getAdminSupabase = () => {
+      adminSupabase ??= createBillingAdminClient()
+      return adminSupabase
+    }
+
+    if (authenticatedUserId) {
+      const adminSupabase = getAdminSupabase()
+      const conflictResponse = await createStripeCheckoutAccessConflictResponse(
         adminSupabase,
+        authenticatedUserId,
         user.email,
       )
-      if (emailConflictResponse) return emailConflictResponse
-    }
-  }
-
-  if (leadId) {
-    const adminSupabase = getAdminSupabase()
-    const { data, error } = await adminSupabase
-      .from("leads")
-      .select("email")
-      .eq("id", leadId)
-      .maybeSingle()
-    if (error) {
-      console.error("[stripe] lead lookup failed before Checkout creation", {
-        leadId,
-        error,
-      })
-      return NextResponse.json({ error: "lead lookup failed" }, { status: 500 })
-    }
-    customerEmail = data?.email ?? undefined
-    if (customerEmail) {
-      resolvedLeadId = leadId
-      const conflictResponse = await createStripeCheckoutEmailAccessConflictResponse(
-        adminSupabase,
-        customerEmail,
-        { includeEmail: false },
-      )
       if (conflictResponse) return conflictResponse
-    }
-  }
-
-  if (!customerId && !customerEmail) {
-    // Resubscribe, direct-entry, or stale lead path — lock to the authenticated user's identity.
-    if (user?.id) {
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("stripe_customer_id")
-        .eq("id", user.id)
-        .single()
-
-      if (profile?.stripe_customer_id) {
-        customerId = profile.stripe_customer_id
-      } else {
-        customerEmail = user.email
+      if (user?.email) {
+        const emailConflictResponse = await createStripeCheckoutEmailAccessConflictResponse(
+          adminSupabase,
+          user.email,
+        )
+        if (emailConflictResponse) return emailConflictResponse
       }
-    } else {
-      return NextResponse.json({ error: "identity required" }, { status: 400 })
     }
+
+    if (leadId) {
+      const adminSupabase = getAdminSupabase()
+      const { data, error } = await adminSupabase
+        .from("leads")
+        .select("email")
+        .eq("id", leadId)
+        .maybeSingle()
+      if (error) {
+        console.error("[stripe] lead lookup failed before Checkout creation", {
+          leadId,
+          error,
+        })
+        captureCheckoutException(error, {
+          provider: "stripe",
+          stage: "stripe_checkout_session_create",
+          source: "pricing_page",
+          interval,
+          leadId,
+          status: 500,
+          reason: "lead_lookup_failed",
+        })
+        return NextResponse.json({ error: "lead lookup failed" }, { status: 500 })
+      }
+      customerEmail = data?.email ?? undefined
+      if (customerEmail) {
+        resolvedLeadId = leadId
+        const conflictResponse = await createStripeCheckoutEmailAccessConflictResponse(
+          adminSupabase,
+          customerEmail,
+          { includeEmail: false },
+        )
+        if (conflictResponse) return conflictResponse
+      }
+    }
+
+    if (!customerId && !customerEmail) {
+      // Resubscribe, direct-entry, or stale lead path — lock to the authenticated user's identity.
+      if (user?.id) {
+        const { data: profile } = await supabase
+          .from("profiles")
+          .select("stripe_customer_id")
+          .eq("id", user.id)
+          .single()
+
+        if (profile?.stripe_customer_id) {
+          customerId = profile.stripe_customer_id
+        } else {
+          customerEmail = user.email
+        }
+      } else {
+        return NextResponse.json({ error: "identity required" }, { status: 400 })
+      }
+    }
+
+    const origin = req.nextUrl.origin
+    const stripe = getStripe()
+    const discountCouponId = process.env.STRIPE_DISCOUNT_COUPON_ID
+    if (!discountCouponId) {
+      // The UI advertises 50%-off discounted prices unconditionally. If the coupon is
+      // not configured, Stripe will charge the full anchor price — surface this loudly
+      // so a misconfigured environment is obvious in logs.
+      console.warn(
+        "[stripe] STRIPE_DISCOUNT_COUPON_ID is not set — checkout will charge the full anchor price. Configure the discount coupon in Stripe + env to match the UI.",
+      )
+    }
+
+    const params = buildStripeCheckoutSessionParams({
+      origin,
+      priceId,
+      customerId,
+      customerEmail,
+      discountCouponId,
+      leadId: resolvedLeadId,
+    })
+    const session = await stripe.checkout.sessions.create(params)
+
+    return NextResponse.json({ client_secret: session.client_secret })
+  } catch (error) {
+    captureCheckoutException(error, {
+      provider: "stripe",
+      stage: "stripe_checkout_session_create",
+      source: "pricing_page",
+      interval,
+      leadId,
+    })
+    throw error
   }
-
-  const origin = req.nextUrl.origin
-  const stripe = getStripe()
-  const discountCouponId = process.env.STRIPE_DISCOUNT_COUPON_ID
-  if (!discountCouponId) {
-    // The UI advertises 50%-off discounted prices unconditionally. If the coupon is
-    // not configured, Stripe will charge the full anchor price — surface this loudly
-    // so a misconfigured environment is obvious in logs.
-    console.warn(
-      "[stripe] STRIPE_DISCOUNT_COUPON_ID is not set — checkout will charge the full anchor price. Configure the discount coupon in Stripe + env to match the UI.",
-    )
-  }
-
-  const params = buildStripeCheckoutSessionParams({
-    origin,
-    priceId,
-    customerId,
-    customerEmail,
-    discountCouponId,
-    leadId: resolvedLeadId,
-  })
-  const session = await stripe.checkout.sessions.create(params)
-
-  return NextResponse.json({ client_secret: session.client_secret })
 }
 
 export async function createStripeCheckoutEmailAccessConflictResponse(

--- a/src/app/pricing/pricing-cards.tsx
+++ b/src/app/pricing/pricing-cards.tsx
@@ -13,6 +13,7 @@ import {
   readCheckoutAccessAlreadyExistsEmail,
 } from "@/components/checkout/active-subscription-dialog"
 import { trackAppEvent } from "@/lib/analytics/track-app-event"
+import { addCheckoutBreadcrumb, captureCheckoutException } from "@/lib/observability/checkout"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 import { getStripePricingPlan, STRIPE_PRICING_PLANS } from "@/lib/stripe/pricing-plans"
 
@@ -63,46 +64,105 @@ export function PricingCards({
 
   const fetchClientSecret = useCallback(async () => {
     if (!selectedInterval) {
-      throw new Error("checkout interval missing")
+      const error = new Error("checkout interval missing")
+      captureCheckoutException(error, {
+        provider: "stripe",
+        stage: "stripe_embedded_checkout_client_secret",
+        source: "pricing_page",
+      })
+      throw error
     }
 
     if (!stripePublishableKey) {
       setCheckoutError(checkoutStartError)
-      throw new Error("stripe publishable key missing")
+      const error = new Error("stripe publishable key missing")
+      captureCheckoutException(error, {
+        provider: "stripe",
+        stage: "stripe_embedded_checkout_load",
+        source: "pricing_page",
+        interval: selectedInterval,
+        leadId,
+        reason: "publishable_key_missing",
+      })
+      throw error
     }
 
     setCheckoutError(null)
-    const res = await fetch("/api/stripe/create-checkout-session", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        interval: selectedInterval,
-        ...(leadId ? { leadId } : {}),
-      }),
+    addCheckoutBreadcrumb({
+      provider: "stripe",
+      stage: "stripe_embedded_checkout_client_secret",
+      source: "pricing_page",
+      interval: selectedInterval,
+      leadId,
     })
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}))
-      if (isCheckoutAccessAlreadyExistsResponse(res, body)) {
-        setCheckoutError(null)
-        setDuplicateEmail(readCheckoutAccessAlreadyExistsEmail(body))
-        setDuplicateDialogOpen(true)
-        throw new Error("checkout access already exists")
+    try {
+      const res = await fetch("/api/stripe/create-checkout-session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          interval: selectedInterval,
+          ...(leadId ? { leadId } : {}),
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        if (isCheckoutAccessAlreadyExistsResponse(res, body)) {
+          setCheckoutError(null)
+          setDuplicateEmail(readCheckoutAccessAlreadyExistsEmail(body))
+          setDuplicateDialogOpen(true)
+          throw new Error("checkout access already exists")
+        }
+        setCheckoutError(checkoutStartError)
+        const error = new Error("failed to create checkout session")
+        captureCheckoutException(error, {
+          provider: "stripe",
+          stage: "stripe_embedded_checkout_client_secret",
+          source: "pricing_page",
+          interval: selectedInterval,
+          leadId,
+          status: res.status,
+        })
+        throw error
+      }
+      const data = (await res.json()) as { client_secret?: string }
+      if (!data.client_secret) {
+        setCheckoutError(checkoutStartError)
+        const error = new Error("checkout session response missing client secret")
+        captureCheckoutException(error, {
+          provider: "stripe",
+          stage: "stripe_embedded_checkout_client_secret",
+          source: "pricing_page",
+          interval: selectedInterval,
+          leadId,
+          status: res.status,
+          reason: "client_secret_missing",
+        })
+        throw error
+      }
+      trackAppEvent("checkout_started", {
+        interval: selectedInterval,
+        leadId: leadId ?? undefined,
+        provider: "stripe",
+        source: "pricing_page",
+      })
+      return data.client_secret
+    } catch (error) {
+      if (error instanceof Error && error.message === "checkout access already exists") {
+        throw error
       }
       setCheckoutError(checkoutStartError)
-      throw new Error("failed to create checkout session")
+      if (error instanceof TypeError) {
+        captureCheckoutException(error, {
+          provider: "stripe",
+          stage: "stripe_embedded_checkout_client_secret",
+          source: "pricing_page",
+          interval: selectedInterval,
+          leadId,
+          reason: "network_error",
+        })
+      }
+      throw error
     }
-    const data = (await res.json()) as { client_secret?: string }
-    if (!data.client_secret) {
-      setCheckoutError(checkoutStartError)
-      throw new Error("checkout session response missing client secret")
-    }
-    trackAppEvent("checkout_started", {
-      interval: selectedInterval,
-      leadId: leadId ?? undefined,
-      provider: "stripe",
-      source: "pricing_page",
-    })
-    return data.client_secret
   }, [selectedInterval, leadId])
 
   const handlePayPalCheckoutStarted = useCallback(() => {

--- a/src/app/welcome/checkout-return-analytics.tsx
+++ b/src/app/welcome/checkout-return-analytics.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation"
 import { useEffect, useRef } from "react"
 import { trackAppEvent } from "@/lib/analytics/track-app-event"
+import { addCheckoutBreadcrumb, captureCheckoutException } from "@/lib/observability/checkout"
 import type { CheckoutPurchaseAnalytics } from "@/lib/stripe/purchase-analytics"
 
 export function CheckoutReturnAnalytics({
@@ -22,6 +23,13 @@ export function CheckoutReturnAnalytics({
     trackedRef.current = true
 
     try {
+      addCheckoutBreadcrumb({
+        provider: sessionId.startsWith("paypal:") ? "paypal" : "stripe",
+        stage: "checkout_return",
+        source: "welcome",
+        stripeSessionId: sessionId.startsWith("paypal:") ? undefined : sessionId,
+        paypalTokenPresent: sessionId.startsWith("paypal:"),
+      })
       trackAppEvent("subscription_started", {
         checkoutSessionId: sessionId,
       })
@@ -37,8 +45,24 @@ export function CheckoutReturnAnalytics({
       }
     } catch (err) {
       console.error("[welcome] checkout analytics failed:", err)
+      captureCheckoutException(err, {
+        provider: sessionId.startsWith("paypal:") ? "paypal" : "stripe",
+        stage: "checkout_return",
+        source: "welcome",
+        stripeSessionId: sessionId.startsWith("paypal:") ? undefined : sessionId,
+        paypalTokenPresent: sessionId.startsWith("paypal:"),
+        reason: "analytics_failed",
+      })
     } finally {
       if (redirectTo) {
+        addCheckoutBreadcrumb({
+          provider: sessionId.startsWith("paypal:") ? "paypal" : "stripe",
+          stage: "checkout_return",
+          source: "welcome",
+          stripeSessionId: sessionId.startsWith("paypal:") ? undefined : sessionId,
+          paypalTokenPresent: sessionId.startsWith("paypal:"),
+          reason: "redirect_to_onboarding",
+        })
         router.replace(redirectTo)
       }
     }

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 import { createHash } from "node:crypto"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
+import { captureCheckoutException } from "@/lib/observability/checkout"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import {
   ensurePayPalCheckoutAccountForToken,
@@ -39,7 +40,16 @@ async function renderStripeWelcome(session_id: string) {
   try {
     session = await verifyCheckoutSessionForActivation(session_id, stripe)
   } catch (err) {
-    if (err instanceof CheckoutActivationError) redirect("/pricing")
+    if (err instanceof CheckoutActivationError) {
+      captureCheckoutException(err, {
+        provider: "stripe",
+        stage: "checkout_return",
+        source: "welcome",
+        stripeSessionId: session_id,
+        reason: err.code,
+      })
+      redirect("/pricing")
+    }
     throw err
   }
 
@@ -47,6 +57,13 @@ async function renderStripeWelcome(session_id: string) {
   if (!email) redirect("/")
   const purchaseAnalytics = await buildCheckoutPurchaseAnalytics(session, stripe).catch((err) => {
     console.error("[welcome] purchase analytics unavailable:", err)
+    captureCheckoutException(err, {
+      provider: "stripe",
+      stage: "checkout_return",
+      source: "welcome",
+      stripeSessionId: session_id,
+      reason: "purchase_analytics_unavailable",
+    })
     return null
   })
 
@@ -92,7 +109,16 @@ async function renderPayPalWelcome(token: string | undefined) {
     premiumTierId: await getPremiumTierId(admin),
     linkQuizToProfile,
   }).catch((err) => {
-    if (err instanceof PayPalCheckoutActivationError) redirect("/pricing")
+    if (err instanceof PayPalCheckoutActivationError) {
+      captureCheckoutException(err, {
+        provider: "paypal",
+        stage: "checkout_return",
+        source: "welcome",
+        paypalTokenPresent: true,
+        reason: err.code,
+      })
+      redirect("/pricing")
+    }
     throw err
   })
 

--- a/src/app/welcome/welcome-client.tsx
+++ b/src/app/welcome/welcome-client.tsx
@@ -9,6 +9,7 @@ import { validatePasswordDraft } from "@/lib/auth/password-policy"
 import type { CheckoutPurchaseAnalytics } from "@/lib/stripe/purchase-analytics"
 import { createClient } from "@/lib/supabase/client"
 import { CheckoutReturnAnalytics } from "./checkout-return-analytics"
+import { addCheckoutBreadcrumb, captureCheckoutException } from "@/lib/observability/checkout"
 
 interface WelcomeClientProps {
   analyticsId?: string
@@ -80,20 +81,63 @@ export function WelcomeClient({
         if (cancelled) return
 
         if (response.ok && body.status === "active") {
+          addCheckoutBreadcrumb({
+            provider: "paypal",
+            stage: "paypal_activation_status_poll",
+            source: "welcome",
+            paypalTokenPresent: true,
+            status: "active",
+          })
           window.location.reload()
           return
         }
         if (response.ok && body.status === "duplicate") {
+          addCheckoutBreadcrumb(
+            {
+              provider: "paypal",
+              stage: "paypal_activation_status_poll",
+              source: "welcome",
+              paypalTokenPresent: true,
+              status: "duplicate",
+            },
+            "warning",
+          )
           window.location.reload()
           return
         }
-      } catch {
+        if (!response.ok && attempts === 1) {
+          captureCheckoutException(new Error("PayPal activation status poll failed"), {
+            provider: "paypal",
+            stage: "paypal_activation_status_poll",
+            source: "welcome",
+            paypalTokenPresent: true,
+            status: response.status,
+          })
+        }
+      } catch (err) {
+        if (cancelled) return
+        if (attempts === 1) {
+          captureCheckoutException(err, {
+            provider: "paypal",
+            stage: "paypal_activation_status_poll",
+            source: "welcome",
+            paypalTokenPresent: true,
+            reason: "network_error",
+          })
+        }
         // Keep the pending screen calm; the next poll or manual refresh can recover.
       }
 
       if (!cancelled && attempts < 15) {
         timer = setTimeout(pollActivation, 2000)
       } else if (!cancelled) {
+        captureCheckoutException(new Error("PayPal activation polling timed out"), {
+          provider: "paypal",
+          stage: "paypal_activation_status_poll",
+          source: "welcome",
+          paypalTokenPresent: true,
+          reason: "polling_timeout",
+        })
         setMessage("Das dauert gerade etwas länger. Bitte aktualisiere die Seite gleich erneut.")
       }
     }
@@ -130,6 +174,10 @@ export function WelcomeClient({
         if (res.status === 409 || errorMessage.includes("Login-Link")) {
           setHighlightMagicLink(true)
         }
+        captureCheckoutException(new Error(errorMessage), {
+          ...checkoutActivationSentryDetails(activationSource, "checkout_password_activation"),
+          status: res.status,
+        })
         throw new Error(errorMessage)
       }
 
@@ -141,6 +189,10 @@ export function WelcomeClient({
       })
 
       if (error) {
+        captureCheckoutException(error, {
+          ...checkoutActivationSentryDetails(activationSource, "checkout_password_activation"),
+          reason: "supabase_password_sign_in_failed",
+        })
         setMessage(SIGN_IN_AFTER_PASSWORD_ERROR)
         return
       }
@@ -166,7 +218,12 @@ export function WelcomeClient({
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
-        throw new Error(typeof body.error === "string" ? body.error : UNKNOWN_ERROR)
+        const errorMessage = typeof body.error === "string" ? body.error : UNKNOWN_ERROR
+        captureCheckoutException(new Error(errorMessage), {
+          ...checkoutActivationSentryDetails(activationSource, "checkout_magic_link_activation"),
+          status: res.status,
+        })
+        throw new Error(errorMessage)
       }
       setState({ view: "sent" })
     } catch (err) {
@@ -417,6 +474,26 @@ function activationRequestBody(source: CheckoutActivationSource): Record<string,
 function activationSourceId(source: CheckoutActivationSource): string {
   if (source.provider === "paypal") return "paypal:checkout"
   return source.sessionId
+}
+
+function checkoutActivationSentryDetails(
+  source: CheckoutActivationSource,
+  stage: "checkout_password_activation" | "checkout_magic_link_activation",
+) {
+  if (source.provider === "paypal") {
+    return {
+      provider: "paypal" as const,
+      stage,
+      source: "welcome" as const,
+      paypalTokenPresent: true,
+    }
+  }
+  return {
+    provider: "stripe" as const,
+    stage,
+    source: "welcome" as const,
+    stripeSessionId: source.sessionId,
+  }
 }
 
 function normalizeError(err: unknown): string {

--- a/src/components/checkout/paypal-subscription-button.tsx
+++ b/src/components/checkout/paypal-subscription-button.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react"
 import { FUNDING, PayPalButtons, PayPalScriptProvider } from "@paypal/react-paypal-js"
 import type { CreateSubscriptionActions, OnApproveData } from "@paypal/paypal-js"
 
+import { addCheckoutBreadcrumb, captureCheckoutException } from "@/lib/observability/checkout"
 import type { BillingInterval } from "@/lib/stripe/intervals"
 import type { PayPalCheckoutSource } from "@/lib/paypal/checkout-intents"
 import {
@@ -80,7 +81,15 @@ export function PayPalSubscriptionButton({
             actions: CreateSubscriptionActions,
           ) => {
             setError(null)
+            suppressNextPayPalErrorRef.current = false
             onCheckoutStarted()
+            addCheckoutBreadcrumb({
+              provider: "paypal",
+              stage: "paypal_create_subscription",
+              source,
+              interval,
+              leadId,
+            })
             try {
               const intent = await createSubscriptionIntent({ interval, leadId, source })
               intentTokenRef.current = intent.token
@@ -99,6 +108,14 @@ export function PayPalSubscriptionButton({
                 throw err
               }
               setError(err instanceof Error ? err.message : paypalStartError)
+              captureCheckoutException(err, {
+                provider: "paypal",
+                stage: "paypal_create_subscription",
+                source,
+                interval,
+                leadId,
+              })
+              suppressNextPayPalErrorRef.current = true
               throw err
             }
           }}
@@ -106,27 +123,87 @@ export function PayPalSubscriptionButton({
             const token = intentTokenRef.current
             if (!data.subscriptionID || !token) {
               setError(paypalStartError)
+              captureCheckoutException(new Error("PayPal approval missing subscription or token"), {
+                provider: "paypal",
+                stage: "paypal_approve_subscription",
+                source,
+                interval,
+                leadId,
+                paypalSubscriptionId: data.subscriptionID,
+                paypalTokenPresent: Boolean(token),
+                reason: "approve_payload_incomplete",
+              })
               return
             }
+            addCheckoutBreadcrumb({
+              provider: "paypal",
+              stage: "paypal_approve_subscription",
+              source,
+              interval,
+              leadId,
+              paypalSubscriptionId: data.subscriptionID,
+              paypalTokenPresent: true,
+            })
             const approved = await approveSubscriptionIntent(token, data.subscriptionID)
             if (!approved.ok) {
               if (approved.duplicate) {
+                addCheckoutBreadcrumb(
+                  {
+                    provider: "paypal",
+                    stage: "checkout_return",
+                    source,
+                    interval,
+                    leadId,
+                    paypalSubscriptionId: data.subscriptionID,
+                    paypalTokenPresent: true,
+                    status: approved.status,
+                    reason: "duplicate_access",
+                  },
+                  "warning",
+                )
                 setError(null)
                 setDuplicateEmail(approved.email ?? null)
                 setDuplicateDialogOpen(true)
                 return
               }
+              captureCheckoutException(new Error("PayPal subscription approval failed"), {
+                provider: "paypal",
+                stage: "paypal_approve_subscription",
+                source,
+                interval,
+                leadId,
+                paypalSubscriptionId: data.subscriptionID,
+                paypalTokenPresent: true,
+                status: approved.status,
+              })
               setError(approved.message)
               return
             }
+            addCheckoutBreadcrumb({
+              provider: "paypal",
+              stage: "checkout_return",
+              source,
+              interval,
+              leadId,
+              paypalSubscriptionId: data.subscriptionID,
+              paypalTokenPresent: true,
+            })
             window.location.assign(buildPayPalWelcomeUrl(token))
           }}
-          onError={() => {
+          onError={(err) => {
             if (suppressNextPayPalErrorRef.current) {
               suppressNextPayPalErrorRef.current = false
               return
             }
             setError(paypalStartError)
+            captureCheckoutException(err, {
+              provider: "paypal",
+              stage: "paypal_create_subscription",
+              source,
+              interval,
+              leadId,
+              reason: "paypal_button_error",
+            })
           }}
           style={{
             borderRadius: 999,
@@ -177,7 +254,8 @@ async function approveSubscriptionIntent(
   token: string,
   subscriptionId: string,
 ): Promise<
-  { ok: true } | { ok: false; duplicate: boolean; email?: string | null; message: string }
+  | { ok: true }
+  | { ok: false; duplicate: boolean; email?: string | null; message: string; status: number }
 > {
   const response = await fetch("/api/paypal/approve-subscription", {
     method: "POST",
@@ -193,5 +271,6 @@ async function approveSubscriptionIntent(
     duplicate: isCheckoutAccessAlreadyExistsResponse(response, body),
     email: readCheckoutAccessAlreadyExistsEmail(body),
     message,
+    status: response.status,
   }
 }

--- a/src/lib/observability/checkout.ts
+++ b/src/lib/observability/checkout.ts
@@ -1,0 +1,400 @@
+import * as Sentry from "@sentry/nextjs"
+
+type CheckoutProvider = "stripe" | "paypal"
+type CheckoutInterval = "month" | "quarter" | "year"
+type CheckoutSource = "pricing_page" | "quiz_result_offer" | "welcome"
+
+type CheckoutStage =
+  | "stripe_checkout_session_create"
+  | "stripe_embedded_checkout_client_secret"
+  | "stripe_embedded_checkout_load"
+  | "paypal_create_subscription_intent"
+  | "paypal_create_subscription"
+  | "paypal_approve_subscription"
+  | "paypal_activation_status_poll"
+  | "checkout_return"
+  | "checkout_password_activation"
+  | "checkout_magic_link_activation"
+
+type BreadcrumbLevel = "debug" | "info" | "warning" | "error"
+type RateLimitSource = "app" | "supabase_auth"
+
+export interface CheckoutSentryDetails {
+  provider: CheckoutProvider
+  stage: CheckoutStage
+  source?: CheckoutSource
+  interval?: CheckoutInterval
+  leadId?: string | null
+  stripeSessionId?: string | null
+  stripeCustomerId?: string | null
+  stripeSubscriptionId?: string | null
+  paypalSubscriptionId?: string | null
+  paypalTokenPresent?: boolean
+  status?: number | string
+  reason?: string | null
+  rateLimitSource?: RateLimitSource
+}
+
+export interface CheckoutSentryPayload {
+  tags: Record<string, string>
+  context: Record<string, unknown>
+}
+
+interface SentryEventLike {
+  breadcrumbs?: SentryBreadcrumbLike[]
+  contexts?: Record<string, unknown>
+  exception?: {
+    values?: unknown[]
+  }
+  extra?: Record<string, unknown>
+  logentry?: {
+    message?: string
+    params?: unknown[]
+  }
+  message?: string
+  request?: {
+    cookies?: unknown
+    data?: unknown
+    headers?: Record<string, unknown>
+    query_string?: unknown
+    url?: string
+  }
+  spans?: SentrySpanLike[]
+  transaction?: string
+}
+
+interface SentryBreadcrumbLike {
+  data?: Record<string, unknown>
+  message?: string
+}
+
+interface SentrySpanLike {
+  data?: Record<string, unknown>
+  description?: string
+}
+
+interface CheckoutScopeLike {
+  setContext(name: string, context: Record<string, unknown>): void
+  setLevel?(level: BreadcrumbLevel): void
+  setTag(key: string, value: string): void
+}
+
+interface CheckoutSentrySink {
+  addBreadcrumb(breadcrumb: {
+    category: string
+    data: Record<string, unknown>
+    level: BreadcrumbLevel
+    message: string
+  }): void
+  captureException(error: unknown): void
+  withScope(callback: (scope: CheckoutScopeLike) => void): void
+}
+
+const CHECKOUT_SECRET_QUERY_KEYS = new Set(["session_id", "token"])
+const CHECKOUT_SECRET_FIELD_KEYS = new Set(["session_id", "token", "stripe_session_id"])
+const REDACTED_VALUE = "[Filtered]"
+
+export function buildCheckoutSentryPayload(details: CheckoutSentryDetails): CheckoutSentryPayload {
+  const context: Record<string, unknown> = {
+    provider: details.provider,
+    stage: details.stage,
+  }
+  const tags: Record<string, string> = {
+    "checkout.provider": details.provider,
+    "checkout.stage": details.stage,
+  }
+
+  addOptional(context, "source", details.source)
+  addOptional(context, "interval", details.interval)
+  addOptional(context, "lead_id", details.leadId)
+  addOptional(context, "stripe_session_id", details.stripeSessionId ? REDACTED_VALUE : null)
+  addOptional(context, "stripe_customer_id", details.stripeCustomerId)
+  addOptional(context, "stripe_subscription_id", details.stripeSubscriptionId)
+  addOptional(context, "paypal_subscription_id", details.paypalSubscriptionId)
+  addOptional(context, "paypal_token_present", details.paypalTokenPresent)
+  addOptional(context, "status", details.status)
+  addOptional(context, "reason", details.reason)
+  addOptional(context, "rate_limit_source", details.rateLimitSource)
+
+  addTag(tags, "checkout.source", details.source)
+  addTag(tags, "checkout.interval", details.interval)
+  addTag(tags, "checkout.status", details.status)
+  addTag(tags, "checkout.reason", details.reason)
+  addTag(tags, "checkout.rate_limit_source", details.rateLimitSource)
+
+  return { tags, context }
+}
+
+export function getCheckoutRateLimitReason(
+  error: unknown,
+): "supabase_auth_email_rate_limit" | null {
+  const combined = `${getErrorText(error, "message")} ${getErrorText(error, "msg")} ${getErrorText(
+    error,
+    "error_code",
+  )} ${getErrorText(error, "code")}`.toLowerCase()
+
+  const status = getErrorNumber(error, "status")
+  if (
+    status === 429 ||
+    combined.includes("over_email_send_rate_limit") ||
+    combined.includes("email rate limit") ||
+    combined.includes("email send rate")
+  ) {
+    return "supabase_auth_email_rate_limit"
+  }
+
+  return null
+}
+
+export function addCheckoutBreadcrumb(
+  details: CheckoutSentryDetails,
+  level: BreadcrumbLevel = "info",
+  sink: CheckoutSentrySink = Sentry,
+) {
+  const payload = buildCheckoutSentryPayload(details)
+  sink.addBreadcrumb({
+    category: "checkout",
+    data: payload.context,
+    level,
+    message: `checkout.${details.stage}`,
+  })
+}
+
+export function captureCheckoutException(
+  error: unknown,
+  details: CheckoutSentryDetails,
+  sink: CheckoutSentrySink = Sentry,
+) {
+  const payload = buildCheckoutSentryPayload(details)
+  sink.withScope((scope) => {
+    for (const [key, value] of Object.entries(payload.tags)) {
+      scope.setTag(key, value)
+    }
+    scope.setContext("checkout", payload.context)
+    scope.setLevel?.("error")
+    sink.captureException(error)
+  })
+}
+
+export function scrubSentryEvent<Event extends SentryEventLike>(event: Event): Event {
+  if (event.request) {
+    scrubSentryRequest(event.request)
+  }
+
+  if (event.breadcrumbs) {
+    event.breadcrumbs = event.breadcrumbs.map(scrubSentryBreadcrumb)
+  }
+
+  if (event.spans) {
+    event.spans = event.spans.map(scrubSentrySpan)
+  }
+
+  if (event.contexts) {
+    event.contexts = scrubSentryValue(event.contexts) as Record<string, unknown>
+  }
+
+  if (event.extra) {
+    event.extra = scrubSentryValue(event.extra) as Record<string, unknown>
+  }
+
+  if (event.exception?.values) {
+    event.exception.values = event.exception.values.map((exception) => scrubSentryValue(exception))
+  }
+
+  if (typeof event.message === "string") {
+    event.message = scrubCheckoutText(event.message)
+  }
+
+  if (event.logentry) {
+    if (typeof event.logentry.message === "string") {
+      event.logentry.message = scrubCheckoutText(event.logentry.message)
+    }
+    if (event.logentry.params) {
+      event.logentry.params = scrubSentryValue(event.logentry.params) as unknown[]
+    }
+  }
+
+  if (typeof event.transaction === "string") {
+    event.transaction = scrubCheckoutUrl(event.transaction)
+  }
+
+  return event
+}
+
+export function scrubSentryBreadcrumb<Breadcrumb extends SentryBreadcrumbLike>(
+  breadcrumb: Breadcrumb,
+): Breadcrumb {
+  const scrubbed = { ...breadcrumb }
+  if (typeof scrubbed.message === "string") {
+    scrubbed.message = scrubCheckoutText(scrubbed.message)
+  }
+  if (scrubbed.data) {
+    scrubbed.data = scrubSentryValue(scrubbed.data) as Record<string, unknown>
+  }
+  return scrubbed
+}
+
+function scrubSentryRequest(request: NonNullable<SentryEventLike["request"]>) {
+  if (typeof request.url === "string") {
+    request.url = scrubCheckoutUrl(request.url)
+  }
+
+  if (typeof request.query_string === "string") {
+    request.query_string = scrubCheckoutQueryString(request.query_string)
+  } else if (request.query_string && isPlainRecord(request.query_string)) {
+    request.query_string = scrubSentryValue(request.query_string)
+  }
+
+  if (request.data) {
+    request.data = scrubSentryValue(request.data)
+  }
+
+  if (request.headers) {
+    const headers = { ...request.headers }
+    for (const key of Object.keys(headers)) {
+      const normalized = key.toLowerCase()
+      if (normalized === "authorization" || normalized === "cookie") {
+        headers[key] = REDACTED_VALUE
+      }
+    }
+    request.headers = headers
+  }
+
+  delete request.cookies
+}
+
+function scrubSentrySpan<Span extends SentrySpanLike>(span: Span): Span {
+  const scrubbed = { ...span }
+  if (typeof scrubbed.description === "string") {
+    scrubbed.description = scrubCheckoutText(scrubbed.description)
+  }
+  if (scrubbed.data) {
+    scrubbed.data = scrubSentryValue(scrubbed.data) as Record<string, unknown>
+  }
+  return scrubbed
+}
+
+function scrubSentryValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === "string") {
+    return scrubCheckoutText(value)
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return value
+  }
+
+  if (seen.has(value)) {
+    return REDACTED_VALUE
+  }
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubSentryValue(item, seen))
+  }
+
+  if (!isPlainRecord(value)) {
+    return value
+  }
+
+  const scrubbed: Record<string, unknown> = {}
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const normalized = key.toLowerCase()
+    if (CHECKOUT_SECRET_FIELD_KEYS.has(normalized)) {
+      scrubbed[key] = REDACTED_VALUE
+      continue
+    }
+    if (normalized === "authorization" || normalized === "cookie" || normalized === "cookies") {
+      scrubbed[key] = REDACTED_VALUE
+      continue
+    }
+    scrubbed[key] = scrubSentryValue(nestedValue, seen)
+  }
+  return scrubbed
+}
+
+function scrubCheckoutUrl(value: string): string {
+  try {
+    const url = new URL(value, "https://chaarlie.invalid")
+    for (const key of CHECKOUT_SECRET_QUERY_KEYS) {
+      if (url.searchParams.has(key)) {
+        url.searchParams.set(key, REDACTED_VALUE)
+      }
+    }
+    if (isLikelyRelativeUrl(value)) {
+      return `${url.pathname}${url.search}${url.hash}`
+    }
+    return url.toString()
+  } catch {
+    return value
+  }
+}
+
+function scrubCheckoutText(value: string): string {
+  if (!hasCheckoutSecretQuery(value)) {
+    return value
+  }
+
+  if (isLikelyUrl(value)) {
+    return scrubCheckoutUrl(value)
+  }
+
+  return value.replace(/(?:https?:\/\/|\/)[^\s"'<>)]*/gi, (match) => scrubCheckoutUrl(match))
+}
+
+function scrubCheckoutQueryString(value: string): string {
+  const params = new URLSearchParams(value.startsWith("?") ? value.slice(1) : value)
+  let changed = false
+  for (const key of CHECKOUT_SECRET_QUERY_KEYS) {
+    if (params.has(key)) {
+      params.set(key, REDACTED_VALUE)
+      changed = true
+    }
+  }
+  return changed ? params.toString() : value
+}
+
+function isLikelyRelativeUrl(value: string): boolean {
+  return !/^[a-z][a-z\d+.-]*:/i.test(value)
+}
+
+function isLikelyUrl(value: string): boolean {
+  return /^(?:https?:\/\/|\/|\?)/i.test(value)
+}
+
+function hasCheckoutSecretQuery(value: string): boolean {
+  return /[?&](session_id|token)=/i.test(value)
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function addOptional(
+  target: Record<string, unknown>,
+  key: string,
+  value: string | number | boolean | null | undefined,
+) {
+  if (value === null || value === undefined || value === "") return
+  target[key] = value
+}
+
+function addTag(
+  target: Record<string, string>,
+  key: string,
+  value: string | number | null | undefined,
+) {
+  if (value === null || value === undefined || value === "") return
+  target[key] = String(value)
+}
+
+function getErrorText(error: unknown, key: string): string {
+  if (typeof error !== "object" || error === null || !(key in error)) return ""
+  const value = (error as Record<string, unknown>)[key]
+  return typeof value === "string" ? value : ""
+}
+
+function getErrorNumber(error: unknown, key: string): number | null {
+  if (typeof error !== "object" || error === null || !(key in error)) return null
+  const value = (error as Record<string, unknown>)[key]
+  return typeof value === "number" ? value : null
+}

--- a/tests/auth-post-checkout-routes.spec.ts
+++ b/tests/auth-post-checkout-routes.spec.ts
@@ -146,12 +146,16 @@ test("rejects weak passwords before changing anything", async () => {
 
 test("returns 429 when the checkout session is rate limited", async () => {
   let rateLimitIdentifier: string | undefined
+  const captured: any[] = []
   const { calls, deps } = stubDeps({
-    checkRateLimit: async (identifier) => {
+    checkRateLimit: async (identifier: string) => {
       rateLimitIdentifier = identifier
       return { allowed: false }
     },
-  })
+    captureCheckoutException: (_error: unknown, details: Record<string, unknown>) => {
+      captured.push(details)
+    },
+  } as any)
 
   const response = await handleSetCheckoutPassword(
     { session_id: "cs_test_password", password: "long-enough" },
@@ -162,6 +166,15 @@ test("returns 429 when the checkout session is rate limited", async () => {
   expect(response.body.error).toContain("Zu viele")
   expect(rateLimitIdentifier).toBe("cs_test_password")
   expect(calls).toEqual([])
+  expect(captured).toEqual([
+    expect.objectContaining({
+      provider: "stripe",
+      stage: "checkout_password_activation",
+      rateLimitSource: "app",
+      reason: "set_checkout_password_rate_limited",
+      status: 429,
+    }),
+  ])
 })
 
 test("returns 503 when the rate-limit service is unavailable", async () => {
@@ -632,6 +645,35 @@ test("send magic link rejects when the checkout activation was already claimed",
   expect(response.body.error).toContain("nicht mehr gültig")
 })
 
+test("send magic link reports app rate limits to checkout Sentry context", async () => {
+  const { deps } = stubDeps()
+  const captured: any[] = []
+  const response = await handleSendMagicLink({ session_id: "cs_magic" }, {
+    stripe: deps.stripe,
+    supabase: deps.supabase,
+    siteUrl: "https://hair.example",
+    checkRateLimit: async () => ({ allowed: false }),
+    verifyCheckoutSessionForActivation: deps.verifyCheckoutSessionForActivation,
+    ensureCheckoutAccount: deps.ensureCheckoutAccount,
+    claimCheckoutActivation: async () => true,
+    releaseCheckoutActivationClaim: async () => {},
+    captureCheckoutException: (_error: unknown, details: Record<string, unknown>) => {
+      captured.push(details)
+    },
+  } as any)
+
+  expect(response.status).toBe(429)
+  expect(captured).toEqual([
+    expect.objectContaining({
+      provider: "stripe",
+      stage: "checkout_magic_link_activation",
+      rateLimitSource: "app",
+      reason: "send_auth_link_rate_limited",
+      status: 429,
+    }),
+  ])
+})
+
 test("send magic link releases the checkout activation claim if email sending fails", async () => {
   const { deps } = stubDeps()
   let releasedSessionId: string | undefined
@@ -658,6 +700,44 @@ test("send magic link releases the checkout activation claim if email sending fa
 
   expect(response.status).toBe(500)
   expect(releasedSessionId).toBe("cs_magic")
+})
+
+test("send magic link reports Supabase Auth email-send rate limits to checkout Sentry context", async () => {
+  const { deps } = stubDeps()
+  const captured: any[] = []
+  deps.supabase.auth.signInWithOtp = async () => ({
+    data: { user: null, session: null },
+    error: {
+      message: "Email rate limit exceeded",
+      error_code: "over_email_send_rate_limit",
+      status: 429,
+    } as any,
+  })
+
+  const response = await handleSendMagicLink({ session_id: "cs_magic" }, {
+    stripe: deps.stripe,
+    supabase: deps.supabase,
+    siteUrl: "https://hair.example",
+    checkRateLimit: deps.checkRateLimit,
+    verifyCheckoutSessionForActivation: deps.verifyCheckoutSessionForActivation,
+    ensureCheckoutAccount: deps.ensureCheckoutAccount,
+    claimCheckoutActivation: async () => true,
+    releaseCheckoutActivationClaim: async () => {},
+    captureCheckoutException: (_error: unknown, details: Record<string, unknown>) => {
+      captured.push(details)
+    },
+  } as any)
+
+  expect(response.status).toBe(500)
+  expect(captured).toEqual([
+    expect.objectContaining({
+      provider: "stripe",
+      stage: "checkout_magic_link_activation",
+      rateLimitSource: "supabase_auth",
+      reason: "supabase_auth_email_rate_limit",
+      status: 429,
+    }),
+  ])
 })
 
 test("send magic link requires only session_id and reports non-leaky German errors", async () => {

--- a/tests/checkout-observability.test.ts
+++ b/tests/checkout-observability.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  buildCheckoutSentryPayload,
+  getCheckoutRateLimitReason,
+  scrubSentryBreadcrumb,
+  scrubSentryEvent,
+} from "../src/lib/observability/checkout"
+
+test("buildCheckoutSentryPayload keeps searchable checkout tags without raw PayPal token", () => {
+  const payload = buildCheckoutSentryPayload({
+    provider: "paypal",
+    stage: "paypal_approve_subscription",
+    source: "pricing_page",
+    interval: "quarter",
+    leadId: "11111111-1111-4111-8111-111111111111",
+    paypalSubscriptionId: "I-SUBSCRIPTION",
+    paypalTokenPresent: true,
+    status: 502,
+  })
+
+  assert.deepEqual(payload.tags, {
+    "checkout.provider": "paypal",
+    "checkout.stage": "paypal_approve_subscription",
+    "checkout.source": "pricing_page",
+    "checkout.interval": "quarter",
+    "checkout.status": "502",
+  })
+  assert.deepEqual(payload.context, {
+    provider: "paypal",
+    stage: "paypal_approve_subscription",
+    source: "pricing_page",
+    interval: "quarter",
+    lead_id: "11111111-1111-4111-8111-111111111111",
+    paypal_subscription_id: "I-SUBSCRIPTION",
+    paypal_token_present: true,
+    status: 502,
+  })
+  assert.equal(JSON.stringify(payload).includes("secret-token"), false)
+})
+
+test("buildCheckoutSentryPayload redacts raw Stripe checkout session ids", () => {
+  const payload = buildCheckoutSentryPayload({
+    provider: "stripe",
+    stage: "checkout_return",
+    source: "welcome",
+    stripeSessionId: "cs_test_secret",
+  })
+
+  assert.equal(payload.context.stripe_session_id, "[Filtered]")
+  assert.equal(JSON.stringify(payload).includes("cs_test_secret"), false)
+})
+
+test("scrubSentryEvent removes checkout activation secrets from request urls", () => {
+  const event = scrubSentryEvent({
+    request: {
+      url: "https://chaarlie.example/welcome?provider=paypal&token=secret-token&session_id=cs_test_123&keep=yes",
+    },
+  })
+
+  assert.equal(
+    event.request?.url,
+    "https://chaarlie.example/welcome?provider=paypal&token=%5BFiltered%5D&session_id=%5BFiltered%5D&keep=yes",
+  )
+})
+
+test("scrubSentryEvent redacts relative urls, query fields, headers, cookies, and spans", () => {
+  const event = scrubSentryEvent({
+    request: {
+      url: "/welcome?provider=paypal&token=secret-token&session_id=cs_test_123&keep=yes",
+      query_string: {
+        token: "secret-token",
+        keep: "yes",
+        session_id: "cs_test_123",
+      },
+      headers: {
+        authorization: "Bearer secret",
+        cookie: "session=secret",
+        "x-safe": "yes",
+      },
+      cookies: { session: "secret" },
+      data: {
+        token: "secret-token",
+        callbackUrl: "/welcome?session_id=cs_test_123",
+      },
+    },
+    contexts: {
+      checkout: {
+        stripe_session_id: "cs_test_secret",
+      },
+    },
+    exception: {
+      values: [
+        {
+          value: "Checkout failed for /welcome?session_id=cs_test_123",
+        },
+      ],
+    },
+    extra: {
+      returnUrl: "/welcome?token=secret-token",
+    },
+    message: "Checkout failed for /welcome?token=secret-token",
+    spans: [
+      {
+        description: "GET /api/paypal/activation-status?token=secret-token",
+        data: {
+          url: "/api/paypal/activation-status?token=secret-token",
+        },
+      },
+    ],
+    transaction: "/welcome?token=secret-token",
+  })
+
+  assert.equal(
+    event.request?.url,
+    "/welcome?provider=paypal&token=%5BFiltered%5D&session_id=%5BFiltered%5D&keep=yes",
+  )
+  assert.deepEqual(event.request?.query_string, {
+    token: "[Filtered]",
+    keep: "yes",
+    session_id: "[Filtered]",
+  })
+  assert.deepEqual(event.request?.headers, {
+    authorization: "[Filtered]",
+    cookie: "[Filtered]",
+    "x-safe": "yes",
+  })
+  assert.equal("cookies" in (event.request ?? {}), false)
+  assert.deepEqual(event.contexts?.checkout, {
+    stripe_session_id: "[Filtered]",
+  })
+  assert.deepEqual(event.request?.data, {
+    token: "[Filtered]",
+    callbackUrl: "/welcome?session_id=%5BFiltered%5D",
+  })
+  assert.deepEqual(event.extra, {
+    returnUrl: "/welcome?token=%5BFiltered%5D",
+  })
+  assert.equal(event.message, "Checkout failed for /welcome?token=%5BFiltered%5D")
+  assert.deepEqual(event.exception?.values, [
+    {
+      value: "Checkout failed for /welcome?session_id=%5BFiltered%5D",
+    },
+  ])
+  assert.equal(
+    event.spans?.[0]?.description,
+    "GET /api/paypal/activation-status?token=%5BFiltered%5D",
+  )
+  assert.deepEqual(event.spans?.[0]?.data, {
+    url: "/api/paypal/activation-status?token=%5BFiltered%5D",
+  })
+  assert.equal(event.transaction, "/welcome?token=%5BFiltered%5D")
+})
+
+test("scrubSentryBreadcrumb removes checkout activation secrets from breadcrumb data", () => {
+  const breadcrumb = scrubSentryBreadcrumb({
+    message: "Navigated to /welcome?session_id=cs_test_123",
+    data: {
+      from: "/pricing",
+      to: "/welcome?token=secret-token",
+      request: {
+        url: "/api/paypal/activation-status?token=secret-token",
+      },
+    },
+  })
+
+  assert.equal(breadcrumb.message, "Navigated to /welcome?session_id=%5BFiltered%5D")
+  assert.deepEqual(breadcrumb.data, {
+    from: "/pricing",
+    to: "/welcome?token=%5BFiltered%5D",
+    request: {
+      url: "/api/paypal/activation-status?token=%5BFiltered%5D",
+    },
+  })
+})
+
+test("buildCheckoutSentryPayload tags checkout rate-limit source", () => {
+  const payload = buildCheckoutSentryPayload({
+    provider: "stripe",
+    stage: "checkout_magic_link_activation",
+    source: "welcome",
+    status: 429,
+    reason: "send_auth_link_rate_limited",
+    rateLimitSource: "app",
+  })
+
+  assert.equal(payload.tags["checkout.rate_limit_source"], "app")
+  assert.equal(payload.context.rate_limit_source, "app")
+})
+
+test("getCheckoutRateLimitReason recognizes Supabase email-send throttling", () => {
+  assert.equal(
+    getCheckoutRateLimitReason({
+      message: "Email rate limit exceeded",
+      error_code: "over_email_send_rate_limit",
+      status: 429,
+    }),
+    "supabase_auth_email_rate_limit",
+  )
+})


### PR DESCRIPTION
## Why
Checkout failures were hard to diagnose when checkout did not load, payment setup failed, return redirects broke, or post-checkout activation hit rate limits. This adds structured Sentry breadcrumbs/events around those flows so production incidents can be grouped by provider, stage, source, and rate-limit cause.

## What changed
- Added a checkout observability helper with privacy scrubbing for Sentry request data and checkout query params.
- Captures checkout failures across Stripe session creation, PayPal subscription intent/approval, pricing-card checkout launch, welcome return handling, and checkout activation flows.
- Adds explicit tags for app-level activation rate limits and Supabase Auth email rate limits so those cases are distinguishable in Sentry.
- Configures client/server Sentry init with `sendDefaultPii: false`, environment tagging, and the checkout scrubber.

## Verification
- `npm run typecheck`
- `npm run lint` passed with existing warnings in `src/components/layout/header.tsx`, `src/components/ui/avatar.tsx`, `src/lib/agent/orchestrator/model-client.ts`, and `src/lib/routines/brush-tools.ts`
- `npm run build`
- `npx tsx --test tests/checkout-observability.test.ts tests/payment-method-checkout.test.tsx tests/billing-paypal-server.test.ts` passed, 70 tests
- `npx playwright test tests/auth-post-checkout-routes.spec.ts --project=chromium` passed, 26 tests

## Risks / follow-up
- Server route catch blocks capture checkout exceptions and then rethrow, so Next/Sentry request-error capture may create duplicate events for some failures. The explicit capture adds checkout tags and context; we can tune deduping after observing production grouping.
- Live Sentry alert recipients/rules were not changed in this branch. That should be confirmed against the Sentry project before promoting from draft.
