### PR TITLE
fix(payments): defer Stripe loading from landing

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -65,6 +65,7 @@ export function Hero() {
               need an anchor element with a multi-line label (CTA + subtitle). */}
           <Link
             href="/quiz"
+            prefetch={false}
             className="block rounded-[14px] bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-dark))] px-8 py-[18px] text-center text-white shadow-[0_10px_32px_rgba(var(--brand-coral-rgb),0.31),inset_0_1px_0_rgba(255,255,255,0.22)] transition-all hover:bg-[linear-gradient(180deg,var(--brand-coral),var(--brand-coral-deep))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral-dark)] focus-visible:ring-offset-2 motion-safe:hover:-translate-y-0.5"
           >
             <span className="block text-lg font-bold text-white">Quiz starten</span>

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -22,6 +22,7 @@ export function LandingHeader() {
           </Link>
           <Link
             href="/quiz"
+            prefetch={false}
             className="whitespace-nowrap rounded-[10px] bg-[var(--brand-coral)] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-coral-dark)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-coral)] focus-visible:ring-offset-2 sm:px-[18px] sm:py-2.5"
           >
             Quiz starten

--- a/src/components/quiz/result-offer-pricing.tsx
+++ b/src/components/quiz/result-offer-pricing.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useCallback, useEffect, useRef, useState } from "react"
-import { loadStripe } from "@stripe/stripe-js"
+import { loadStripe } from "@stripe/stripe-js/pure"
+import type { Stripe } from "@stripe/stripe-js"
 
 import {
   isPayPalCheckoutEnabled,
@@ -22,9 +23,7 @@ import {
 } from "@/lib/stripe/pricing-plans"
 
 const stripePublishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
-const stripePromise = stripePublishableKey
-  ? loadStripe(stripePublishableKey)
-  : Promise.resolve(null)
+const unloadedStripePromise = Promise.resolve(null)
 const checkoutStartError = "Zahlung konnte nicht gestartet werden. Bitte versuche es erneut."
 
 function getPlanDetail(plan: ReturnType<typeof getStripePricingPlan>): string {
@@ -39,13 +38,45 @@ export function ResultOfferPricing({
   onCheckoutOpen?: () => void
 }) {
   const checkoutRef = useRef<HTMLDivElement | null>(null)
+  const stripePromiseRef = useRef<Promise<Stripe | null> | null>(null)
   const [selectedInterval, setSelectedInterval] =
     useState<BillingInterval>(DEFAULT_PRICING_INTERVAL)
   const [checkoutInterval, setCheckoutInterval] = useState<BillingInterval | null>(null)
   const [checkoutError, setCheckoutError] = useState<string | null>(null)
+  const [checkoutStripePromise, setCheckoutStripePromise] =
+    useState<Promise<Stripe | null>>(unloadedStripePromise)
   const [duplicateEmail, setDuplicateEmail] = useState<string | null>(null)
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false)
   const selectedPlan = getStripePricingPlan(selectedInterval)
+
+  const getStripePromise = useCallback(() => {
+    if (!stripePublishableKey) {
+      stripePromiseRef.current = unloadedStripePromise
+      return unloadedStripePromise
+    }
+
+    if (!stripePromiseRef.current) {
+      const promise = loadStripe(stripePublishableKey)
+      promise.catch(() => {
+        if (stripePromiseRef.current === promise) {
+          stripePromiseRef.current = null
+        }
+      })
+      stripePromiseRef.current = promise
+    }
+
+    return stripePromiseRef.current
+  }, [])
+
+  const ensureStripePromise = useCallback(() => {
+    const promise = getStripePromise()
+    setCheckoutStripePromise(promise)
+    return promise
+  }, [getStripePromise])
+
+  useEffect(() => {
+    getStripePromise()
+  }, [getStripePromise])
 
   useEffect(() => {
     trackAppEvent("pricing_viewed", {
@@ -61,6 +92,7 @@ export function ResultOfferPricing({
   }
 
   function openCheckout() {
+    ensureStripePromise()
     setCheckoutError(
       !isPayPalCheckoutEnabled() && !stripePublishableKey ? checkoutStartError : null,
     )
@@ -221,7 +253,7 @@ export function ResultOfferPricing({
             }}
             planLabel={getStripePricingPlan(checkoutInterval).ctaLabel}
             source="quiz_result_offer"
-            stripe={stripePromise}
+            stripe={checkoutStripePromise}
           />
         ) : null}
       </div>

--- a/tests/acquisition-funnel-tracking.test.ts
+++ b/tests/acquisition-funnel-tracking.test.ts
@@ -32,3 +32,31 @@ test("acquisition funnel keeps Meta, Customer.io, and PostHog tracking from land
   )
   assert.match(read("src/app/quiz/layout.tsx"), /<AppRouteProviders>/)
 })
+
+test("landing quiz CTAs do not prefetch checkout-heavy quiz bundles", () => {
+  for (const path of [
+    "src/components/landing/landing-header.tsx",
+    "src/components/landing/hero.tsx",
+    "src/components/landing/pricing.tsx",
+    "src/components/landing/final-cta.tsx",
+    "src/components/landing/site-footer.tsx",
+  ]) {
+    const source = read(path)
+    const quizLinks = source.match(/<Link\b(?=[^>]*href="\/quiz")[^>]*>/g) ?? []
+    assert.ok(quizLinks.length > 0, `${path} should contain at least one /quiz link`)
+
+    for (const link of quizLinks) {
+      assert.match(link, /prefetch=\{false\}/, `${path} /quiz links should opt out of prefetch`)
+    }
+  }
+})
+
+test("result offer preloads Stripe only after the offer component mounts", () => {
+  const source = read("src/components/quiz/result-offer-pricing.tsx")
+  const moduleScope = source.slice(0, source.indexOf("export function ResultOfferPricing"))
+
+  assert.match(source, /from "@stripe\/stripe-js\/pure"/)
+  assert.doesNotMatch(source, /const stripePromise\s*=/)
+  assert.doesNotMatch(moduleScope, /loadStripe\(/)
+  assert.match(source, /useEffect\(\(\) => \{\s*getStripePromise\(\)/)
+})


### PR DESCRIPTION
## Summary

Fixes the Sentry noise where the landing page could prefetch `/quiz`, evaluate checkout-heavy quiz result code, and inject Stripe.js while the user was still on `/`.

## What changed

- Disabled prefetch on the remaining landing `/quiz` CTAs in the header and hero.
- Switched result-offer Stripe loading to `@stripe/stripe-js/pure` so importing the quiz bundle does not inject Stripe.js.
- Warm Stripe only after the result offer mounts, then reuse the same promise when checkout opens.
- Added regression coverage for landing CTA prefetch and result-offer Stripe loading behavior.
- Ran Claude code review; it found no blocking issues. Its low-severity test robustness findings were addressed before commit.

## Verification

- `npx tsx --test tests/acquisition-funnel-tracking.test.ts`
- `npm run typecheck`
- `npm run lint` — 0 errors; 4 existing warnings outside this change
- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_123456789 NEXT_PUBLIC_PAYPAL_ENABLED=true NEXT_PUBLIC_SENTRY_DSN= npm run build`
- Production Playwright repro with `js.stripe.com` blocked: idle `/` made no `/quiz` prefetch, injected no Stripe script, and raised no page errors
- Homepage CTA click still navigated to `/quiz` cleanly

## Risks / notes

- No migrations.
- Stripe is intentionally warmed when the result offer is actually mounted, so checkout stays fast without loading payment code from the landing page.