### PR TITLE
Validate multi-slot product recommendations

### DIFF
--- a/src/lib/agent-v2/validation/final-answer-validator.ts
+++ b/src/lib/agent-v2/validation/final-answer-validator.ts
@@ -814,6 +814,7 @@ function validateInterpretationToolArguments(
   const latestRoutineTool = [...context.toolCallHistory]
     .reverse()
     .find((call) => call.name === "build_or_fix_routine")
+  const multiSlotProductContext = isMultiSlotProductSelectionContext(answer, context)
 
   if (latestProductTool) {
     if (!latestProductTool.arguments) {
@@ -837,20 +838,24 @@ function validateInterpretationToolArguments(
         interpretation.product_request_kind,
         errors,
       )
-      compareToolArgument(
-        latestProductTool.arguments,
-        "requested_product_count",
-        interpretation.requested_product_count,
-        errors,
-      )
-      compareToolArgument(
-        latestProductTool.arguments,
-        "count_policy",
-        interpretation.count_policy,
-        errors,
-      )
+      if (!multiSlotProductContext) {
+        compareToolArgument(
+          latestProductTool.arguments,
+          "requested_product_count",
+          interpretation.requested_product_count,
+          errors,
+        )
+        compareToolArgument(
+          latestProductTool.arguments,
+          "count_policy",
+          interpretation.count_policy,
+          errors,
+        )
+      }
     }
-    compareCategoryArgument(latestProductTool.arguments, interpretation, errors)
+    if (!multiSlotProductContext) {
+      compareCategoryArgument(latestProductTool.arguments, interpretation, errors)
+    }
   }
 
   if (latestRoutineTool) {
@@ -910,6 +915,190 @@ function isProductSelectionSupportingRoutineAnswer(
   return isProductBackedRoutineAnswer(answer) && Boolean(latestRoutineTool?.arguments)
 }
 
+type MultiSlotProductSelectionInfo = {
+  isSlotShaped: boolean
+  isValid: boolean
+  distinctCategoryCount: number
+}
+
+const MULTI_SLOT_CATEGORY_EVIDENCE_PATTERNS: Partial<Record<AgentV2CareCategory, RegExp[]>> = {
+  shampoo: [/\bshampoo\b/, /\balltagsshampoo\b/],
+  conditioner: [/\bconditioner\b/, /\bspuelung\b/],
+  mask: [/\bmaske\b/, /\bmask\b/],
+  leave_in: [/\bleave\s?in\b/, /\bleavein\b/],
+  oil: [/\boel\b/, /\bol\b/, /\boil\b/],
+  bondbuilder: [/\bbondbuilder\b/, /\bbond\s?builder\b/, /\bbonding\b/, /\bk18\b/, /\bolaplex\b/],
+  deep_cleansing_shampoo: [
+    /\btiefenreinigung\b/,
+    /\btiefenreinigungsshampoo\b/,
+    /\bdeep\s?cleansing\b/,
+    /\bclarifying\b/,
+    /\bdetox\b/,
+    /\breset\b/,
+  ],
+  dry_shampoo: [/\btrockenshampoo\b/, /\bdry\s?shampoo\b/],
+  peeling: [/\bpeeling\b/, /\bscalp\s?scrub\b/],
+  styling: [/\bstyling\b/, /\bstyler\b/],
+  treatment: [/\btreatment\b/, /\bbehandlung\b/],
+}
+
+function getProductToolCalls(
+  context: AgentV2FinalAnswerValidationContext,
+): readonly Partial<AgentV2ToolCallTrace>[] {
+  return context.toolCallHistory.filter((call) => call.name === "select_products")
+}
+
+function getCurrentProductProjections(
+  context: AgentV2FinalAnswerValidationContext,
+  productToolCallCount: number,
+): AgentV2FinalAnswerValidationContext["selectedProductProjections"] {
+  // responses-agent prepends prior-turn projections and appends one current projection per product call.
+  if (context.selectedProductProjections.length < productToolCallCount) return []
+  return context.selectedProductProjections.slice(-productToolCallCount)
+}
+
+function getToolArgumentString(call: Partial<AgentV2ToolCallTrace>, key: string): string | null {
+  const value = call.arguments?.[key]
+  return typeof value === "string" && value.trim().length > 0 ? value : null
+}
+
+function getToolArgumentNumber(call: Partial<AgentV2ToolCallTrace>, key: string): number | null {
+  const value = call.arguments?.[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function userEvidenceMentionsCategory(category: string, evidenceText: string): boolean {
+  const patterns = MULTI_SLOT_CATEGORY_EVIDENCE_PATTERNS[category as AgentV2CareCategory]
+  return Boolean(patterns?.some((pattern) => pattern.test(evidenceText)))
+}
+
+function userFacingAdmitsMissingSlot(category: string, userFacingText: string): boolean {
+  const normalized = normalizeAgentV2EvidenceText(userFacingText)
+  const mentionsCategory = userEvidenceMentionsCategory(category, normalized)
+  const admitsMissingCatalogMatch = [
+    /\b(?:kein|keinen|keine)\s+(?:sicher(?:er|en|e|es)|passend(?:er|en|e|es))?\s*(?:treffer|katalogtreffer|produkt|option|match)\b/,
+    /\bkein(?:e|en)?\s+passend(?:es|en|e|er)?\s+(?:produkt|option|treffer|match)\b/,
+    /\bnichts\s+passend(?:es|en|e|er)?\b/,
+    /\bfehl(?:t|en)?\s+(?:mir\s+|uns\s+)?(?:ein|eine|einen|den|der)?\s*(?:sicher(?:er|en|e|es)?|passend(?:er|en|e|es)?|katalog)\s*(?:treffer|produkt|option|match)\b/,
+    /\bohne\s+(?:sicher(?:en|er|e|es)?|passend(?:en|er|e|es)?)\s*(?:treffer|produkt|option|match)\b/,
+    /\bno\s+(?:safe|catalog)\s+(?:hit|match|product)\b/,
+  ].some((pattern) => pattern.test(normalized))
+
+  return mentionsCategory && admitsMissingCatalogMatch
+}
+
+function getMultiSlotEvidenceText(context: AgentV2FinalAnswerValidationContext): string {
+  return normalizeAgentV2EvidenceText(context.latestUserMessage)
+}
+
+function getEmptySlotCategories(
+  categories: readonly string[],
+  projections: AgentV2FinalAnswerValidationContext["selectedProductProjections"],
+): string[] {
+  return projections.flatMap((projection, index) =>
+    (projection.valid_product_ids?.length ?? 0) === 0 && categories[index]
+      ? [categories[index]]
+      : [],
+  )
+}
+
+function getMultiSlotProductSelectionInfo(
+  answer: AgentV2TerminalAnswer,
+  context: AgentV2FinalAnswerValidationContext,
+): MultiSlotProductSelectionInfo {
+  const productToolCalls = getProductToolCalls(context)
+  const categories = productToolCalls
+    .map((call) => getToolArgumentString(call, "category"))
+    .filter((category): category is string => Boolean(category))
+  const allProductCallsHaveCategories = categories.length === productToolCalls.length
+  const distinctCategoryCount = new Set(categories).size
+  const invalidInfo = {
+    isSlotShaped: false,
+    isValid: false,
+    distinctCategoryCount,
+  }
+
+  if (
+    answer.answer_mode !== "product_recommendation" ||
+    answer.request_interpretation.product_request_kind === "product_detail" ||
+    answer.request_interpretation.product_request_kind === "compare_products" ||
+    productToolCalls.length < 2 ||
+    !allProductCallsHaveCategories ||
+    distinctCategoryCount < 2
+  ) {
+    return invalidInfo
+  }
+
+  const isSlotShaped =
+    productToolCalls.length === distinctCategoryCount &&
+    productToolCalls.every(
+      (call) =>
+        getToolArgumentString(call, "count_policy") === "exact" &&
+        getToolArgumentNumber(call, "requested_product_count") === 1,
+    )
+  if (!isSlotShaped) return invalidInfo
+
+  const categorySet = new Set(categories)
+  const interpretationMatchesSlotShape =
+    answer.request_interpretation.count_policy === "exact" &&
+    answer.request_interpretation.requested_product_count === distinctCategoryCount &&
+    categorySet.has(answer.request_interpretation.care_category)
+  const evidenceText = getMultiSlotEvidenceText(context)
+  const evidenceMentionsEverySlot = categories.every((category) =>
+    userEvidenceMentionsCategory(category, evidenceText),
+  )
+  const visibleRecommendationIds = answer.payload.recommendations.map(
+    (recommendation) => recommendation.product_id,
+  )
+  const currentProductProjections = getCurrentProductProjections(context, productToolCalls.length)
+  const emptySlotCategories = getEmptySlotCategories(categories, currentProductProjections)
+  const userFacing = readUserFacingAnswer(answer.payload)
+  const userFacingAdmitsEveryEmptySlot = emptySlotCategories.every((category) =>
+    userFacingAdmitsMissingSlot(category, userFacing),
+  )
+  const fillableProjectionIndexes = new Set(
+    currentProductProjections.flatMap((projection, index) =>
+      (projection.valid_product_ids?.length ?? 0) > 0 ? [index] : [],
+    ),
+  )
+  const visibleProjectionIndexes = new Set<number>()
+  const allVisibleRecommendationsSelected = visibleRecommendationIds.every((id) => {
+    const projectionIndex = currentProductProjections.findIndex((projection) =>
+      (projection.valid_product_ids ?? []).includes(id),
+    )
+    if (projectionIndex === -1) return false
+    visibleProjectionIndexes.add(projectionIndex)
+    return true
+  })
+  const visibleRecommendationsUseDistinctSlots =
+    visibleProjectionIndexes.size === visibleRecommendationIds.length
+  const allFillableSlotsAreVisible =
+    visibleRecommendationIds.length === fillableProjectionIndexes.size &&
+    Array.from(fillableProjectionIndexes).every((index) => visibleProjectionIndexes.has(index))
+  const visibleRecommendationCountAllowsRelaxation =
+    visibleRecommendationIds.length <= distinctCategoryCount
+
+  return {
+    isSlotShaped,
+    isValid:
+      interpretationMatchesSlotShape &&
+      evidenceMentionsEverySlot &&
+      userFacingAdmitsEveryEmptySlot &&
+      visibleRecommendationCountAllowsRelaxation &&
+      allVisibleRecommendationsSelected &&
+      visibleRecommendationsUseDistinctSlots &&
+      allFillableSlotsAreVisible,
+    distinctCategoryCount,
+  }
+}
+
+function isMultiSlotProductSelectionContext(
+  answer: AgentV2TerminalAnswer,
+  context: AgentV2FinalAnswerValidationContext,
+): boolean {
+  return getMultiSlotProductSelectionInfo(answer, context).isValid
+}
+
 function validateProductAnswerShape(
   answer: AgentV2TerminalAnswer,
   context: AgentV2FinalAnswerValidationContext,
@@ -932,6 +1121,18 @@ function validateProductAnswerShape(
   }
 
   const recommendations = answer.payload.recommendations
+  const multiSlotProductContext = getMultiSlotProductSelectionInfo(answer, context)
+  if (
+    multiSlotProductContext.isSlotShaped &&
+    recommendations.length > multiSlotProductContext.distinctCategoryCount
+  ) {
+    errors.push({
+      validator_id: "requested_product_count",
+      message: `Multi-category product requests must not surface more visible recommendations than the ${multiSlotProductContext.distinctCategoryCount} selected category slot(s).`,
+      severity: "block",
+    })
+  }
+
   const recommendationIds = new Set(
     recommendations.map((recommendation) => recommendation.product_id),
   )
@@ -947,7 +1148,11 @@ function validateProductAnswerShape(
     answer.request_interpretation,
     availableRecommendationCount,
   )
-  if (countRequirement.kind === "exact" && recommendations.length !== countRequirement.count) {
+  if (
+    countRequirement.kind === "exact" &&
+    recommendations.length !== countRequirement.count &&
+    !multiSlotProductContext.isValid
+  ) {
     errors.push({
       validator_id: "requested_product_count",
       message: `The user asked for ${countRequirement.count} product recommendation(s); return exactly that many when enough valid products are available.`,

--- a/tests/agent-v2-final-answer-validator.spec.ts
+++ b/tests/agent-v2-final-answer-validator.spec.ts
@@ -174,6 +174,13 @@ function selectProductsToolCall(
   }
 }
 
+function selectedProjection(productId: string, name: string) {
+  return {
+    valid_product_ids: [productId],
+    products: [{ product_id: productId, name }],
+  }
+}
+
 function routineToolCall(
   overrides: Partial<{
     objective: string | null
@@ -2425,6 +2432,1013 @@ test("validator accepts explicit one and two product recommendation counts", () 
   )
 
   assert.equal(two.ok, true)
+})
+
+test("validator accepts one visible recommendation per multi-category product slot", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in", "prod_deep_cleanse"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo**, **Leave-in Creme** und **Tiefenreinigungsshampoo** decken die drei Slots ab.",
+        recommendations: [
+          {
+            product_id: "prod_shampoo",
+            reason_de: "Passt als Alltagsshampoo für feines, welliges Haar.",
+            usage_de: null,
+            caveat_de: null,
+          },
+          {
+            product_id: "prod_leave_in",
+            reason_de: "Passt als Leave-in gegen Frizz.",
+            usage_de: null,
+            caveat_de: null,
+          },
+          {
+            product_id: "prod_deep_cleanse",
+            reason_de: "Passt als Tiefenreinigung für gelegentliche Klärung.",
+            usage_de: null,
+            caveat_de: null,
+          },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        selectedProjection("prod_deep_cleanse", "Tiefenreinigungsshampoo"),
+      ],
+    },
+  )
+
+  assert.equal(result.ok, true, JSON.stringify(result.errors))
+})
+
+test("validator still blocks single-category exact-count mismatches", () => {
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 2,
+        count_policy: "exact",
+      }),
+    },
+    {
+      ...baseValidationContext,
+      toolCallHistory: [
+        selectProductsToolCall({
+          requested_product_count: 2,
+          count_policy: "exact",
+        }),
+      ],
+      selectedProductProjections: [
+        {
+          valid_product_ids: ["prod_1", "prod_2"],
+          products: [
+            { product_id: "prod_1", name: "Test Shampoo" },
+            { product_id: "prod_2", name: "Second Shampoo" },
+          ],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "requested_product_count"))
+})
+
+test("validator does not relax single-category exact-count requests into invented slots", () => {
+  const prompt = "Bitte empfiehl mir genau zwei Shampoos für feines welliges Haar."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 2,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_conditioner"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Shampoo** und **Conditioner** sind sichtbar, obwohl nur Shampoos gefragt waren.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_conditioner", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "conditioner",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Shampoo"),
+        selectedProjection("prod_conditioner", "Conditioner"),
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(
+    result.errors.some((error) => error.validator_id === "request_interpretation_tool_args_match"),
+  )
+})
+
+test("validator does not let model-authored evidence unlock invented slots", () => {
+  const prompt = "Bitte empfiehl mir genau zwei Shampoos für feines welliges Haar."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 2,
+        count_policy: "exact",
+        evidence_quote: "zwei Shampoos und Conditioner",
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_conditioner"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de: "**Shampoo** und **Conditioner** sind sichtbar.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_conditioner", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: "zwei Shampoos und Conditioner",
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: "zwei Shampoos und Conditioner",
+        }),
+        selectProductsToolCall({
+          category: "conditioner",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: "zwei Shampoos und Conditioner",
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Shampoo"),
+        selectedProjection("prod_conditioner", "Conditioner"),
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(
+    result.errors.some((error) => error.validator_id === "request_interpretation_tool_args_match"),
+  )
+})
+
+test("validator blocks multi-slot answers that surface products outside selected projections", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in", "prod_unknown"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo**, **Leave-in Creme** und **Unbekanntes Produkt** decken die drei Slots ab.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_unknown", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: [],
+          products: [],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "known_product_ids"))
+})
+
+test("validator blocks multi-slot answers above the distinct category cap", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 4,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in", "prod_deep_cleanse", "prod_extra"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo**, **Leave-in Creme**, **Tiefenreinigungsshampoo** und **Extra Shampoo** sind sichtbar.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_deep_cleanse", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_extra", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: ["prod_deep_cleanse", "prod_extra"],
+          products: [
+            { product_id: "prod_deep_cleanse", name: "Tiefenreinigungsshampoo" },
+            { product_id: "prod_extra", name: "Extra Shampoo" },
+          ],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(
+    result.errors.some(
+      (error) =>
+        error.validator_id === "requested_product_count" &&
+        error.message.includes("must not surface more visible recommendations"),
+    ),
+  )
+})
+
+test("validator does not relax multi-slot answers that double-fill one slot", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_deep_cleanse", "prod_deep_cleanse_extra"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo**, **Tiefenreinigungsshampoo** und **Extra Tiefenreinigung** sind sichtbar; das Leave-in fehlt.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_deep_cleanse", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          {
+            product_id: "prod_deep_cleanse_extra",
+            reason_de: "Passt.",
+            usage_de: null,
+            caveat_de: null,
+          },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: ["prod_deep_cleanse", "prod_deep_cleanse_extra"],
+          products: [
+            { product_id: "prod_deep_cleanse", name: "Tiefenreinigungsshampoo" },
+            { product_id: "prod_deep_cleanse_extra", name: "Extra Tiefenreinigung" },
+          ],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(
+    result.errors.some((error) => error.validator_id === "request_interpretation_tool_args_match"),
+  )
+})
+
+test("validator does not relax multi-slot answers with duplicate recommendation rows", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo**, **Alltagsshampoo** und **Leave-in Creme** sind sichtbar; die Tiefenreinigung fehlt.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_shampoo", reason_de: "Doppelt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        selectedProjection("prod_deep_cleanse", "Tiefenreinigungsshampoo"),
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(
+    result.errors.some((error) => error.validator_id === "request_interpretation_tool_args_match"),
+  )
+})
+
+test("validator does not apply the multi-slot cap to non-A2 multi-category traces", () => {
+  const prompt = "Bitte empfiehl mir Shampoo und Leave-in."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "leave_in",
+        requested_product_count: null,
+        count_policy: "default",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        used_guidance_package_ids: requiredGuidanceForAnswer("product_recommendation", "leave_in"),
+        product_ids: ["prod_shampoo", "prod_leave_in", "prod_extra"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Shampoo**, **Leave-in Creme** und **Extra Pflege** sind sichtbar.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_extra", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          count_policy: "default",
+          requested_product_count: null,
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          count_policy: "default",
+          requested_product_count: null,
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        {
+          valid_product_ids: ["prod_shampoo", "prod_leave_in", "prod_extra"],
+          products: [
+            { product_id: "prod_shampoo", name: "Shampoo" },
+            { product_id: "prod_leave_in", name: "Leave-in Creme" },
+            { product_id: "prod_extra", name: "Extra Pflege" },
+          ],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, true, JSON.stringify(result.errors))
+})
+
+test("validator does not relax exact counts for terminal-only multi-category slot shape", () => {
+  const prompt = "Bitte empfiehl mir zwei konkrete Produkte: Shampoo und Leave-in."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "leave_in",
+        requested_product_count: 2,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        used_guidance_package_ids: requiredGuidanceForAnswer("product_recommendation", "leave_in"),
+        product_ids: ["prod_shampoo"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de: "**Shampoo** ist sichtbar; das Leave-in fehlt.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          count_policy: "default",
+          requested_product_count: null,
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          count_policy: "default",
+          requested_product_count: null,
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [selectedProjection("prod_shampoo", "Shampoo")],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(
+    result.errors.some((error) => error.validator_id === "request_interpretation_tool_args_match"),
+  )
+})
+
+test("validator does not relax multi-slot answers using prior-turn selected products", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_prior_shampoo", "prod_leave_in", "prod_deep_cleanse"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Altes Shampoo**, **Leave-in Creme** und **Tiefenreinigungsshampoo** sind sichtbar.",
+        recommendations: [
+          {
+            product_id: "prod_prior_shampoo",
+            reason_de: "Passt.",
+            usage_de: null,
+            caveat_de: null,
+          },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_deep_cleanse", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_prior_shampoo", "Altes Shampoo"),
+        selectedProjection("prod_current_shampoo", "Aktuelles Shampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        selectedProjection("prod_deep_cleanse", "Tiefenreinigungsshampoo"),
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "requested_product_count"))
+})
+
+test("validator does not relax multi-slot answers that omit a fillable slot", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo** und **Leave-in Creme** sind sichtbar; die Tiefenreinigung fehlt.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        selectedProjection("prod_deep_cleanse", "Tiefenreinigungsshampoo"),
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "requested_product_count"))
+})
+
+test("validator accepts partial success for multi-category product slots", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo** und **Leave-in Creme** sind sicher genug; für Tiefenreinigung fehlt mir ein sicherer Treffer.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: [],
+          products: [],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, true, JSON.stringify(result.errors))
+})
+
+test("validator does not relax partial success that hides an empty slot", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de: "**Alltagsshampoo** und **Leave-in Creme** decken deine Anfrage ab.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: [],
+          products: [],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "requested_product_count"))
+})
+
+test("validator does not relax partial success that names an empty slot without no-match copy", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo** und **Leave-in Creme** passen; die Tiefenreinigung fehlt.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: [],
+          products: [],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "requested_product_count"))
+})
+
+test("validator does not relax missing-slot copy when safe language refers elsewhere", () => {
+  const prompt =
+    "Bitte empfiehl mir drei konkrete Produkte für feines welliges Haar mit Frizz: Alltagsshampoo, Leave-in und Tiefenreinigung."
+  const result = validateAgentV2FinalAnswer(
+    {
+      ...baseAnswer,
+      request_interpretation: requestInterpretation({
+        care_category: "shampoo",
+        requested_product_count: 3,
+        count_policy: "exact",
+        evidence_quote: prompt,
+      }),
+      tool_grounding: {
+        ...baseAnswer.tool_grounding,
+        product_ids: ["prod_shampoo", "prod_leave_in"],
+      },
+      payload: {
+        ...baseAnswer.payload,
+        user_facing_answer_de:
+          "**Alltagsshampoo** und **Leave-in Creme** passen; die Tiefenreinigung fehlt, die beiden sichtbaren Optionen sind sicher.",
+        recommendations: [
+          { product_id: "prod_shampoo", reason_de: "Passt.", usage_de: null, caveat_de: null },
+          { product_id: "prod_leave_in", reason_de: "Passt.", usage_de: null, caveat_de: null },
+        ],
+      },
+    },
+    {
+      ...baseValidationContext,
+      latestUserMessage: prompt,
+      recentEvidenceText: prompt,
+      toolCallHistory: [
+        selectProductsToolCall({
+          category: "shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "leave_in",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+        selectProductsToolCall({
+          category: "deep_cleansing_shampoo",
+          requested_product_count: 1,
+          count_policy: "exact",
+          evidence_quote: prompt,
+        }),
+      ],
+      selectedProductProjections: [
+        selectedProjection("prod_shampoo", "Alltagsshampoo"),
+        selectedProjection("prod_leave_in", "Leave-in Creme"),
+        {
+          valid_product_ids: [],
+          products: [],
+        },
+      ],
+    },
+  )
+
+  assert.equal(result.ok, false)
+  assert.ok(result.errors.some((error) => error.validator_id === "requested_product_count"))
 })
 
 test("validator allows routine product asks as product recommendations with routine context", () => {


### PR DESCRIPTION
## Summary
- allows multi-category product requests to return one grounded product per requested category slot
- keeps single-category exact-count requests strict so model-created slots cannot satisfy them
- permits partial success only when empty slots are explicitly disclosed with no safe/catalog match wording
- adds validator regressions for invented slots, prior-turn leakage, duplicate rows, double-filled slots, omitted fillable slots, and dishonest partial success

## Verification
- `npx tsx --test tests/agent-v2-final-answer-validator.spec.ts` passed: 112/112
- `npm run typecheck` passed
- `git diff --check` passed
- `npm run test:agent` passed: 684 pass, 1 skipped
- final code-review subagent pass: no blocking findings

## Notes
- No Supabase migrations in this PR.
- Claude second-pass review was blocked by monthly spend limit after the branch was updated; the earlier Claude finding was fixed and the final diff was re-reviewed by a code-review subagent.
- The multi-slot evidence gate intentionally uses only the latest user message, not model-authored evidence, to avoid invented slots.