### PR TITLE
feat(products): add reviewed product image pipeline

### DIFF
--- a/docs/product-image-background-removal.md
+++ b/docs/product-image-background-removal.md
@@ -1,9 +1,10 @@
 # Product-Image Background Removal
 
-Reliable, fully local pipeline for turning product packshots (JPG/WebP, any source)
-into clean transparent-background PNGs (RGBA), ready for compositing onto our own
-backgrounds. Battle-tested on the 20-image pilot batch (2026-06-10,
-`data/product-images/pilot-2026-06-10/selected/` → `selected-nobg/`).
+Reliable, fully local pipeline for turning product packshots (JPG/WebP/PNG/AVIF,
+any source) into clean transparent-background PNGs (RGBA), ready for compositing
+onto our own backgrounds. Battle-tested on 181 images across 5 batches
+(2026-06-10..12: 20-image pilot + catalog batches 02–05, each
+`data/product-images/<batch>/selected/` → `selected-nobg/`).
 
 This document covers the cutout/background-removal stage only. For the full
 scrape → review → cutout → final composite → manifest → Supabase publish flow,
@@ -21,45 +22,63 @@ Scripts live in `scripts/product-images/`:
 ## TL;DR decision tree
 
 ```
-For each image:
-1. Does the source already have a usable alpha channel?   → check FIRST (step 0)
-   └─ yes, and it's clean on magenta                      → just convert to PNG, done
-   └─ yes, but shadow is baked in (opaque, inside alpha)  → remove-baked-shadow.py (+ step 4b)
-2. Flat/studio background, product not touching edges     → removebg.swift (Vision)
-   └─ Vision says "no subject found" (product fills frame)→ removebg-padded.swift
-3. QA on magenta. Background haze / gradient remnants?    → rembg isnet-general-use
-4. Shadow remnant survives every model?                    → it's baked in → remove-baked-shadow.py
-   └─ bright warm fade still left after that              → 4b: flatten on white + BiRefNet 2nd pass
+0. Check source alpha FIRST (step 0)
+   ├─ HAS alpha (any %) → composite on magenta and inspect
+   │   ├─ clean                          → PNG passthrough, done (most common: dm/Rossmann assets)
+   │   ├─ only ~0–5% transparent         → likely a legit edge-to-edge tight crop, NOT broken:
+   │   │                                    alpha histogram ≈ 9x% at 255 + rest at 0 → passthrough
+   │   └─ baked-in shadow (opaque, inside the alpha)
+   │       ├─ product vividly colored    → flatten on white + BiRefNet (one command, try first)
+   │       └─ product white/light        → remove-baked-shadow.py
+   │           ├─ shadow touches a dark badge/label → add saturation gate (3rd arg, ~10)
+   │           └─ warm fade remains on magenta      → step 4b (flatten + BiRefNet)
+   └─ NO alpha (flat photo) → removebg.swift (Vision)
+       ├─ "no subject found" (product fills frame)  → removebg-padded.swift
+       ├─ product is a sachet/box with people in the
+       │  printed artwork (Vision lifts the person!) → full-opacity passthrough instead
+       └─ background haze remains on magenta         → rembg isnet-general-use
+
+Always: QA every output on magenta (step 2) + final RGBA/dimension check.
 ```
 
 ## Step 0 — Inspect sources before running any model
 
-Two things bit us in the pilot; both are cheap to check up front:
+Across the catalog batches, **most images (60–90%) already shipped usable
+alpha** — the passthrough is the most common path, not the exception. Check
+up front (use the rembg venv python; system python3 has no PIL):
 
 ```bash
-# Which sources already ship transparency? (brand assets often do)
-python3 - <<'EOF'
+# Which sources already ship transparency? (brand + dm/Rossmann assets usually do)
+/tmp/rembg-venv/bin/python3 - <<'EOF'
 from PIL import Image
 import numpy as np, glob
 for f in sorted(glob.glob('selected/*')):
     im = Image.open(f)
-    if 'A' in im.mode:
+    if 'A' in im.mode or im.mode == 'P':
         a = np.array(im.convert('RGBA'))[:,:,3]
-        print(f, im.mode, f'transparent={(a==0).mean():.0%}')
+        print(f, im.mode, f'transparent={(a==0).mean():.1%}')
     else:
         print(f, im.mode, '(no alpha)')
 EOF
 ```
 
-- **Source already >80% transparent** → it's an official brand cutout. Don't run a
-  model on it (models receive the flattened RGB and re-include baked shadows).
-  Work with the existing alpha instead.
-- **Source has no alpha** → proceed to Vision (step 1).
+Interpreting the numbers — the % is only a hint; the magenta composite
+(step 2) is the real test:
 
-## Step 1 — macOS Vision subject-lift (default, handles ~75% of images)
+- **Any transparency at all** → composite on magenta and look. Clean → convert
+  to RGBA PNG, done. Never run a model on a source with good alpha: models see
+  the flattened RGB and re-include baked shadows (pilot lesson).
+- **~0–5% transparent** → usually a legit edge-to-edge tight crop (dm strip
+  images), not broken alpha. Confirm via histogram: ~9x% of pixels at alpha 255
+  + remainder at 0 = fine. Don't "fix" it.
+- **`P` (palette) mode with 0% transparent** → treat as flat, go to Vision.
+- **No alpha** → Vision (step 1). AVIF/WebP/JPG/PNG all work as Vision input.
+
+## Step 1 — macOS Vision subject-lift (default for flat sources)
 
 Zero install, runs locally, same tech as "lift subject" in Photos. Excellent on
-retailer packshots (dm/Rossmann style: product on white).
+retailer packshots (product on white/studio background) — 52/52 clean across
+catalog batches 2–5, including AVIF sources.
 
 ```bash
 swift scripts/product-images/removebg.swift <outputDir> <inputs...>
@@ -67,13 +86,19 @@ swift scripts/product-images/removebg.swift <outputDir> <inputs...>
 swift scripts/product-images/removebg.swift selected-nobg selected/*.jpg selected/*.webp
 ```
 
-**Known failure:** "SKIP (no subject found)" when the product fills the frame
+**Known failure 1:** "SKIP (no subject found)" when the product fills the frame
 edge-to-edge (tight crops). Fix: pad with a white border, cut out, crop back —
 that's exactly what the padded variant does:
 
 ```bash
 swift scripts/product-images/removebg-padded.swift <input> <output.png>
 ```
+
+**Known failure 2 — sachet/box artwork (silent, caught only in QA):** flat
+packets/boxes whose printed artwork features a person make Vision lift the
+*person out of the packaging art* — padded variant too (batch 3 #44
+Schaebens). If the product is the full rectangle, the correct output is a
+full-opacity passthrough of the source, not segmentation.
 
 ## Step 2 — QA every batch on magenta (non-negotiable)
 
