### PR TITLE
Fix AgentV2 off-catalog named product detail handling

### DIFF
--- a/data/agent-v2/guidance/base/product-recommendation.json
+++ b/data/agent-v2/guidance/base/product-recommendation.json
@@ -35,6 +35,13 @@
       "source": "base/product-recommendation.md",
       "validator_id": "request_interpretation_tool_args_match",
       "message": "For product_detail turns, select_products arguments and terminal request_interpretation must match on kind, count, category, and evidence."
+    },
+    {
+      "rule_id": "product.named_detail_no_repeat_or_substitute",
+      "severity": "block",
+      "source": "base/product-recommendation.md",
+      "validator_id": "named_product_detail_unverified",
+      "message": "When the user already gave a plausible exact named product and select_products cannot verify it, do not ask for the exact name again or substitute unrelated catalog recommendations; use constraint_blocked."
     }
   ],
   "soft_rubrics": [
@@ -114,7 +121,7 @@
       "rubric_id": "product.detail_check_after_tool",
       "priority": "high",
       "source": "base/product-recommendation.md",
-      "message": "For named-product claim checks, call select_products first; if the catalog cannot confirm the product or claim, ask for the exact variant or explain the unsupported claim instead of inferring from the name."
+      "message": "For named-product claim checks, call select_products first; if the catalog cannot confirm the product or claim, ask for the exact variant only when the user has not already provided one, or explain the unsupported claim instead of inferring from the name."
     },
     {
       "rubric_id": "product.user_facing_unsupported_claim_fallback",

--- a/data/agent-v2/guidance/base/product-recommendation.md
+++ b/data/agent-v2/guidance/base/product-recommendation.md
@@ -52,6 +52,8 @@ For questions such as "Kann ich Produkt X als Hitzeschutz benutzen?", "Ist Produ
 
 If the tool cannot safely identify the product or support the requested claim, do not answer from the product name. Ask for the exact variant only when that could unlock supported metadata; otherwise explain the unsupported claim in the user-facing fallback style above and continue with grounded facts.
 
+When `named_product_context` says the user already gave a plausible exact product name, do not ask for the exact name again. If `select_products` cannot verify that named product as an exact or supported product-detail match, use `constraint_blocked`: say it is not a verified catalog hit, do not evaluate it exactly, and do not substitute unrelated catalog recommendations as the answer. You may add a cautious category-level note only when it is clearly not presented as a product-specific evaluation.
+
 ## Recommendation Framing
 
 Present ranked products as options with tradeoffs, not as a winner-takes-all verdict. The first product may be the cleanest fit, but explain that as a grounded fit judgment rather than an absolute truth.
@@ -132,7 +134,7 @@ If budget, availability, avoid list, allergy, or unsupported requested signals b
 
 Product-detail CTAs must stay inside the current product metadata contract. Do not offer to check photos, external links, reviews, ingredient lists, no-white-cast residue, exact usage protocols, color safety, chelating status, heat protection, or other claims unless select_products has surfaced that product detail as supported for this turn.
 
-When the requested detail is unsupported, a feasible CTA is to ask for the exact variant, offer a broader category recommendation, or bridge back to where the product would sit in the routine. Do not ask the user whether they want the same unsupported claim checked again.
+When the requested detail is unsupported, a feasible CTA is to ask for the exact variant only if the user has not already provided a plausible exact name, offer a broader category recommendation, or bridge back to where the product would sit in the routine. Do not ask the user whether they want the same unsupported claim checked again.
 
 ## German Answer Shape
 

--- a/src/lib/agent-v2/contracts.ts
+++ b/src/lib/agent-v2/contracts.ts
@@ -467,6 +467,13 @@ export const AgentV2TraceSchema = z.object({
   reasoning_effort: AgentV2ReasoningEffortSchema,
   safety_mode: AgentV2SafetyModeSchema,
   answer_mode: AgentV2AnswerModeSchema.nullable(),
+  named_product_context: z
+    .strictObject({
+      display_name: z.string(),
+      category: AgentV2CareCategorySchema,
+    })
+    .nullable()
+    .default(null),
   response_ids: z.array(z.string()),
   model_steps: z.array(AgentV2ModelStepTraceSchema),
   tool_calls: z.array(AgentV2ToolCallTraceSchema),

--- a/src/lib/agent-v2/named-product-context.ts
+++ b/src/lib/agent-v2/named-product-context.ts
@@ -1,0 +1,342 @@
+import type { AgentV2CareCategory } from "./contracts"
+
+export interface AgentV2NamedProductContext {
+  display_name: string
+  category: AgentV2CareCategory
+  plausible_exact_name: boolean
+}
+
+type SupportedCategoryConfig = {
+  category: AgentV2CareCategory
+  displayLabel: string
+  matchSource: string
+}
+
+const SUPPORTED_CATEGORY_CONFIGS: SupportedCategoryConfig[] = [
+  {
+    category: "deep_cleansing_shampoo",
+    displayLabel: "Tiefenreinigungsshampoo",
+    matchSource:
+      "tiefenreinigung(?:s)?shampoo|tiefenreinigungs\\s+shampoo|clarifying\\s+shampoo|deep\\s+cleansing\\s+shampoo",
+  },
+  {
+    category: "dry_shampoo",
+    displayLabel: "Trockenshampoo",
+    matchSource: "trockenshampoo|trocken\\s*shampoo|dry\\s+shampoo",
+  },
+  {
+    category: "leave_in",
+    displayLabel: "Leave-in",
+    matchSource: "leave[\\s-]?in(?:\\s+conditioner)?",
+  },
+  {
+    category: "bondbuilder",
+    displayLabel: "Bondbuilder",
+    matchSource:
+      "bond\\s*builder|bondbuilder|bonding\\s+treatment|(?<![\\p{L}\\p{N}])plex(?![\\p{L}\\p{N}])",
+  },
+  {
+    category: "conditioner",
+    displayLabel: "Conditioner",
+    matchSource: "conditioner|sp(?:ue|ü)lung",
+  },
+  {
+    category: "shampoo",
+    displayLabel: "Shampoo",
+    matchSource: "shampoo",
+  },
+  {
+    category: "mask",
+    displayLabel: "Maske",
+    matchSource: "haar\\s*maske|haarmaske|maske|mask",
+  },
+  {
+    category: "oil",
+    displayLabel: "Oil",
+    matchSource: "(?<![\\p{L}\\p{N}])(?:haar\\s*)?(?:oel|öl|oil)(?![\\p{L}\\p{N}])",
+  },
+  {
+    category: "peeling",
+    displayLabel: "Peeling",
+    matchSource: "kopfhaut\\s*peeling|scalp\\s+scrub|peeling",
+  },
+]
+
+const CURRENT_USE_PHRASE =
+  /\bich\s+(?:nutze|benutze|verwende|habe|nehme)\b|\b(?:nutze|benutze|verwende|nehme)\s+ich\b/iu
+
+const PRODUCT_EVALUATION_PHRASE = /\bwas\s+h(?:ae|ä)ltst\s+du\s+von\b|\bwas\s+haelst\s+du\s+von\b/iu
+
+const GENERIC_CATEGORY_QUESTION =
+  /\bwelch(?:er|en|es|e)\b|\bkannst\s+du\s+mir\b.*\bempfehlen\b|\bempfiehlst\s+du\b|\bempfehlung(?:en)?\b/iu
+
+const QUOTED_PRODUCT_NAME = /["“”]([^"“”]{2,80})["“”]/u
+
+const BRAND_AFTER_VON =
+  /\bvon\s+([A-ZÄÖÜ0-9][\p{L}\p{M}\p{N}&'.-]*(?:\s+[A-ZÄÖÜ0-9][\p{L}\p{M}\p{N}&'.-]*){0,4})/u
+
+const WORD_TOKEN = /[\p{L}\p{M}\p{N}&'.-]+/gu
+
+const CATEGORY_STOPWORDS = new Set([
+  "bondbuilder",
+  "conditioner",
+  "deep",
+  "dry",
+  "haar",
+  "haarmaske",
+  "leave",
+  "maske",
+  "mask",
+  "oel",
+  "oil",
+  "peeling",
+  "plex",
+  "scalp",
+  "scrub",
+  "shampoo",
+  "spuelung",
+  "tiefenreinigungsshampoo",
+  "trockenshampoo",
+])
+
+const QUESTION_WORDS = new Set(["welche", "welchen", "welcher", "welches"])
+
+export function normalizeNamedProductForComparison(value: string): string {
+  return value
+    .toLocaleLowerCase("de-DE")
+    .normalize("NFD")
+    .replace(/\p{M}/gu, "")
+    .replace(/(^|[^\p{L}\p{N}])von(?=$|[^\p{L}\p{N}])/gu, "$1 ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+export function buildAgentV2NamedProductContext(params: {
+  latestMessage: string
+  recentMessages: unknown[]
+}): AgentV2NamedProductContext | null {
+  void params.recentMessages
+
+  const latestMessage = params.latestMessage.trim()
+  if (latestMessage.length === 0) return null
+
+  const category = inferCategory(latestMessage)
+  if (category === null) return null
+
+  const brand = extractBrandAfterVon(latestMessage, category)
+  const quotedProductName = extractQuotedProductName(latestMessage)
+  const hasCurrentUse = hasCurrentUsePhrasing(latestMessage)
+  const hasProductEvaluation = hasProductEvaluationPhrasing(latestMessage)
+
+  if (isGenericCategoryQuestion(latestMessage) && !brand && !quotedProductName && !hasCurrentUse) {
+    return null
+  }
+  if (
+    !hasPositiveNamedProductSignal({
+      brand,
+      quotedProductName,
+      hasCurrentUse,
+      hasProductEvaluation,
+    })
+  ) {
+    return null
+  }
+
+  const messageWithoutBrand = brand
+    ? latestMessage.replace(new RegExp(`\\bvon\\s+${escapeRegExp(brand)}`, "u"), " ")
+    : latestMessage
+  const rawProductName =
+    quotedProductName ?? extractCategoryAdjacentProductName(messageWithoutBrand, category)
+  if (rawProductName === null) return null
+
+  const productName = ensureCategoryLabel(cleanupProductName(rawProductName), category)
+  if (!isPlausibleExactProductName(productName, category)) return null
+
+  return {
+    display_name: buildDisplayName({ brand, productName, category }),
+    category,
+    plausible_exact_name: true,
+  }
+}
+
+function inferCategory(message: string): AgentV2CareCategory | null {
+  for (const config of SUPPORTED_CATEGORY_CONFIGS) {
+    if (new RegExp(config.matchSource, "iu").test(message)) return config.category
+  }
+  return null
+}
+
+function extractBrandAfterVon(message: string, category: AgentV2CareCategory): string | null {
+  const match = BRAND_AFTER_VON.exec(message)
+  if (!match?.[1]) return null
+
+  const candidate = cleanupDisplayText(match[1])
+  const config = getCategoryConfig(category)
+  if (config !== null && new RegExp(config.matchSource, "iu").test(candidate)) return null
+
+  return candidate
+}
+
+function extractQuotedProductName(message: string): string | null {
+  const match = QUOTED_PRODUCT_NAME.exec(message)
+  return match?.[1] ? cleanupDisplayText(match[1]) : null
+}
+
+function hasCurrentUsePhrasing(message: string): boolean {
+  return CURRENT_USE_PHRASE.test(message)
+}
+
+function hasProductEvaluationPhrasing(message: string): boolean {
+  return PRODUCT_EVALUATION_PHRASE.test(message)
+}
+
+function hasPositiveNamedProductSignal(params: {
+  brand: string | null
+  quotedProductName: string | null
+  hasCurrentUse: boolean
+  hasProductEvaluation: boolean
+}): boolean {
+  return (
+    params.brand !== null ||
+    params.quotedProductName !== null ||
+    params.hasCurrentUse ||
+    params.hasProductEvaluation
+  )
+}
+
+function isGenericCategoryQuestion(message: string): boolean {
+  return GENERIC_CATEGORY_QUESTION.test(message)
+}
+
+function extractCategoryAdjacentProductName(
+  messageWithoutBrand: string,
+  category: AgentV2CareCategory,
+): string | null {
+  const config = getCategoryConfig(category)
+  if (config === null) return null
+
+  const match = new RegExp(config.matchSource, "iu").exec(messageWithoutBrand)
+  if (!match) return null
+
+  const beforeCategory = messageWithoutBrand.slice(0, match.index)
+  const afterCategory = messageWithoutBrand.slice(match.index + match[0].length)
+  const nameBeforeCategory = getCapitalizedNameTail(beforeCategory)
+  if (nameBeforeCategory !== null) return `${nameBeforeCategory} ${config.displayLabel}`
+
+  const nameAfterCategory = getCapitalizedNameHead(afterCategory)
+  if (nameAfterCategory !== null) return `${config.displayLabel} ${nameAfterCategory}`
+
+  return null
+}
+
+function getCapitalizedNameTail(value: string): string | null {
+  const tokens = getTokens(value)
+  const nameTokens: string[] = []
+  for (let index = tokens.length - 1; index >= 0; index -= 1) {
+    const token = tokens[index]
+    if (!isNameToken(token)) break
+    nameTokens.unshift(token)
+  }
+  if (nameTokens.some((token) => QUESTION_WORDS.has(normalizeNamedProductForComparison(token)))) {
+    return null
+  }
+  return nameTokens.length > 0 ? nameTokens.join(" ") : null
+}
+
+function getCapitalizedNameHead(value: string): string | null {
+  const firstClause = value.split(/[,.!?;:]/u)[0] ?? ""
+  const tokens = getTokens(firstClause)
+  const nameTokens: string[] = []
+  for (const token of tokens) {
+    if (!isNameToken(token)) break
+    nameTokens.push(token)
+  }
+  return nameTokens.length > 0 ? nameTokens.join(" ") : null
+}
+
+function getTokens(value: string): string[] {
+  return value.match(WORD_TOKEN) ?? []
+}
+
+function isNameToken(token: string): boolean {
+  const firstCharacter = token[0]
+  if (!firstCharacter) return false
+  if (/\p{N}/u.test(firstCharacter)) return true
+  return (
+    firstCharacter === firstCharacter.toLocaleUpperCase("de-DE") &&
+    firstCharacter !== firstCharacter.toLocaleLowerCase("de-DE")
+  )
+}
+
+function cleanupProductName(value: string): string {
+  return cleanupDisplayText(value.replace(/["“”]/gu, " "))
+}
+
+function cleanupDisplayText(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[\s,.:;!?-]+|[\s,.:;!?-]+$/gu, "")
+}
+
+function isPlausibleExactProductName(productName: string, category: AgentV2CareCategory): boolean {
+  const normalized = normalizeNamedProductForComparison(productName)
+  if (normalized.length === 0) return false
+
+  const categoryConfig = getCategoryConfig(category)
+  const categoryLabel = categoryConfig
+    ? normalizeNamedProductForComparison(categoryConfig.displayLabel)
+    : category
+
+  const detailTokens = normalized
+    .split(" ")
+    .filter((token) => token !== categoryLabel)
+    .filter((token) => !isCategoryStopword(token))
+
+  return detailTokens.length > 0
+}
+
+function buildDisplayName(params: {
+  brand: string | null
+  productName: string
+  category: AgentV2CareCategory
+}): string {
+  const productName = params.brand
+    ? cleanupDisplayText(
+        params.productName.replace(new RegExp(`\\b${escapeRegExp(params.brand)}\\b`, "iu"), " "),
+      )
+    : params.productName
+
+  return cleanupDisplayText(
+    [params.brand, moveCategoryLabelToEnd(productName, params.category)].filter(Boolean).join(" "),
+  )
+}
+
+function moveCategoryLabelToEnd(productName: string, category: AgentV2CareCategory): string {
+  const config = getCategoryConfig(category)
+  if (config === null) return cleanupDisplayText(productName)
+
+  const productWithoutCategory = cleanupDisplayText(
+    productName.replace(new RegExp(`(?:^|\\s)(?:${config.matchSource})(?=\\s|$)`, "giu"), " "),
+  )
+  if (productWithoutCategory.length === 0) return config.displayLabel
+
+  return cleanupDisplayText(`${productWithoutCategory} ${config.displayLabel}`)
+}
+
+function ensureCategoryLabel(productName: string, category: AgentV2CareCategory): string {
+  return moveCategoryLabelToEnd(productName, category)
+}
+
+function isCategoryStopword(value: string): boolean {
+  return CATEGORY_STOPWORDS.has(value)
+}
+
+function getCategoryConfig(category: AgentV2CareCategory): SupportedCategoryConfig | null {
+  return SUPPORTED_CATEGORY_CONFIGS.find((config) => config.category === category) ?? null
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/src/lib/agent-v2/runtime/responses-agent.ts
+++ b/src/lib/agent-v2/runtime/responses-agent.ts
@@ -15,6 +15,10 @@ import {
 } from "@/lib/agent-v2/contracts"
 import { normalizeAgentV2EvidenceText } from "@/lib/agent-v2/evidence-normalization"
 import { getAgentV2ModelPolicy, type AgentV2ModelPolicy } from "@/lib/agent-v2/model-policy"
+import {
+  buildAgentV2NamedProductContext,
+  type AgentV2NamedProductContext,
+} from "@/lib/agent-v2/named-product-context"
 import { AGENT_V2_RESPONSES_SYSTEM_PROMPT } from "@/lib/agent-v2/runtime/prompt"
 import { createAgentV2Trace } from "@/lib/agent-v2/runtime/trace"
 import { LoadAgentV2AdvisorGuidanceInputSchema } from "@/lib/agent-v2/tools/guidance-tool"
@@ -221,6 +225,17 @@ export async function runAgentV2ResponsesTurn(params: {
     return completeWithAnswer(buildSafetyBoundaryAnswer(params.message), trace)
   }
 
+  const namedProductContext = buildAgentV2NamedProductContext({
+    latestMessage: params.message,
+    recentMessages: params.recentMessages,
+  })
+  trace.named_product_context = namedProductContext
+    ? {
+        display_name: namedProductContext.display_name,
+        category: namedProductContext.category,
+      }
+    : null
+
   const routineToolPolicy = resolveRoutineToolPolicy({
     message: params.message,
     routineThreadContext,
@@ -256,6 +271,7 @@ export async function runAgentV2ResponsesTurn(params: {
     params.priorSelectedProductProjections ?? [],
     routineToolPolicy,
     turnGateEnabled,
+    namedProductContext,
   )
   const buildCurrentClarificationFallback = () =>
     isNonProceedTurnGate(turnGateAuthorized)
@@ -302,6 +318,7 @@ export async function runAgentV2ResponsesTurn(params: {
     currentCareContextConflicts: effectiveCareContext.conflicts,
     knownHardRuleIds: [...knownHardRuleIds],
     turnGate: turnGateEnabled ? turnGateAuthorized : null,
+    namedProductContext,
   })
 
   for (let step = 0; step < policy.max_model_steps; step += 1) {
@@ -798,6 +815,7 @@ function buildInputItems(
   priorSelectedProductProjections: readonly Partial<AgentV2SelectProductsProjection>[],
   routineToolPolicy: RoutineToolPolicy,
   turnGateEnabled: boolean,
+  namedProductContext: AgentV2NamedProductContext | null,
 ): unknown[] {
   const items: unknown[] = [
     {
@@ -869,6 +887,13 @@ function buildInputItems(
     })
   }
 
+  if (namedProductContext) {
+    items.push({
+      role: "system",
+      content: buildNamedProductContextGuidance(namedProductContext),
+    })
+  }
+
   if (safetyMode === "restricted") {
     items.push({
       role: "system",
@@ -890,6 +915,15 @@ function buildInputItems(
   )
 
   return items
+}
+
+function buildNamedProductContextGuidance(context: AgentV2NamedProductContext): string {
+  return [
+    `Current user named a plausible exact product: "${context.display_name}" (${context.category}). Treat it as user-provided but not catalog-verified.`,
+    "For product_detail, still call select_products before the terminal answer.",
+    "If select_products returns no exact or supported product_detail match, do not ask for the exact name again and do not substitute unrelated catalog alternatives as the answer.",
+    "Use constraint_blocked or a cautious non-evaluative answer: say it is not a verified catalog hit, cannot be evaluated exactly, and only discuss category-level plausibility or limitations if useful.",
+  ].join(" ")
 }
 
 function normalizeRoutineThreadContext(
@@ -1064,7 +1098,7 @@ function buildTerminalPayloadFieldGuidance(): string {
     "Social and domain_boundary answers are complete visible answers. They must not use product or routine tools, product_ids, routine_step_ids, session_memory_writes, active routine_context, or pending_routine_action.",
     "Set pending_routine_action to null unless you explicitly offer a future routine create/change for the user to confirm. If you do offer that future action, keep the current answer non-mutating, set routine_intent none, and describe the pending action structurally so a short next-turn confirmation can authorize build_or_fix_routine.",
     "Before submitting non-trivial category, product, routine, or general advice, load the relevant guidance package. Terminal tool_grounding.used_guidance_package_ids must include required base packages and category packages.",
-    "For named-product detail or product-specific claim checks, including heat protection, color safety, chelating, ingredient-free status, exact cadence, or product protocol, call select_products before submitting any terminal answer. Use product_request_kind product_detail. If the tool cannot confirm the product or claim, answer as clarification or constraint_blocked after the tool call; do not infer from the product name.",
+    "For named-product detail or product-specific claim checks, including heat protection, color safety, chelating, ingredient-free status, exact cadence, or product protocol, call select_products before submitting any terminal answer. Use product_request_kind product_detail. If the tool cannot confirm the product or claim, answer as clarification or constraint_blocked after the tool call; when named_product_context says the user already gave a plausible exact product name, use constraint_blocked instead of repeated clarification. Do not infer from the product name.",
     "For product_detail turns, terminal request_interpretation must match select_products on product_request_kind, requested_product_count, count_policy, care_category/category, and evidence_quote, even if the answer is clarification or constraint_blocked.",
     "For a concrete product ask inside an active routine, including a short acceptance of the previous offer such as matching products for that routine step, use answer_mode product_recommendation, set request_interpretation.product_request_kind to specific_products, call select_products first, keep routine_context.active=true, include routine_context step/category when known, and preserve routine_context.return_path. Return to the routine through routine_context and visible prose only when useful. Do not also call build_or_fix_routine unless the latest user message asks to change the routine.",
     "For pure summary, recap, overview, or explanation follow-ups inside an active routine thread, answer from routineThreadContext as general_advice, keep routine_context.active=true, set routine_intent none, and do not call build_or_fix_routine.",

--- a/src/lib/agent-v2/runtime/trace.ts
+++ b/src/lib/agent-v2/runtime/trace.ts
@@ -20,6 +20,7 @@ export function createAgentV2Trace(params: {
     reasoning_effort: params.policy.reasoning_effort,
     safety_mode: params.safetyMode,
     answer_mode: null,
+    named_product_context: null,
     response_ids: [],
     model_steps: [],
     tool_calls: [],

--- a/src/lib/agent-v2/validation/final-answer-validator.ts
+++ b/src/lib/agent-v2/validation/final-answer-validator.ts
@@ -18,6 +18,10 @@ import {
 } from "@/lib/agent-v2/contracts"
 import type { CareBalanceConflict } from "@/lib/recommendation-engine/types"
 import { normalizeAgentV2EvidenceText } from "@/lib/agent-v2/evidence-normalization"
+import {
+  normalizeNamedProductForComparison,
+  type AgentV2NamedProductContext,
+} from "@/lib/agent-v2/named-product-context"
 import { validateUserFacingLanguage } from "@/lib/agent-v2/validation/user-facing-language"
 export interface AgentV2FinalAnswerValidationContext {
   selectedProductProjections: readonly {
@@ -40,6 +44,7 @@ export interface AgentV2FinalAnswerValidationContext {
   currentCareContextConflicts?: readonly CareBalanceConflict[]
   knownHardRuleIds?: readonly string[]
   turnGate?: AgentV2TurnGateResult | null
+  namedProductContext?: AgentV2NamedProductContext | null
 }
 
 export interface AgentV2FinalAnswerValidationResult {
@@ -88,6 +93,7 @@ export function validateAgentV2FinalAnswer(
   validateKnownProductIds(terminalAnswer, context, findings)
   validateKnownRoutineStepIds(terminalAnswer, context, findings)
   validateProductToolRequired(terminalAnswer, context, findings)
+  validateNamedProductDetailAnswer(terminalAnswer, context, findings)
   validateRoutineToolRequired(terminalAnswer, context, findings)
   validateRoutineThreadContinuity(terminalAnswer, context, findings)
   validateRoutineProductDeepDive(terminalAnswer, context, findings)
@@ -1127,6 +1133,83 @@ function validateProductToolRequired(
       severity: "block",
     })
   }
+}
+
+function validateNamedProductDetailAnswer(
+  answer: AgentV2TerminalAnswer,
+  context: AgentV2FinalAnswerValidationContext,
+  errors: AgentV2ValidationError[],
+): void {
+  const namedProductContext = context.namedProductContext
+  if (
+    !namedProductContext ||
+    !namedProductContext.plausible_exact_name ||
+    answer.request_interpretation.product_request_kind !== "product_detail"
+  ) {
+    return
+  }
+
+  if (answer.answer_mode === "clarification" && asksForExactProductNameAgain(answer)) {
+    errors.push({
+      validator_id: "named_product_detail_unverified",
+      message:
+        "The user already gave a plausible exact product name; do not ask for the exact name again. Use constraint_blocked if select_products cannot verify it.",
+      severity: "block",
+      path: ["payload", "question_de"],
+    })
+    return
+  }
+
+  if (
+    answer.answer_mode === "product_recommendation" &&
+    !referencesNamedProductMatch(answer, context, namedProductContext)
+  ) {
+    errors.push({
+      validator_id: "named_product_detail_unverified",
+      message:
+        "Named product detail turns must not substitute unrelated catalog recommendations when the named product is not verified.",
+      severity: "block",
+      path: ["payload", "recommendations"],
+    })
+  }
+}
+
+function asksForExactProductNameAgain(
+  answer: Extract<AgentV2TerminalAnswer, { answer_mode: "clarification" }>,
+): boolean {
+  const text = [answer.payload.user_facing_answer_de, answer.payload.question_de].join("\n")
+  return /(?:genaue?|exakte?)\s+(?:produkt(?:bezeichnung|name)?|bezeichnung|name)|wie\s+hei(?:ß|ss)t\s+(?:das\s+)?produkt\s+genau/iu.test(
+    text,
+  )
+}
+
+function referencesNamedProductMatch(
+  answer: Extract<AgentV2TerminalAnswer, { answer_mode: "product_recommendation" }>,
+  context: AgentV2FinalAnswerValidationContext,
+  namedProductContext: AgentV2NamedProductContext,
+): boolean {
+  const referencedProductIds = new Set([
+    ...answer.tool_grounding.product_ids,
+    ...extractPayloadProductIds(answer),
+  ])
+  if (referencedProductIds.size === 0) return false
+
+  const referencedProductNames = context.selectedProductProjections.flatMap((projection) =>
+    (projection.products ?? [])
+      .filter((product) => product.product_id && referencedProductIds.has(product.product_id))
+      .map((product) => product.name)
+      .filter((name): name is string => Boolean(name)),
+  )
+  return referencedProductNames.some((name) =>
+    namedProductNamesMatch(name, namedProductContext.display_name),
+  )
+}
+
+function namedProductNamesMatch(candidateName: string, namedProductName: string): boolean {
+  const candidate = normalizeNamedProductForComparison(candidateName)
+  const named = normalizeNamedProductForComparison(namedProductName)
+  if (candidate.length === 0 || named.length === 0) return false
+  return candidate === named || candidate.includes(named) || named.includes(candidate)
 }
 
 function validateRoutineToolRequired(

--- a/tests/agent-compare-api.spec.ts
+++ b/tests/agent-compare-api.spec.ts
@@ -306,6 +306,7 @@ test("handleAgentCompareRequest preserves AgentV2 request interpretation trace i
             reasoning_effort: "low",
             safety_mode: "normal",
             answer_mode: "product_recommendation",
+            named_product_context: null,
             request_interpretation_summary:
               "Intent: product_recommendation · specific_products · conditioner · 2 exact · confidence 0.91",
             request_interpretation: {
@@ -1242,6 +1243,7 @@ test("analysis snapshot extracts AgentV2 trace tool calls and guidance ids", asy
             reasoning_effort: "low",
             safety_mode: "normal",
             answer_mode: null,
+            named_product_context: null,
             request_interpretation_summary: null,
             request_interpretation: null,
             validation_warnings: [],
@@ -1296,6 +1298,7 @@ test("AgentV2 trace display data separates warnings from fatal validation errors
     reasoning_effort: "low",
     safety_mode: "normal",
     answer_mode: "product_recommendation",
+    named_product_context: null,
     request_interpretation_summary:
       "Intent: product_recommendation · specific_products · conditioner · 2 exact · confidence 0.91",
     request_interpretation: {

--- a/tests/agent-v2-contracts.spec.ts
+++ b/tests/agent-v2-contracts.spec.ts
@@ -278,6 +278,7 @@ test("AgentV2TraceSchema accepts turn-gate trace fields", () => {
     reasoning_effort: "low",
     safety_mode: "normal",
     answer_mode: "social",
+    named_product_context: null,
     response_ids: [],
     model_steps: [],
     tool_calls: [],

--- a/tests/agent-v2-final-answer-validator.spec.ts
+++ b/tests/agent-v2-final-answer-validator.spec.ts
@@ -713,6 +713,128 @@ test("validator requires product guidance for product-detail clarifications", ()
   )
 })
 
+test("validator blocks repeated exact-name clarification for already named off-catalog products", () => {
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      answer_mode: "clarification",
+      request_interpretation: requestInterpretation({
+        primary_intent: "clarification",
+        product_request_kind: "product_detail",
+        routine_intent: "none",
+        care_category: "conditioner",
+        requested_product_count: 1,
+        count_policy: "none",
+        evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        used_product_tool: true,
+        product_ids: [],
+        used_guidance_package_ids: [
+          ...requiredGuidanceForAnswer("clarification"),
+          "base.product_recommendation.v1",
+          "category.conditioner.v1",
+        ],
+      },
+      payload: {
+        user_facing_answer_de: "Wie heißt das Produkt genau?",
+        question_de: "Schick mir bitte die genaue Produktbezeichnung.",
+        missing_keys: ["product_detail"],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: "Moisture Mist Conditioner von Urban Alchemy",
+      recentEvidenceText: "Moisture Mist Conditioner von Urban Alchemy",
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "conditioner",
+          product_request_kind: "product_detail",
+          requested_product_count: 1,
+          count_policy: "none",
+          evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+        }),
+      ],
+      namedProductContext: {
+        display_name: "Urban Alchemy Moisture Mist Conditioner",
+        category: "conditioner",
+        plausible_exact_name: true,
+      },
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "named_product_detail_unverified"))
+})
+
+test("validator blocks substitute catalog recommendations for already named off-catalog product detail turns", () => {
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        primary_intent: "product_recommendation",
+        product_request_kind: "product_detail",
+        routine_intent: "none",
+        care_category: "conditioner",
+        requested_product_count: 1,
+        count_policy: "none",
+        evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["balea_aqua_hyaluron"],
+        used_guidance_package_ids: requiredGuidanceForAnswer(
+          "product_recommendation",
+          "conditioner",
+        ),
+      },
+      payload: {
+        user_facing_answer_de: "**Balea Aqua Hyaluron** passt besser zu deinem Haar.",
+        recommendations: [
+          {
+            product_id: "balea_aqua_hyaluron",
+            reason_de: "Leichte Feuchtigkeit.",
+            usage_de: null,
+            caveat_de: null,
+          },
+        ],
+        comparison_notes_de: [],
+        usage_notes_de: [],
+        next_step_offer_de: null,
+      },
+    },
+    {
+      ...baseValidationContext,
+      selectedProductProjections: [
+        {
+          valid_product_ids: ["balea_aqua_hyaluron"],
+          products: [{ product_id: "balea_aqua_hyaluron", name: "Balea Aqua Hyaluron" }],
+        },
+      ],
+      latestUserMessage: "Moisture Mist Conditioner von Urban Alchemy",
+      recentEvidenceText: "Moisture Mist Conditioner von Urban Alchemy",
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "conditioner",
+          product_request_kind: "product_detail",
+          requested_product_count: 1,
+          count_policy: "none",
+          evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+        }),
+      ],
+      namedProductContext: {
+        display_name: "Urban Alchemy Moisture Mist Conditioner",
+        category: "conditioner",
+        plausible_exact_name: true,
+      },
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "named_product_detail_unverified"))
+})
+
 test("validator requires category guidance for category education answers", () => {
   const answer = {
     ...baseAnswer,

--- a/tests/agent-v2-guidance-compiler.spec.ts
+++ b/tests/agent-v2-guidance-compiler.spec.ts
@@ -934,6 +934,7 @@ test("product guidance preserves old claim boundaries and comparison fallback ru
   const metadata = JSON.parse(
     readFileSync("data/agent-v2/guidance/base/product-recommendation.json", "utf8"),
   ) as {
+    hard_rules: Array<{ rule_id: string; validator_id: string; message: string }>
     soft_rubrics: Array<{ rubric_id: string; message: string }>
   }
 
@@ -947,6 +948,16 @@ test("product guidance preserves old claim boundaries and comparison fallback ru
   assert.match(brief, /caveated fallback/i)
   assert.match(brief, /not_recommended.*no_catalog_match/i)
   assert.match(brief, /effectively equivalent/i)
+  assert.match(brief, /named_product_context/i)
+  assert.match(brief, /do not ask for the exact name again/i)
+  assert.match(brief, /do not substitute unrelated catalog recommendations/i)
+  assert.ok(
+    metadata.hard_rules.some(
+      (rule) =>
+        rule.rule_id === "product.named_detail_no_repeat_or_substitute" &&
+        rule.validator_id === "named_product_detail_unverified",
+    ),
+  )
   assert.ok(
     metadata.soft_rubrics.some((rubric) => rubric.rubric_id === "product.no_claims_from_names"),
   )
@@ -976,7 +987,7 @@ test("compiled product-detail guidance uses user-facing unsupported-claim fallba
   assert.match(brief, /translate missing metadata into user-facing language/i)
   assert.match(brief, /Das kann ich für diese Variante nicht sicher versprechen/i)
   assert.match(brief, /Sicher berücksichtigen kann ich aktuell/i)
-  assert.match(brief, /generic attributes, safe uncertainty, or ask for a supported exact variant/i)
+  assert.match(brief, /ask for the exact variant only if the user has not already provided/i)
   assert.match(brief, /do not invite photo or link checks/i)
   assert.match(brief, /current tooling can actually process and ground them/i)
   assert.match(brief, /only confirmed color, format, or product facts/i)

--- a/tests/agent-v2-named-product-context.spec.ts
+++ b/tests/agent-v2-named-product-context.spec.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildAgentV2NamedProductContext,
+  normalizeNamedProductForComparison,
+} from "../src/lib/agent-v2/named-product-context"
+
+test("detects exact Urban Alchemy conditioner name from latest user message", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage: "Moisture Mist Conditioner von Urban Alchemy",
+    recentMessages: [],
+  })
+
+  assert.equal(context?.plausible_exact_name, true)
+  assert.equal(context?.category, "conditioner")
+  assert.equal(context?.display_name, "Urban Alchemy Moisture Mist Conditioner")
+})
+
+test("detects named product from a fuller product-detail question", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage:
+      "Ich nutze gerade von Urban Alchemy den Conditioner Moisture Mist, was haelst du von dem fuer meine Haare?",
+    recentMessages: [],
+  })
+
+  assert.equal(context?.plausible_exact_name, true)
+  assert.equal(context?.category, "conditioner")
+  assert.equal(context?.display_name, "Urban Alchemy Moisture Mist Conditioner")
+})
+
+test("detects named product from common what-do-you-think wording", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage: "Was haelst du von Urban Alchemy Moisture Mist Conditioner?",
+    recentMessages: [],
+  })
+
+  assert.equal(context?.plausible_exact_name, true)
+  assert.equal(context?.category, "conditioner")
+  assert.equal(context?.display_name, "Urban Alchemy Moisture Mist Conditioner")
+})
+
+test("detects quoted named product with category signal", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage: 'Was haelst du vom Conditioner "Moisture Mist" von Urban Alchemy?',
+    recentMessages: [],
+  })
+
+  assert.equal(context?.display_name, "Urban Alchemy Moisture Mist Conditioner")
+})
+
+test("does not classify generic category asks as named products", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage: "Welcher Conditioner passt gerade am besten zu meinem Haar?",
+    recentMessages: [],
+  })
+
+  assert.equal(context, null)
+})
+
+test("does not include sentence-initial question words in noisy named product asks", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage: "Welche Moisture Mist Conditioner von Urban Alchemy passt?",
+    recentMessages: [],
+  })
+
+  assert.equal(context, null)
+})
+
+test("does not classify generic product recommendation asks as named products", () => {
+  const context = buildAgentV2NamedProductContext({
+    latestMessage: "Kannst du mir einen leichten Conditioner empfehlen?",
+    recentMessages: [],
+  })
+
+  assert.equal(context, null)
+})
+
+test("does not infer categories from aliases embedded inside product tokens", () => {
+  assert.equal(
+    buildAgentV2NamedProductContext({
+      latestMessage: "Was haelst du von Olaplex No. 3?",
+      recentMessages: [],
+    }),
+    null,
+  )
+  assert.equal(
+    buildAgentV2NamedProductContext({
+      latestMessage: "Was haelst du von Moroccanoil Treatment?",
+      recentMessages: [],
+    }),
+    null,
+  )
+})
+
+test("normalizes product names for overlap comparison", () => {
+  assert.equal(
+    normalizeNamedProductForComparison("Urban Alchemy Moisture Mist Conditioner"),
+    "urban alchemy moisture mist conditioner",
+  )
+  assert.equal(
+    normalizeNamedProductForComparison("Moisture Mist Conditioner von Urban Alchemy"),
+    "moisture mist conditioner urban alchemy",
+  )
+})

--- a/tests/agent-v2-production-chat-pipeline.spec.ts
+++ b/tests/agent-v2-production-chat-pipeline.spec.ts
@@ -253,6 +253,7 @@ function createAgentV2Result(): AgentV2ResponsesTurnResult {
       reasoning_effort: "medium",
       safety_mode: "normal",
       answer_mode: "product_recommendation",
+      named_product_context: null,
       response_ids: ["response-1"],
       model_steps: [
         {

--- a/tests/agent-v2-responses-runtime.spec.ts
+++ b/tests/agent-v2-responses-runtime.spec.ts
@@ -722,6 +722,45 @@ function terminalNamedProductRecommendation(
   })
 }
 
+function terminalOffCatalogNamedProductBlocked(call_id: string) {
+  return terminalCall(call_id, {
+    ...terminalGeneralAdviceArguments(),
+    answer_mode: "constraint_blocked",
+    interpreted_intent: "User asks for detail evaluation of a named conditioner.",
+    request_interpretation: requestInterpretation({
+      primary_intent: "product_recommendation",
+      product_request_kind: "product_detail",
+      care_category: "conditioner",
+      requested_product_count: 1,
+      count_policy: "none",
+      evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+    }),
+    extracted_constraints: {
+      ...emptyExtractedConstraints(),
+      product_categories: ["conditioner"],
+      raw_constraints: ["Moisture Mist Conditioner von Urban Alchemy"],
+    },
+    tool_grounding: {
+      ...terminalGeneralAdviceArguments().tool_grounding,
+      used_guidance_package_ids: [
+        ...requiredGuidanceForAnswer("constraint_blocked", "conditioner"),
+        "base.product_recommendation.v1",
+      ],
+      used_product_tool: true,
+      product_ids: [],
+    },
+    payload: {
+      user_facing_answer_de:
+        "Den Urban Alchemy Moisture Mist Conditioner habe ich nicht als verifizierten Katalogtreffer. Ich kann ihn deshalb nicht exakt bewerten. Von der Kategorie her klingt ein leichter Conditioner für dein feines, lockiges, trockenes oder frizziges Haar plausibel; achte vor allem auf Beschwerung und genug Slip.",
+      blocking_constraints: [
+        "kein verifizierter Katalogtreffer für Urban Alchemy Moisture Mist Conditioner",
+      ],
+      safe_alternative_de:
+        "Ich kann ihn vorsichtig gegen verifizierte Conditioner einordnen, ohne ihn als geprüftes Produkt zu bewerten.",
+    },
+  })
+}
+
 function terminalPartiallyRenderedProductRecommendation(
   call_id: string,
   products: Array<{ product_id: string; name: string }>,
@@ -1641,6 +1680,34 @@ test("AgentV2 runtime injects surfaced product facts for referential follow-ups"
   assert.match(content, /shampoo/)
   assert.match(content, /Test Shampoo/)
   assert.match(content, /Use the recent conversation/)
+})
+
+test("AgentV2 runtime injects named product context for plausible off-catalog product detail turns", async () => {
+  const client = fakeResponsesClientWithOutputs([terminalGeneralAdvice("call_1")])
+
+  const result = await runAgentV2ResponsesTurn({
+    client,
+    message: "Kannst du den Moisture Mist Conditioner von Urban Alchemy bewerten?",
+    recentMessages: [],
+    userContext: { hairProfile: null, routineInventory: [], sessionMemory: [] },
+    tools: fakeAgentV2Tools(),
+  })
+
+  const firstInput = getInputItems(client.requests[0])
+  const namedProductContextItem = firstInput
+    .map(asRecord)
+    .find((item) =>
+      String(item?.content ?? "").includes("Current user named a plausible exact product"),
+    )
+  const content = String(namedProductContextItem?.content ?? "")
+  assert.match(content, /Urban Alchemy Moisture Mist Conditioner/)
+  assert.match(content, /conditioner/)
+  assert.match(content, /not catalog-verified/)
+  assert.match(content, /constraint_blocked/)
+  assert.deepEqual(result.trace.named_product_context, {
+    display_name: "Urban Alchemy Moisture Mist Conditioner",
+    category: "conditioner",
+  })
 })
 
 test("AgentV2 runtime injects terminal payload field guidance", async () => {
@@ -2887,6 +2954,70 @@ test("AgentV2 runtime repairs concrete category-fit asks that hide selected prod
   assert.equal(
     result.trace.repair_attempts[0].validation_errors[0].validator_id,
     "request_interpretation_answer_mode",
+  )
+})
+
+test("AgentV2 runtime repairs off-catalog named product detail substitutes to constraint_blocked", async () => {
+  const substituteProducts = [{ product_id: "balea_aqua_hyaluron", name: "Balea Aqua Hyaluron" }]
+  const client = fakeResponsesClientWithOutputs([
+    guidanceCall("call_1", {
+      answer_mode_hint: "product_recommendation",
+      categories: ["conditioner"],
+    }),
+    functionCall("call_2", "select_products", {
+      ...selectProductsArguments({
+        category: "conditioner",
+        reason: "User asks about a named conditioner.",
+        user_request: "Moisture Mist Conditioner von Urban Alchemy",
+        product_request_kind: "product_detail",
+        requested_product_count: 1,
+        count_policy: "none",
+        evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+      }),
+    }),
+    terminalNamedProductRecommendation("call_3", substituteProducts, {
+      product_request_kind: "product_detail",
+      requested_product_count: 1,
+      count_policy: "none",
+      evidence_quote: "Moisture Mist Conditioner von Urban Alchemy",
+    }),
+    terminalOffCatalogNamedProductBlocked("call_4"),
+  ])
+
+  const result = await runAgentV2ResponsesTurn({
+    client,
+    message: "Moisture Mist Conditioner von Urban Alchemy",
+    recentMessages: [],
+    userContext: {
+      hairProfile: {
+        hair_texture: "curly",
+        thickness: "fine",
+        concerns: ["dryness", "frizz"],
+      },
+      routineInventory: [],
+      sessionMemory: [],
+    },
+    tools: {
+      ...fakeAgentV2Tools(),
+      select_products: async () => ({
+        valid_product_ids: substituteProducts.map((product) => product.product_id),
+        products: substituteProducts,
+      }),
+    },
+  })
+
+  assert.equal(result.final_answer.answer_mode, "constraint_blocked")
+  assert.match(
+    result.final_answer.payload.user_facing_answer_de,
+    /nicht als verifizierten Katalogtreffer/,
+  )
+  assert.match(result.final_answer.payload.user_facing_answer_de, /nicht exakt bewerten/)
+  assert.doesNotMatch(result.final_answer.payload.user_facing_answer_de, /Balea Aqua Hyaluron/)
+  assert.equal(result.trace.validation_errors.length, 0)
+  assert.equal(result.trace.repair_attempts.length, 1)
+  assert.equal(
+    result.trace.repair_attempts[0].validation_errors[0].validator_id,
+    "named_product_detail_unverified",
   )
 })
 

--- a/tests/chat-debug-trace.spec.ts
+++ b/tests/chat-debug-trace.spec.ts
@@ -1041,6 +1041,7 @@ test.describe("Chat debug trace", () => {
       reasoning_effort: "medium",
       safety_mode: "normal",
       answer_mode: "product_recommendation",
+      named_product_context: null,
       response_ids: ["resp_1"],
       model_steps: [{ response_id: "resp_1", latency_ms: 12 }],
       tool_calls: [{ call_id: "call_1", name: "select_products", latency_ms: 5 }],


### PR DESCRIPTION
## Why

AgentV2 could repeatedly ask users for an exact product name even after they had already provided one, then sometimes answer a named off-catalog product-detail question by substituting unrelated catalog recommendations. This patch keeps the behavior conservative: it does not evaluate arbitrary off-catalog products, but it stops the frustrating exact-name loop and prevents unrelated catalog substitutes from being presented as the answer.

## What changed

- Added a current-turn named-product context detector for plausible exact user-named products in supported care categories.
- Injected `named_product_context` into AgentV2 trace and prompt guidance so product-detail turns know the product is user-provided but not catalog-verified.
- Added validator guardrails for named `product_detail` turns:
  - block repeated exact-name clarification when the user already gave a plausible exact name
  - block unrelated catalog product recommendations as substitutes for the named product
- Updated product recommendation guidance metadata and markdown for the `constraint_blocked`/non-evaluative response shape.
- Added runtime repair coverage for the Urban Alchemy Moisture Mist case and regression coverage for category-alias false positives such as Olaplex/Moroccanoil.

## Verification

- `npx tsx --test tests/agent-v2-contracts.spec.ts tests/agent-v2-named-product-context.spec.ts tests/agent-v2-final-answer-validator.spec.ts tests/agent-v2-guidance-compiler.spec.ts tests/agent-v2-responses-runtime.spec.ts tests/agent-v2-compare-runner.spec.ts`
- `npm run ci:verify`

Notes: `ci:verify` exits 0. ESLint reports 4 existing warnings unrelated to this branch.

## Follow-ups / risks

- This remains a scoped bridge, not a full arbitrary off-catalog product evaluator.
- Softer clarification variants like “Welche Variante meinst du?” are still primarily prompt/guidance governed unless we choose to add more deterministic language patterns later.