@@ -85,8 +110,14 @@ swift scripts/product-images/qa-composite.swift /tmp/qa-magenta selected-nobg/*.
 # then visually inspect /tmp/qa-magenta/*.png
 ```
 
+For batches, contact sheets beat per-image files: PIL grid of 8 images per
+sheet at ~420px cells, magenta background, image number in the corner. Big
+enough to spot shadows, few enough files to actually look at all of them.
+
 Look for: gray/beige smudges next to the product (shadow), lighter bands
-(background haze), color fringes on edges. Also verify file properties:
+(background haze), color fringes on edges. **Zoom suspicious bases/edges at
+full resolution** — batch 2's badge-eating looked like a generic gash at
+sheet scale. Also verify file properties:
 
 ```bash
 python3 -c "
@@ -121,9 +152,15 @@ writes proper RGBA.
 ## Step 4 — Baked-in shadows (the hard case)
 
 Some brand assets (Olaplex, epres in the pilot) bake the drop shadow into the
-product cutout as **fully opaque pixels**. Every segmentation model
-(Vision, ISNet, BiRefNet, BiRefNet-DIS, BRIA) treats it as subject — trying more
-models is a dead end; we tried five.
+product cutout as **fully opaque pixels**. For WHITE/light products, every
+segmentation model (Vision, ISNet, BiRefNet, BiRefNet-DIS, BRIA) treats the
+shadow as subject — trying more models is a dead end; we tried five.
+
+**Exception — strongly colored products:** if the product is vividly colored
+(catalog batch 3 #34, yellow Olaplex No.7 oil), BiRefNet on the flattened
+image separates the gray shadow cleanly — try that FIRST, it's one command.
+The geometric script can be unusable there anyway: a dark product body (amber
+oil, lum < 185) merges with the shadow into one boundary-connected component.
 
 What works — `remove-baked-shadow.py`, which exploits geometry instead of color:
 
@@ -190,6 +227,32 @@ is the working answer.
 2. All outputs `RGBA` mode, dimensions identical to source
 3. Contact sheet on a beige/colored background for one last eyeball:
    every product clean, no smudges, label text intact
+
+## Catalog batch 5 notes (2026-06-12, `catalog-2026-06-10-05/`)
+
+- 11 images: 7 alpha passthroughs (dry-shampoo cans), 4 Vision cutouts incl.
+  AVIF sources — zero failures.
+- #09 was an Olaplex but as a flat retailer photo, not a brand asset — Vision
+  excluded the photo shadow naturally. The baked-shadow problem is specific
+  to Olaplex's official transparent brand assets.
+
+## Catalog batch 4 notes (2026-06-12, `catalog-2026-06-10-04/`)
+
+- 50 images, the easy case: 44 clean alpha passthroughs (dm/Rossmann-style
+  assets), 6 Vision cutouts, zero failures, no baked shadows. No new lessons.
+
+## Catalog batch 3 notes (2026-06-11, `catalog-2026-06-10-03/`)
+
+- 50 images: 26 clean alpha passthroughs, 23 Vision cutouts (zero failures),
+  1 baked shadow (#34 Olaplex No.7).
+- #34: geometric deshadow unusable (dark amber oil body merges with the
+  shadow; saturation ranges overlap). Plain BiRefNet on the flattened image
+  worked — vivid yellow vs gray shadow is exactly what models separate well.
+- **Sachet/box artwork trap (#44 Schaebens):** flat packets whose printed
+  artwork features a person fool Vision — it lifts the person out of the
+  packaging art (padded variant too). If the product is the full rectangle,
+  the fix is a full-opacity passthrough, not segmentation. Same family as
+  batch 2's #15 Gliss box / #19 HASK sachet.
 
 ## Catalog batch 2 notes (2026-06-11, `catalog-2026-06-10-02/`)
 

--- a/docs/product-image-background-removal.md
+++ b/docs/product-image-background-removal.md
@@ -136,7 +136,30 @@ What works — `remove-baked-shadow.py`, which exploits geometry instead of colo
 # input must have an alpha channel (the brand asset's own, or a model cutout)
 ```
 
-### Step 4b — second pass for the bright shadow fade
+### When the shadow touches a dark product feature
+
+If a dark badge/label sits at the silhouette edge AND the shadow runs along
+that edge (catalog batch 2 #39: full-height side shadow + bronze badge), the
+badge and shadow merge into one boundary-connected dark component and the
+badge gets eaten. The discriminator is **saturation**: cast shadows are
+warm-tinted (sat = max(rgb)−min(rgb) ≈ 14–20) while product darks are
+neutral (sat ≤ 6). Verify per image, then pass the gate as a third arg:
+
+```bash
+/tmp/rembg-venv/bin/python3 scripts/product-images/remove-baked-shadow.py input.webp output.png 10
+```
+
+**Debug technique:** render a removal overlay — removed pixels in red on the
+grayscale source — to see exactly what the script classified as shadow. This
+is how the badge-eating was found; the magenta composite alone made it look
+like a generic gash.
+
+### Step 4b — second pass for the bright shadow fade (only if needed)
+
+First check the de-shadowed result on magenta — the fade-dilation inside the
+script often catches everything, and the second pass is not free: on catalog
+batch 2 #39, BiRefNet cut a wedge out of the bottle's badge. Only run it when
+a visible warm fade actually remains (pilot #16/#18–20 needed it).
 
 The luminance threshold misses the brightest part of the shadow fade (warm
 beige, lum > 185). Fix: flatten the de-shadowed result onto white, then run
@@ -167,6 +190,17 @@ is the working answer.
 2. All outputs `RGBA` mode, dimensions identical to source
 3. Contact sheet on a beige/colored background for one last eyeball:
    every product clean, no smudges, label text intact
+
+## Catalog batch 2 notes (2026-06-11, `catalog-2026-06-10-02/`)
+
+- 50 images: 30 already-clean brand cutouts (PNG passthrough), 19 Vision
+  cutouts (zero failures, no padding needed), 1 baked shadow (#39 Olaplex
+  No.6).
+- #39 needed the saturation gate (`min_sat=10`) — full-height side shadow
+  touching the bronze BOND SMOOTHER badge; no BiRefNet second pass.
+- Tight crops with ~1% transparency (#09, #41) are legit edge-to-edge
+  product crops, not broken alpha — check the alpha histogram (98% at 255,
+  rest at 0) and composite on magenta before "fixing" anything.
 
 ## Pilot batch notes (2026-06-10)
 

--- a/docs/product-image-background-removal.md
+++ b/docs/product-image-background-removal.md
@@ -1,0 +1,178 @@
+# Product-Image Background Removal
+
+Reliable, fully local pipeline for turning product packshots (JPG/WebP, any source)
+into clean transparent-background PNGs (RGBA), ready for compositing onto our own
+backgrounds. Battle-tested on the 20-image pilot batch (2026-06-10,
+`data/product-images/pilot-2026-06-10/selected/` → `selected-nobg/`).
+
+This document covers the cutout/background-removal stage only. For the full
+scrape → review → cutout → final composite → manifest → Supabase publish flow,
+see `docs/runbooks/product-image-pilot-runbook.md`.
+
+Scripts live in `scripts/product-images/`:
+
+| Script                   | Purpose                                                            |
+| ------------------------ | ------------------------------------------------------------------ |
+| `removebg.swift`         | Batch cutout via macOS Vision subject-lift (default path)          |
+| `removebg-padded.swift`  | Fallback for frame-filling products ("no subject found")           |
+| `remove-baked-shadow.py` | Removes opaque drop shadows baked into brand assets                |
+| `qa-composite.swift`     | QA: composites cutouts onto magenta to expose shadow/halo remnants |
+
+## TL;DR decision tree
+
+```
+For each image:
+1. Does the source already have a usable alpha channel?   → check FIRST (step 0)
+   └─ yes, and it's clean on magenta                      → just convert to PNG, done
+   └─ yes, but shadow is baked in (opaque, inside alpha)  → remove-baked-shadow.py (+ step 4b)
+2. Flat/studio background, product not touching edges     → removebg.swift (Vision)
+   └─ Vision says "no subject found" (product fills frame)→ removebg-padded.swift
+3. QA on magenta. Background haze / gradient remnants?    → rembg isnet-general-use
+4. Shadow remnant survives every model?                    → it's baked in → remove-baked-shadow.py
+   └─ bright warm fade still left after that              → 4b: flatten on white + BiRefNet 2nd pass
+```
+
+## Step 0 — Inspect sources before running any model
+
+Two things bit us in the pilot; both are cheap to check up front:
+
+```bash
+# Which sources already ship transparency? (brand assets often do)
+python3 - <<'EOF'
+from PIL import Image
+import numpy as np, glob
+for f in sorted(glob.glob('selected/*')):
+    im = Image.open(f)
+    if 'A' in im.mode:
+        a = np.array(im.convert('RGBA'))[:,:,3]
+        print(f, im.mode, f'transparent={(a==0).mean():.0%}')
+    else:
+        print(f, im.mode, '(no alpha)')
+EOF
+```
+
+- **Source already >80% transparent** → it's an official brand cutout. Don't run a
+  model on it (models receive the flattened RGB and re-include baked shadows).
+  Work with the existing alpha instead.
+- **Source has no alpha** → proceed to Vision (step 1).
+
+## Step 1 — macOS Vision subject-lift (default, handles ~75% of images)
+
+Zero install, runs locally, same tech as "lift subject" in Photos. Excellent on
+retailer packshots (dm/Rossmann style: product on white).
+
+```bash
+swift scripts/product-images/removebg.swift <outputDir> <inputs...>
+# e.g.
+swift scripts/product-images/removebg.swift selected-nobg selected/*.jpg selected/*.webp
+```
+
+**Known failure:** "SKIP (no subject found)" when the product fills the frame
+edge-to-edge (tight crops). Fix: pad with a white border, cut out, crop back —
+that's exactly what the padded variant does:
+
+```bash
+swift scripts/product-images/removebg-padded.swift <input> <output.png>
+```
+
+## Step 2 — QA every batch on magenta (non-negotiable)
+
+White-bg cutout flaws are invisible on a white preview. Magenta exposes
+shadow remnants, background haze, and halos instantly:
+
+```bash
+swift scripts/product-images/qa-composite.swift /tmp/qa-magenta selected-nobg/*.png
+# then visually inspect /tmp/qa-magenta/*.png
+```
+
+Look for: gray/beige smudges next to the product (shadow), lighter bands
+(background haze), color fringes on edges. Also verify file properties:
+
+```bash
+python3 -c "
+from PIL import Image
+import glob
+for f in sorted(glob.glob('selected-nobg/*.png')):
+    im = Image.open(f)
+    assert im.mode == 'RGBA', f'{f}: {im.mode}'  # 'P' = palette = degraded, redo
+print('all RGBA ok')"
+```
+
+## Step 3 — rembg for images Vision gets wrong
+
+Setup (one-time; models cache in `~/.u2net`, ~180MB–1GB each):
+
+```bash
+brew install python@3.13
+python3.13 -m venv /tmp/rembg-venv
+/tmp/rembg-venv/bin/pip install "rembg[cpu,cli]" scipy
+```
+
+Use `isnet-general-use` for background haze/gradients that Vision included:
+
+```bash
+/tmp/rembg-venv/bin/rembg i -m isnet-general-use input.webp output.png
+```
+
+⚠️ Do **not** use the npm package `@imgly/background-removal-node` for final
+output — it writes palette-mode PNGs (256 colors, quantized alpha). rembg
+writes proper RGBA.
+
+## Step 4 — Baked-in shadows (the hard case)
+
+Some brand assets (Olaplex, epres in the pilot) bake the drop shadow into the
+product cutout as **fully opaque pixels**. Every segmentation model
+(Vision, ISNet, BiRefNet, BiRefNet-DIS, BRIA) treats it as subject — trying more
+models is a dead end; we tried five.
+
+What works — `remove-baked-shadow.py`, which exploits geometry instead of color:
+
+> Shadow = dark pixels **connected to the outer boundary** of the alpha
+> silhouette. Dark label text is also dark, but it's an **interior island**
+> surrounded by bright product pixels, so it survives.
+
+```bash
+/tmp/rembg-venv/bin/python3 scripts/product-images/remove-baked-shadow.py input.webp output.png
+# input must have an alpha channel (the brand asset's own, or a model cutout)
+```
+
+### Step 4b — second pass for the bright shadow fade
+
+The luminance threshold misses the brightest part of the shadow fade (warm
+beige, lum > 185). Fix: flatten the de-shadowed result onto white, then run
+BiRefNet — with the dark shadow core gone, the model now drops the faint rest:
+
+```bash
+python3 - <<'EOF'
+from PIL import Image
+im = Image.open('deshadowed.png').convert('RGBA')
+bg = Image.new('RGBA', im.size, (255,255,255,255))
+Image.alpha_composite(bg, im).convert('RGB').save('deshadowed-white.png')
+EOF
+/tmp/rembg-venv/bin/rembg i -m birefnet-general deshadowed-white.png final.png
+```
+
+Then re-QA on magenta (step 2).
+
+### Dead end to avoid
+
+Growing the shadow region through _warm-tinted_ (r−b) pixels sounds clever but
+**eats translucent bottle parts** (caps/necks show the warm background through
+them). Don't refine in that direction; the flatten-white + BiRefNet second pass
+is the working answer.
+
+## Final check before handoff
+
+1. File count matches source count
+2. All outputs `RGBA` mode, dimensions identical to source
+3. Contact sheet on a beige/colored background for one last eyeball:
+   every product clean, no smudges, label text intact
+
+## Pilot batch notes (2026-06-10)
+
+- #05 Balea Natural Beauty keeps its coconut/hibiscus props — part of the brand
+  arrangement, kept intentionally.
+- #09/#10/#14 are tight crops (product fills frame) — low transparency share is
+  expected, not a bug.
+- Model cache `~/.u2net` was ~3GB after the pilot (birefnet-general,
+  birefnet-dis, bria-rmbg, isnet). Safe to delete; re-downloads on demand.

--- a/docs/runbooks/product-image-pilot-runbook.claude-review.md
+++ b/docs/runbooks/product-image-pilot-runbook.claude-review.md
@@ -1,0 +1,40 @@
+All checks done. Here is the verdict report.
+
+---
+
+**Verdict:** Approve with revisions
+
+**Lean shape**
+
+- Irreducible goal: a repeatable, audited pipeline to publish reviewed 1200×1200 product images to Supabase and `products.image_url`, batch by batch.
+- Cut or defer: nothing major — the runbook documents work that already exists and resists scope creep well (it explicitly defers the admin page, source-search helper, and contact-sheet command to "Known Follow-Ups"). The "Scaling Recommendation" section partially repeats "Before Scaling Beyond the Pilot" (both list the batch-id/count generalization); could be merged, but that's cosmetic.
+- Hard tradeoff the plan is avoiding: none — it names the real one (manual review doesn't scale linearly) and chooses controlled 50-product batches.
+
+**Prior art**
+
+- Immutable hash-versioned storage paths: matches content-addressed asset pattern — OK (`scripts/product-images/manifest.ts:184` includes a 12-char SHA prefix; verified by `tests/product-images-manifest.spec.ts:17`).
+- Publish with compensation: upload → RPC → delete-on-failure (`publish-pilot-images.ts:130,150`) is a correct saga/compensation shape for the cross-system write (Storage + DB can't share a transaction). The DB side (`UPDATE products.image_url` + audit upsert) is atomic inside the RPC (`supabase/migrations/20260610120000_product_image_assets.sql:60–130`) — OK.
+- Idempotency: re-running publish re-uploads the same hash-versioned path and the RPC upserts on `product_id` (`...sql:48` unique index), so replays converge — OK, though the runbook doesn't say re-runs are safe; worth one sentence.
+- Dry-run before mutation: matches canonical gated-publish — OK (`publish-pilot-images.ts:14`).
+- Migration handling deviates from canonical `supabase db push` (applied surgically, marked applied) — the runbook discloses this honestly, which is the right call given divergent history.
+
+**Blockers** (will fail or mislead as written)
+
+1. The manifest spec isn't wired into any test script — `package.json:36` runs `tsx --test tests/*.test.ts tests/*.test.tsx`, but the new file is `tests/product-images-manifest.spec.ts`, so neither `test:node` nor `test:contracts` ever runs it (and plain `node --test` fails on it — only `tsx --test` passes, 7/7). Either rename to `.test.ts` or add it to a script; otherwise the validation logic the runbook leans on is unprotected in CI.
+2. Step 8 implies the publisher checks "the bucket … preflight" — it doesn't. `preflightDatabase` (`publish-pilot-images.ts:67–90`) checks products and the audit table only; there is no bucket or RPC existence check before upload. A missing bucket fails mid-upload, a missing RPC fails after upload (compensated, but noisy). Either soften the runbook claim or add the preflight.
+
+**High-confidence issues**
+
+- The runbook says "expected count … update the constants deliberately" but doesn't say _where_: `expectedCount` is a function option (`manifest.ts:191,227`) that `publish-pilot-images.ts` never sets or exposes via CLI — for a 50-batch you must edit `manifest.ts:191`'s default of `20` _and_ `PRODUCT_IMAGE_BATCH_ID` at `manifest.ts:6` (which also changes storage paths, `manifest.ts:184`). Name both exact edit sites in the runbook so the next operator doesn't hunt.
+- Step 9's check "product image URLs are loaded from the Supabase public storage bucket" works because `next.config.ts:46` allowlists `pqdkhefxsxkyeqelqegq.supabase.co` and CSP `img-src` allows `https://*.supabase.co` (`next.config.ts:11`) — fine, but the runbook should note this dependency: a future project-ref change silently breaks images.
+- Fallback folder names are load-bearing: `generate-pilot-manifest.ts:100–103` hardcodes exactly `fallback`–`fallback4`. The runbook shows these as an "example" — say explicitly that a `fallback5/` round will be silently ignored by manifest generation until the script is updated.
+
+**Smaller / nice-to-haves**
+
+- Step 3's localStorage warning is correct and the JSON-as-source-of-truth instruction matches `serve-review.ts:46` (POST endpoint writes `review-state.json`). Good.
+- The `--input-dir` semantics in Step 6 match `process-selected-images.ts:10–11` (implies `skipBackgroundRemoval`) and per-product file matching by id (`:211,265–267`). Verified.
+- `product_image_assets` has RLS enabled with no policies (`...sql:135`) — service-role-only by design; one line in Step 8 noting "audit table is not client-readable; that's intentional" would pre-empt the question.
+- "Each file name must include the product id" (Step 5) is accurate but could cite the matcher (`process-selected-images.ts:265`) so it doesn't read like superstition.
+
+**Bottom line**
+This is an unusually honest, well-grounded runbook — every script, flag, folder, and validation it cites exists and behaves as described, and it correctly flags its own pilot-specific hardcodes. Fix two things before treating it as the scaling playbook: wire `tests/product-images-manifest.spec.ts` into a test script (it currently runs nowhere), and either correct or implement the claimed bucket/RPC preflight in Step 8. With those plus naming the exact constants to edit for a 50-batch, ship it.

--- a/docs/runbooks/product-image-pilot-runbook.md
+++ b/docs/runbooks/product-image-pilot-runbook.md
@@ -1,0 +1,514 @@
+# Product Image Pilot Runbook
+
+This runbook documents the 20-product image pilot from June 10, 2026 and the
+repeatable process we should use before scaling to the full catalog.
+
+The goal is to publish exact single-product images for recommendation cards:
+reviewed source image, transparent cutout, Chaarlie-neutral background, coherent
+visual sizing, Supabase Storage asset, and an audit row that records provenance.
+
+## Current Pilot State
+
+- Batch id: `pilot-2026-06-10`
+- Batch directory: `data/product-images/pilot-2026-06-10/`
+- Published count: 20 products
+- Storage bucket: `product-images`
+- App field updated: `products.image_url`
+- Audit table: `public.product_image_assets`
+- Final asset format: `1200x1200` WebP
+- Final background: neutral light beige `rgb(243, 239, 232)`
+- Final visual sizing: transparent subject bounds centered and fit inside a
+  `940x940` max side box with an additional visual-area cap on the
+  `1200x1200` canvas
+
+The pilot proved that public product pages can work, but source quality varies a
+lot. User review remains required before publishing.
+
+## Before Scaling Beyond the Pilot
+
+Do not run a larger batch accidentally with the pilot defaults. The scripts now
+support explicit scale-up flags, but default to the pilot for reproducibility:
+
+- `--batch-id` controls immutable storage path prefix and
+  `product_image_assets.manifest_batch_id`.
+- `--expected-count` controls manifest/final-asset row validation.
+- `--candidate-file` or `--candidate-files` controls which scrape/fallback
+  `image-candidates.json` files feed source provenance.
+- The review UI uses fixed localStorage keys, so browser state can carry across
+  runs unless the JSON review-state file is treated as the source of truth.
+
+For every non-pilot batch, pass those flags explicitly. Never publish a larger
+batch until a dry-run shows the intended storage paths, batch id, and product
+count.
+
+The pilot defaults live in:
+
+- `DEFAULT_PRODUCT_IMAGE_BATCH_ID` in `scripts/product-images/manifest.ts`
+- `DEFAULT_PRODUCT_IMAGE_EXPECTED_COUNT` in
+  `scripts/product-images/manifest.ts`
+- default fallback source folders in
+  `scripts/product-images/generate-pilot-manifest.ts`
+
+Important: a new folder like `fallback5/` is ignored by manifest generation
+unless it is passed with `--candidate-file=fallback5/image-candidates.json` or
+included in `--candidate-files=...`.
+
+## What Counts as a Good Image
+
+Use these rules during review:
+
+- The image must show the exact product and variant, not merely the same brand or
+  category.
+- Prefer a clean single-product packshot. Keep brand-provided props only when
+  they are part of the official product arrangement and do not confuse the exact
+  product.
+- Front or recognizable packaging views are preferred. Top views are acceptable
+  for tubs/masks when they are the exact product and there is no better source.
+- Reject tiny, blurry, cropped, multi-product, outdated-packaging, or wrong-size
+  candidates.
+- Brand and retailer sources are preferred. Search-result or unknown sources need
+  extra notes and should stay `medium` confidence at most.
+
+The pilot used a practical publish threshold of 20/20 user-approved final
+images. For larger batches, only publish rows with `user_approved=yes`; do not
+publish low-confidence or unresolved rows.
+
+## Local Batch Layout
+
+Each batch should use one directory:
+
+```text
+data/product-images/<batch-id>/
+  pilot-products.csv
+  candidates/
+  image-candidates.json
+  review.html
+  review-state.json
+  fallback*/
+  merged-review-decisions.json
+  selected/
+  selected-nobg/
+  final/
+  final-assets.json
+  final-review.html
+  final-review-state.json
+  manifest.csv
+```
+
+`selected/` contains the reviewed original source images. `selected-nobg/`
+contains the transparent PNG cutouts. `final/` contains the publishable WebP
+assets.
+
+## Step 1: Select Products
+
+For the pilot, we selected a mixed 20-product set from active products without
+`image_url`, spreading across categories before filling the remaining slots.
+
+Preflight the selected CSV before scraping:
+
+- every row has a product id that exists in Supabase
+- every row has a usable public product page or source page URL
+- products already published in a previous batch are excluded unless the goal is
+  to replace their image
+- the batch size matches the expected publish count
+
+```bash
+npx tsx scripts/product-images/select-pilot-products.ts \
+  --out=data/product-images/pilot-2026-06-10/pilot-products.csv
+```
+
+For the next scale batch, keep the same idea but change the batch id and batch
+size deliberately. The current validation scripts default to exactly 20; update
+the expected count before publishing larger batches.
+
+## Step 2: Scrape Candidates
+
+Scrape public product pages from `pilot-products.csv`.
+
+```bash
+npx tsx scripts/product-images/scrape-pilot-images.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10
+```
+
+The scraper uses:
+
+- static HTML candidates: Open Graph, Twitter image, JSON-LD, image tags, srcset
+- browser-rendered candidates via Playwright for pages that hydrate images
+- score heuristics for product-looking URLs and usable dimensions
+- filters for SVGs, logos, tiny assets, and non-image downloads
+
+Expected failure modes:
+
+- product page blocks requests with 403
+- candidate image download returns 404
+- page image is a thumbnail
+- source is wrong variant or old packaging
+- image is embedded behind shop-specific scripts and needs a fallback search
+
+## Step 3: Review Candidates
+
+Serve the batch review UI:
+
+```bash
+npx tsx scripts/product-images/serve-review.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10 \
+  --port=3357
+```
+
+Open:
+
+```text
+http://127.0.0.1:3357/review.html
+```
+
+Review each product:
+
+- mark the best candidate `Good`, `Maybe`, or `Bad`
+- select the candidate image
+- mark product decision as approved, needs work, or rejected
+- add a comment when the match is uncertain, wrong, or manually fixed
+
+The review UI stores state in browser localStorage and posts a JSON copy beside
+the review page as `review-state.json`. Use the JSON file as the source of
+truth for later merge steps.
+
+For a new batch, verify that `review-state.json` exists and contains the current
+review before merging. If the browser was used for an older batch, do not trust
+the localStorage badge alone.
+
+## Step 4: Fallback Search Rounds
+
+Do fallback rounds for unresolved products only. Keep each round in its own
+folder, for example:
+
+```text
+fallback/
+fallback2/
+fallback3/
+fallback4/
+```
+
+Each fallback should produce its own `review.html`, `image-candidates.json`, and
+`review-state.json`. The pilot used these rounds for products where the first
+scrape found broken images, wrong variants, or no usable source.
+
+If a product is sourced manually outside the scraper, record enough provenance
+for manifest generation:
+
+- source page URL
+- direct source image URL
+- local selected file path
+- source type and confidence
+- reviewer note explaining why the manual source was accepted
+
+If that manual source does not appear in an `image-candidates.json` file, edit
+the manifest after generation. Otherwise `generate-pilot-manifest.ts` may fall
+back to the product affiliate page as `source_page_url`, which is wrong for a
+manually sourced image.
+
+Merge review decisions after the main and fallback rounds:
+
+```bash
+npx tsx scripts/product-images/merge-review-decisions.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10
+```
+
+For non-pilot folders, pass every review source that should participate in the
+merge:
+
+```bash
+npx tsx scripts/product-images/merge-review-decisions.ts \
+  --batch-dir=data/product-images/catalog-2026-06-11 \
+  --review-source=main:review-state.json:image-candidates.json \
+  --review-source=fallback:fallback/review-state.json:fallback/image-candidates.json \
+  --review-source=manual:manual/review-state.json:manual/image-candidates.json
+```
+
+The merged output should contain exactly the products approved for final image
+processing.
+
+## Step 5: Background Removal
+
+The final pilot cutouts were not produced by the rough Sharp edge-removal
+heuristic. The good results came from the local cutout workflow documented in:
+
+[Product-Image Background Removal](../product-image-background-removal.md)
+
+Use that document as the authoritative cutout step. In short:
+
+1. Check whether the source already has a useful alpha channel.
+2. Use macOS Vision subject-lift first for normal packshots.
+3. Use the padded Vision variant for tight crops.
+4. QA every cutout on magenta.
+5. Use `rembg` for haze/gradient failures.
+6. Use `remove-baked-shadow.py` plus the second-pass workflow for baked-in
+   shadows, especially brand assets with opaque drop shadows.
+
+Place final transparent PNG cutouts in:
+
+```text
+data/product-images/<batch-id>/selected-nobg/
+```
+
+Each file name must include the product id, because the final compositor matches
+files by product id.
+
+Important: do not run the old local Sharp background-removal heuristic as the
+final cutout method. It was useful as an early prototype, but it produced worse
+edges than the Vision/rembg workflow.
+
+## Step 6: Composite and Normalize Final Assets
+
+Once `selected-nobg/` contains one transparent PNG per approved product,
+generate the final assets:
+
+```bash
+npx tsx scripts/product-images/process-selected-images.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10 \
+  --input-dir=data/product-images/pilot-2026-06-10/selected-nobg \
+  --expected-count=20
+```
+
+When `--input-dir` is provided, the script skips background removal and treats
+the files as already-cut transparent assets. It then:
+
+- reads the alpha bounds
+- crops to product content with a small margin
+- resizes the product into a `940x940` max box
+- centers it on a `1200x1200` canvas
+- paints the neutral Chaarlie background
+- writes WebP at quality 88
+- writes `final-assets.json`
+- writes `final-review.html`
+
+The important sizing decision from the pilot: do allow upscaling into the
+`940x940` box. Without upscaling, small source files stay visually tiny next to
+larger products.
+
+The first 50-product catalog batch added one more sizing rule: cap visual area,
+not only max side length. Wide tubs, masks, and squat jars can look much larger
+than tall bottles when everything is normalized only by the longest side. The
+compositor now uses both:
+
+- max product side: `940px`
+- target visual alpha area: `460000px`
+
+This keeps tall bottles readable while preventing wide products from dominating
+the card.
+
+Review the final page:
+
+```text
+http://127.0.0.1:3357/final-review.html
+```
+
+Only proceed when the final images look coherent together.
+
+## Step 7: Generate the Publish Manifest
+
+Generate the manifest from the final assets and reviewed source metadata:
+
+```bash
+npx tsx scripts/product-images/generate-pilot-manifest.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10
+```
+
+For a larger batch, be explicit:
+
+```bash
+npx tsx scripts/product-images/generate-pilot-manifest.ts \
+  --batch-dir=data/product-images/catalog-2026-06-11 \
+  --expected-count=50 \
+  --candidate-files=image-candidates.json,fallback/image-candidates.json,fallback2/image-candidates.json
+```
+
+The manifest captures:
+
+- product id, brand, name, category
+- source page URL
+- source image URL
+- source type: `brand`, `retailer`, `marketplace`, `search_result`, `unknown`
+- quality confidence: `high` or `medium`
+- processing method: `local`, `third_party`, or `manual`
+- final file path
+- SHA-256 hash
+- user approval
+- notes
+
+The publish code validates:
+
+- exact expected row count
+- no duplicate product ids
+- approved rows only
+- no `low` confidence rows
+- hash matches local file
+- final file stays inside the batch directory
+- search-result/unknown sources include notes
+
+These validations are covered by `tests/product-images-manifest.test.ts`, which
+should run through `npm run test:node`.
+
+After generation, manually scan `manifest.csv` before dry-run. Pay special
+attention to rows from fallback or manual sourcing: `source_page_url`,
+`source_image_url`, `source_type`, `quality_confidence`, and `notes` must
+describe the actual image that was used, not just the original product page.
+
+## Step 8: Publish to Supabase
+
+Before publishing, make sure the storage bucket, audit table, and RPC exist via:
+
+```text
+supabase/migrations/20260610120000_product_image_assets.sql
+```
+
+The migration creates:
+
+- public storage bucket `product-images`
+- `public.product_image_assets`
+- one audit row per product image
+- `public.publish_product_image_asset(...)`
+
+Do not run a broad `supabase db push` if migration history is divergent. For the
+pilot, this migration was applied surgically and then marked applied.
+
+For future batches, check whether the migration is already applied before
+publishing. The current publisher preflights products, storage bucket, and the
+audit table. It does not currently preflight the RPC before the first upload; a
+missing RPC is surfaced during publish, with cleanup for objects uploaded in the
+same run.
+
+The audit table has RLS enabled without client read policies. That is
+intentional: publishing uses the service role, and the app reads the final public
+URL from `products.image_url`.
+
+Dry-run first:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10 \
+  --batch-id=pilot-2026-06-10 \
+  --expected-count=20 \
+  --dry-run
+```
+
+Publish only after dry-run passes:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=data/product-images/pilot-2026-06-10 \
+  --batch-id=pilot-2026-06-10 \
+  --expected-count=20
+```
+
+For a larger batch, change all three values deliberately:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=data/product-images/catalog-2026-06-11 \
+  --batch-id=catalog-2026-06-11 \
+  --expected-count=50 \
+  --dry-run
+```
+
+The publisher:
+
+- validates the manifest
+- checks the products exist
+- checks the storage bucket exists
+- checks the audit table exists
+- uploads immutable hash-versioned files to Supabase Storage
+- calls `publish_product_image_asset` to update `products.image_url` and upsert
+  the audit row atomically
+- removes any just-uploaded object if the DB publish step fails
+
+Re-running a publish with the same manifest is expected to converge: storage
+paths include the asset hash, existing objects are skipped, and the audit row is
+upserted by product id.
+
+## Step 9: Verify in the App
+
+Run the local app:
+
+```bash
+LOCAL_DEV_LOGIN_ENABLED=1 npm run dev:worktree
+```
+
+Log in locally:
+
+```text
+http://localhost:<port>/api/dev/login?next=/chat
+```
+
+Then trigger a recommendation flow that returns products from the pilot set.
+Check:
+
+- image renders in the recommendation card
+- image and text fit on mobile
+- fallback icon still renders for products without `image_url`
+- product image URLs are loaded from the Supabase public storage bucket
+
+The current app allowlists the Supabase public storage host in `next.config.ts`.
+If the Supabase project ref or storage host changes, update the image
+`remotePatterns` and CSP image sources before expecting product images to render.
+
+## Scaling Recommendation
+
+Scale in controlled batches, not in one blind publish.
+
+Recommended next batch:
+
+- 50 products
+- same scrape/review/cutout/publish pipeline
+- manual review only for uncertain scrape results and every final contact sheet
+- publish only approved rows
+
+Before moving beyond 50-product batches, preserve every batch manifest and
+review-state file as the provenance record for future audits.
+
+## Catalog Batch 01 Learnings
+
+Batch `catalog-2026-06-10-01` published 49 reviewed assets and intentionally
+excluded one duplicate product (`OGX Renewing` duplicated `OGX Renewing Argan
+Oil` by product code `3574661799162`). Reuse these lessons for later batches:
+
+- Duplicate detection should happen before review. If two catalog rows share a
+  GTIN/product code or clearly resolve to the same retailer product, pick one
+  canonical row and leave the duplicate for catalog cleanup.
+- DM and Rossmann product pages often gave the cleanest exact packshots. Prefer
+  those retailer product images when they match exactly, even when a brand page
+  exists but has lifestyle, multi-product, or wrong-variant imagery.
+- Brand assets with alpha are useful, but still require magenta QA. A transparent
+  PNG can still contain baked shadows or graphic overlays inside the alpha.
+- Hagel-style pages can fail through Node/browser fetch because of very large
+  headers. If that happens, manual `curl`/HTML extraction is acceptable, but the
+  fallback `image-candidates.json`, review note, and manifest provenance must
+  record the real source page and direct image URL.
+- Similar product names are risky. The Sante correction showed why final review
+  must check exact product form, not just brand/category/name similarity; a mask
+  sachet can look plausible for a conditioner unless the package is inspected.
+- Top views are acceptable for tubs/masks when the reviewer confirms they are
+  exact products. Do not reject them only because they are not front-facing.
+- If one asset looks too big after max-side normalization, regenerate with the
+  area-capped compositor instead of shrinking the image in the UI.
+
+For the first 50-product batch, run the full local pipeline but publish only
+after:
+
+- final review page is approved
+- `manifest.csv` is manually spot-checked for every fallback/manual row
+- publish dry-run shows exactly 50 payloads
+- at least a few published images are verified in the local chat UI on mobile
+  width
+
+## Known Follow-Ups
+
+- Generalize `PRODUCT_IMAGE_BATCH_ID` and expected manifest count for larger
+  batches.
+- Add a source-search helper for unresolved products instead of creating
+  fallback folders manually.
+- Add a final contact sheet command to make visual QA faster.
+- Decide whether rejected/needs-work rows should be saved in a separate backlog
+  CSV for later manual sourcing.
+- Consider a small admin/internal page later, but keep messy scraping and image
+  processing local for now. Supabase should receive only the clean final assets
+  and provenance rows.

--- a/docs/runbooks/product-image-pilot-runbook.md
+++ b/docs/runbooks/product-image-pilot-runbook.md
@@ -465,6 +465,185 @@ Recommended next batch:
 Before moving beyond 50-product batches, preserve every batch manifest and
 review-state file as the provenance record for future audits.
 
+## Next Batch Recipe
+
+Use this as the short operational recipe for the next 50-product batch. Replace
+`catalog-YYYY-MM-DD-NN` once at the top and keep the same value through every
+command.
+
+```bash
+export BATCH_ID=catalog-YYYY-MM-DD-NN
+export BATCH_DIR=data/product-images/$BATCH_ID
+```
+
+1. Select the next products after the previous batch is published:
+
+```bash
+npx tsx scripts/product-images/select-pilot-products.ts \
+  --limit=50 \
+  --allow-partial \
+  --out=$BATCH_DIR/pilot-products.csv
+```
+
+2. Scrape raw candidates:
+
+```bash
+npx tsx scripts/product-images/scrape-pilot-images.ts \
+  --batch-dir=$BATCH_DIR \
+  --pilot=$BATCH_DIR/pilot-products.csv
+```
+
+3. Do not send the raw scrape straight to review. First apply the source
+   learnings from batches 01-05:
+
+- Prefer exact retailer/brand hero or meta images over page `img` tags.
+- On DM pages, `browser-meta` is often the exact product hero. Related-product
+  carousel thumbnails can share brand/category words but be the wrong SKU.
+- Compare image URL slugs against the product page slug. If the URL slug points
+  at another product, drop it.
+- Drop banners, lifestyle panels, recommendation-grid images, logos, icons,
+  ingredient/texture detail shots, and back-of-pack-only candidates unless they
+  are the only exact source and the reviewer explicitly accepts them.
+- For hard cases, make a small rescue review folder rather than expanding the
+  full review set with noise. Good rescue sources so far: official brand CDN,
+  DM/Rossmann/Mueller/Hagel product images, YesStyle/Lyko/Walmart/Incidecoder
+  originals when they show the exact single product.
+
+Create learned review folders as needed, for example:
+
+```text
+$BATCH_DIR/learned/
+$BATCH_DIR/learned2/
+$BATCH_DIR/learned3/
+```
+
+Each review folder must contain its own `image-candidates.json`, `review.html`,
+and `review-state.json`. Keep the final reviewer work small: first show the
+high-confidence learned set, then only show rejected rows in rescue rounds.
+
+4. Serve review pages locally:
+
+```bash
+npx tsx scripts/product-images/serve-review.ts \
+  --batch-dir=$BATCH_DIR \
+  --port=3357
+```
+
+Review URLs then follow the folder names:
+
+```text
+http://127.0.0.1:3357/learned/review.html
+http://127.0.0.1:3357/learned2/review.html
+http://127.0.0.1:3357/learned3/review.html
+```
+
+5. Merge every approved review source into `selected/`. Pass the final set of
+   review folders explicitly:
+
+```bash
+npx tsx scripts/product-images/merge-review-decisions.ts \
+  --batch-dir=$BATCH_DIR \
+  --review-source=learned:learned/review-state.json:learned/image-candidates.json \
+  --review-source=learned2:learned2/review-state.json:learned2/image-candidates.json \
+  --review-source=learned3:learned3/review-state.json:learned3/image-candidates.json
+```
+
+Only continue when this reports exactly 50 approved rows and `selected/` has 50
+files whose names include product ids.
+
+6. Remove backgrounds and QA the transparent cutouts.
+
+Use [Product-Image Background Removal](../product-image-background-removal.md)
+as the authoritative cutout procedure. The short operational rule is:
+
+- Check source alpha first. If the source already has clean transparency, pass
+  it through as RGBA PNG; do not run a segmentation model over good alpha.
+- For flat packshots without alpha, use macOS Vision subject-lift
+  (`removebg.swift`) first.
+- If Vision reports no subject because the product fills the frame, use
+  `removebg-padded.swift`.
+- If Vision leaves haze/gradients, try `rembg` with `isnet-general-use`.
+- For fully opaque baked-in shadows inside brand alpha assets, use
+  `remove-baked-shadow.py`; for vividly colored products, try flattened
+  BiRefNet first because it can separate gray shadow from the product body.
+- For sachets or boxes whose printed artwork includes people, do not let
+  Vision lift the person out of the package art. If the product is the full
+  rectangle, use full-opacity passthrough instead.
+- QA every output on magenta with `qa-composite.swift`. White preview
+  backgrounds hide halos, haze, and shadow remnants.
+
+If the cutout work is outsourced, keep the same acceptance bar: returned files
+must be transparent PNG/RGBA cutouts, visually QA'd on a colored background, and
+saved in:
+
+```text
+$BATCH_DIR/selected-nobg/
+```
+
+Keep product ids in the filenames. The compositor matches by product id, not by
+file order. Before compositing, verify file count, product-id coverage, and that
+the returned files are PNG/RGBA.
+
+7. Composite final assets from the returned cutouts:
+
+```bash
+npx tsx scripts/product-images/process-selected-images.ts \
+  --batch-dir=$BATCH_DIR \
+  --input-dir=$BATCH_DIR/selected-nobg \
+  --expected-count=50
+```
+
+Review:
+
+```text
+http://127.0.0.1:3357/final-review.html
+```
+
+8. Generate and validate the manifest. Include every candidate file that
+   contributed approved sources:
+
+```bash
+npx tsx scripts/product-images/generate-pilot-manifest.ts \
+  --batch-dir=$BATCH_DIR \
+  --expected-count=50 \
+  --candidate-files=learned/image-candidates.json,learned2/image-candidates.json,learned3/image-candidates.json
+```
+
+If the background removal was outsourced, set `processing_method` to
+`third_party` in all manifest rows before publishing. Use a real CSV parser or
+regenerate the manifest before editing; product image URLs can contain commas,
+so a naive `split(",")` corrupts the manifest.
+
+9. Dry-run publish:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=$BATCH_DIR \
+  --batch-id=$BATCH_ID \
+  --expected-count=50 \
+  --dry-run
+```
+
+Only publish after the dry-run shows exactly 50 payloads, bucket/database
+preflight passes, and storage paths use the intended batch id.
+
+10. Publish and verify:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=$BATCH_DIR \
+  --batch-id=$BATCH_ID \
+  --expected-count=50
+```
+
+After publishing, verify:
+
+- 50 `products.image_url` values point to `/product-images/$BATCH_ID/`
+- 50 `product_image_assets` rows exist for `manifest_batch_id = $BATCH_ID`
+- product URLs match audit public URLs
+- one sampled public asset returns `200 image/webp`
+- local chat recommendation cards still render on mobile width
+
 ## Catalog Batch 01 Learnings
 
 Batch `catalog-2026-06-10-01` published 49 reviewed assets and intentionally

--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,12 @@ const nextConfig: NextConfig = {
         hostname: "assets.cdn.filesafe.space",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "pqdkhefxsxkyeqelqegq.supabase.co",
+        pathname: "/storage/v1/object/public/product-images/**",
+        search: "",
+      },
     ],
   },
   outputFileTracingIncludes: {

--- a/plans/2026-06-10-product-image-catalog-rollout.md
+++ b/plans/2026-06-10-product-image-catalog-rollout.md
@@ -1,0 +1,519 @@
+# Product Image Catalog Rollout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish reviewed, provenance-tracked product images for the remaining active catalog products that still have `products.image_url IS NULL`.
+
+**Architecture:** Reuse the completed 20-product pilot pipeline, but run the catalog in controlled batches. Keep messy scraping, fallback sourcing, background removal, and visual review local; publish only reviewed final assets plus provenance rows to Supabase.
+
+**Tech Stack:** TypeScript/Node scripts with `tsx`, Playwright scraping, local Vision/rembg cutouts, Sharp final compositing, Supabase Storage + Postgres RPC, Next.js image rendering.
+
+---
+
+## Source Inputs
+
+- Pilot runbook: `docs/runbooks/product-image-pilot-runbook.md`
+- Background-removal runbook: `docs/product-image-background-removal.md`
+- Claude review: `docs/runbooks/product-image-pilot-runbook.claude-review.md`
+- Current live count on 2026-06-10:
+  - active products: 233
+  - active products with images: 20
+  - active products missing images: 213
+
+## Promised End-State
+
+- Every active product either has a reviewed product image in `products.image_url` or is recorded in a local unresolved backlog with the reason it could not be sourced safely.
+- Supabase Storage contains immutable, hash-versioned final images grouped by batch id.
+- `public.product_image_assets` contains one provenance row per published image.
+- Product recommendation cards continue to render image assets where present and icon fallback where missing.
+
+## Target File Map
+
+- Modify `scripts/product-images/select-pilot-products.ts`
+  - Add `--limit` and `--allow-partial` so the same selector can create 50-product batches and the final smaller batch.
+  - Keep the existing default pilot behavior for reproducibility.
+- Modify `docs/runbooks/product-image-pilot-runbook.md`
+  - Add the selector command for non-pilot batches.
+  - Add the concrete 213-product rollout cadence.
+- Possibly create `data/product-images/catalog-YYYY-MM-DD-XX/`
+  - One local batch folder per rollout batch.
+  - These are working artifacts, not application source.
+- Do not modify recommendation logic unless QA finds product-card rendering bugs.
+
+## Scope Boundaries
+
+- In scope: batch selection, scraping, review, fallback sourcing, cutout, final compositing, manifest generation, dry-run, publish, local app QA.
+- In scope: script tweaks required to run non-pilot batches safely.
+- Out of scope: admin UI upload flow, fully automatic background-removal approval, unreviewed auto-publish, changing recommendation ranking.
+- Out of scope: replacing the local Vision/rembg cutout workflow with a third-party API unless local results clearly fail for a batch.
+
+---
+
+## Task 1: Make Batch Selection Scale-Safe
+
+**Files:**
+
+- Modify: `scripts/product-images/select-pilot-products.ts`
+- Test/verify: shell command against Supabase, no DB mutation
+
+- [x] **Step 1: Add selector flags**
+
+Add:
+
+```ts
+const limit = Number(
+  process.argv.find((arg) => arg.startsWith("--limit="))?.slice("--limit=".length) ?? 20,
+)
+const allowPartial = process.argv.includes("--allow-partial")
+
+if (!Number.isInteger(limit) || limit <= 0) {
+  throw new Error(`--limit must be a positive integer, got ${limit}`)
+}
+```
+
+- [x] **Step 2: Use `limit` instead of hardcoded 20**
+
+Replace every selection cutoff and message that assumes 20 with `limit`.
+
+Expected behavior:
+
+```text
+--limit=50
+```
+
+selects up to 50 active products with `image_url IS NULL`.
+
+- [x] **Step 3: Allow the final smaller batch**
+
+Replace the current strict failure:
+
+```ts
+if (selected.length < 20) {
+  throw new Error(`Expected 20 eligible pilot products, found ${selected.length}`)
+}
+```
+
+with:
+
+```ts
+if (selected.length < limit && !allowPartial) {
+  throw new Error(
+    `Expected ${limit} eligible products, found ${selected.length}. Use --allow-partial for the final batch.`,
+  )
+}
+```
+
+- [x] **Step 4: Verify selector output for the first catalog batch**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/select-pilot-products.ts \
+  --out=data/product-images/catalog-2026-06-10-01/pilot-products.csv \
+  --limit=50
+```
+
+Expected:
+
+```text
+Wrote 50 products to data/product-images/catalog-2026-06-10-01/pilot-products.csv
+```
+
+Open the CSV and confirm:
+
+- 50 rows plus header
+- all product ids are unique
+- all rows have `affiliate_link`
+- none of the 20 pilot products are included
+
+---
+
+## Task 2: Run Batch 01 as the Scale Trial
+
+**Files/artifacts:**
+
+- Create: `data/product-images/catalog-2026-06-10-01/`
+- Read: `docs/runbooks/product-image-pilot-runbook.md`
+- Read: `docs/product-image-background-removal.md`
+
+- [x] **Step 1: Scrape candidates**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/scrape-pilot-images.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01
+```
+
+Expected:
+
+```text
+data/product-images/catalog-2026-06-10-01/review.html
+data/product-images/catalog-2026-06-10-01/image-candidates.json
+```
+
+- [x] **Step 2: Start review server**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/serve-review.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01 \
+  --port=3357
+```
+
+Open:
+
+```text
+http://127.0.0.1:3357/review.html
+```
+
+- [x] **Step 3: Review candidates**
+
+Approve only exact product matches. Mark unresolved rows as needs work with a short comment.
+
+Expected artifact:
+
+```text
+data/product-images/catalog-2026-06-10-01/review-state.json
+```
+
+- [x] **Step 4: Run fallback rounds only for unresolved rows**
+
+Use folders such as:
+
+```text
+fallback/
+fallback2/
+manual/
+```
+
+Every fallback/manual source must have enough provenance to populate:
+
+- source page URL
+- source image URL
+- source type
+- confidence
+- review note
+
+- [x] **Step 5: Merge decisions**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/merge-review-decisions.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01 \
+  --review-source=main:review-state.json:image-candidates.json \
+  --review-source=fallback:fallback/review-state.json:fallback/image-candidates.json \
+  --review-source=manual:manual/review-state.json:manual/image-candidates.json
+```
+
+Expected:
+
+```text
+data/product-images/catalog-2026-06-10-01/merged-review-decisions.json
+```
+
+---
+
+## Task 3: Cut Out and Finalize Batch 01
+
+**Files/artifacts:**
+
+- Create: `data/product-images/catalog-2026-06-10-01/selected/`
+- Create: `data/product-images/catalog-2026-06-10-01/selected-nobg/`
+- Create: `data/product-images/catalog-2026-06-10-01/final/`
+
+- [x] **Step 1: Copy selected originals**
+
+Use `merged-review-decisions.json` to create `selected/` with one reviewed source image per approved product.
+
+Expected:
+
+```text
+data/product-images/catalog-2026-06-10-01/selected/
+```
+
+contains one original source image per approved product.
+
+- [x] **Step 2: Remove backgrounds using the documented local workflow**
+
+Follow:
+
+```text
+docs/product-image-background-removal.md
+```
+
+Use Vision first, padded Vision for tight crops, rembg for haze, and baked-shadow removal only where needed.
+
+Expected:
+
+```text
+data/product-images/catalog-2026-06-10-01/selected-nobg/
+```
+
+contains RGBA PNGs, one per approved product, with product ids in filenames.
+
+- [x] **Step 3: QA cutouts on magenta**
+
+Run from the batch directory:
+
+```bash
+swift scripts/product-images/qa-composite.swift \
+  /tmp/catalog-2026-06-10-01-magenta \
+  data/product-images/catalog-2026-06-10-01/selected-nobg/*.png
+```
+
+Expected:
+
+- no obvious halos
+- no beige/gray shadow smears
+- label text preserved
+- product edges not eaten
+
+- [x] **Step 4: Composite final assets**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/process-selected-images.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01 \
+  --input-dir=data/product-images/catalog-2026-06-10-01/selected-nobg \
+  --expected-count=50
+```
+
+Expected:
+
+```text
+data/product-images/catalog-2026-06-10-01/final/
+data/product-images/catalog-2026-06-10-01/final-assets.json
+data/product-images/catalog-2026-06-10-01/final-review.html
+```
+
+- [x] **Step 5: Final visual review**
+
+Open:
+
+```text
+http://127.0.0.1:3357/final-review.html
+```
+
+Approve only if the batch looks coherent in size, clean on the neutral background, and exact-product correct.
+
+---
+
+## Task 4: Manifest, Dry-Run, Publish Batch 01
+
+**Files/artifacts:**
+
+- Create: `data/product-images/catalog-2026-06-10-01/manifest.csv`
+- Mutates: Supabase Storage and `public.products.image_url` only after publish
+
+- [x] **Step 1: Generate manifest**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/generate-pilot-manifest.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01 \
+  --expected-count=50 \
+  --candidate-files=image-candidates.json,fallback/image-candidates.json,fallback2/image-candidates.json,manual/image-candidates.json
+```
+
+If fewer than 50 products are approved, either complete fallback sourcing first or intentionally reduce `--expected-count` and record unresolved rows in a backlog CSV.
+
+- [x] **Step 2: Spot-check manifest**
+
+Open:
+
+```text
+data/product-images/catalog-2026-06-10-01/manifest.csv
+```
+
+Check every fallback/manual row:
+
+- `source_page_url` points to the actual source
+- `source_image_url` points to the actual image
+- `source_type` is plausible
+- `quality_confidence` is not inflated
+- `notes` explain uncertainty or manual sourcing
+
+- [x] **Step 3: Dry-run publish**
+
+Run:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01 \
+  --batch-id=catalog-2026-06-10-01 \
+  --expected-count=50 \
+  --dry-run
+```
+
+Expected:
+
+- validates 50 approved payloads
+- storage bucket preflight passed
+- database preflight passed
+- storage paths start with `catalog-2026-06-10-01/`
+
+- [x] **Step 4: Publish**
+
+Run only after dry-run and final review pass:
+
+```bash
+npx tsx scripts/product-images/publish-pilot-images.ts \
+  --batch-dir=data/product-images/catalog-2026-06-10-01 \
+  --batch-id=catalog-2026-06-10-01 \
+  --expected-count=50
+```
+
+Expected:
+
+- `OK product=... url=...` for each approved product
+- Supabase `products.image_url` updated for the batch
+- `product_image_assets.manifest_batch_id = catalog-2026-06-10-01`
+
+- [x] **Step 5: Verify database counts**
+
+Run:
+
+```bash
+npx supabase db query --linked "
+select
+  count(*) filter (where is_active and image_url is null) as active_missing_images,
+  count(*) filter (where is_active and image_url is not null) as active_with_images
+from public.products;
+"
+```
+
+Expected after a full 50-product publish:
+
+```text
+active_missing_images decreases by 50
+active_with_images increases by 50
+```
+
+Actual Batch 01 result on 2026-06-11:
+
+- 49 product images published for `catalog-2026-06-10-01`
+- 1 catalog duplicate intentionally excluded: `OGX Renewing` duplicates
+  `OGX Renewing Argan Oil`
+- Post-publish verification found 49 manifest rows, 49 matching
+  `products.image_url` values, 49 matching audit rows, and 0 missing products or
+  mismatches
+
+---
+
+## Task 5: Local App QA for Batch 01
+
+**Files:**
+
+- Existing UI: `src/components/chat/product-card.tsx`
+- Existing UI: `src/components/chat/product-image.tsx`
+
+- [x] **Step 1: Run local app with dev login**
+
+Run:
+
+```bash
+LOCAL_DEV_LOGIN_ENABLED=1 npm run dev:worktree
+```
+
+Open:
+
+```text
+http://localhost:<port>/api/dev/login?next=/chat
+```
+
+- [x] **Step 2: Trigger recommendation cards**
+
+Ask for categories/products represented in the new batch.
+
+Check:
+
+- product image renders
+- mobile card layout remains stable
+- fallback icon still works for products without images
+- no distorted or tiny product images
+
+- [x] **Step 3: Capture unresolved issues**
+
+If a product image is wrong, too small, or ugly, do not patch the UI first. Fix the source asset and republish that product with a new hash-versioned asset.
+
+Batch 01 local app QA notes:
+
+- Product cards rendered real Supabase image URLs in chat on mobile width.
+- The fallback icon path remains in place for products without `image_url`.
+- The Sante conditioner wrong-candidate issue was fixed at source and
+  republished before considering the batch complete.
+- Final sizing was regenerated with area-based normalization after visual QA
+  showed wide products could look too large against tall bottles.
+
+---
+
+## Task 6: Repeat Remaining Batches
+
+**Batch cadence based on 213 missing active images on 2026-06-10:**
+
+- `catalog-2026-06-10-01`: 50 products
+- `catalog-2026-06-10-02`: 50 products
+- `catalog-2026-06-10-03`: 50 products
+- `catalog-2026-06-10-04`: 50 products
+- `catalog-2026-06-10-05`: final 13 products with `--allow-partial` and `--expected-count=13`
+
+- [ ] **Step 1: Repeat selection after each publish**
+
+Because published products no longer have `image_url IS NULL`, rerun selection after each batch instead of precomputing all five batches up front.
+
+- [ ] **Step 2: Use the same review/publish gates**
+
+Do not publish a batch unless:
+
+- final review is approved
+- manifest has been spot-checked
+- dry-run passes
+- local app QA passes for a sample of products
+
+- [ ] **Step 3: Track unresolved products**
+
+Create:
+
+```text
+data/product-images/catalog-unresolved-products.csv
+```
+
+Columns:
+
+```text
+product_id,brand,name,category,reason,last_checked_at,notes
+```
+
+Use this only for products that cannot be confidently sourced after fallback/manual search.
+
+---
+
+## Verification Checklist
+
+Automated:
+
+- [x] `npx tsx --test tests/product-images-manifest.test.ts`
+- [x] `npm run test:node`
+- [x] `npm run typecheck`
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] Publish dry-run for Batch 01
+
+Manual:
+
+- [x] Candidate review UI checked for every Batch 01 product
+- [x] Magenta cutout QA checked for every Batch 01 cutout
+- [x] Final review page checked for every Batch 01 final asset
+- [x] Manifest fallback/manual rows spot-checked for Batch 01
+- [x] Local chat recommendation cards checked on mobile width after publish
+
+Shipping gates:
+
+- [ ] Run `autoreview` after final code/script/doc changes
+- [ ] Ask for explicit approval before commit/push/PR
+- [ ] Before merge, confirm Supabase migration state and live PR CI

--- a/scripts/product-images/apply-review-decisions.ts
+++ b/scripts/product-images/apply-review-decisions.ts
@@ -1,0 +1,159 @@
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { basename, join } from "node:path"
+
+const batchDir =
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+  "data/product-images/pilot-2026-06-10"
+const reviewStatePath = join(batchDir, "review-state.json")
+const candidatesPath = join(batchDir, "image-candidates.json")
+const selectedDir = join(batchDir, "selected")
+const decisionsPath = join(batchDir, "review-decisions.json")
+const followUpPath = join(batchDir, "follow-up-products.csv")
+
+interface ReviewRow {
+  product_id: string
+  product: string
+  product_rating: string
+  selected_candidate_id: string
+  selected_image_url: string
+  selected_local_path: string
+  selected_source: string
+  candidate_ratings: Record<string, "good" | "maybe" | "bad">
+  comment: string
+}
+
+interface Candidate {
+  url: string
+  source: string
+  score: number
+  localPath?: string
+  error?: string
+}
+
+interface CandidateResult {
+  product: {
+    id: string
+    brand: string
+    name: string
+    category: string
+    affiliate_link: string
+  }
+  candidates: Candidate[]
+}
+
+interface Decision {
+  product_id: string
+  product: string
+  status: "approved" | "needs_selection_fix" | "needs_manual_search" | "rejected"
+  selected_local_path: string
+  selected_image_url: string
+  selected_source: string
+  selected_file: string
+  comment: string
+  reason: string
+}
+
+function csvCell(value: unknown): string {
+  const text = String(value ?? "")
+  return `"${text.replace(/"/g, '""')}"`
+}
+
+function usableCandidates(result: CandidateResult): Candidate[] {
+  return result.candidates.filter((candidate) => candidate.localPath && !candidate.error)
+}
+
+function candidateForReviewId(result: CandidateResult, candidateId: string): Candidate | undefined {
+  const index = Number(candidateId.split(":").at(-1))
+  if (!Number.isFinite(index)) return undefined
+  return usableCandidates(result)[index]
+}
+
+function inferGoodCandidate(row: ReviewRow, result: CandidateResult): Candidate | undefined {
+  const goodIds = Object.entries(row.candidate_ratings ?? {})
+    .filter(([, rating]) => rating === "good")
+    .map(([candidateId]) => candidateId)
+
+  const usable = usableCandidates(result)
+  if (row.product_rating === "approved" && usable.length === 1) {
+    return usable[0]
+  }
+
+  if (goodIds.length !== 1) return undefined
+  return candidateForReviewId(result, goodIds[0])
+}
+
+function main(): void {
+  const reviews = JSON.parse(readFileSync(reviewStatePath, "utf8")) as ReviewRow[]
+  const candidateResults = JSON.parse(readFileSync(candidatesPath, "utf8")) as CandidateResult[]
+  const candidatesByProductId = new Map(
+    candidateResults.map((result) => [result.product.id, result]),
+  )
+  const decisions: Decision[] = []
+
+  mkdirSync(selectedDir, { recursive: true })
+
+  for (const row of reviews) {
+    const result = candidatesByProductId.get(row.product_id)
+    const inferred = result ? inferGoodCandidate(row, result) : undefined
+    const selectedLocalPath = row.selected_local_path || inferred?.localPath || ""
+    const selectedImageUrl = row.selected_image_url || inferred?.url || ""
+    const selectedSource = row.selected_source || inferred?.source || ""
+    const selectedFile = selectedLocalPath
+      ? `${String(decisions.length + 1).padStart(2, "0")}-${row.product_id}-${basename(selectedLocalPath)}`
+      : ""
+
+    let status: Decision["status"] = "needs_manual_search"
+    let reason = "No approved selected image"
+
+    if (row.product_rating === "reject") {
+      status = "rejected"
+      reason = "Reviewer rejected product image candidates"
+    } else if (row.product_rating === "approved" && selectedLocalPath) {
+      status = "approved"
+      reason = row.selected_local_path
+        ? "Reviewer selected approved image"
+        : "Inferred from single good candidate"
+      copyFileSync(selectedLocalPath, join(selectedDir, selectedFile))
+    } else if (row.product_rating === "approved") {
+      status = "needs_selection_fix"
+      reason = "Product approved but no selected/good candidate could be resolved"
+    } else if (inferred?.localPath) {
+      status = "needs_manual_search"
+      reason = "Has a maybe/good candidate but product was not approved"
+    }
+
+    decisions.push({
+      product_id: row.product_id,
+      product: row.product,
+      status,
+      selected_local_path: selectedLocalPath,
+      selected_image_url: selectedImageUrl,
+      selected_source: selectedSource,
+      selected_file: selectedFile,
+      comment: row.comment,
+      reason,
+    })
+  }
+
+  writeFileSync(decisionsPath, `${JSON.stringify(decisions, null, 2)}\n`)
+
+  const followUps = decisions.filter((decision) => decision.status !== "approved")
+  const csv = [
+    ["product_id", "product", "status", "reason", "comment"].join(","),
+    ...followUps.map((decision) =>
+      [decision.product_id, decision.product, decision.status, decision.reason, decision.comment]
+        .map(csvCell)
+        .join(","),
+    ),
+  ].join("\n")
+  writeFileSync(followUpPath, `${csv}\n`)
+
+  const counts = decisions.reduce<Record<string, number>>((acc, decision) => {
+    acc[decision.status] = (acc[decision.status] ?? 0) + 1
+    return acc
+  }, {})
+
+  console.log(JSON.stringify({ counts, decisionsPath, followUpPath, selectedDir }, null, 2))
+}
+
+main()

--- a/scripts/product-images/generate-pilot-manifest.ts
+++ b/scripts/product-images/generate-pilot-manifest.ts
@@ -1,0 +1,218 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+import {
+  MANIFEST_HEADER,
+  type ProductImageProcessingMethod,
+  type ProductImageQualityConfidence,
+  type ProductImageSourceType,
+} from "./manifest"
+
+const batchDir =
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+  "data/product-images/pilot-2026-06-10"
+const expectedCount = Number(
+  process.argv
+    .find((arg) => arg.startsWith("--expected-count="))
+    ?.slice("--expected-count=".length) ?? 20,
+)
+const candidateFileArgs = process.argv
+  .filter((arg) => arg.startsWith("--candidate-file="))
+  .map((arg) => arg.slice("--candidate-file=".length))
+const candidateFilesArg = process.argv.find((arg) => arg.startsWith("--candidate-files="))
+const configuredCandidateFiles = [
+  ...(candidateFilesArg
+    ?.slice("--candidate-files=".length)
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean) ?? []),
+  ...candidateFileArgs,
+]
+
+if (!Number.isInteger(expectedCount) || expectedCount <= 0) {
+  throw new Error(`--expected-count must be a positive integer, got ${expectedCount}`)
+}
+
+interface PilotProduct {
+  id: string
+  brand: string
+  name: string
+  category: string
+  affiliate_link: string
+}
+
+interface CandidateResult {
+  product: PilotProduct
+  candidates: Array<{
+    url: string
+    source: string
+    localPath?: string
+  }>
+}
+
+interface FinalAsset {
+  product_id: string
+  product: string
+  source_image_url: string
+  final_file: string
+  sha256: string
+  notes: string
+}
+
+interface MergedDecision {
+  product_id: string
+  source_round: string
+  comment: string
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = []
+  let current = ""
+  let quoted = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    const next = line[index + 1]
+    if (char === '"' && quoted && next === '"') {
+      current += '"'
+      index += 1
+      continue
+    }
+    if (char === '"') {
+      quoted = !quoted
+      continue
+    }
+    if (char === "," && !quoted) {
+      values.push(current)
+      current = ""
+      continue
+    }
+    current += char
+  }
+
+  values.push(current)
+  return values
+}
+
+function readCsv(path: string): Record<string, string>[] {
+  const lines = readFileSync(path, "utf8")
+    .replace(/\r/g, "")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+  const header = parseCsvLine(lines[0] ?? "")
+  return lines.slice(1).map((line) => {
+    const values = parseCsvLine(line)
+    return Object.fromEntries(header.map((key, index) => [key, values[index] ?? ""]))
+  })
+}
+
+function csvCell(value: unknown): string {
+  const text = String(value ?? "")
+  return `"${text.replace(/"/g, '""')}"`
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T
+}
+
+function candidateFiles(): string[] {
+  const relativePaths =
+    configuredCandidateFiles.length > 0
+      ? configuredCandidateFiles
+      : [
+          "image-candidates.json",
+          "fallback/image-candidates.json",
+          "fallback2/image-candidates.json",
+          "fallback3/image-candidates.json",
+          "fallback4/image-candidates.json",
+          "k18-clean/image-candidates.json",
+        ]
+
+  return relativePaths.map((relativePath) => join(batchDir, relativePath))
+}
+
+function buildSourcePageMap(): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const file of candidateFiles()) {
+    try {
+      const results = readJson<CandidateResult[]>(file)
+      for (const result of results) {
+        for (const candidate of result.candidates) {
+          map.set(candidate.url, result.product.affiliate_link)
+          if (candidate.localPath) map.set(candidate.localPath, result.product.affiliate_link)
+        }
+      }
+    } catch {
+      // Optional fallback files do not always exist in early pilot runs.
+    }
+  }
+  return map
+}
+
+function sourceTypeFor(url: string): ProductImageSourceType {
+  const host = new URL(url).hostname.replace(/^www\./, "")
+  if (/(epres|k18hair|olaplex)\./.test(host)) return "brand"
+  if (/(amazon|ebay)\./.test(host)) return "marketplace"
+  if (/(google|bing|duckduckgo)\./.test(host)) return "search_result"
+  return "retailer"
+}
+
+function confidenceFor(sourceType: ProductImageSourceType): ProductImageQualityConfidence {
+  return sourceType === "search_result" || sourceType === "unknown" ? "medium" : "high"
+}
+
+function main(): void {
+  const products = readCsv(join(batchDir, "pilot-products.csv")) as unknown as PilotProduct[]
+  const productsById = new Map(products.map((product) => [product.id, product]))
+  const finalAssets = readJson<FinalAsset[]>(join(batchDir, "final-assets.json"))
+  const decisions = readJson<MergedDecision[]>(join(batchDir, "merged-review-decisions.json"))
+  const decisionsById = new Map(decisions.map((decision) => [decision.product_id, decision]))
+  const sourcePageByImageUrl = buildSourcePageMap()
+
+  if (finalAssets.length !== expectedCount) {
+    throw new Error(`Expected ${expectedCount} final assets, found ${finalAssets.length}`)
+  }
+
+  const rows = finalAssets.map((asset) => {
+    const product = productsById.get(asset.product_id)
+    if (!product) throw new Error(`Missing product metadata for ${asset.product_id}`)
+
+    const sourcePageUrl = sourcePageByImageUrl.get(asset.source_image_url) ?? product.affiliate_link
+    const sourceType = sourceTypeFor(sourcePageUrl)
+    const decision = decisionsById.get(asset.product_id)
+    const notes = [
+      "approved pilot image",
+      decision?.source_round ? `source_round=${decision.source_round}` : "",
+      decision?.comment ? `review_note=${decision.comment}` : "",
+    ]
+      .filter(Boolean)
+      .join("; ")
+
+    return {
+      product_id: asset.product_id,
+      brand: product.brand,
+      name: product.name,
+      category: product.category,
+      source_page_url: sourcePageUrl,
+      source_image_url: asset.source_image_url,
+      source_type: sourceType,
+      quality_confidence: confidenceFor(sourceType),
+      processing_method: "local" satisfies ProductImageProcessingMethod,
+      final_file: asset.final_file,
+      asset_sha256: asset.sha256,
+      user_approved: "yes",
+      notes,
+    }
+  })
+
+  const csv = [
+    MANIFEST_HEADER.join(","),
+    ...rows.map((row) => MANIFEST_HEADER.map((key) => csvCell(row[key])).join(",")),
+  ].join("\n")
+
+  const manifestPath = join(batchDir, "manifest.csv")
+  writeFileSync(manifestPath, `${csv}\n`)
+  console.log(`Wrote ${manifestPath}`)
+}
+
+main()

--- a/scripts/product-images/manifest.ts
+++ b/scripts/product-images/manifest.ts
@@ -1,0 +1,281 @@
+import { createHash } from "node:crypto"
+import { existsSync, readFileSync } from "node:fs"
+import { basename, extname, isAbsolute, relative, resolve, sep } from "node:path"
+
+export const PRODUCT_IMAGE_BUCKET = "product-images"
+export const DEFAULT_PRODUCT_IMAGE_BATCH_ID = "pilot-2026-06-10"
+export const DEFAULT_PRODUCT_IMAGE_EXPECTED_COUNT = 20
+export const PRODUCT_IMAGE_BATCH_ID = DEFAULT_PRODUCT_IMAGE_BATCH_ID
+export const SUPABASE_PROJECT_ID = "pqdkhefxsxkyeqelqegq"
+
+export const MANIFEST_HEADER = [
+  "product_id",
+  "brand",
+  "name",
+  "category",
+  "source_page_url",
+  "source_image_url",
+  "source_type",
+  "quality_confidence",
+  "processing_method",
+  "final_file",
+  "asset_sha256",
+  "user_approved",
+  "notes",
+] as const
+
+export type ProductImageSourceType =
+  | "brand"
+  | "retailer"
+  | "marketplace"
+  | "search_result"
+  | "unknown"
+export type ProductImageQualityConfidence = "high" | "medium"
+export type ProductImageProcessingMethod = "local" | "third_party" | "manual"
+
+export interface ProductImageManifestRow {
+  product_id: string
+  brand: string
+  name: string
+  category: string
+  source_page_url: string
+  source_image_url: string
+  source_type: ProductImageSourceType
+  quality_confidence: ProductImageQualityConfidence
+  processing_method: ProductImageProcessingMethod
+  final_file: string
+  asset_sha256: string
+  user_approved: "yes"
+  notes: string
+}
+
+export interface ProductImagePublishPayload {
+  productId: string
+  localFilePath: string
+  storageBucket: string
+  storagePath: string
+  publicUrl: string
+  auditRow: {
+    product_id: string
+    storage_bucket: string
+    storage_path: string
+    public_url: string
+    source_page_url: string
+    source_image_url: string | null
+    source_type: ProductImageSourceType
+    quality_confidence: ProductImageQualityConfidence
+    processing_method: ProductImageProcessingMethod
+    asset_sha256: string
+    manifest_batch_id: string
+    user_approved: boolean
+    notes: string | null
+  }
+}
+
+interface BuildPublishPayloadOptions {
+  expectedCount?: number
+  batchId?: string
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = []
+  let current = ""
+  let quoted = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    const next = line[index + 1]
+
+    if (char === '"' && quoted && next === '"') {
+      current += '"'
+      index += 1
+      continue
+    }
+    if (char === '"') {
+      quoted = !quoted
+      continue
+    }
+    if (char === "," && !quoted) {
+      values.push(current)
+      current = ""
+      continue
+    }
+    current += char
+  }
+
+  values.push(current)
+  return values.map((value) => value.trim())
+}
+
+export function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex")
+}
+
+export function readProductImageManifest(path: string): ProductImageManifestRow[] {
+  const lines = readFileSync(path, "utf8")
+    .replace(/\r/g, "")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+  const header = parseCsvLine(lines[0] ?? "")
+
+  if (header.join(",") !== MANIFEST_HEADER.join(",")) {
+    throw new Error(`Unexpected manifest header in ${path}: ${header.join(",")}`)
+  }
+
+  return lines.slice(1).map((line, index) => {
+    const values = parseCsvLine(line)
+    const row = Object.fromEntries(
+      MANIFEST_HEADER.map((key, column) => [key, values[column] ?? ""]),
+    )
+    return validateManifestRow(row, index + 2)
+  })
+}
+
+export function validateManifestRow(
+  row: Record<string, string>,
+  lineNumber: number,
+): ProductImageManifestRow {
+  const required = [
+    "product_id",
+    "source_page_url",
+    "source_type",
+    "quality_confidence",
+    "processing_method",
+    "final_file",
+    "asset_sha256",
+    "user_approved",
+  ]
+
+  for (const key of required) {
+    if (!row[key]?.trim()) throw new Error(`Line ${lineNumber}: ${key} is required`)
+  }
+
+  if (!["brand", "retailer", "marketplace", "search_result", "unknown"].includes(row.source_type)) {
+    throw new Error(`Line ${lineNumber}: invalid source_type ${row.source_type}`)
+  }
+  if (row.quality_confidence === "low") {
+    throw new Error(`Line ${lineNumber}: low confidence images cannot be published`)
+  }
+  if (!["high", "medium"].includes(row.quality_confidence)) {
+    throw new Error(`Line ${lineNumber}: invalid quality_confidence ${row.quality_confidence}`)
+  }
+  if (!["local", "third_party", "manual"].includes(row.processing_method)) {
+    throw new Error(`Line ${lineNumber}: invalid processing_method ${row.processing_method}`)
+  }
+  if (!/^[a-f0-9]{64}$/.test(row.asset_sha256)) {
+    throw new Error(`Line ${lineNumber}: asset_sha256 must be a lowercase SHA-256 hex digest`)
+  }
+  if (row.user_approved !== "yes") {
+    throw new Error(`Line ${lineNumber}: user_approved must be yes before publishing`)
+  }
+  if (
+    (row.source_type === "unknown" || row.source_type === "search_result") &&
+    !row.notes?.trim()
+  ) {
+    throw new Error(`Line ${lineNumber}: notes are required for ${row.source_type} sources`)
+  }
+
+  const ext = extname(row.final_file).toLowerCase()
+  if (![".webp", ".png", ".jpg", ".jpeg"].includes(ext)) {
+    throw new Error(`Line ${lineNumber}: final_file must be webp, png, jpg, or jpeg`)
+  }
+
+  return row as unknown as ProductImageManifestRow
+}
+
+export function buildStoragePath(
+  row: ProductImageManifestRow,
+  batchId = DEFAULT_PRODUCT_IMAGE_BATCH_ID,
+): string {
+  const ext = extname(row.final_file).toLowerCase() || ".webp"
+  const fileBase = basename(row.final_file, ext).replace(/[^a-zA-Z0-9_-]+/g, "-")
+  const version = row.asset_sha256.slice(0, 12)
+  return `${batchId}/${row.product_id}/${fileBase}-${version}${ext}`
+}
+
+export function buildPublicUrl(storagePath: string): string {
+  return `https://${SUPABASE_PROJECT_ID}.supabase.co/storage/v1/object/public/${PRODUCT_IMAGE_BUCKET}/${storagePath}`
+}
+
+export function validateManifestBatch(rows: ProductImageManifestRow[], expectedCount = 20): void {
+  if (rows.length !== expectedCount) {
+    throw new Error(
+      `Manifest must contain exactly ${expectedCount} approved products, found ${rows.length}`,
+    )
+  }
+
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (seen.has(row.product_id)) {
+      throw new Error(`Manifest contains duplicate product_id ${row.product_id}`)
+    }
+    seen.add(row.product_id)
+  }
+}
+
+function resolveFinalFilePath(batchDir: string, finalFile: string): string {
+  const batchRoot = resolve(batchDir)
+  const localFilePath = resolve(batchRoot, finalFile)
+  const relativePath = relative(batchRoot, localFilePath)
+
+  if (
+    relativePath === "" ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(`final_file must stay inside the batch directory: ${finalFile}`)
+  }
+
+  return localFilePath
+}
+
+export function buildPublishPayloads(
+  rows: ProductImageManifestRow[],
+  batchDir: string,
+  options: BuildPublishPayloadOptions = {},
+): ProductImagePublishPayload[] {
+  const batchId = options.batchId ?? DEFAULT_PRODUCT_IMAGE_BATCH_ID
+  validateManifestBatch(rows, options.expectedCount ?? DEFAULT_PRODUCT_IMAGE_EXPECTED_COUNT)
+
+  return rows.map((row) => {
+    const localFilePath = resolveFinalFilePath(batchDir, row.final_file)
+
+    if (!existsSync(localFilePath)) {
+      throw new Error(`Missing final image file: ${localFilePath}`)
+    }
+
+    const actualSha = sha256File(localFilePath)
+    if (actualSha !== row.asset_sha256) {
+      throw new Error(
+        `SHA mismatch for ${localFilePath}: manifest=${row.asset_sha256} actual=${actualSha}`,
+      )
+    }
+
+    const storagePath = buildStoragePath(row, batchId)
+    const publicUrl = buildPublicUrl(storagePath)
+
+    return {
+      productId: row.product_id,
+      localFilePath,
+      storageBucket: PRODUCT_IMAGE_BUCKET,
+      storagePath,
+      publicUrl,
+      auditRow: {
+        product_id: row.product_id,
+        storage_bucket: PRODUCT_IMAGE_BUCKET,
+        storage_path: storagePath,
+        public_url: publicUrl,
+        source_page_url: row.source_page_url,
+        source_image_url: row.source_image_url.trim() || null,
+        source_type: row.source_type,
+        quality_confidence: row.quality_confidence,
+        processing_method: row.processing_method,
+        asset_sha256: row.asset_sha256,
+        manifest_batch_id: batchId,
+        user_approved: true,
+        notes: row.notes.trim() || null,
+      },
+    }
+  })
+}

--- a/scripts/product-images/merge-review-decisions.ts
+++ b/scripts/product-images/merge-review-decisions.ts
@@ -118,7 +118,20 @@ function inferredCandidate(row: ReviewRow, result?: CandidateResult): Candidate 
     return usableCandidates(result)[0]
   }
   if (goodIds.length === 1) return candidateForReviewId(result, goodIds[0])
+  if (goodIds.length > 1) return candidateForReviewId(result, goodIds[0])
   return undefined
+}
+
+function isCandidateApproved(row: ReviewRow): boolean {
+  if (row.product_rating === "reject" || row.product_rating === "needs_work") return false
+  if (row.product_rating === "approved") return true
+
+  const selectedRating = row.selected_candidate_id
+    ? row.candidate_ratings?.[row.selected_candidate_id]
+    : undefined
+  if (selectedRating === "good") return true
+
+  return Object.values(row.candidate_ratings ?? {}).some((rating) => rating === "good")
 }
 
 function loadSource(source: ReviewSource): MergedDecision[] {
@@ -136,7 +149,7 @@ function loadSource(source: ReviewSource): MergedDecision[] {
     const selectedImageUrl = row.selected_image_url || candidate?.url || ""
     const selectedSource = row.selected_source || candidate?.source || ""
     const status =
-      row.product_rating === "approved" && selectedLocalPath
+      isCandidateApproved(row) && selectedLocalPath
         ? "approved"
         : row.product_rating === "reject"
           ? "rejected"

--- a/scripts/product-images/merge-review-decisions.ts
+++ b/scripts/product-images/merge-review-decisions.ts
@@ -1,0 +1,193 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { basename, join } from "node:path"
+
+const batchDir =
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+  "data/product-images/pilot-2026-06-10"
+const selectedDir = join(batchDir, "selected")
+const mergedPath = join(batchDir, "merged-review-decisions.json")
+interface ReviewSource {
+  name: string
+  state: string
+  candidates: string
+}
+
+const configuredReviewSources = process.argv
+  .filter((arg) => arg.startsWith("--review-source="))
+  .map((arg): ReviewSource => {
+    const value = arg.slice("--review-source=".length)
+    const [name, state, candidates] = value.split(":")
+    if (!name || !state || !candidates) {
+      throw new Error("--review-source must use name:review-state-path:image-candidates-path")
+    }
+    return {
+      name,
+      state: join(batchDir, state),
+      candidates: join(batchDir, candidates),
+    }
+  })
+
+const reviewSources: ReviewSource[] = configuredReviewSources.length
+  ? configuredReviewSources
+  : [
+      {
+        name: "main",
+        state: join(batchDir, "review-state.json"),
+        candidates: join(batchDir, "image-candidates.json"),
+      },
+      {
+        name: "fallback",
+        state: join(batchDir, "fallback/review-state.json"),
+        candidates: join(batchDir, "fallback/image-candidates.json"),
+      },
+      {
+        name: "fallback2",
+        state: join(batchDir, "fallback2/review-state.json"),
+        candidates: join(batchDir, "fallback2/image-candidates.json"),
+      },
+      {
+        name: "fallback3",
+        state: join(batchDir, "fallback3/review-state.json"),
+        candidates: join(batchDir, "fallback3/image-candidates.json"),
+      },
+    ]
+
+interface ReviewRow {
+  product_id: string
+  product: string
+  product_rating: string
+  selected_candidate_id: string
+  selected_image_url: string
+  selected_local_path: string
+  selected_source: string
+  candidate_ratings: Record<string, "good" | "maybe" | "bad">
+  comment: string
+}
+
+interface Candidate {
+  url: string
+  source: string
+  localPath?: string
+  error?: string
+}
+
+interface CandidateResult {
+  product: {
+    id: string
+    brand: string
+    name: string
+    category: string
+    affiliate_link: string
+  }
+  candidates: Candidate[]
+}
+
+interface MergedDecision {
+  product_id: string
+  product: string
+  status: "approved" | "needs_manual_search" | "rejected"
+  source_round: string
+  selected_local_path: string
+  selected_image_url: string
+  selected_source: string
+  selected_file: string
+  comment: string
+}
+
+function usableCandidates(result: CandidateResult): Candidate[] {
+  return result.candidates.filter((candidate) => candidate.localPath && !candidate.error)
+}
+
+function candidateForReviewId(result: CandidateResult, candidateId: string): Candidate | undefined {
+  const index = Number(candidateId.split(":").at(-1))
+  if (!Number.isFinite(index)) return undefined
+  return usableCandidates(result)[index]
+}
+
+function inferredCandidate(row: ReviewRow, result?: CandidateResult): Candidate | undefined {
+  if (!result) return undefined
+  const selected = row.selected_candidate_id
+    ? candidateForReviewId(result, row.selected_candidate_id)
+    : undefined
+  if (selected) return selected
+
+  const goodIds = Object.entries(row.candidate_ratings ?? {})
+    .filter(([, rating]) => rating === "good")
+    .map(([candidateId]) => candidateId)
+  if (row.product_rating === "approved" && usableCandidates(result).length === 1) {
+    return usableCandidates(result)[0]
+  }
+  if (goodIds.length === 1) return candidateForReviewId(result, goodIds[0])
+  return undefined
+}
+
+function loadSource(source: ReviewSource): MergedDecision[] {
+  if (!existsSync(source.state) || !existsSync(source.candidates)) return []
+
+  const reviews = JSON.parse(readFileSync(source.state, "utf8")) as ReviewRow[]
+  const candidateResults = JSON.parse(readFileSync(source.candidates, "utf8")) as CandidateResult[]
+  const candidatesByProductId = new Map(
+    candidateResults.map((result) => [result.product.id, result]),
+  )
+
+  return reviews.map((row) => {
+    const candidate = inferredCandidate(row, candidatesByProductId.get(row.product_id))
+    const selectedLocalPath = row.selected_local_path || candidate?.localPath || ""
+    const selectedImageUrl = row.selected_image_url || candidate?.url || ""
+    const selectedSource = row.selected_source || candidate?.source || ""
+    const status =
+      row.product_rating === "approved" && selectedLocalPath
+        ? "approved"
+        : row.product_rating === "reject"
+          ? "rejected"
+          : "needs_manual_search"
+
+    return {
+      product_id: row.product_id,
+      product: row.product,
+      status,
+      source_round: source.name,
+      selected_local_path: selectedLocalPath,
+      selected_image_url: selectedImageUrl,
+      selected_source: selectedSource,
+      selected_file: "",
+      comment: row.comment,
+    }
+  })
+}
+
+function main(): void {
+  const byProduct = new Map<string, MergedDecision>()
+  for (const source of reviewSources) {
+    for (const decision of loadSource(source)) {
+      const previous = byProduct.get(decision.product_id)
+      if (!previous || previous.status !== "approved" || decision.status === "approved") {
+        byProduct.set(decision.product_id, decision)
+      }
+    }
+  }
+
+  const decisions = [...byProduct.values()].sort((a, b) => a.product.localeCompare(b.product))
+
+  rmSync(selectedDir, { recursive: true, force: true })
+  mkdirSync(selectedDir, { recursive: true })
+
+  let approvedIndex = 0
+  for (const decision of decisions) {
+    if (decision.status !== "approved") continue
+    approvedIndex += 1
+    decision.selected_file = `${String(approvedIndex).padStart(2, "0")}-${decision.product_id}-${basename(decision.selected_local_path)}`
+    copyFileSync(decision.selected_local_path, join(selectedDir, decision.selected_file))
+  }
+
+  writeFileSync(mergedPath, `${JSON.stringify(decisions, null, 2)}\n`)
+
+  const counts = decisions.reduce<Record<string, number>>((acc, decision) => {
+    acc[decision.status] = (acc[decision.status] ?? 0) + 1
+    return acc
+  }, {})
+
+  console.log(JSON.stringify({ counts, selectedDir, mergedPath }, null, 2))
+}
+
+main()

--- a/scripts/product-images/process-selected-images.ts
+++ b/scripts/product-images/process-selected-images.ts
@@ -1,0 +1,501 @@
+import { createHash } from "node:crypto"
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { basename, join, relative, resolve } from "node:path"
+import sharp from "sharp"
+
+const batchDir =
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+  "data/product-images/pilot-2026-06-10"
+const expectedCount = Number(
+  process.argv
+    .find((arg) => arg.startsWith("--expected-count="))
+    ?.slice("--expected-count=".length) ?? 20,
+)
+const decisionsPath = join(batchDir, "merged-review-decisions.json")
+const inputDir = process.argv
+  .find((arg) => arg.startsWith("--input-dir="))
+  ?.slice("--input-dir=".length)
+const skipBackgroundRemoval =
+  process.argv.includes("--skip-background-removal") || Boolean(inputDir)
+const finalDir = join(batchDir, "final")
+const reviewPath = join(batchDir, "final-review.html")
+const reportPath = join(batchDir, "final-assets.json")
+
+const CANVAS_SIZE = 1200
+const PRODUCT_MAX_SIZE = 940
+const PRODUCT_TARGET_AREA = 460_000
+const PRODUCT_PADDING = 130
+const BACKGROUND = { r: 243, g: 239, b: 232 }
+
+if (!Number.isInteger(expectedCount) || expectedCount <= 0) {
+  throw new Error(`--expected-count must be a positive integer, got ${expectedCount}`)
+}
+
+interface MergedDecision {
+  product_id: string
+  product: string
+  status: "approved" | "needs_manual_search" | "rejected"
+  source_round: string
+  selected_local_path: string
+  selected_image_url: string
+  selected_source: string
+  selected_file: string
+  comment: string
+}
+
+interface FinalAsset {
+  product_id: string
+  product: string
+  source_round: string
+  source_page_url: string
+  source_image_url: string
+  selected_local_path: string
+  final_file: string
+  final_path: string
+  sha256: string
+  width: number
+  height: number
+  removed_background_pixels: number
+  notes: string
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function luminance(r: number, g: number, b: number): number {
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function colorDistance(a: [number, number, number], b: [number, number, number]): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2])
+}
+
+function estimateBackground(data: Buffer, width: number, height: number): [number, number, number] {
+  const samples: [number, number, number][] = []
+  const sampleSize = Math.max(12, Math.floor(Math.min(width, height) * 0.06))
+  const corners = [
+    [0, 0],
+    [width - sampleSize, 0],
+    [0, height - sampleSize],
+    [width - sampleSize, height - sampleSize],
+  ]
+
+  for (const [startX, startY] of corners) {
+    for (let y = startY; y < startY + sampleSize; y += 4) {
+      for (let x = startX; x < startX + sampleSize; x += 4) {
+        const index = (y * width + x) * 4
+        const alpha = data[index + 3]
+        if (alpha > 20) samples.push([data[index], data[index + 1], data[index + 2]])
+      }
+    }
+  }
+
+  if (samples.length === 0) return [255, 255, 255]
+
+  const totals = samples.reduce(
+    (acc, sample) => [acc[0] + sample[0], acc[1] + sample[1], acc[2] + sample[2]],
+    [0, 0, 0],
+  )
+  return [
+    Math.round(totals[0] / samples.length),
+    Math.round(totals[1] / samples.length),
+    Math.round(totals[2] / samples.length),
+  ]
+}
+
+function removeEdgeBackground(data: Buffer, width: number, height: number): number {
+  const background = estimateBackground(data, width, height)
+  const backgroundLum = luminance(...background)
+  const backgroundIsLight = backgroundLum > 205
+  const distanceThreshold = backgroundIsLight ? 46 : 92
+  const visited = new Uint8Array(width * height)
+  const queue: number[] = []
+
+  function shouldRemove(pixelIndex: number): boolean {
+    const offset = pixelIndex * 4
+    const alpha = data[offset + 3]
+    if (alpha < 12) return true
+
+    const r = data[offset]
+    const g = data[offset + 1]
+    const b = data[offset + 2]
+    const lum = luminance(r, g, b)
+    const chroma = Math.max(r, g, b) - Math.min(r, g, b)
+    const nearBackground = colorDistance([r, g, b], background) < distanceThreshold
+    const nearWhite = r > 236 && g > 236 && b > 232 && chroma < 28
+
+    return (nearBackground && (!backgroundIsLight || (lum > 190 && chroma < 42))) || nearWhite
+  }
+
+  function enqueue(x: number, y: number): void {
+    if (x < 0 || y < 0 || x >= width || y >= height) return
+    const pixelIndex = y * width + x
+    if (visited[pixelIndex]) return
+    visited[pixelIndex] = 1
+    if (shouldRemove(pixelIndex)) queue.push(pixelIndex)
+  }
+
+  for (let x = 0; x < width; x += 1) {
+    enqueue(x, 0)
+    enqueue(x, height - 1)
+  }
+  for (let y = 0; y < height; y += 1) {
+    enqueue(0, y)
+    enqueue(width - 1, y)
+  }
+
+  let removed = 0
+  while (queue.length > 0) {
+    const pixelIndex = queue.shift()
+    if (pixelIndex === undefined) continue
+
+    const offset = pixelIndex * 4
+    if (data[offset + 3] !== 0) {
+      data[offset + 3] = 0
+      removed += 1
+    }
+
+    const x = pixelIndex % width
+    const y = Math.floor(pixelIndex / width)
+    enqueue(x + 1, y)
+    enqueue(x - 1, y)
+    enqueue(x, y + 1)
+    enqueue(x, y - 1)
+  }
+
+  return removed
+}
+
+function contentBounds(data: Buffer, width: number, height: number): sharp.Region {
+  let left = width
+  let top = height
+  let right = -1
+  let bottom = -1
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const alpha = data[(y * width + x) * 4 + 3]
+      if (alpha > 18) {
+        left = Math.min(left, x)
+        top = Math.min(top, y)
+        right = Math.max(right, x)
+        bottom = Math.max(bottom, y)
+      }
+    }
+  }
+
+  if (right < left || bottom < top) {
+    return { left: 0, top: 0, width, height }
+  }
+
+  const margin = Math.round(Math.min(width, height) * 0.025)
+  left = clamp(left - margin, 0, width - 1)
+  top = clamp(top - margin, 0, height - 1)
+  right = clamp(right + margin, 0, width - 1)
+  bottom = clamp(bottom + margin, 0, height - 1)
+
+  return { left, top, width: right - left + 1, height: bottom - top + 1 }
+}
+
+function targetProductSize(bounds: sharp.Region): { width: number; height: number } {
+  const maxSideScale = Math.min(PRODUCT_MAX_SIZE / bounds.width, PRODUCT_MAX_SIZE / bounds.height)
+  const areaScale = Math.sqrt(PRODUCT_TARGET_AREA / (bounds.width * bounds.height))
+  const scale = Math.min(maxSideScale, areaScale)
+
+  return {
+    width: Math.max(1, Math.round(bounds.width * scale)),
+    height: Math.max(1, Math.round(bounds.height * scale)),
+  }
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 70)
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex")
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+async function processAsset(decision: MergedDecision, index: number): Promise<FinalAsset> {
+  const inputPath = inputDir
+    ? findInputFileForProduct(decision.product_id)
+    : decision.selected_local_path
+  const source = sharp(inputPath).rotate().ensureAlpha()
+  const { data, info } = await source.raw().toBuffer({ resolveWithObject: true })
+  const removed = skipBackgroundRemoval ? 0 : removeEdgeBackground(data, info.width, info.height)
+  const bounds = contentBounds(data, info.width, info.height)
+  const finalFile = `${String(index + 1).padStart(2, "0")}-${decision.product_id}-${slug(decision.product)}.webp`
+  const finalPath = join(finalDir, finalFile)
+
+  const productBuffer = await sharp(data, {
+    raw: { width: info.width, height: info.height, channels: 4 },
+  })
+    .extract(bounds)
+    .resize({
+      ...targetProductSize(bounds),
+      fit: "fill",
+    })
+    .png()
+    .toBuffer()
+
+  const productMeta = await sharp(productBuffer).metadata()
+  const left = Math.round((CANVAS_SIZE - (productMeta.width ?? PRODUCT_MAX_SIZE)) / 2)
+  const top = Math.round((CANVAS_SIZE - (productMeta.height ?? PRODUCT_MAX_SIZE)) / 2)
+
+  await sharp({
+    create: {
+      width: CANVAS_SIZE,
+      height: CANVAS_SIZE,
+      channels: 3,
+      background: BACKGROUND,
+    },
+  })
+    .composite([{ input: productBuffer, left, top }])
+    .webp({ quality: 88, effort: 5 })
+    .toFile(finalPath)
+
+  return {
+    product_id: decision.product_id,
+    product: decision.product,
+    source_round: decision.source_round,
+    source_page_url: "",
+    source_image_url: decision.selected_image_url,
+    selected_local_path: inputPath,
+    final_file: `final/${finalFile}`,
+    final_path: finalPath,
+    sha256: sha256File(finalPath),
+    width: CANVAS_SIZE,
+    height: CANVAS_SIZE,
+    removed_background_pixels: removed,
+    notes: decision.comment,
+  }
+}
+
+function findInputFileForProduct(productId: string): string {
+  if (!inputDir) throw new Error("Missing inputDir")
+
+  const files = readdirSync(inputDir)
+    .filter((file) => file.includes(productId))
+    .map((file) => join(inputDir, file))
+
+  if (files.length !== 1) {
+    throw new Error(
+      `Expected exactly one input image for ${productId} in ${inputDir}, found ${files.length}`,
+    )
+  }
+
+  return files[0]
+}
+
+function writeReview(assets: FinalAsset[]): void {
+  const reviewDir = resolve(batchDir)
+  const sections = assets
+    .map((asset, index) => {
+      const original = relative(reviewDir, resolve(asset.selected_local_path))
+      const final = relative(reviewDir, resolve(asset.final_path))
+      return `<section data-product-id="${htmlEscape(asset.product_id)}">
+        <header>
+          <div>
+            <p class="index">${index + 1} / ${assets.length}</p>
+            <h2>${htmlEscape(asset.product)}</h2>
+            <p>${htmlEscape(asset.source_round)} · ${Math.round(asset.removed_background_pixels / 1000)}k background pixels removed</p>
+          </div>
+          <div class="actions">
+            <button type="button" data-rating="approved">Approve</button>
+            <button type="button" data-rating="needs_work">Needs Work</button>
+          </div>
+        </header>
+        <div class="compare">
+          <figure>
+            <img src="${htmlEscape(original)}" alt="">
+            <figcaption>Selected original</figcaption>
+          </figure>
+          <figure>
+            <img src="${htmlEscape(final)}" alt="">
+            <figcaption>Processed final</figcaption>
+          </figure>
+        </div>
+        <textarea data-comment-for="${htmlEscape(asset.product_id)}" rows="2" placeholder="Comment"></textarea>
+      </section>`
+    })
+    .join("")
+
+  writeFileSync(
+    reviewPath,
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Final Product Image Review</title>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f7f4ef; color: #1d1b18; }
+    .topbar { position: sticky; top: 0; z-index: 2; display: flex; justify-content: space-between; gap: 16px; align-items: center; padding: 16px 32px; border-bottom: 1px solid #d8d0c3; background: rgba(247,244,239,.96); backdrop-filter: blur(8px); }
+    main { max-width: 1280px; margin: 0 auto; padding: 24px 32px 40px; }
+    h1 { margin: 0 0 4px; font-size: 24px; }
+    h2 { margin: 0; font-size: 18px; }
+    p { margin: 4px 0 0; color: #5e574d; }
+    section { border-top: 1px solid #d8d0c3; padding: 24px 0; }
+    header { display: flex; justify-content: space-between; gap: 16px; align-items: start; }
+    .index { font-size: 12px; text-transform: uppercase; color: #81786b; }
+    .compare { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin-top: 16px; }
+    figure { margin: 0; border: 1px solid #d8d0c3; border-radius: 8px; overflow: hidden; background: #ebe6dd; }
+    img { display: block; width: 100%; aspect-ratio: 1; object-fit: contain; background: #f3efe8; }
+    figcaption { padding: 10px; font-size: 13px; color: #5e574d; }
+    .actions, .toolbar { display: flex; gap: 8px; flex-wrap: wrap; }
+    button, a.download { appearance: none; border: 1px solid #cfc5b6; background: #fffaf1; color: #29251f; border-radius: 6px; padding: 8px 10px; font: inherit; font-size: 13px; cursor: pointer; text-decoration: none; }
+    button.active[data-rating="approved"] { border-color: #3c7a4b; background: #dcebd8; }
+    button.active[data-rating="needs_work"] { border-color: #a66c19; background: #f4e2c2; }
+    textarea { margin-top: 12px; width: 100%; box-sizing: border-box; border: 1px solid #cfc5b6; border-radius: 6px; padding: 10px; background: #fffaf1; color: #1d1b18; font: inherit; resize: vertical; }
+    @media (max-width: 720px) {
+      .topbar, header { display: block; }
+      .toolbar, .actions { margin-top: 12px; }
+      .compare { grid-template-columns: 1fr; }
+      main, .topbar { padding-left: 16px; padding-right: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="topbar">
+    <div>
+      <h1>Final Product Image Review</h1>
+      <p><span id="progress">0 reviewed</span> · final 1200x1200 WebP assets</p>
+    </div>
+    <div class="toolbar">
+      <button type="button" id="approveAll">Approve All</button>
+      <button type="button" id="copyJson">Copy JSON</button>
+      <a class="download" id="downloadJson" href="#">Download Review</a>
+    </div>
+  </div>
+  <main>${sections}</main>
+  <script>
+    const storageKey = "product-image-final-review-nobg-v2:" + window.location.pathname;
+    const review = JSON.parse(localStorage.getItem(storageKey) || "{}");
+
+    function state(productId) {
+      review[productId] ||= { rating: "", comment: "" };
+      return review[productId];
+    }
+
+    function exportPayload() {
+      return Array.from(document.querySelectorAll("section")).map((section) => {
+        const productId = section.dataset.productId;
+        const current = state(productId);
+        return {
+          product_id: productId,
+          product: section.querySelector("h2")?.textContent || "",
+          rating: current.rating,
+          comment: current.comment
+        };
+      });
+    }
+
+    function syncToServer() {
+      fetch("/final-review-state", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(exportPayload(), null, 2)
+      }).catch(() => {});
+    }
+
+    function save() {
+      localStorage.setItem(storageKey, JSON.stringify(review, null, 2));
+      syncToServer();
+      render();
+    }
+
+    function render() {
+      document.querySelectorAll("section").forEach((section) => {
+        const current = state(section.dataset.productId);
+        section.querySelectorAll("[data-rating]").forEach((button) => {
+          button.classList.toggle("active", current.rating === button.dataset.rating);
+        });
+        const textarea = section.querySelector("textarea");
+        if (textarea && document.activeElement !== textarea) textarea.value = current.comment || "";
+      });
+      const reviewed = Object.values(review).filter((item) => item.rating || item.comment).length;
+      document.getElementById("progress").textContent = reviewed + " / ${assets.length} reviewed";
+      document.getElementById("downloadJson").href = URL.createObjectURL(new Blob([JSON.stringify(exportPayload(), null, 2)], { type: "application/json" }));
+      document.getElementById("downloadJson").download = "final-product-image-review.json";
+    }
+
+    document.addEventListener("click", async (event) => {
+      const button = event.target.closest("button");
+      if (!button) return;
+      if (button.id === "approveAll") {
+        document.querySelectorAll("section").forEach((section) => {
+          state(section.dataset.productId).rating = "approved";
+        });
+        save();
+        return;
+      }
+      if (button.id === "copyJson") {
+        await navigator.clipboard.writeText(JSON.stringify(exportPayload(), null, 2));
+        button.textContent = "Copied";
+        setTimeout(() => { button.textContent = "Copy JSON"; }, 1200);
+        return;
+      }
+      if (button.dataset.rating) {
+        state(button.closest("section").dataset.productId).rating = button.dataset.rating;
+        save();
+      }
+    });
+
+    document.addEventListener("input", (event) => {
+      if (!event.target.matches("textarea[data-comment-for]")) return;
+      state(event.target.dataset.commentFor).comment = event.target.value;
+      save();
+    });
+
+    render();
+    syncToServer();
+  </script>
+</body>
+</html>
+`,
+  )
+}
+
+async function main(): Promise<void> {
+  const decisions = (JSON.parse(readFileSync(decisionsPath, "utf8")) as MergedDecision[]).filter(
+    (decision) => decision.status === "approved",
+  )
+  if (decisions.length !== expectedCount) {
+    throw new Error(`Expected ${expectedCount} approved image decisions, found ${decisions.length}`)
+  }
+
+  rmSync(finalDir, { recursive: true, force: true })
+  mkdirSync(finalDir, { recursive: true })
+
+  const assets: FinalAsset[] = []
+  for (const [index, decision] of decisions.entries()) {
+    assets.push(await processAsset(decision, index))
+    console.log(`${String(index + 1).padStart(2, "0")}/${decisions.length} ${decision.product}`)
+  }
+
+  writeFileSync(reportPath, `${JSON.stringify(assets, null, 2)}\n`)
+  writeReview(assets)
+
+  console.log(`Wrote ${reportPath}`)
+  console.log(`Wrote ${reviewPath}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/product-images/publish-pilot-images.ts
+++ b/scripts/product-images/publish-pilot-images.ts
@@ -1,0 +1,201 @@
+import { config as loadEnv } from "dotenv"
+import { readFileSync } from "node:fs"
+import { extname, join } from "node:path"
+import { createClient } from "@supabase/supabase-js"
+
+import {
+  DEFAULT_PRODUCT_IMAGE_BATCH_ID,
+  DEFAULT_PRODUCT_IMAGE_EXPECTED_COUNT,
+  PRODUCT_IMAGE_BUCKET,
+  buildPublishPayloads,
+  readProductImageManifest,
+} from "./manifest"
+
+loadEnv({ path: ".env.local" })
+
+const dry = process.argv.includes("--dry-run")
+const batchDir =
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+  "data/product-images/pilot-2026-06-10"
+const manifestPath =
+  process.argv.find((arg) => arg.startsWith("--manifest="))?.slice("--manifest=".length) ??
+  join(batchDir, "manifest.csv")
+const batchId =
+  process.argv.find((arg) => arg.startsWith("--batch-id="))?.slice("--batch-id=".length) ??
+  DEFAULT_PRODUCT_IMAGE_BATCH_ID
+const expectedCount = Number(
+  process.argv
+    .find((arg) => arg.startsWith("--expected-count="))
+    ?.slice("--expected-count=".length) ?? DEFAULT_PRODUCT_IMAGE_EXPECTED_COUNT,
+)
+
+if (!Number.isInteger(expectedCount) || expectedCount <= 0) {
+  throw new Error(`--expected-count must be a positive integer, got ${expectedCount}`)
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+function contentTypeFor(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".webp":
+      return "image/webp"
+    case ".png":
+      return "image/png"
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg"
+    default:
+      throw new Error(`Unsupported image extension: ${path}`)
+  }
+}
+
+function storageFolder(path: string): string {
+  return path.split("/").slice(0, -1).join("/")
+}
+
+function storageFileName(path: string): string {
+  return path.split("/").at(-1) ?? path
+}
+
+async function storageObjectExists(path: string): Promise<boolean> {
+  const { data, error } = await supabase.storage
+    .from(PRODUCT_IMAGE_BUCKET)
+    .list(storageFolder(path), {
+      search: storageFileName(path),
+    })
+
+  if (error) {
+    throw new Error(`Storage lookup failed for ${path}: ${error.message}`)
+  }
+
+  return (data ?? []).some((object) => object.name === storageFileName(path))
+}
+
+async function preflightStorageBucket(): Promise<void> {
+  const { data, error } = await supabase.storage.listBuckets()
+
+  if (error) {
+    throw new Error(`Storage bucket preflight failed: ${error.message}`)
+  }
+
+  if (
+    !(data ?? []).some(
+      (bucket) => bucket.name === PRODUCT_IMAGE_BUCKET || bucket.id === PRODUCT_IMAGE_BUCKET,
+    )
+  ) {
+    throw new Error(`Storage bucket preflight failed: missing bucket ${PRODUCT_IMAGE_BUCKET}`)
+  }
+}
+
+async function preflightDatabase(payloads: ReturnType<typeof buildPublishPayloads>): Promise<void> {
+  const productIds = [...new Set(payloads.map((payload) => payload.productId))]
+  const { data: products, error: productsError } = await supabase
+    .from("products")
+    .select("id")
+    .in("id", productIds)
+
+  if (productsError) {
+    throw new Error(`Product preflight failed: ${productsError.message}`)
+  }
+
+  const foundProductIds = new Set((products ?? []).map((product) => product.id as string))
+  const missingProductIds = productIds.filter((productId) => !foundProductIds.has(productId))
+  if (missingProductIds.length > 0) {
+    throw new Error(`Product preflight failed: missing products ${missingProductIds.join(", ")}`)
+  }
+
+  const { error: auditTableError } = await supabase
+    .from("product_image_assets")
+    .select("id")
+    .limit(1)
+
+  if (auditTableError) {
+    throw new Error(`Product image audit table preflight failed: ${auditTableError.message}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const rows = readProductImageManifest(manifestPath)
+  const payloads = buildPublishPayloads(rows, batchDir, { batchId, expectedCount })
+
+  console.log(
+    `Validated ${payloads.length} approved image payloads from ${manifestPath} for batch ${batchId}.`,
+  )
+  await preflightStorageBucket()
+  console.log("Storage bucket preflight passed.")
+  await preflightDatabase(payloads)
+  console.log("Database preflight passed.")
+
+  for (const payload of payloads) {
+    const alreadyUploaded = await storageObjectExists(payload.storagePath)
+    let uploadedThisRun = false
+
+    if (dry) {
+      console.log(
+        `DRY product=${payload.productId} upload=${payload.storagePath} exists=${alreadyUploaded} url=${payload.publicUrl}`,
+      )
+      continue
+    }
+
+    if (!alreadyUploaded) {
+      const file = readFileSync(payload.localFilePath)
+      const { error: uploadError } = await supabase.storage
+        .from(PRODUCT_IMAGE_BUCKET)
+        .upload(payload.storagePath, file, {
+          contentType: contentTypeFor(payload.localFilePath),
+          cacheControl: "31536000",
+          upsert: false,
+        })
+
+      if (uploadError) {
+        throw new Error(`Upload failed for ${payload.storagePath}: ${uploadError.message}`)
+      }
+      uploadedThisRun = true
+    }
+
+    try {
+      const { error: publishError } = await supabase.rpc("publish_product_image_asset", {
+        p_product_id: payload.auditRow.product_id,
+        p_storage_bucket: payload.auditRow.storage_bucket,
+        p_storage_path: payload.auditRow.storage_path,
+        p_public_url: payload.auditRow.public_url,
+        p_source_page_url: payload.auditRow.source_page_url,
+        p_source_image_url: payload.auditRow.source_image_url,
+        p_source_type: payload.auditRow.source_type,
+        p_quality_confidence: payload.auditRow.quality_confidence,
+        p_processing_method: payload.auditRow.processing_method,
+        p_asset_sha256: payload.auditRow.asset_sha256,
+        p_manifest_batch_id: payload.auditRow.manifest_batch_id,
+        p_user_approved: payload.auditRow.user_approved,
+        p_notes: payload.auditRow.notes,
+      })
+      if (publishError) throw publishError
+    } catch (error) {
+      if (uploadedThisRun) {
+        const { error: cleanupError } = await supabase.storage
+          .from(PRODUCT_IMAGE_BUCKET)
+          .remove([payload.storagePath])
+        if (cleanupError) {
+          console.error(`Cleanup failed for ${payload.storagePath}: ${cleanupError.message}`)
+        }
+      }
+      throw error
+    }
+
+    console.log(`OK product=${payload.productId} url=${payload.publicUrl}`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/product-images/qa-composite.swift
+++ b/scripts/product-images/qa-composite.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreImage
+import AppKit
+
+// usage: swift qa_composite.swift <outputDir> <input pngs...>
+// Composites each cutout onto a magenta background to inspect edge quality.
+let outputDir = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+let ciContext = CIContext()
+
+for path in CommandLine.arguments.dropFirst(2) {
+    let url = URL(fileURLWithPath: path)
+    guard let img = CIImage(contentsOf: url) else { continue }
+    let bg = CIImage(color: CIColor(red: 1, green: 0, blue: 1)).cropped(to: img.extent)
+    let composited = img.composited(over: bg)
+    let outURL = outputDir.appendingPathComponent(url.lastPathComponent)
+    try ciContext.writePNGRepresentation(of: composited, to: outURL, format: .RGBA8,
+                                         colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!)
+}
+print("done")

--- a/scripts/product-images/remove-baked-shadow.py
+++ b/scripts/product-images/remove-baked-shadow.py
@@ -3,6 +3,16 @@
 Shadow = dark, desaturated pixels connected to the OUTER boundary of the
 alpha silhouette. Label text/badges are dark too, but they are interior
 islands fully surrounded by bright product pixels, so they survive.
+
+Usage: remove-baked-shadow.py <input> <output.png> [min_sat]
+
+min_sat (optional, default 0): only treat dark pixels with
+max(r,g,b)-min(r,g,b) >= min_sat as shadow candidates. Use ~10 when the
+shadow touches a dark product feature (badge, dark label edge) — cast
+shadows are usually warm-tinted while product darks are neutral, so the
+saturation gate separates them. Verify per image: compare the saturation
+of shadow vs. product dark pixels first (catalog-2026-06-10-02 #39 had
+shadow sat 14-20 vs badge sat 0-6).
 """
 import sys
 import numpy as np
@@ -13,7 +23,7 @@ DARK_LUM = 185        # core shadow luminance
 FADE_LUM = 238        # anti-aliased shadow fade
 FADE_RADIUS = 4       # how far the fade-extension may grow from core shadow
 
-def deshadow(src_path, out_path):
+def deshadow(src_path, out_path, min_sat=0):
     im = Image.open(src_path).convert('RGBA')
     arr = np.array(im)
     rgb = arr[:, :, :3].astype(float)
@@ -28,6 +38,9 @@ def deshadow(src_path, out_path):
 
     # core shadow: dark pixels connected to the boundary
     dark = (lum < DARK_LUM) & mask
+    if min_sat > 0:
+        sat = rgb.max(axis=2) - rgb.min(axis=2)
+        dark &= sat >= min_sat
     labels, n = ndimage.label(dark)
     touching = np.unique(labels[boundary & dark])
     touching = touching[touching > 0]
@@ -56,4 +69,4 @@ def deshadow(src_path, out_path):
     print(f"OK: {out_path.split('/')[-1]}  (removed {removed:.1%} of silhouette)")
 
 if __name__ == '__main__':
-    deshadow(sys.argv[1], sys.argv[2])
+    deshadow(sys.argv[1], sys.argv[2], float(sys.argv[3]) if len(sys.argv) > 3 else 0)

--- a/scripts/product-images/remove-baked-shadow.py
+++ b/scripts/product-images/remove-baked-shadow.py
@@ -1,0 +1,59 @@
+"""Remove baked-in drop shadows from product cutouts with alpha channels.
+
+Shadow = dark, desaturated pixels connected to the OUTER boundary of the
+alpha silhouette. Label text/badges are dark too, but they are interior
+islands fully surrounded by bright product pixels, so they survive.
+"""
+import sys
+import numpy as np
+from PIL import Image
+from scipy import ndimage
+
+DARK_LUM = 185        # core shadow luminance
+FADE_LUM = 238        # anti-aliased shadow fade
+FADE_RADIUS = 4       # how far the fade-extension may grow from core shadow
+
+def deshadow(src_path, out_path):
+    im = Image.open(src_path).convert('RGBA')
+    arr = np.array(im)
+    rgb = arr[:, :, :3].astype(float)
+    alpha = arr[:, :, 3].astype(float)
+
+    lum = rgb @ [0.299, 0.587, 0.114]
+    mask = alpha > 0
+
+    # outer boundary of the silhouette
+    outside = ~mask
+    boundary = ndimage.binary_dilation(outside, iterations=2) & mask
+
+    # core shadow: dark pixels connected to the boundary
+    dark = (lum < DARK_LUM) & mask
+    labels, n = ndimage.label(dark)
+    touching = np.unique(labels[boundary & dark])
+    touching = touching[touching > 0]
+    shadow = np.isin(labels, touching)
+
+    # extend into the anti-aliased fade around the core shadow
+    fade = (lum < FADE_LUM) & mask
+    shadow = ndimage.binary_dilation(shadow, mask=fade, iterations=FADE_RADIUS)
+
+    # also kill remaining semi-transparent fringe touching the shadow
+    semi = (alpha < 250) & mask
+    shadow = ndimage.binary_dilation(shadow, mask=semi, iterations=FADE_RADIUS)
+
+    new_alpha = alpha.copy()
+    new_alpha[shadow] = 0
+
+    # feather only around the cut: soften the new hard edge
+    cut_zone = ndimage.binary_dilation(shadow, iterations=3) & ~shadow
+    blurred = ndimage.gaussian_filter(new_alpha, sigma=1.2)
+    new_alpha[cut_zone] = blurred[cut_zone]
+
+    out = arr.copy()
+    out[:, :, 3] = np.clip(new_alpha, 0, 255).astype(np.uint8)
+    Image.fromarray(out).save(out_path)
+    removed = shadow.sum() / mask.sum()
+    print(f"OK: {out_path.split('/')[-1]}  (removed {removed:.1%} of silhouette)")
+
+if __name__ == '__main__':
+    deshadow(sys.argv[1], sys.argv[2])

--- a/scripts/product-images/removebg-padded.swift
+++ b/scripts/product-images/removebg-padded.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Vision
+import CoreImage
+import AppKit
+
+// usage: swift removebg_padded.swift <input> <output.png>
+// Pads the image with a white border so Vision can find a frame-filling subject,
+// then crops the cutout back to the original canvas.
+let inputURL = URL(fileURLWithPath: CommandLine.arguments[1])
+let outURL = URL(fileURLWithPath: CommandLine.arguments[2])
+
+guard let original = CIImage(contentsOf: inputURL) else {
+    print("cannot read \(inputURL.path)"); exit(1)
+}
+let pad: CGFloat = 100
+let extent = original.extent
+let canvas = CGRect(x: 0, y: 0, width: extent.width + 2 * pad, height: extent.height + 2 * pad)
+let white = CIImage(color: .white).cropped(to: canvas)
+let padded = original.transformed(by: .init(translationX: pad, y: pad)).composited(over: white)
+
+let handler = VNImageRequestHandler(ciImage: padded, options: [:])
+let request = VNGenerateForegroundInstanceMaskRequest()
+try handler.perform([request])
+guard let result = request.results?.first else {
+    print("still no subject found"); exit(1)
+}
+let maskedBuffer = try result.generateMaskedImage(
+    ofInstances: result.allInstances,
+    from: handler,
+    croppedToInstancesExtent: false
+)
+// Crop back to original canvas
+let masked = CIImage(cvPixelBuffer: maskedBuffer)
+    .cropped(to: CGRect(x: pad, y: pad, width: extent.width, height: extent.height))
+    .transformed(by: .init(translationX: -pad, y: -pad))
+
+let ciContext = CIContext()
+try ciContext.writePNGRepresentation(of: masked, to: outURL, format: .RGBA8,
+                                     colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!)
+print("OK: \(outURL.lastPathComponent)")

--- a/scripts/product-images/removebg.swift
+++ b/scripts/product-images/removebg.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Vision
+import CoreImage
+import AppKit
+
+// usage: swift removebg.swift <outputDir> <input files...>
+guard CommandLine.arguments.count >= 3 else {
+    print("usage: removebg <outputDir> <input files...>")
+    exit(1)
+}
+
+let outputDir = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+
+let ciContext = CIContext()
+let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+
+for path in CommandLine.arguments.dropFirst(2) {
+    let inputURL = URL(fileURLWithPath: path)
+    guard let inputImage = CIImage(contentsOf: inputURL) else {
+        print("SKIP (cannot read): \(inputURL.lastPathComponent)")
+        continue
+    }
+    let handler = VNImageRequestHandler(ciImage: inputImage, options: [:])
+    let request = VNGenerateForegroundInstanceMaskRequest()
+    do {
+        try handler.perform([request])
+        guard let result = request.results?.first else {
+            print("SKIP (no subject found): \(inputURL.lastPathComponent)")
+            continue
+        }
+        // Soft-matted cutout on the original canvas size
+        let maskedBuffer = try result.generateMaskedImage(
+            ofInstances: result.allInstances,
+            from: handler,
+            croppedToInstancesExtent: false
+        )
+        let masked = CIImage(cvPixelBuffer: maskedBuffer)
+        let baseName = inputURL.deletingPathExtension().lastPathComponent
+        let outURL = outputDir.appendingPathComponent(baseName + ".png")
+        try ciContext.writePNGRepresentation(of: masked, to: outURL, format: .RGBA8, colorSpace: colorSpace)
+        print("OK: \(outURL.lastPathComponent)")
+    } catch {
+        print("FAIL: \(inputURL.lastPathComponent) — \(error.localizedDescription)")
+    }
+}

--- a/scripts/product-images/scrape-pilot-images.ts
+++ b/scripts/product-images/scrape-pilot-images.ts
@@ -1,0 +1,751 @@
+import { createHash } from "node:crypto"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { basename, dirname, extname, join, relative, resolve } from "node:path"
+import { chromium, type Browser } from "playwright"
+
+const batchDir =
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+  "data/product-images/pilot-2026-06-10"
+const pilotPath =
+  process.argv.find((arg) => arg.startsWith("--pilot="))?.slice("--pilot=".length) ??
+  join(batchDir, "pilot-products.csv")
+const candidatesDir = join(batchDir, "candidates")
+const reviewPath = join(batchDir, "review.html")
+const reportPath = join(batchDir, "image-candidates.json")
+
+interface PilotProduct {
+  id: string
+  brand: string
+  name: string
+  category: string
+  affiliate_link: string
+  notes: string
+}
+
+interface ImageCandidate {
+  url: string
+  source: string
+  score: number
+  localPath?: string
+  contentType?: string
+  bytes?: number
+  sha256?: string
+  error?: string
+}
+
+interface ProductResult {
+  product: PilotProduct
+  pageStatus?: number
+  pageError?: string
+  candidates: ImageCandidate[]
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = []
+  let current = ""
+  let quoted = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    const next = line[index + 1]
+
+    if (char === '"' && quoted && next === '"') {
+      current += '"'
+      index += 1
+      continue
+    }
+    if (char === '"') {
+      quoted = !quoted
+      continue
+    }
+    if (char === "," && !quoted) {
+      values.push(current)
+      current = ""
+      continue
+    }
+    current += char
+  }
+
+  values.push(current)
+  return values
+}
+
+function readPilotProducts(path: string): PilotProduct[] {
+  const lines = readFileSync(path, "utf8")
+    .replace(/\r/g, "")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+  const header = parseCsvLine(lines[0] ?? "")
+
+  return lines.slice(1).map((line) => {
+    const values = parseCsvLine(line)
+    return Object.fromEntries(
+      header.map((key, index) => [key, values[index] ?? ""]),
+    ) as PilotProduct
+  })
+}
+
+function decodeUrlish(value: string): string {
+  return value
+    .replace(/\\u002F/g, "/")
+    .replace(/\\\//g, "/")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .trim()
+}
+
+function addCandidate(
+  candidates: Map<string, ImageCandidate>,
+  pageUrl: string,
+  rawUrl: string | undefined,
+  source: string,
+  baseScore: number,
+  bonus = 0,
+): void {
+  if (!rawUrl) return
+
+  const candidateUrl = decodeUrlish(rawUrl).trim().split(/\s+/)[0]
+  if (!candidateUrl) return
+
+  let url: URL
+  try {
+    url = new URL(candidateUrl, pageUrl)
+  } catch {
+    return
+  }
+
+  if (!["http:", "https:"].includes(url.protocol)) return
+
+  const normalized = url.toString()
+  const lower = normalized.toLowerCase()
+  const looksLikeImage =
+    /\.(webp|png|jpe?g)(\?|$)/.test(lower) ||
+    lower.includes("/image") ||
+    lower.includes("image=") ||
+    lower.includes("images")
+  if (!looksLikeImage) return
+
+  let score = baseScore + bonus
+  if (lower.includes("product")) score += 8
+  if (lower.includes("pdm") || lower.includes("media")) score += 4
+  if (lower.includes("1200") || lower.includes("1000") || lower.includes("800")) score += 4
+  if (lower.includes("thumbnail") || lower.includes("thumb")) score -= 4
+  if (lower.includes("logo") || lower.includes("icon") || lower.includes("sprite")) score -= 20
+  if (lower.includes("placeholder") || lower.includes("transparent")) score -= 20
+
+  const previous = candidates.get(normalized)
+  if (!previous || previous.score < score) {
+    candidates.set(normalized, { url: normalized, source, score })
+  }
+}
+
+function addSrcsetCandidates(
+  candidates: Map<string, ImageCandidate>,
+  pageUrl: string,
+  rawSrcset: string | undefined,
+  source: string,
+  baseScore: number,
+): void {
+  if (!rawSrcset) return
+
+  for (const part of decodeUrlish(rawSrcset).split(/,\s+(?=\S)/)) {
+    addCandidate(candidates, pageUrl, part, source, baseScore)
+  }
+}
+
+function extractJsonLdImages(value: unknown): string[] {
+  if (!value) return []
+  if (Array.isArray(value)) return value.flatMap(extractJsonLdImages)
+  if (typeof value === "string") return [value]
+  if (typeof value !== "object") return []
+
+  const record = value as Record<string, unknown>
+  return [
+    ...extractJsonLdImages(record.image),
+    ...extractJsonLdImages(record.images),
+    ...extractJsonLdImages(record.thumbnailUrl),
+    ...extractJsonLdImages(record.offers),
+    ...extractJsonLdImages(record["@graph"]),
+  ]
+}
+
+function extractCandidates(pageUrl: string, html: string): ImageCandidate[] {
+  const candidates = new Map<string, ImageCandidate>()
+
+  for (const match of html.matchAll(
+    /<meta[^>]+(?:property|name)=["'](?:og:image(?::secure_url)?|twitter:image|twitter:image:src)["'][^>]+content=["']([^"']+)["'][^>]*>/gi,
+  )) {
+    addCandidate(candidates, pageUrl, match[1], "meta", 90)
+  }
+
+  for (const match of html.matchAll(
+    /<link[^>]+rel=["'][^"']*(?:image_src|preload)[^"']*["'][^>]+href=["']([^"']+)["'][^>]*>/gi,
+  )) {
+    addCandidate(candidates, pageUrl, match[1], "link", 65)
+  }
+
+  for (const match of html.matchAll(
+    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+  )) {
+    try {
+      const parsed = JSON.parse(decodeUrlish(match[1] ?? ""))
+      for (const image of extractJsonLdImages(parsed)) {
+        addCandidate(candidates, pageUrl, image, "json-ld", 95)
+      }
+    } catch {
+      // Some shops emit malformed JSON-LD. Other extractors still cover them.
+    }
+  }
+
+  for (const match of html.matchAll(
+    /<img[^>]+(?:src|data-src|data-original|data-image|data-zoom-image)=["']([^"']+)["'][^>]*>/gi,
+  )) {
+    addCandidate(candidates, pageUrl, match[1], "img", 50)
+  }
+
+  for (const match of html.matchAll(/<(?:img|source)[^>]+srcset=["']([^"']+)["'][^>]*>/gi)) {
+    addSrcsetCandidates(candidates, pageUrl, match[1], "srcset", 55)
+  }
+
+  for (const match of html.matchAll(
+    /https?:\\?\/\\?\/[^"' <>)]+?\.(?:webp|png|jpe?g)(?:\?[^"' <>)]+)?/gi,
+  )) {
+    addCandidate(candidates, pageUrl, match[0], "raw-url", 35)
+  }
+
+  return [...candidates.values()]
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6)
+}
+
+function mergeCandidates(...groups: ImageCandidate[][]): ImageCandidate[] {
+  const candidates = new Map<string, ImageCandidate>()
+
+  for (const group of groups) {
+    for (const candidate of group) {
+      const previous = candidates.get(candidate.url)
+      if (!previous || previous.score < candidate.score) {
+        candidates.set(candidate.url, candidate)
+      }
+    }
+  }
+
+  return [...candidates.values()]
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6)
+}
+
+function productMatchBonus(product: PilotProduct, value: string): number {
+  const haystack = value.toLowerCase()
+  const words = `${product.brand} ${product.name}`
+    .toLowerCase()
+    .split(/[^a-z0-9äöüß]+/i)
+    .filter((word) => word.length >= 4)
+
+  return words.filter((word) => haystack.includes(word)).length * 3
+}
+
+async function extractBrowserCandidates(
+  browser: Browser,
+  product: PilotProduct,
+): Promise<ImageCandidate[]> {
+  const candidates = new Map<string, ImageCandidate>()
+  const page = await browser.newPage({
+    locale: "de-DE",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+  })
+
+  try {
+    await page.goto(product.affiliate_link, { waitUntil: "domcontentloaded", timeout: 30000 })
+    await page.waitForTimeout(3000)
+
+    const rendered = await page.evaluate(() => {
+      const metas = Array.from(document.querySelectorAll("meta"))
+        .map((meta) => ({
+          key: meta.getAttribute("property") || meta.getAttribute("name") || "",
+          content: meta.getAttribute("content") || "",
+        }))
+        .filter((meta) => /image/i.test(meta.key))
+
+      const images = Array.from(document.images)
+        .map((image) => ({
+          src: image.currentSrc || image.src,
+          alt: image.alt || "",
+          width: image.naturalWidth,
+          height: image.naturalHeight,
+        }))
+        .filter((image) => image.src)
+
+      return { metas, images }
+    })
+
+    for (const meta of rendered.metas) {
+      addCandidate(
+        candidates,
+        product.affiliate_link,
+        meta.content,
+        "browser-meta",
+        110,
+        productMatchBonus(product, meta.content),
+      )
+    }
+
+    for (const image of rendered.images) {
+      const dimensionsBonus = Math.min(image.width, image.height) >= 250 ? 12 : 0
+      const productBonus = productMatchBonus(product, `${image.alt} ${image.src}`)
+      const penalty = /logo|icon|sprite|star|rating|payback|seal/i.test(`${image.alt} ${image.src}`)
+        ? -30
+        : 0
+      addCandidate(
+        candidates,
+        product.affiliate_link,
+        image.src,
+        "browser-img",
+        70,
+        dimensionsBonus + productBonus + penalty,
+      )
+    }
+  } finally {
+    await page.close()
+  }
+
+  return [...candidates.values()]
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6)
+}
+
+function extensionFor(url: string, contentType?: string | null): string {
+  const fromContentType = contentType?.split(";")[0]?.trim().toLowerCase()
+  if (fromContentType === "image/webp") return ".webp"
+  if (fromContentType === "image/png") return ".png"
+  if (fromContentType === "image/jpeg") return ".jpg"
+  if (fromContentType === "image/avif") return ".avif"
+
+  const ext = extname(new URL(url).pathname).toLowerCase()
+  if ([".webp", ".png", ".jpg", ".jpeg", ".avif"].includes(ext)) return ext
+  return ".jpg"
+}
+
+function safeFileName(
+  product: PilotProduct,
+  index: number,
+  url: string,
+  contentType?: string | null,
+): string {
+  const slug = `${product.brand}-${product.name}`
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80)
+  return `${String(index + 1).padStart(2, "0")}-${slug || product.id}${extensionFor(url, contentType)}`
+}
+
+async function fetchText(url: string): Promise<{ status: number; html: string }> {
+  const response = await fetch(url, {
+    headers: {
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "accept-language": "de-DE,de;q=0.9,en;q=0.8",
+      "user-agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+    },
+  })
+  return { status: response.status, html: await response.text() }
+}
+
+async function downloadCandidate(
+  product: PilotProduct,
+  candidate: ImageCandidate,
+  productDir: string,
+  index: number,
+): Promise<ImageCandidate> {
+  try {
+    const response = await fetch(candidate.url, {
+      headers: {
+        accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+        referer: product.affiliate_link,
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+      },
+    })
+
+    if (!response.ok) {
+      return { ...candidate, error: `download status ${response.status}` }
+    }
+
+    const contentType = response.headers.get("content-type")
+    if (!contentType?.startsWith("image/")) {
+      return {
+        ...candidate,
+        contentType: contentType ?? undefined,
+        error: "download was not an image",
+      }
+    }
+    if (contentType.includes("svg")) {
+      return { ...candidate, contentType, error: "skipped svg/non-product asset" }
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    if (buffer.byteLength < 12000) {
+      return {
+        ...candidate,
+        contentType,
+        bytes: buffer.byteLength,
+        error: "skipped tiny image asset",
+      }
+    }
+    const localPath = join(productDir, safeFileName(product, index, candidate.url, contentType))
+    writeFileSync(localPath, buffer)
+
+    return {
+      ...candidate,
+      localPath,
+      contentType,
+      bytes: buffer.byteLength,
+      sha256: createHash("sha256").update(buffer).digest("hex"),
+    }
+  } catch (error) {
+    return { ...candidate, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}
+
+function writeReview(results: ProductResult[]): void {
+  const reviewDir = dirname(resolve(reviewPath))
+  const batchLabel = basename(resolve(batchDir))
+  const body = results
+    .map((result, productIndex) => {
+      const usableCandidates = result.candidates.filter(
+        (candidate) => candidate.localPath && !candidate.error,
+      )
+      const failedCandidates = result.candidates.filter(
+        (candidate) => candidate.error || !candidate.localPath,
+      )
+      const candidates = usableCandidates
+        .map((candidate, candidateIndex) => {
+          const reviewImagePath = candidate.localPath
+            ? relative(reviewDir, resolve(candidate.localPath))
+            : undefined
+          const candidateId = `${result.product.id}:${candidateIndex}`
+          return `<article class="candidate" data-product-id="${htmlEscape(result.product.id)}" data-candidate-id="${htmlEscape(candidateId)}" data-candidate-url="${htmlEscape(candidate.url)}" data-local-path="${htmlEscape(candidate.localPath ?? "")}" data-source="${htmlEscape(candidate.source)}">
+            <button class="imageButton" type="button" data-action="select" aria-label="Select candidate">
+              <img src="${htmlEscape(reviewImagePath ?? candidate.localPath ?? "")}" alt="">
+            </button>
+            <div class="candidateMeta">
+              <strong>${htmlEscape(candidate.source)}</strong> score ${candidate.score}
+              ${candidate.bytes ? `<span>${Math.round(candidate.bytes / 1024)} KB</span>` : ""}
+              <a href="${htmlEscape(candidate.url)}" target="_blank" rel="noreferrer">source</a>
+            </div>
+            <div class="actions" role="group" aria-label="Candidate review">
+              <button type="button" data-rating="good">Good</button>
+              <button type="button" data-rating="maybe">Maybe</button>
+              <button type="button" data-rating="bad">Bad</button>
+            </div>
+          </article>`
+        })
+        .join("")
+      const failed = failedCandidates
+        .map(
+          (candidate) =>
+            `<li><strong>${htmlEscape(candidate.source)}</strong>: ${htmlEscape(candidate.error ?? "not downloaded")} · <a href="${htmlEscape(candidate.url)}" target="_blank" rel="noreferrer">source</a></li>`,
+        )
+        .join("")
+
+      return `<section>
+        <header class="productHeader">
+          <div>
+            <p class="index">${productIndex + 1} / ${results.length}</p>
+            <h2>${htmlEscape(result.product.brand)} ${htmlEscape(result.product.name)}</h2>
+            <p>${htmlEscape(result.product.category)} · <a href="${htmlEscape(result.product.affiliate_link)}" target="_blank" rel="noreferrer">product page</a></p>
+          </div>
+          <div class="productDecision" data-product-id="${htmlEscape(result.product.id)}">
+            <button type="button" data-product-rating="approved">Approve Product</button>
+            <button type="button" data-product-rating="needs_work">Needs Work</button>
+            <button type="button" data-product-rating="reject">Reject</button>
+          </div>
+          ${result.pageError ? `<p class="error">${htmlEscape(result.pageError)}</p>` : ""}
+        </header>
+        <div class="grid">${candidates || '<p class="error">No usable image candidates found.</p>'}</div>
+        <label class="comment">
+          Comment
+          <textarea data-comment-for="${htmlEscape(result.product.id)}" rows="2" placeholder="Exact product? Wrong packaging? Needs manual search?"></textarea>
+        </label>
+        ${
+          failed
+            ? `<details class="failed"><summary>${failedCandidates.length} hidden failed/noisy candidates</summary><ul>${failed}</ul></details>`
+            : ""
+        }
+      </section>`
+    })
+    .join("")
+
+  writeFileSync(
+    reviewPath,
+    `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Product Image Review - ${htmlEscape(batchLabel)}</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: #f7f4ef; color: #1d1b18; }
+    .topbar { position: sticky; top: 0; z-index: 5; display: flex; justify-content: space-between; gap: 16px; align-items: center; padding: 16px 32px; background: rgba(247, 244, 239, 0.96); border-bottom: 1px solid #d8d0c3; backdrop-filter: blur(8px); }
+    main { max-width: 1280px; margin: 0 auto; padding: 24px 32px 40px; }
+    h1 { font-size: 24px; margin: 0 0 4px; }
+    h2 { font-size: 18px; margin: 0; }
+    p { margin: 4px 0 0; color: #5e574d; }
+    section { border-top: 1px solid #d8d0c3; padding: 24px 0; }
+    .productHeader { display: flex; justify-content: space-between; gap: 16px; align-items: start; }
+    .index { font-size: 12px; text-transform: uppercase; letter-spacing: 0; color: #81786b; }
+    .summary { font-size: 14px; color: #5e574d; }
+    .toolbar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+    button, .download { appearance: none; border: 1px solid #cfc5b6; background: #fffaf1; color: #29251f; border-radius: 6px; padding: 8px 10px; font: inherit; font-size: 13px; cursor: pointer; text-decoration: none; }
+    button:hover, .download:hover { background: #f0e7d7; }
+    button.active, .download.active { border-color: #78614a; background: #dfd1be; }
+    button[data-rating="good"].active, button[data-product-rating="approved"].active { border-color: #3c7a4b; background: #dcebd8; }
+    button[data-rating="maybe"].active, button[data-product-rating="needs_work"].active { border-color: #a66c19; background: #f4e2c2; }
+    button[data-rating="bad"].active, button[data-product-rating="reject"].active { border-color: #9b2c2c; background: #efd7d3; }
+    .productDecision { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 16px; margin-top: 16px; }
+    .candidate { margin: 0; background: #ebe6dd; border: 1px solid #d8d0c3; border-radius: 8px; overflow: hidden; }
+    .candidate.selected { outline: 3px solid #78614a; border-color: #78614a; }
+    .imageButton { display: block; width: 100%; padding: 0; border: 0; border-radius: 0; background: #f3efe8; }
+    img { width: 100%; aspect-ratio: 1; object-fit: contain; display: block; background: #f3efe8; }
+    .candidateMeta { padding: 10px 10px 0; font-size: 12px; line-height: 1.35; word-break: break-word; }
+    .candidateMeta span { display: block; color: #5e574d; }
+    .actions { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; padding: 10px; }
+    .actions button { padding: 7px 6px; }
+    .comment { display: grid; gap: 6px; margin-top: 14px; font-size: 13px; font-weight: 700; }
+    textarea { width: 100%; box-sizing: border-box; border: 1px solid #cfc5b6; border-radius: 6px; padding: 10px; background: #fffaf1; color: #1d1b18; font: inherit; resize: vertical; }
+    details { margin-top: 12px; color: #5e574d; font-size: 13px; }
+    li { margin: 4px 0; }
+    a { color: #67513d; }
+    .error { color: #9b2c2c; }
+    @media (max-width: 720px) {
+      .topbar, .productHeader { display: block; }
+      .toolbar, .productDecision { margin-top: 12px; justify-content: flex-start; }
+      main, .topbar { padding-left: 16px; padding-right: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="topbar">
+    <div>
+      <h1>Product Image Review</h1>
+      <p class="summary">${htmlEscape(batchLabel)} · <span id="progress">0 reviewed</span> · selections are saved in this browser</p>
+    </div>
+    <div class="toolbar">
+      <button type="button" id="showAll">Show All</button>
+      <button type="button" id="showOpen">Show Open</button>
+      <button type="button" id="copyJson">Copy JSON</button>
+      <a class="download" id="downloadJson" href="#">Download Review</a>
+    </div>
+  </div>
+  <main>
+    ${body}
+  </main>
+  <script>
+    const storageKey = "product-image-review-v2:" + window.location.pathname;
+    const review = JSON.parse(localStorage.getItem(storageKey) || "{}");
+
+    function productState(productId) {
+      review[productId] ||= { productRating: "", selectedCandidateId: "", candidateRatings: {}, comment: "" };
+      return review[productId];
+    }
+
+    function save() {
+      localStorage.setItem(storageKey, JSON.stringify(review, null, 2));
+      syncToServer();
+      render();
+    }
+
+    function syncToServer() {
+      const statePath = window.location.pathname.replace(/review\\.html$/, "review-state");
+      fetch(statePath, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(exportPayload(), null, 2)
+      }).catch(() => {});
+    }
+
+    function render() {
+      document.querySelectorAll("section").forEach((section) => {
+        const productId = section.querySelector("[data-product-id]")?.dataset.productId;
+        if (!productId) return;
+        const state = productState(productId);
+        section.querySelectorAll("[data-product-rating]").forEach((button) => {
+          button.classList.toggle("active", state.productRating === button.dataset.productRating);
+        });
+        section.querySelectorAll(".candidate").forEach((card) => {
+          const candidateId = card.dataset.candidateId;
+          card.classList.toggle("selected", state.selectedCandidateId === candidateId);
+          card.querySelectorAll("[data-rating]").forEach((button) => {
+            button.classList.toggle("active", state.candidateRatings[candidateId] === button.dataset.rating);
+          });
+        });
+        const textarea = section.querySelector("textarea");
+        if (textarea && document.activeElement !== textarea) textarea.value = state.comment || "";
+      });
+
+      const states = Object.values(review);
+      const reviewed = states.filter((state) => state.productRating || state.selectedCandidateId || state.comment).length;
+      document.getElementById("progress").textContent = reviewed + " / ${results.length} reviewed";
+      document.getElementById("downloadJson").href = URL.createObjectURL(
+        new Blob([JSON.stringify(exportPayload(), null, 2)], { type: "application/json" })
+      );
+      document.getElementById("downloadJson").download = "product-image-pilot-review.json";
+    }
+
+    function exportPayload() {
+      return Array.from(document.querySelectorAll("section")).map((section) => {
+        const productId = section.querySelector("[data-product-id]")?.dataset.productId;
+        const state = productState(productId);
+        const selected = state.selectedCandidateId
+          ? section.querySelector("[data-candidate-id='" + CSS.escape(state.selectedCandidateId) + "']")
+          : null;
+        return {
+          product_id: productId,
+          product: section.querySelector("h2")?.textContent || "",
+          product_rating: state.productRating,
+          selected_candidate_id: state.selectedCandidateId,
+          selected_image_url: selected?.dataset.candidateUrl || "",
+          selected_local_path: selected?.dataset.localPath || "",
+          selected_source: selected?.dataset.source || "",
+          candidate_ratings: state.candidateRatings,
+          comment: state.comment || ""
+        };
+      });
+    }
+
+    document.addEventListener("click", async (event) => {
+      const target = event.target.closest("button, a");
+      if (!target) return;
+
+      if (target.id === "showAll") {
+        document.querySelectorAll("section").forEach((section) => section.hidden = false);
+        return;
+      }
+      if (target.id === "showOpen") {
+        document.querySelectorAll("section").forEach((section) => {
+          const productId = section.querySelector("[data-product-id]")?.dataset.productId;
+          const state = productState(productId);
+          section.hidden = Boolean(state.productRating || state.selectedCandidateId || state.comment);
+        });
+        return;
+      }
+      if (target.id === "copyJson") {
+        await navigator.clipboard.writeText(JSON.stringify(exportPayload(), null, 2));
+        target.textContent = "Copied";
+        setTimeout(() => { target.textContent = "Copy JSON"; }, 1200);
+        return;
+      }
+
+      const candidate = target.closest(".candidate");
+      const productId = candidate?.dataset.productId || target.closest("[data-product-id]")?.dataset.productId;
+      if (!productId) return;
+
+      const state = productState(productId);
+      if (target.dataset.action === "select" && candidate) {
+        state.selectedCandidateId = candidate.dataset.candidateId;
+        state.candidateRatings[candidate.dataset.candidateId] = "good";
+        if (!state.productRating) state.productRating = "approved";
+        save();
+      }
+      if (target.dataset.rating && candidate) {
+        state.candidateRatings[candidate.dataset.candidateId] = target.dataset.rating;
+        if (target.dataset.rating === "good") {
+          state.selectedCandidateId = candidate.dataset.candidateId;
+          if (!state.productRating) state.productRating = "approved";
+        }
+        save();
+      }
+      if (target.dataset.productRating) {
+        state.productRating = target.dataset.productRating;
+        save();
+      }
+    });
+
+    document.addEventListener("input", (event) => {
+      if (!event.target.matches("textarea[data-comment-for]")) return;
+      const state = productState(event.target.dataset.commentFor);
+      state.comment = event.target.value;
+      save();
+    });
+
+    render();
+    syncToServer();
+  </script>
+</body>
+</html>
+`,
+  )
+}
+
+async function main(): Promise<void> {
+  mkdirSync(candidatesDir, { recursive: true })
+
+  const products = readPilotProducts(pilotPath)
+  const results: ProductResult[] = []
+  const browser = await chromium.launch({ headless: true })
+
+  try {
+    for (const [productIndex, product] of products.entries()) {
+      const productDir = join(
+        candidatesDir,
+        `${String(productIndex + 1).padStart(2, "0")}-${product.id}`,
+      )
+      mkdirSync(productDir, { recursive: true })
+
+      const result: ProductResult = { product, candidates: [] }
+      try {
+        const page = await fetchText(product.affiliate_link)
+        result.pageStatus = page.status
+        if (page.status >= 400) {
+          result.pageError = `Product page returned HTTP ${page.status}`
+        }
+
+        const staticCandidates = extractCandidates(product.affiliate_link, page.html)
+        const browserCandidates = await extractBrowserCandidates(browser, product)
+        const candidates = mergeCandidates(staticCandidates, browserCandidates)
+        result.candidates = await Promise.all(
+          candidates.map((candidate, index) =>
+            downloadCandidate(product, candidate, productDir, index),
+          ),
+        )
+      } catch (error) {
+        result.pageError = error instanceof Error ? error.message : String(error)
+      }
+
+      results.push(result)
+      const downloaded = result.candidates.filter((candidate) => candidate.localPath).length
+      console.log(
+        `${String(productIndex + 1).padStart(2, "0")}/${products.length} ${product.brand} ${product.name}: ${downloaded}/${result.candidates.length} downloaded`,
+      )
+    }
+  } finally {
+    await browser.close()
+  }
+
+  writeFileSync(reportPath, JSON.stringify(results, null, 2))
+  writeReview(results)
+
+  console.log(`Wrote ${reportPath}`)
+  console.log(`Wrote ${reviewPath}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/product-images/select-pilot-products.ts
+++ b/scripts/product-images/select-pilot-products.ts
@@ -1,0 +1,100 @@
+import { config as loadEnv } from "dotenv"
+import { mkdirSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
+import { createClient } from "@supabase/supabase-js"
+
+loadEnv({ path: ".env.local" })
+
+const outputPath =
+  process.argv.find((arg) => arg.startsWith("--out="))?.slice("--out=".length) ??
+  "data/product-images/pilot-2026-06-10/pilot-products.csv"
+const limit = Number(
+  process.argv.find((arg) => arg.startsWith("--limit="))?.slice("--limit=".length) ?? 20,
+)
+const allowPartial = process.argv.includes("--allow-partial")
+
+if (!Number.isInteger(limit) || limit <= 0) {
+  throw new Error(`--limit must be a positive integer, got ${limit}`)
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+})
+
+function csvCell(value: unknown): string {
+  const text = String(value ?? "")
+  return `"${text.replace(/"/g, '""')}"`
+}
+
+async function main(): Promise<void> {
+  const { data, error } = await supabase
+    .from("products")
+    .select("id,brand,name,category,affiliate_link,image_url,lifecycle_status,is_active")
+    .is("image_url", null)
+    .eq("is_active", true)
+    .order("category", { ascending: true })
+    .order("brand", { ascending: true })
+    .limit(Math.max(limit * 3, limit))
+
+  if (error) throw error
+
+  const rows = data ?? []
+  const byCategory = new Map<string, typeof rows>()
+
+  for (const row of rows) {
+    const key = row.category ?? "Uncategorized"
+    byCategory.set(key, [...(byCategory.get(key) ?? []), row])
+  }
+
+  const selected: typeof rows = []
+  for (const categoryRows of byCategory.values()) {
+    if (selected.length >= limit) break
+    if (categoryRows[0]) selected.push(categoryRows[0])
+  }
+  for (const row of rows) {
+    if (selected.length >= limit) break
+    if (!selected.some((entry) => entry.id === row.id)) selected.push(row)
+  }
+
+  if (selected.length < limit && !allowPartial) {
+    throw new Error(
+      `Expected ${limit} eligible products, found ${selected.length}. Use --allow-partial for the final batch.`,
+    )
+  }
+
+  mkdirSync(dirname(outputPath), { recursive: true })
+
+  const header = ["id", "brand", "name", "category", "affiliate_link", "notes"]
+  const csv = [
+    header.join(","),
+    ...selected
+      .slice(0, limit)
+      .map((row) =>
+        [
+          row.id,
+          row.brand,
+          row.name,
+          row.category,
+          row.affiliate_link,
+          "manual source review required",
+        ]
+          .map(csvCell)
+          .join(","),
+      ),
+  ].join("\n")
+
+  writeFileSync(outputPath, `${csv}\n`)
+  console.log(`Wrote ${Math.min(selected.length, limit)} products to ${outputPath}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/product-images/serve-review.ts
+++ b/scripts/product-images/serve-review.ts
@@ -1,0 +1,90 @@
+import { createReadStream, existsSync, writeFileSync } from "node:fs"
+import { createServer } from "node:http"
+import { extname, join, normalize, resolve } from "node:path"
+
+const batchDir = resolve(
+  process.argv.find((arg) => arg.startsWith("--batch-dir="))?.slice("--batch-dir=".length) ??
+    "data/product-images/pilot-2026-06-10",
+)
+const port = Number(
+  process.argv.find((arg) => arg.startsWith("--port="))?.slice("--port=".length) ?? 3357,
+)
+
+function contentType(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".html":
+      return "text/html; charset=utf-8"
+    case ".json":
+      return "application/json; charset=utf-8"
+    case ".webp":
+      return "image/webp"
+    case ".png":
+      return "image/png"
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg"
+    case ".avif":
+      return "image/avif"
+    default:
+      return "application/octet-stream"
+  }
+}
+
+function safePath(urlPath: string): string | null {
+  const relativePath = normalize(
+    decodeURIComponent(urlPath === "/" ? "/review.html" : urlPath),
+  ).replace(/^(\.\.[/\\])+/, "")
+  const fullPath = resolve(batchDir, `.${relativePath}`)
+  if (!fullPath.startsWith(batchDir)) return null
+  return fullPath
+}
+
+const server = createServer((request, response) => {
+  const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname
+
+  if (
+    request.method === "POST" &&
+    (requestPath.endsWith("/review-state") || requestPath.endsWith("/final-review-state"))
+  ) {
+    const statePath = safePath(`${requestPath}.json`)
+    const chunks: Buffer[] = []
+    request.on("data", (chunk) => chunks.push(Buffer.from(chunk)))
+    request.on("end", () => {
+      try {
+        if (!statePath) throw new Error("Invalid review state path")
+        const raw = Buffer.concat(chunks).toString("utf8")
+        const parsed = JSON.parse(raw)
+        writeFileSync(statePath, `${JSON.stringify(parsed, null, 2)}\n`)
+        response.writeHead(204).end()
+      } catch (error) {
+        response.writeHead(400, { "content-type": "text/plain; charset=utf-8" })
+        response.end(error instanceof Error ? error.message : String(error))
+      }
+    })
+    return
+  }
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405).end()
+    return
+  }
+
+  const filePath = safePath(new URL(request.url ?? "/", "http://127.0.0.1").pathname)
+  if (!filePath || !existsSync(filePath)) {
+    response.writeHead(404, { "content-type": "text/plain; charset=utf-8" })
+    response.end("Not found")
+    return
+  }
+
+  response.writeHead(200, { "content-type": contentType(filePath) })
+  if (request.method === "HEAD") {
+    response.end()
+    return
+  }
+  createReadStream(filePath).pipe(response)
+})
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Review server running at http://127.0.0.1:${port}/review.html`)
+  console.log(`Review state will be written beside each review.html`)
+})

--- a/src/components/chat/product-card.tsx
+++ b/src/components/chat/product-card.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/chat/product-display-model"
 import type { Product } from "@/lib/types"
 import { Icon, type IconName } from "@/components/ui/icon"
+import { ProductImage } from "./product-image"
 
 interface ProductCardProps {
   product: Product
@@ -50,17 +51,25 @@ export function ProductCard({ product, onClick }: ProductCardProps) {
   const iconName = categoryIconName(product.category)
   const facts = buildCompactProductFacts(product)
   const price = formatProductPrice(product.price_eur, product.currency)
+  const hasImage = Boolean(product.image_url)
 
   return (
     <button
       type="button"
       onClick={() => onClick(product)}
-      className="flex w-full min-w-0 cursor-pointer items-center gap-3 overflow-hidden rounded-xl border border-border bg-card p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
+      className={
+        hasImage
+          ? "grid w-full min-w-0 cursor-pointer grid-cols-[5.5rem_minmax(0,1fr)_auto_auto] items-center gap-3 overflow-hidden rounded-xl border border-border bg-card p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
+          : "flex w-full min-w-0 cursor-pointer items-center gap-3 overflow-hidden rounded-xl border border-border bg-card p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-sm"
+      }
     >
-      {/* Category icon */}
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[var(--brand-plum-ice)]">
-        <Icon name={iconName} size={18} className="text-primary" />
-      </div>
+      {product.image_url ? (
+        <ProductImage imageUrl={product.image_url} category={product.category} size="card" />
+      ) : (
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[var(--brand-plum-ice)]">
+          <Icon name={iconName} size={18} className="text-primary" />
+        </div>
+      )}
 
       {/* Product info */}
       <div className="min-w-0 flex-1">

--- a/src/components/chat/product-image.tsx
+++ b/src/components/chat/product-image.tsx
@@ -40,25 +40,28 @@ function getCategoryConfig(category: string | null) {
 interface ProductImageProps {
   imageUrl: string | null
   category: string | null
-  size?: "sm" | "md" | "lg"
+  size?: "sm" | "md" | "lg" | "card"
 }
 
 const SIZES = {
   sm: "h-10 w-10",
   md: "h-14 w-14",
   lg: "h-20 w-20",
+  card: "h-24 w-[5.5rem]",
 }
 
 const SIZE_PX = {
   sm: 40,
   md: 56,
   lg: 80,
+  card: 96,
 }
 
 const ICON_SIZES = {
   sm: "h-5 w-5",
   md: "h-7 w-7",
   lg: "h-10 w-10",
+  card: "h-8 w-8",
 }
 
 export function ProductImage({ imageUrl, category, size = "md" }: ProductImageProps) {
@@ -69,7 +72,7 @@ export function ProductImage({ imageUrl, category, size = "md" }: ProductImagePr
         alt=""
         width={SIZE_PX[size]}
         height={SIZE_PX[size]}
-        className={`${SIZES[size]} shrink-0 rounded-xl object-cover`}
+        className={`${SIZES[size]} shrink-0 rounded-xl object-contain`}
         unoptimized
       />
     )

--- a/supabase/migrations/20260610120000_product_image_assets.sql
+++ b/supabase/migrations/20260610120000_product_image_assets.sql
@@ -1,0 +1,138 @@
+-- Product image pilot storage + flat provenance metadata.
+-- Final product images are public catalog assets. Messy candidate research
+-- stays local; this table stores only approved published assets.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'product-images',
+  'product-images',
+  true,
+  2097152,
+  ARRAY['image/webp', 'image/png', 'image/jpeg']
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+CREATE TABLE IF NOT EXISTS public.product_image_assets (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  product_id uuid NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  storage_bucket text NOT NULL DEFAULT 'product-images',
+  storage_path text NOT NULL,
+  public_url text NOT NULL,
+  source_page_url text NOT NULL,
+  source_image_url text,
+  source_type text NOT NULL CHECK (
+    source_type IN ('brand', 'retailer', 'marketplace', 'search_result', 'unknown')
+  ),
+  quality_confidence text NOT NULL CHECK (
+    quality_confidence IN ('high', 'medium')
+  ),
+  processing_method text NOT NULL CHECK (
+    processing_method IN ('local', 'third_party', 'manual')
+  ),
+  asset_sha256 text NOT NULL CHECK (asset_sha256 ~ '^[a-f0-9]{64}$'),
+  manifest_batch_id text NOT NULL,
+  user_approved boolean NOT NULL DEFAULT false,
+  notes text,
+  published_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS product_image_assets_storage_path_idx
+  ON public.product_image_assets(storage_path);
+
+CREATE UNIQUE INDEX IF NOT EXISTS product_image_assets_product_id_idx
+  ON public.product_image_assets(product_id);
+
+CREATE INDEX IF NOT EXISTS product_image_assets_manifest_batch_id_idx
+  ON public.product_image_assets(manifest_batch_id);
+
+DROP TRIGGER IF EXISTS set_updated_at_product_image_assets ON public.product_image_assets;
+CREATE TRIGGER set_updated_at_product_image_assets
+  BEFORE UPDATE ON public.product_image_assets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE OR REPLACE FUNCTION public.publish_product_image_asset(
+  p_product_id uuid,
+  p_storage_bucket text,
+  p_storage_path text,
+  p_public_url text,
+  p_source_page_url text,
+  p_source_image_url text,
+  p_source_type text,
+  p_quality_confidence text,
+  p_processing_method text,
+  p_asset_sha256 text,
+  p_manifest_batch_id text,
+  p_user_approved boolean,
+  p_notes text
+)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.products
+  SET image_url = p_public_url
+  WHERE id = p_product_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Product not found: %', p_product_id;
+  END IF;
+
+  INSERT INTO public.product_image_assets (
+    product_id,
+    storage_bucket,
+    storage_path,
+    public_url,
+    source_page_url,
+    source_image_url,
+    source_type,
+    quality_confidence,
+    processing_method,
+    asset_sha256,
+    manifest_batch_id,
+    user_approved,
+    notes
+  )
+  VALUES (
+    p_product_id,
+    p_storage_bucket,
+    p_storage_path,
+    p_public_url,
+    p_source_page_url,
+    p_source_image_url,
+    p_source_type,
+    p_quality_confidence,
+    p_processing_method,
+    p_asset_sha256,
+    p_manifest_batch_id,
+    p_user_approved,
+    p_notes
+  )
+  ON CONFLICT (product_id) DO UPDATE
+  SET
+    storage_bucket = EXCLUDED.storage_bucket,
+    storage_path = EXCLUDED.storage_path,
+    public_url = EXCLUDED.public_url,
+    source_page_url = EXCLUDED.source_page_url,
+    source_image_url = EXCLUDED.source_image_url,
+    source_type = EXCLUDED.source_type,
+    quality_confidence = EXCLUDED.quality_confidence,
+    processing_method = EXCLUDED.processing_method,
+    asset_sha256 = EXCLUDED.asset_sha256,
+    manifest_batch_id = EXCLUDED.manifest_batch_id,
+    user_approved = EXCLUDED.user_approved,
+    notes = EXCLUDED.notes;
+END;
+$$;
+
+ALTER TABLE public.product_image_assets ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.product_image_assets IS
+  'Flat provenance table for approved published product image assets. Messy candidate research stays local.';

--- a/tests/product-images-manifest.test.ts
+++ b/tests/product-images-manifest.test.ts
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildPublishPayloads,
+  buildStoragePath,
+  validateManifestBatch,
+  validateManifestRow,
+} from "../scripts/product-images/manifest"
+
+const fakeHash = createHash("sha256").update("fake").digest("hex")
+
+test("buildStoragePath includes a content hash version", () => {
+  const path = buildStoragePath({
+    product_id: "11111111-1111-1111-1111-111111111111",
+    brand: "Brand",
+    name: "Name",
+    category: "Shampoo",
+    source_page_url: "https://example.com/product",
+    source_image_url: "https://example.com/product.jpg",
+    source_type: "brand",
+    quality_confidence: "high",
+    processing_method: "local",
+    final_file: "final/brand-name.webp",
+    asset_sha256: fakeHash,
+    user_approved: "yes",
+    notes: "",
+  })
+
+  assert.equal(
+    path,
+    `pilot-2026-06-10/11111111-1111-1111-1111-111111111111/brand-name-${fakeHash.slice(0, 12)}.webp`,
+  )
+})
+
+test("buildStoragePath accepts an explicit batch id", () => {
+  const path = buildStoragePath(
+    {
+      product_id: "11111111-1111-1111-1111-111111111111",
+      brand: "Brand",
+      name: "Name",
+      category: "Shampoo",
+      source_page_url: "https://example.com/product",
+      source_image_url: "https://example.com/product.jpg",
+      source_type: "brand",
+      quality_confidence: "high",
+      processing_method: "local",
+      final_file: "final/brand-name.webp",
+      asset_sha256: fakeHash,
+      user_approved: "yes",
+      notes: "",
+    },
+    "catalog-2026-06-11",
+  )
+
+  assert.equal(
+    path,
+    `catalog-2026-06-11/11111111-1111-1111-1111-111111111111/brand-name-${fakeHash.slice(0, 12)}.webp`,
+  )
+})
+
+test("manifest rows require user approval before publish", () => {
+  assert.throws(
+    () =>
+      validateManifestRow(
+        {
+          product_id: "p1",
+          source_page_url: "https://example.com",
+          source_image_url: "",
+          source_type: "brand",
+          quality_confidence: "high",
+          processing_method: "local",
+          final_file: "final/p1.webp",
+          asset_sha256: fakeHash,
+          user_approved: "no",
+          brand: "",
+          name: "",
+          category: "",
+          notes: "",
+        },
+        2,
+      ),
+    /user_approved must be yes/,
+  )
+})
+
+test("unknown source rows require notes without throwing TypeError", () => {
+  assert.throws(
+    () =>
+      validateManifestRow(
+        {
+          product_id: "p1",
+          source_page_url: "https://example.com",
+          source_image_url: "",
+          source_type: "unknown",
+          quality_confidence: "medium",
+          processing_method: "manual",
+          final_file: "final/p1.webp",
+          asset_sha256: fakeHash,
+          user_approved: "yes",
+          brand: "",
+          name: "",
+          category: "",
+        },
+        3,
+      ),
+    /notes are required/,
+  )
+})
+
+test("buildPublishPayloads verifies file hash and maps audit payload", () => {
+  const dir = mkdtempSync(join(tmpdir(), "product-images-"))
+  writeFileSync(join(dir, "p1.webp"), "fake")
+
+  const payloads = buildPublishPayloads(
+    [
+      {
+        product_id: "22222222-2222-2222-2222-222222222222",
+        brand: "Brand",
+        name: "Name",
+        category: "Maske",
+        source_page_url: "https://example.com/product",
+        source_image_url: "",
+        source_type: "retailer",
+        quality_confidence: "medium",
+        processing_method: "third_party",
+        final_file: "p1.webp",
+        asset_sha256: fakeHash,
+        user_approved: "yes",
+        notes: "exact SKU match",
+      },
+    ],
+    dir,
+    { batchId: "catalog-2026-06-11", expectedCount: 1 },
+  )
+
+  assert.equal(payloads[0].storageBucket, "product-images")
+  assert.equal(payloads[0].auditRow.manifest_batch_id, "catalog-2026-06-11")
+  assert.match(payloads[0].storagePath, /^catalog-2026-06-11\//)
+  assert.equal(payloads[0].auditRow.user_approved, true)
+  assert.equal(payloads[0].auditRow.source_image_url, null)
+  assert.match(payloads[0].publicUrl, /storage\/v1\/object\/public\/product-images/)
+})
+
+test("pilot manifest requires exactly 20 products", () => {
+  assert.throws(() => validateManifestBatch([], 20), /exactly 20 approved products/)
+})
+
+test("pilot manifest rejects duplicate product ids", () => {
+  const row = {
+    product_id: "33333333-3333-3333-3333-333333333333",
+    brand: "Brand",
+    name: "Name",
+    category: "Maske",
+    source_page_url: "https://example.com/product",
+    source_image_url: "",
+    source_type: "brand" as const,
+    quality_confidence: "high" as const,
+    processing_method: "local" as const,
+    final_file: "p1.webp",
+    asset_sha256: fakeHash,
+    user_approved: "yes" as const,
+    notes: "",
+  }
+
+  assert.throws(() => validateManifestBatch([row, row], 2), /duplicate product_id/)
+})
+
+test("buildPublishPayloads rejects files outside the batch directory", () => {
+  const dir = mkdtempSync(join(tmpdir(), "product-images-"))
+
+  assert.throws(
+    () =>
+      buildPublishPayloads(
+        [
+          {
+            product_id: "44444444-4444-4444-4444-444444444444",
+            brand: "Brand",
+            name: "Name",
+            category: "Maske",
+            source_page_url: "https://example.com/product",
+            source_image_url: "",
+            source_type: "brand",
+            quality_confidence: "high",
+            processing_method: "local",
+            final_file: "../outside.webp",
+            asset_sha256: fakeHash,
+            user_approved: "yes",
+            notes: "",
+          },
+        ],
+        dir,
+        { expectedCount: 1 },
+      ),
+    /inside the batch directory/,
+  )
+})


### PR DESCRIPTION
## Why

Product recommendation cards need reviewed product images instead of category icons wherever we have a confident exact-product match. We also need a repeatable local process for sourcing, reviewing, cutting out, publishing, and auditing catalog images without sending messy scrape artifacts to Supabase.

## What changed

- Adds a reviewed product image pipeline under `scripts/product-images/` for selection, scraping, review-state merging, final compositing, manifest validation, and Supabase publishing.
- Adds the one-time Supabase setup migration for the public `product-images` bucket, `product_image_assets` provenance table, and `publish_product_image_asset` RPC.
- Updates recommendation product cards to render `products.image_url` when present, while preserving the existing category icon fallback.
- Allows the Supabase Storage host in Next image config.
- Documents the background-removal workflow, the pilot runbook, Claude doc review, and the catalog rollout plan.
- Adds manifest/publish validation tests for approval, duplicate, hash, path, and provenance guards.

## Batch status

- The original 20-product pilot and Batch 01 were reviewed locally.
- Batch 01 published 49 approved assets under `catalog-2026-06-10-01`.
- One OGX duplicate was intentionally excluded from Batch 01.
- Post-publish DB verification found 49 matching `products.image_url` values and 49 matching `product_image_assets` audit rows.

## Verification

- `npx tsx --test tests/product-images-manifest.test.ts` passed: 8/8
- `npm run test:node` passed: 640/640
- `npm run typecheck` passed
- `npm run lint` passed with 0 errors and 5 existing warnings
- `npm run build` passed
- Local visual QA: chat product cards rendered real images on mobile width; pilot-vs-Batch-01 comparison page looked consistent
- Local review gate: no blocking findings

## Supabase migration note

Changed migration: `20260610120000_product_image_assets.sql`.

`npx supabase migration list --linked` shows this migration is already applied remotely. The same command also shows unrelated historical migration drift in older migration IDs, so do not run a broad blind `supabase db push` from this branch.

## Follow-ups / risks

- Future batches should use the same reviewed manifest flow; no new migration should be needed unless the schema changes.
- Clean up or canonicalize the duplicate OGX catalog row separately.
- Keep manual review for exact-product matching and final contact sheets until the fallback-source rules have more batch evidence.
