### PR TITLE
Add product intake identity matching

### DIFF
--- a/src/lib/product-identity/brand-resolution.ts
+++ b/src/lib/product-identity/brand-resolution.ts
@@ -1,0 +1,533 @@
+import { normalizeIdentityText } from "./normalize"
+
+export type ProductIdentityProductLine = {
+  id?: string
+  key?: string
+  brandId?: string
+  brand_id?: string
+  canonicalName?: string
+  canonical_name?: string
+  normalizedName?: string
+  normalized_name?: string
+  name?: string
+  aliases?: readonly string[]
+}
+
+export type ProductIdentityBrand = {
+  id?: string
+  key?: string
+  canonicalName?: string
+  canonical_name?: string
+  normalizedName?: string
+  normalized_name?: string
+  name?: string
+  aliases?: readonly string[]
+  productLines?: readonly ProductIdentityProductLine[]
+}
+
+export type ProductIdentityBrandAlias = {
+  brandId?: string
+  brand_id?: string
+  productLineId?: string | null
+  product_line_id?: string | null
+  alias: string
+  normalizedAlias?: string
+  normalized_alias?: string
+}
+
+export type BrandResolutionCatalogInput = {
+  brands: readonly ProductIdentityBrand[]
+  productLines?: readonly ProductIdentityProductLine[]
+  brandAliases?: readonly ProductIdentityBrandAlias[]
+}
+
+export type BrandAliasConflict = {
+  normalizedAlias: string
+  targets: Array<{
+    brandKey: string
+    label: string
+  }>
+}
+
+export type BrandResolutionReason =
+  | "brand_alias_exact"
+  | "brand_line_alias_exact"
+  | "brand_alias_with_line_alias"
+  | "canonical_brand_exact"
+  | "canonical_brand_with_line_inference"
+  | "unresolved"
+
+export type BrandResolutionConfidence = "high" | "medium" | "none"
+
+export type BrandResolution = {
+  match: "brand_line" | "brand" | "none"
+  brand: ProductIdentityBrand | null
+  productLine: ProductIdentityProductLine | null
+  matchedText: string | null
+  confidence: BrandResolutionConfidence
+  reason: BrandResolutionReason
+  unresolvedRawText: string | null
+}
+
+type AliasTarget = {
+  brand: ProductIdentityBrand
+  productLine: ProductIdentityProductLine | null
+  alias: string
+  normalizedAlias: string
+}
+
+export type BrandResolutionCatalog = {
+  brands: readonly ProductIdentityBrand[]
+  aliases: readonly AliasTarget[]
+  productLines: ReadonlyArray<{
+    brandId: string
+    line: ProductIdentityProductLine
+  }>
+  conflicts: BrandAliasConflict[]
+}
+
+type TokenSpan = {
+  normalized: string
+  start: number
+  end: number
+}
+
+function brandId(brand: ProductIdentityBrand): string {
+  return brand.id ?? brand.key ?? brand.canonical_name ?? brand.canonicalName ?? brand.name ?? ""
+}
+
+function lineId(line: ProductIdentityProductLine): string {
+  return line.id ?? line.key ?? line.canonical_name ?? line.canonicalName ?? line.name ?? ""
+}
+
+function brandName(brand: ProductIdentityBrand): string {
+  return brand.name ?? brand.canonical_name ?? brand.canonicalName ?? brand.key ?? brand.id ?? ""
+}
+
+function brandNormalizedName(brand: ProductIdentityBrand): string {
+  return brand.normalized_name ?? brand.normalizedName ?? normalizeIdentityText(brandName(brand))
+}
+
+function lineName(line: ProductIdentityProductLine): string {
+  return line.name ?? line.canonical_name ?? line.canonicalName ?? line.key ?? line.id ?? ""
+}
+
+function lineNormalizedName(line: ProductIdentityProductLine): string {
+  return line.normalized_name ?? line.normalizedName ?? normalizeIdentityText(lineName(line))
+}
+
+function lineBrandId(line: ProductIdentityProductLine): string {
+  return line.brand_id ?? line.brandId ?? ""
+}
+
+function aliasBrandId(alias: ProductIdentityBrandAlias): string {
+  return alias.brand_id ?? alias.brandId ?? ""
+}
+
+function aliasLineId(alias: ProductIdentityBrandAlias): string | null {
+  return alias.product_line_id ?? alias.productLineId ?? null
+}
+
+function normalizedAliasValue(alias: ProductIdentityBrandAlias): string {
+  return normalizeIdentityText(alias.normalized_alias ?? alias.normalizedAlias ?? alias.alias)
+}
+
+function uniqueLabels(name: string, aliases: readonly string[] | undefined): string[] {
+  const labels = [name, ...(aliases ?? [])]
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const label of labels) {
+    const normalized = normalizeIdentityText(label)
+    if (!normalized || seen.has(normalized)) continue
+
+    seen.add(normalized)
+    unique.push(label)
+  }
+
+  return unique
+}
+
+function uniqueAliases(aliases: readonly string[] | undefined): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const alias of aliases ?? []) {
+    const normalized = normalizeIdentityText(alias)
+    if (!normalized || seen.has(normalized)) continue
+
+    seen.add(normalized)
+    unique.push(alias)
+  }
+
+  return unique
+}
+
+function tokenSignature(label: string): string {
+  return tokenSpans(label)
+    .map((span) => span.normalized)
+    .join("\u0000")
+}
+
+function uniquePrefixLabels(...labels: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const label of labels) {
+    if (!label) continue
+
+    const signature = tokenSignature(label)
+    if (!signature || seen.has(signature)) continue
+
+    seen.add(signature)
+    unique.push(label)
+  }
+
+  return unique
+}
+
+function brandPrefixLabels(brand: ProductIdentityBrand): string[] {
+  return uniquePrefixLabels(brandName(brand), brandNormalizedName(brand))
+}
+
+function linePrefixLabels(line: ProductIdentityProductLine): string[] {
+  return uniquePrefixLabels(lineName(line), lineNormalizedName(line), ...(line.aliases ?? []))
+}
+
+function aliasPrefixLabels(alias: AliasTarget): string[] {
+  return uniquePrefixLabels(alias.alias, alias.normalizedAlias)
+}
+
+export function detectBrandAliasConflicts(
+  brands: readonly ProductIdentityBrand[],
+): BrandAliasConflict[] {
+  const targetsByAlias = new Map<string, Map<string, { brandKey: string; label: string }>>()
+
+  for (const brand of brands) {
+    for (const label of uniqueLabels(brandName(brand), brand.aliases)) {
+      const normalizedAlias = normalizeIdentityText(label)
+      const targets = targetsByAlias.get(normalizedAlias) ?? new Map()
+      const key = brandId(brand)
+
+      if (!targets.has(key)) {
+        targets.set(key, { brandKey: key, label })
+      }
+
+      targetsByAlias.set(normalizedAlias, targets)
+    }
+  }
+
+  return Array.from(targetsByAlias.entries())
+    .filter(([, targets]) => targets.size > 1)
+    .map(([normalizedAlias, targets]) => ({
+      normalizedAlias,
+      targets: Array.from(targets.values()),
+    }))
+}
+
+function tokenSpans(value: string): TokenSpan[] {
+  const spans: TokenSpan[] = []
+  const tokenPattern =
+    /[\p{Letter}\p{Number}]+(?:[\u2018\u2019'`´](?=[\p{Letter}\p{Number}])[\p{Letter}\p{Number}]+)*/gu
+
+  for (const match of value.matchAll(tokenPattern)) {
+    const rawToken = match[0]
+    const normalized = normalizeIdentityText(rawToken)
+    if (!normalized) continue
+
+    spans.push({
+      normalized,
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + rawToken.length,
+    })
+  }
+
+  return spans
+}
+
+function prefixMatch(source: string, prefix: string): { end: number; tokenCount: number } | null {
+  const sourceTokens = tokenSpans(source)
+  const prefixTokens = tokenSpans(prefix)
+
+  if (prefixTokens.length === 0 || sourceTokens.length < prefixTokens.length) {
+    return null
+  }
+
+  for (let index = 0; index < prefixTokens.length; index += 1) {
+    if (sourceTokens[index].normalized !== prefixTokens[index].normalized) {
+      return null
+    }
+  }
+
+  return {
+    end: sourceTokens[prefixTokens.length - 1].end,
+    tokenCount: prefixTokens.length,
+  }
+}
+
+function trimLeadingSeparators(value: string): { text: string; offset: number } {
+  const match = value.match(/^[\s\p{Punctuation}\p{Symbol}]+/u)
+  const offset = match?.[0].length ?? 0
+  return { text: value.slice(offset), offset }
+}
+
+function bestPrefixMatch<T>(
+  source: string,
+  candidates: readonly T[],
+  labelsFor: (candidate: T) => string[],
+): { candidate: T; end: number; tokenCount: number; label: string } | null {
+  let bestMatch: { candidate: T; end: number; tokenCount: number; label: string } | null = null
+
+  for (const candidate of candidates) {
+    for (const label of labelsFor(candidate)) {
+      const match = prefixMatch(source, label)
+      if (!match) continue
+
+      if (!bestMatch || match.tokenCount > bestMatch.tokenCount || match.end > bestMatch.end) {
+        bestMatch = { candidate, label, ...match }
+      }
+    }
+  }
+
+  return bestMatch
+}
+
+function aliasConflictKey(target: AliasTarget): string {
+  const line = target.productLine ? `:${lineId(target.productLine)}` : ""
+  return `${brandId(target.brand)}${line}`
+}
+
+function addConflictTarget(
+  targetsByAlias: Map<string, Map<string, { brandKey: string; label: string }>>,
+  normalizedAlias: string,
+  targetKey: string,
+  target: { brandKey: string; label: string },
+): void {
+  if (!normalizedAlias) return
+
+  const targets = targetsByAlias.get(normalizedAlias) ?? new Map()
+  targets.set(targetKey, target)
+  targetsByAlias.set(normalizedAlias, targets)
+}
+
+function toCatalog(
+  input: readonly ProductIdentityBrand[] | BrandResolutionCatalogInput | BrandResolutionCatalog,
+): BrandResolutionCatalog {
+  if (!Array.isArray(input) && "aliases" in input && "conflicts" in input) {
+    return input
+  }
+
+  if (Array.isArray(input)) {
+    return buildBrandResolutionCatalog({ brands: input })
+  }
+
+  return buildBrandResolutionCatalog(input as BrandResolutionCatalogInput)
+}
+
+export function buildBrandResolutionCatalog(
+  input: BrandResolutionCatalogInput,
+): BrandResolutionCatalog {
+  const brandsById = new Map(input.brands.map((brand) => [brandId(brand), brand]))
+  const linesById = new Map<string, ProductIdentityProductLine>()
+  const productLinesByBrandId = new Map<string, ProductIdentityProductLine[]>()
+
+  for (const brand of input.brands) {
+    for (const line of brand.productLines ?? []) {
+      const id = lineId(line)
+      linesById.set(id, line)
+      const list = productLinesByBrandId.get(brandId(brand)) ?? []
+      list.push(line)
+      productLinesByBrandId.set(brandId(brand), list)
+    }
+  }
+
+  for (const line of input.productLines ?? []) {
+    const id = lineId(line)
+    const ownerId = lineBrandId(line)
+    linesById.set(id, line)
+    const list = productLinesByBrandId.get(ownerId) ?? []
+    list.push(line)
+    productLinesByBrandId.set(ownerId, list)
+  }
+
+  const aliases: AliasTarget[] = []
+  const productLines: Array<{ brandId: string; line: ProductIdentityProductLine }> = []
+
+  for (const brand of input.brands) {
+    for (const label of uniqueAliases(brand.aliases)) {
+      aliases.push({
+        brand,
+        productLine: null,
+        alias: label,
+        normalizedAlias: normalizeIdentityText(label),
+      })
+    }
+
+    for (const line of productLinesByBrandId.get(brandId(brand)) ?? []) {
+      productLines.push({ brandId: brandId(brand), line })
+    }
+  }
+
+  for (const alias of input.brandAliases ?? []) {
+    const brand = brandsById.get(aliasBrandId(alias))
+    if (!brand) continue
+
+    const productLineId = aliasLineId(alias)
+    const productLine = productLineId ? (linesById.get(productLineId) ?? null) : null
+    if (productLineId && !productLine) continue
+
+    aliases.push({
+      brand,
+      productLine,
+      alias: alias.alias,
+      normalizedAlias: normalizedAliasValue(alias),
+    })
+  }
+
+  const targetKeysByAlias = new Map<string, Map<string, { brandKey: string; label: string }>>()
+
+  for (const brand of input.brands) {
+    addConflictTarget(targetKeysByAlias, brandNormalizedName(brand), brandId(brand), {
+      brandKey: brandId(brand),
+      label: brandName(brand),
+    })
+  }
+
+  for (const alias of aliases) {
+    addConflictTarget(targetKeysByAlias, alias.normalizedAlias, aliasConflictKey(alias), {
+      brandKey: brandId(alias.brand),
+      label: alias.alias,
+    })
+  }
+
+  const conflicts = Array.from(targetKeysByAlias.entries())
+    .filter(([, targets]) => targets.size > 1)
+    .map(([normalizedAlias, targets]) => ({
+      normalizedAlias,
+      targets: Array.from(targets.values()),
+    }))
+
+  const conflictAliases = new Set(conflicts.map((conflict) => conflict.normalizedAlias))
+
+  return {
+    brands: input.brands,
+    aliases: aliases.filter((alias) => !conflictAliases.has(alias.normalizedAlias)),
+    productLines,
+    conflicts,
+  }
+}
+
+function none(rawText: string): BrandResolution {
+  return {
+    match: "none",
+    brand: null,
+    productLine: null,
+    matchedText: null,
+    confidence: "none",
+    reason: "unresolved",
+    unresolvedRawText: rawText,
+  }
+}
+
+export function resolveBrandFromText(
+  rawText: string,
+  catalogInput:
+    | readonly ProductIdentityBrand[]
+    | BrandResolutionCatalogInput
+    | BrandResolutionCatalog,
+): BrandResolution {
+  const catalog = toCatalog(catalogInput)
+  const aliasMatch = bestPrefixMatch(rawText, catalog.aliases, aliasPrefixLabels)
+
+  if (aliasMatch) {
+    const alias = aliasMatch.candidate
+
+    if (alias.productLine) {
+      return {
+        match: "brand_line",
+        brand: alias.brand,
+        productLine: alias.productLine,
+        matchedText: rawText.slice(0, aliasMatch.end).trim(),
+        confidence: "high",
+        reason: "brand_line_alias_exact",
+        unresolvedRawText: null,
+      }
+    }
+
+    const remainder = trimLeadingSeparators(rawText.slice(aliasMatch.end))
+    const productLines = catalog.productLines
+      .filter((candidate) => candidate.brandId === brandId(alias.brand))
+      .map((candidate) => candidate.line)
+
+    const lineMatch = bestPrefixMatch(remainder.text, productLines, linePrefixLabels)
+
+    if (lineMatch) {
+      const lineEnd = aliasMatch.end + remainder.offset + lineMatch.end
+
+      return {
+        match: "brand_line",
+        brand: alias.brand,
+        productLine: lineMatch.candidate,
+        matchedText: rawText.slice(0, lineEnd).trim(),
+        confidence: "high",
+        reason: "brand_alias_with_line_alias",
+        unresolvedRawText: null,
+      }
+    }
+
+    return {
+      match: "brand",
+      brand: alias.brand,
+      productLine: null,
+      matchedText: rawText.slice(0, aliasMatch.end).trim(),
+      confidence: "high",
+      reason: "brand_alias_exact",
+      unresolvedRawText: null,
+    }
+  }
+
+  const brandMatch = bestPrefixMatch(rawText, catalog.brands, brandPrefixLabels)
+
+  if (!brandMatch) {
+    return none(rawText)
+  }
+
+  const remainder = trimLeadingSeparators(rawText.slice(brandMatch.end))
+  const productLines = catalog.productLines
+    .filter((candidate) => candidate.brandId === brandId(brandMatch.candidate))
+    .map((candidate) => candidate.line)
+
+  const uniqueLineIds = new Set<string>()
+  const uniqueLines = productLines.filter((line) => {
+    const id = lineId(line)
+    if (uniqueLineIds.has(id)) return false
+    uniqueLineIds.add(id)
+    return true
+  })
+
+  const lineMatch = bestPrefixMatch(remainder.text, uniqueLines, linePrefixLabels)
+
+  if (lineMatch) {
+    const lineEnd = brandMatch.end + remainder.offset + lineMatch.end
+
+    return {
+      match: "brand_line",
+      brand: brandMatch.candidate,
+      productLine: lineMatch.candidate,
+      matchedText: rawText.slice(0, lineEnd).trim(),
+      confidence: "high",
+      reason: "canonical_brand_with_line_inference",
+      unresolvedRawText: null,
+    }
+  }
+
+  return {
+    match: "brand",
+    brand: brandMatch.candidate,
+    productLine: null,
+    matchedText: rawText.slice(0, brandMatch.end).trim(),
+    confidence: "medium",
+    reason: "canonical_brand_exact",
+    unresolvedRawText: null,
+  }
+}

--- a/src/lib/product-identity/index.ts
+++ b/src/lib/product-identity/index.ts
@@ -1,3 +1,8 @@
+export * from "./brand-resolution"
+export * from "./normalize"
+
+import { normalizeIdentifier, normalizeIdentityText } from "./normalize"
+
 export const SUPPORTED_PRODUCT_CATEGORY_KEYS = [
   "shampoo",
   "conditioner",
@@ -76,30 +81,6 @@ const CATEGORY_ALIASES: Array<[KnownProductCategoryKey, string]> = [
   ["hairspray", "Hairspray"],
 ]
 
-function normalizeGermanText(value: string): string {
-  return value
-    .replace(/ß/g, "ss")
-    .replace(/ẞ/g, "ss")
-    .normalize("NFKD")
-    .replace(/\p{Mark}/gu, "")
-}
-
-export function normalizeText(value: string | null | undefined): string {
-  if (!value) return ""
-
-  return normalizeGermanText(value)
-    .toLowerCase()
-    .replace(/n[º°]/g, "no")
-    .replace(/[_-]+/g, " ")
-    .replace(/[^\p{Letter}\p{Number}]+/gu, " ")
-    .trim()
-    .replace(/\s+/g, " ")
-}
-
-export function normalizeIdentifier(value: string | null | undefined): string {
-  return normalizeText(value).replace(/\s+/g, "_")
-}
-
 const CATEGORY_ALIAS_BY_IDENTIFIER = new Map<string, KnownProductCategoryKey>()
 
 for (const key of KNOWN_PRODUCT_CATEGORY_KEYS) {
@@ -113,6 +94,7 @@ for (const [key, alias] of CATEGORY_ALIASES) {
 export function normalizeCategoryKey(
   value: string | null | undefined,
 ): KnownProductCategoryKey | null {
+  if (!value) return null
   const normalized = normalizeIdentifier(value)
   return CATEGORY_ALIAS_BY_IDENTIFIER.get(normalized) ?? null
 }
@@ -125,11 +107,12 @@ type TokenSpan = {
 
 function tokenSpans(value: string): TokenSpan[] {
   const spans: TokenSpan[] = []
-  const tokenPattern = /[\p{Letter}\p{Number}]+/gu
+  const tokenPattern =
+    /[\p{Letter}\p{Number}]+(?:[\u2018\u2019'`´](?=[\p{Letter}\p{Number}])[\p{Letter}\p{Number}]+)*/gu
 
   for (const match of value.matchAll(tokenPattern)) {
     const rawToken = match[0]
-    const normalized = normalizeText(rawToken)
+    const normalized = normalizeIdentityText(rawToken)
     if (!normalized) continue
 
     spans.push({
@@ -142,7 +125,7 @@ function tokenSpans(value: string): TokenSpan[] {
   return spans
 }
 
-function prefixMatch(source: string, prefix: string): { end: number; tokenCount: number } | null {
+function prefixMatch(source: string, prefix: string): { end: number } | null {
   const sourceTokens = tokenSpans(source)
   const prefixTokens = tokenSpans(prefix)
 
@@ -156,10 +139,7 @@ function prefixMatch(source: string, prefix: string): { end: number; tokenCount:
     }
   }
 
-  return {
-    end: sourceTokens[prefixTokens.length - 1].end,
-    tokenCount: prefixTokens.length,
-  }
+  return { end: sourceTokens[prefixTokens.length - 1].end }
 }
 
 function stripTokenPrefix(source: string, prefix: string | null | undefined): string {
@@ -182,138 +162,4 @@ export function cleanProductDisplayName(
 ): string {
   const withoutBrand = stripTokenPrefix(value, options.brand)
   return stripTokenPrefix(withoutBrand, options.productLine)
-}
-
-export type ProductIdentityProductLine = {
-  key: string
-  name: string
-  aliases?: readonly string[]
-}
-
-export type ProductIdentityBrand = {
-  key: string
-  name: string
-  aliases?: readonly string[]
-  productLines?: readonly ProductIdentityProductLine[]
-}
-
-export type BrandAliasConflict = {
-  normalizedAlias: string
-  targets: Array<{
-    brandKey: string
-    label: string
-  }>
-}
-
-export type BrandResolution = {
-  match: "brand_line" | "brand" | "none"
-  brand: ProductIdentityBrand | null
-  productLine: ProductIdentityProductLine | null
-  matchedText: string | null
-}
-
-function uniqueLabels(name: string, aliases: readonly string[] | undefined): string[] {
-  const labels = [name, ...(aliases ?? [])]
-  const seen = new Set<string>()
-  const unique: string[] = []
-
-  for (const label of labels) {
-    const normalized = normalizeText(label)
-    if (!normalized || seen.has(normalized)) continue
-
-    seen.add(normalized)
-    unique.push(label)
-  }
-
-  return unique
-}
-
-export function detectBrandAliasConflicts(
-  brands: readonly ProductIdentityBrand[],
-): BrandAliasConflict[] {
-  const targetsByAlias = new Map<string, Map<string, { brandKey: string; label: string }>>()
-
-  for (const brand of brands) {
-    for (const label of uniqueLabels(brand.name, brand.aliases)) {
-      const normalizedAlias = normalizeText(label)
-      const targets = targetsByAlias.get(normalizedAlias) ?? new Map()
-
-      if (!targets.has(brand.key)) {
-        targets.set(brand.key, { brandKey: brand.key, label })
-      }
-
-      targetsByAlias.set(normalizedAlias, targets)
-    }
-  }
-
-  return Array.from(targetsByAlias.entries())
-    .filter(([, targets]) => targets.size > 1)
-    .map(([normalizedAlias, targets]) => ({
-      normalizedAlias,
-      targets: Array.from(targets.values()),
-    }))
-}
-
-function trimLeadingSeparators(value: string): { text: string; offset: number } {
-  const match = value.match(/^[\s\p{Punctuation}\p{Symbol}]+/u)
-  const offset = match?.[0].length ?? 0
-  return { text: value.slice(offset), offset }
-}
-
-function bestPrefixMatch<T>(
-  source: string,
-  candidates: readonly T[],
-  labelsFor: (candidate: T) => string[],
-): { candidate: T; end: number; tokenCount: number } | null {
-  let bestMatch: { candidate: T; end: number; tokenCount: number } | null = null
-
-  for (const candidate of candidates) {
-    for (const label of labelsFor(candidate)) {
-      const match = prefixMatch(source, label)
-      if (!match) continue
-
-      if (!bestMatch || match.tokenCount > bestMatch.tokenCount || match.end > bestMatch.end) {
-        bestMatch = { candidate, ...match }
-      }
-    }
-  }
-
-  return bestMatch
-}
-
-export function resolveBrandFromText(
-  rawText: string,
-  brands: readonly ProductIdentityBrand[],
-): BrandResolution {
-  const brandMatch = bestPrefixMatch(rawText, brands, (brand) =>
-    uniqueLabels(brand.name, brand.aliases),
-  )
-
-  if (!brandMatch) {
-    return { match: "none", brand: null, productLine: null, matchedText: null }
-  }
-
-  const remainder = trimLeadingSeparators(rawText.slice(brandMatch.end))
-  const productLines = brandMatch.candidate.productLines ?? []
-  const lineMatch = bestPrefixMatch(remainder.text, productLines, (line) =>
-    uniqueLabels(line.name, line.aliases),
-  )
-
-  if (lineMatch) {
-    const lineEnd = brandMatch.end + remainder.offset + lineMatch.end
-
-    return {
-      match: "brand_line",
-      brand: brandMatch.candidate,
-      productLine: lineMatch.candidate,
-      matchedText: rawText.slice(0, lineEnd).trim(),
-    }
-  }
-
-  return {
-    match: "brand",
-    brand: brandMatch.candidate,
-    productLine: null,
-    matchedText: rawText.slice(0, brandMatch.end).trim(),
-  }
 }

--- a/src/lib/product-identity/normalize.ts
+++ b/src/lib/product-identity/normalize.ts
@@ -1,0 +1,42 @@
+function foldGermanText(value: string): string {
+  return value
+    .replace(/ß/g, "ss")
+    .replace(/ẞ/g, "ss")
+    .normalize("NFKD")
+    .replace(/\p{Mark}/gu, "")
+}
+
+function normalizeNoSymbol(value: string): string {
+  return foldGermanText(value)
+    .toLowerCase()
+    .replace(/n[º°]/g, "no")
+    .replace(/[\u2018\u2019'`´](?=\p{Letter})/gu, "")
+    .replace(/[_-]+/g, " ")
+    .replace(/[^\p{Letter}\p{Number}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ")
+}
+
+export function normalizeIdentityText(input: string): string {
+  return normalizeNoSymbol(input)
+}
+
+export function normalizeText(value: string | null | undefined): string {
+  if (!value) return ""
+  return normalizeIdentityText(value)
+}
+
+export function normalizeIdentifier(input: string | null | undefined): string {
+  if (!input) return ""
+  return normalizeIdentityText(input).replace(/\s+/g, "_")
+}
+
+export function normalizeIdentifierValue(input: string): string {
+  return foldGermanText(input).toLowerCase().replace(/\s+/g, "").trim()
+}
+
+export function tokenizeProductName(input: string): string[] {
+  return normalizeIdentityText(input)
+    .split(" ")
+    .filter((token) => token.length > 0)
+}

--- a/src/lib/product-intake/product-matching.ts
+++ b/src/lib/product-intake/product-matching.ts
@@ -1,0 +1,552 @@
+import {
+  normalizeIdentifierValue,
+  normalizeIdentityText,
+  tokenizeProductName,
+} from "../product-identity/normalize"
+import type { ProductIntakeCategoryKey } from "../types"
+
+export type ProductIdentifierType = "ean" | "gtin" | "barcode" | "retailer_sku" | "retailer_url"
+
+const BARCODE_IDENTIFIER_TYPES = new Set(["ean", "gtin", "barcode"])
+
+export type ProductIntakeCatalogProduct = {
+  id: string
+  name: string
+  cleanName?: string | null
+  brandId?: string | null
+  brand_id?: string | null
+  productLineId?: string | null
+  product_line_id?: string | null
+  categoryKey?: string | null
+  category_key?: string | null
+  isActive?: boolean | null
+  is_active?: boolean | null
+  isChaarlieRecommended?: boolean | null
+  is_chaarlie_recommended?: boolean | null
+}
+
+export type ProductIntakeCatalogIdentifier = {
+  productId?: string
+  product_id?: string
+  identifierType?: ProductIdentifierType | string
+  identifier_type?: ProductIdentifierType | string
+  identifierValue?: string
+  identifier_value?: string
+  normalizedIdentifierValue?: string
+  normalized_identifier_value?: string
+  source?: string | null
+}
+
+export type ProductIntakeCatalog = {
+  products: readonly ProductIntakeCatalogProduct[]
+  identifiers?: readonly ProductIntakeCatalogIdentifier[]
+}
+
+export type ProductIntakeIdentifierInput = {
+  type?: ProductIdentifierType | string | null
+  value: string
+  source?: string | null
+}
+
+export type ProductIntakeMatchInput = {
+  selectedCategoryKey?: ProductIntakeCategoryKey | string | null
+  identifier?: ProductIntakeIdentifierInput | string | null
+  brandId?: string | null
+  brand_id?: string | null
+  productLineId?: string | null
+  product_line_id?: string | null
+  cleanProductName?: string | null
+  productName?: string | null
+}
+
+export type ProductIntakeMatchStatus = "matched" | "pending_review" | "needs_more_info" | "rejected"
+
+export type ProductIntakeMatchReason =
+  | "identifier_category_exact"
+  | "identifier_requires_category_review"
+  | "identifier_category_mismatch_review"
+  | "identifier_ambiguous_review"
+  | "identifier_source_mismatch_review"
+  | "brand_line_name_category_exact"
+  | "brand_name_category_exact"
+  | "fuzzy_candidates_review"
+  | "text_category_mismatch_review"
+  | "category_required"
+  | "insufficient_identity"
+  | "invalid_identifier"
+
+export type ProductIntakeMatchCandidate = {
+  product: ProductIntakeCatalogProduct
+  productId: string
+  confidence: "exact" | "review"
+  reason: ProductIntakeMatchReason
+  reasonCodes: ProductIntakeMatchReason[]
+}
+
+export type ProductIntakeMatchResult = {
+  status: ProductIntakeMatchStatus
+  matchedProduct: ProductIntakeCatalogProduct | null
+  productId: string | null
+  candidates: ProductIntakeMatchCandidate[]
+  confidence: "exact" | "review" | "none"
+  reason: ProductIntakeMatchReason
+  reasonCodes: ProductIntakeMatchReason[]
+  missingFields: string[]
+}
+
+type IdentifierMatchEvidence = {
+  product: ProductIntakeCatalogProduct
+  autoLinkEligible: boolean
+}
+
+function productBrandId(product: ProductIntakeCatalogProduct): string | null {
+  return product.brandId ?? product.brand_id ?? null
+}
+
+function productLineId(product: ProductIntakeCatalogProduct): string | null {
+  return product.productLineId ?? product.product_line_id ?? null
+}
+
+function productCategoryKey(product: ProductIntakeCatalogProduct): string | null {
+  return product.categoryKey ?? product.category_key ?? null
+}
+
+function productIsActive(product: ProductIntakeCatalogProduct): boolean {
+  return product.isActive ?? product.is_active ?? false
+}
+
+function productCleanName(product: ProductIntakeCatalogProduct): string {
+  return product.cleanName ?? product.name
+}
+
+function identifierProductId(identifier: ProductIntakeCatalogIdentifier): string {
+  return identifier.productId ?? identifier.product_id ?? ""
+}
+
+function identifierType(identifier: ProductIntakeCatalogIdentifier): string {
+  return normalizeIdentifierType(identifier.identifierType ?? identifier.identifier_type ?? "")
+}
+
+function normalizeIdentifierType(type: string | null | undefined): string {
+  return type?.trim().toLowerCase() ?? ""
+}
+
+function identifierTypesCompatible(inputType: string | null, catalogType: string): boolean {
+  if (!inputType) return true
+  if (BARCODE_IDENTIFIER_TYPES.has(inputType) && BARCODE_IDENTIFIER_TYPES.has(catalogType)) {
+    return true
+  }
+
+  return inputType === catalogType
+}
+
+function identifierValueForType(value: string, type: string): string {
+  if (BARCODE_IDENTIFIER_TYPES.has(type)) {
+    const normalized = normalizeIdentifierValue(value)
+    return normalized.replace(/[^\p{Letter}\p{Number}]+/gu, "")
+  }
+
+  return value.toLowerCase().replace(/\s+/g, "").trim()
+}
+
+function identifierValue(identifier: ProductIntakeCatalogIdentifier): string {
+  const type = identifierType(identifier)
+  const value =
+    identifier.normalizedIdentifierValue ??
+    identifier.normalized_identifier_value ??
+    identifier.identifierValue ??
+    identifier.identifier_value ??
+    ""
+
+  return identifierValueForType(value, type)
+}
+
+function normalizeIdentifierSource(source: string | null | undefined): string | null {
+  const normalized = source?.trim().toLowerCase() ?? ""
+  return normalized || null
+}
+
+function identifierAutoLinkEligible(params: {
+  type: string | null
+  inputSource: string | null
+  catalogSource: string | null
+}): boolean {
+  if (params.type !== "retailer_sku") return true
+
+  return Boolean(
+    params.inputSource && params.catalogSource && params.inputSource === params.catalogSource,
+  )
+}
+
+function inputBrandId(input: ProductIntakeMatchInput): string | null {
+  return input.brandId ?? input.brand_id ?? null
+}
+
+function inputLineId(input: ProductIntakeMatchInput): string | null {
+  return input.productLineId ?? input.product_line_id ?? null
+}
+
+function inputCleanName(input: ProductIntakeMatchInput): string {
+  return input.cleanProductName ?? input.productName ?? ""
+}
+
+function normalizeIdentifierInput(
+  identifier: ProductIntakeIdentifierInput | string | null | undefined,
+): { type: string | null; rawValue: string; source: string | null } | null {
+  if (!identifier) return null
+
+  if (typeof identifier === "string") {
+    const value = normalizeIdentifierValue(identifier)
+    return value ? { type: null, rawValue: identifier, source: null } : null
+  }
+
+  const value = normalizeIdentifierValue(identifier.value)
+  return value
+    ? {
+        type: normalizeIdentifierType(identifier.type) || null,
+        rawValue: identifier.value,
+        source: normalizeIdentifierSource(identifier.source),
+      }
+    : null
+}
+
+function exactCandidate(
+  product: ProductIntakeCatalogProduct,
+  reason: ProductIntakeMatchReason,
+): ProductIntakeMatchCandidate {
+  return { product, productId: product.id, confidence: "exact", reason, reasonCodes: [reason] }
+}
+
+function reviewCandidate(
+  product: ProductIntakeCatalogProduct,
+  reason: ProductIntakeMatchReason,
+): ProductIntakeMatchCandidate {
+  return { product, productId: product.id, confidence: "review", reason, reasonCodes: [reason] }
+}
+
+function reviewCandidatesByCategory(
+  products: readonly ProductIntakeCatalogProduct[],
+  categoryKey: string,
+  sameCategoryReason: ProductIntakeMatchReason,
+  crossCategoryReason: ProductIntakeMatchReason,
+): ProductIntakeMatchCandidate[] {
+  return products.map((product) =>
+    reviewCandidate(
+      product,
+      sameCategory(product, categoryKey) ? sameCategoryReason : crossCategoryReason,
+    ),
+  )
+}
+
+function identifierReviewCandidate(
+  evidence: IdentifierMatchEvidence,
+  categoryKey: string | null,
+  sameCategoryReason: ProductIntakeMatchReason,
+): ProductIntakeMatchCandidate {
+  if (!categoryKey) {
+    return reviewCandidate(evidence.product, "identifier_requires_category_review")
+  }
+
+  if (!sameCategory(evidence.product, categoryKey)) {
+    return reviewCandidate(evidence.product, "identifier_category_mismatch_review")
+  }
+
+  if (!evidence.autoLinkEligible) {
+    return reviewCandidate(evidence.product, "identifier_source_mismatch_review")
+  }
+
+  return reviewCandidate(evidence.product, sameCategoryReason)
+}
+
+function result(
+  status: ProductIntakeMatchStatus,
+  reason: ProductIntakeMatchReason,
+  candidates: ProductIntakeMatchCandidate[] = [],
+  matchedProduct: ProductIntakeCatalogProduct | null = null,
+  missingFields: string[] = [],
+): ProductIntakeMatchResult {
+  return {
+    status,
+    matchedProduct,
+    productId: matchedProduct?.id ?? null,
+    candidates,
+    confidence: status === "matched" ? "exact" : candidates.length > 0 ? "review" : "none",
+    reason,
+    reasonCodes: [reason],
+    missingFields,
+  }
+}
+
+function activeProducts(catalog: ProductIntakeCatalog): ProductIntakeCatalogProduct[] {
+  return catalog.products.filter(productIsActive)
+}
+
+function sameCategory(product: ProductIntakeCatalogProduct, categoryKey: string): boolean {
+  return productCategoryKey(product) === categoryKey
+}
+
+function sameBrand(product: ProductIntakeCatalogProduct, brandId: string | null): boolean {
+  return Boolean(brandId) && productBrandId(product) === brandId
+}
+
+function sameLine(product: ProductIntakeCatalogProduct, lineId: string | null): boolean {
+  return Boolean(lineId) && productLineId(product) === lineId
+}
+
+function normalizedProductName(product: ProductIntakeCatalogProduct): string {
+  return normalizeIdentityText(productCleanName(product))
+}
+
+function categoryExactMatches(
+  products: readonly ProductIntakeCatalogProduct[],
+  categoryKey: string,
+): ProductIntakeCatalogProduct[] {
+  return products.filter((product) => sameCategory(product, categoryKey))
+}
+
+function allIdentifierMatches(
+  inputIdentifier: { type: string | null; rawValue: string; source: string | null },
+  catalog: ProductIntakeCatalog,
+): IdentifierMatchEvidence[] {
+  const productsById = new Map(activeProducts(catalog).map((product) => [product.id, product]))
+  const evidenceByProductId = new Map<string, IdentifierMatchEvidence>()
+
+  for (const identifier of catalog.identifiers ?? []) {
+    const catalogType = identifierType(identifier)
+    if (!identifierTypesCompatible(inputIdentifier.type, catalogType)) {
+      continue
+    }
+
+    if (
+      identifierValue(identifier) !== identifierValueForType(inputIdentifier.rawValue, catalogType)
+    ) {
+      continue
+    }
+
+    const productId = identifierProductId(identifier)
+    const product = productsById.get(productId)
+    if (!product) continue
+
+    const existing = evidenceByProductId.get(productId)
+    const autoLinkEligible = identifierAutoLinkEligible({
+      type: inputIdentifier.type || catalogType,
+      inputSource: inputIdentifier.source,
+      catalogSource: normalizeIdentifierSource(identifier.source),
+    })
+
+    evidenceByProductId.set(productId, {
+      product,
+      autoLinkEligible: Boolean(existing?.autoLinkEligible || autoLinkEligible),
+    })
+  }
+
+  return Array.from(evidenceByProductId.values())
+}
+
+function fuzzyTextCandidates(
+  input: ProductIntakeMatchInput,
+  catalog: ProductIntakeCatalog,
+): ProductIntakeCatalogProduct[] {
+  const brandId = inputBrandId(input)
+  const lineId = inputLineId(input)
+  const inputTokens = new Set(tokenizeProductName(inputCleanName(input)))
+  if (!brandId || inputTokens.size === 0) return []
+
+  return activeProducts(catalog)
+    .filter((product) => sameBrand(product, brandId))
+    .filter((product) => (!lineId ? true : sameLine(product, lineId)))
+    .map((product) => {
+      const productTokens = new Set(tokenizeProductName(productCleanName(product)))
+      const overlap = Array.from(inputTokens).filter((token) => productTokens.has(token)).length
+      return { product, overlap }
+    })
+    .filter(({ overlap }) => overlap > 0)
+    .sort(
+      (left, right) =>
+        right.overlap - left.overlap || left.product.name.localeCompare(right.product.name, "de"),
+    )
+    .slice(0, 5)
+    .map(({ product }) => product)
+}
+
+export function matchProductIntake(
+  input: ProductIntakeMatchInput,
+  catalog: ProductIntakeCatalog,
+): ProductIntakeMatchResult {
+  const selectedCategoryKey = input.selectedCategoryKey ?? null
+  const identifier = normalizeIdentifierInput(input.identifier)
+
+  if (input.identifier && !identifier) {
+    return result("rejected", "invalid_identifier")
+  }
+
+  if (identifier) {
+    const identifierEvidence = allIdentifierMatches(identifier, catalog)
+    const identifierMatches = identifierEvidence.map((evidence) => evidence.product)
+    const candidates = identifierEvidence.map((evidence) =>
+      identifierReviewCandidate(evidence, selectedCategoryKey, "identifier_ambiguous_review"),
+    )
+
+    if (!selectedCategoryKey) {
+      return result("pending_review", "identifier_requires_category_review", candidates)
+    }
+
+    const sameCategoryEvidence = identifierEvidence.filter((evidence) =>
+      sameCategory(evidence.product, selectedCategoryKey),
+    )
+    const sameCategoryMatches = sameCategoryEvidence.map((evidence) => evidence.product)
+
+    if (
+      sameCategoryEvidence.length === 1 &&
+      sameCategoryEvidence[0].autoLinkEligible &&
+      identifierMatches.length === 1
+    ) {
+      return result(
+        "matched",
+        "identifier_category_exact",
+        [exactCandidate(sameCategoryMatches[0], "identifier_category_exact")],
+        sameCategoryMatches[0],
+      )
+    }
+
+    if (sameCategoryMatches.length > 1) {
+      return result(
+        "pending_review",
+        "identifier_ambiguous_review",
+        identifierEvidence.map((evidence) =>
+          identifierReviewCandidate(evidence, selectedCategoryKey, "identifier_ambiguous_review"),
+        ),
+      )
+    }
+
+    if (identifierMatches.length > 0) {
+      const reason = sameCategoryEvidence.some((evidence) => !evidence.autoLinkEligible)
+        ? "identifier_source_mismatch_review"
+        : "identifier_category_mismatch_review"
+
+      return result("pending_review", reason, candidates)
+    }
+  }
+
+  if (!selectedCategoryKey) {
+    return result("needs_more_info", "category_required", [], null, ["category"])
+  }
+
+  const brandId = inputBrandId(input)
+  const lineId = inputLineId(input)
+  const normalizedInputName = normalizeIdentityText(inputCleanName(input))
+
+  if (!brandId || !normalizedInputName) {
+    const missingFields = [
+      ...(brandId ? [] : ["brandText"]),
+      ...(normalizedInputName ? [] : ["productNameText"]),
+    ]
+    return result("needs_more_info", "insufficient_identity", [], null, missingFields)
+  }
+
+  const products = activeProducts(catalog)
+  const lineMatches = lineId
+    ? products.filter(
+        (product) =>
+          sameBrand(product, brandId) &&
+          sameLine(product, lineId) &&
+          normalizedProductName(product) === normalizedInputName,
+      )
+    : []
+  const sameCategoryLineMatches = categoryExactMatches(lineMatches, selectedCategoryKey)
+
+  if (sameCategoryLineMatches.length === 1 && lineMatches.length === 1) {
+    return result(
+      "matched",
+      "brand_line_name_category_exact",
+      [exactCandidate(sameCategoryLineMatches[0], "brand_line_name_category_exact")],
+      sameCategoryLineMatches[0],
+    )
+  }
+
+  if (sameCategoryLineMatches.length > 1) {
+    return result(
+      "pending_review",
+      "fuzzy_candidates_review",
+      reviewCandidatesByCategory(
+        lineMatches,
+        selectedCategoryKey,
+        "fuzzy_candidates_review",
+        "text_category_mismatch_review",
+      ),
+    )
+  }
+
+  if (lineMatches.length > 0) {
+    return result(
+      "pending_review",
+      "text_category_mismatch_review",
+      reviewCandidatesByCategory(
+        lineMatches,
+        selectedCategoryKey,
+        "fuzzy_candidates_review",
+        "text_category_mismatch_review",
+      ),
+    )
+  }
+
+  const brandNameMatches = products.filter(
+    (product) =>
+      sameBrand(product, brandId) &&
+      normalizedProductName(product) === normalizedInputName &&
+      (!lineId || !productLineId(product)),
+  )
+  const sameCategoryBrandNameMatches = categoryExactMatches(brandNameMatches, selectedCategoryKey)
+
+  if (sameCategoryBrandNameMatches.length === 1 && brandNameMatches.length === 1) {
+    return result(
+      "matched",
+      "brand_name_category_exact",
+      [exactCandidate(sameCategoryBrandNameMatches[0], "brand_name_category_exact")],
+      sameCategoryBrandNameMatches[0],
+    )
+  }
+
+  if (sameCategoryBrandNameMatches.length > 1) {
+    return result(
+      "pending_review",
+      "fuzzy_candidates_review",
+      reviewCandidatesByCategory(
+        brandNameMatches,
+        selectedCategoryKey,
+        "fuzzy_candidates_review",
+        "text_category_mismatch_review",
+      ),
+    )
+  }
+
+  if (brandNameMatches.length > 0) {
+    return result(
+      "pending_review",
+      "text_category_mismatch_review",
+      reviewCandidatesByCategory(
+        brandNameMatches,
+        selectedCategoryKey,
+        "fuzzy_candidates_review",
+        "text_category_mismatch_review",
+      ),
+    )
+  }
+
+  const fuzzyCandidates = fuzzyTextCandidates(input, catalog)
+
+  if (fuzzyCandidates.length > 0) {
+    return result(
+      "pending_review",
+      "fuzzy_candidates_review",
+      reviewCandidatesByCategory(
+        fuzzyCandidates,
+        selectedCategoryKey,
+        "fuzzy_candidates_review",
+        "text_category_mismatch_review",
+      ),
+    )
+  }
+
+  return result("pending_review", "fuzzy_candidates_review")
+}

--- a/tests/product-identity-normalize.test.ts
+++ b/tests/product-identity-normalize.test.ts
@@ -6,9 +6,11 @@ import {
   PRODUCT_CATEGORY_DISPLAY_LABELS,
   SUPPORTED_PRODUCT_CATEGORY_KEYS,
   cleanProductDisplayName,
+  normalizeIdentityText,
   normalizeCategoryKey,
   normalizeIdentifier,
   normalizeText,
+  tokenizeProductName,
 } from "../src/lib/product-identity"
 
 test("canonical category constants include supported and known unsupported keys", () => {
@@ -58,10 +60,36 @@ test("normalizeText folds accents, punctuation, case, and spacing", () => {
   assert.equal(normalizeText("Tiefenreinigungs-Shampoo"), "tiefenreinigungs shampoo")
 })
 
+test("normalizeIdentityText is stable for case, whitespace, punctuation, and safe diacritics", () => {
+  assert.equal(normalizeIdentityText("  OLAPLEX   Nº. 5 -- Leave-In  "), "olaplex no 5 leave in")
+  assert.equal(normalizeIdentityText("Olaplex No 5 Leave In"), "olaplex no 5 leave in")
+  assert.equal(normalizeIdentityText("Garnier Fructis / Hair-Food"), "garnier fructis hair food")
+})
+
+test("normalizeIdentityText matches L'Oreal variants without broad unsafe rewrites", () => {
+  assert.equal(normalizeIdentityText("L'Oréal"), "loreal")
+  assert.equal(normalizeIdentityText("L’Oréal"), "loreal")
+  assert.equal(normalizeIdentityText("Loreal"), "loreal")
+})
+
 test("normalizeIdentifier returns stable snake-case identifiers", () => {
   assert.equal(normalizeIdentifier("Deep Cleansing Shampoo"), "deep_cleansing_shampoo")
   assert.equal(normalizeIdentifier("  Öle + Pflege  "), "ole_pflege")
   assert.equal(normalizeIdentifier("leave_in"), "leave_in")
+  assert.equal(normalizeIdentifier(null), "")
+  assert.equal(normalizeIdentifier(undefined), "")
+})
+
+test("tokenizeProductName returns normalized searchable product-name tokens", () => {
+  assert.deepEqual(tokenizeProductName("Garnier Fructis Hair-Food Aloe"), [
+    "garnier",
+    "fructis",
+    "hair",
+    "food",
+    "aloe",
+  ])
+  assert.deepEqual(tokenizeProductName("L'Oréal Professionnel"), ["loreal", "professionnel"])
+  assert.deepEqual(tokenizeProductName("OLAPLEX No. 5"), ["olaplex", "no", "5"])
 })
 
 test("cleanProductDisplayName removes exact brand and product line prefixes conservatively", () => {
@@ -94,5 +122,13 @@ test("cleanProductDisplayName removes exact brand and product line prefixes cons
       productLine: "No. 5",
     }),
     "Olaplexx No. 5 Leave-In Conditioner",
+  )
+
+  assert.equal(
+    cleanProductDisplayName("L'Oréal Paris Elvital Dream Length", {
+      brand: "Loreal Paris",
+      productLine: "Elvital",
+    }),
+    "Dream Length",
   )
 })

--- a/tests/product-identity-resolution.test.ts
+++ b/tests/product-identity-resolution.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict"
 import test from "node:test"
 
 import {
+  buildBrandResolutionCatalog,
   detectBrandAliasConflicts,
   resolveBrandFromText,
   type ProductIdentityBrand,
@@ -28,6 +29,8 @@ test("resolveBrandFromText returns an exact brand and product line prefix match"
   assert.equal(resolution.brand?.key, "olaplex")
   assert.equal(resolution.productLine?.key, "no_5")
   assert.equal(resolution.matchedText, "Olaplex Nr. 5")
+  assert.equal(resolution.confidence, "high")
+  assert.equal(resolution.reason, "canonical_brand_with_line_inference")
 })
 
 test("resolveBrandFromText returns an exact brand match without over-matching inside words", () => {
@@ -35,10 +38,208 @@ test("resolveBrandFromText returns an exact brand match without over-matching in
   assert.equal(resolution.match, "brand")
   assert.equal(resolution.brand?.key, "k18")
   assert.equal(resolution.productLine, null)
+  assert.equal(resolution.reason, "brand_alias_exact")
 
   const nonMatch = resolveBrandFromText("SK18 Leave-in Molecular Repair Hair Oil", brands)
   assert.equal(nonMatch.match, "none")
   assert.equal(nonMatch.brand, null)
+  assert.equal(nonMatch.unresolvedRawText, "SK18 Leave-in Molecular Repair Hair Oil")
+})
+
+test("resolveBrandFromText resolves Phase 0 aliases before canonical brand names", () => {
+  const catalog = buildBrandResolutionCatalog({
+    brands: [
+      { id: "brand-pantene", canonical_name: "Pantene", normalized_name: "pantene" },
+      { id: "brand-garnier", canonical_name: "Garnier", normalized_name: "garnier" },
+    ],
+    productLines: [
+      {
+        id: "line-pro-v",
+        brand_id: "brand-pantene",
+        canonical_name: "Pro-V",
+        normalized_name: "pro v",
+      },
+      {
+        id: "line-fructis",
+        brand_id: "brand-garnier",
+        canonical_name: "Fructis",
+        normalized_name: "fructis",
+      },
+    ],
+    brandAliases: [
+      {
+        brand_id: "brand-garnier",
+        product_line_id: "line-fructis",
+        alias: "Fructis",
+        normalized_alias: "fructis",
+      },
+    ],
+  })
+
+  const proV = resolveBrandFromText("Pantene Pro-V Repair & Care Shampoo", catalog)
+  assert.equal(proV.match, "brand_line")
+  assert.equal(proV.brand?.id, "brand-pantene")
+  assert.equal(proV.productLine?.id, "line-pro-v")
+  assert.equal(proV.reason, "canonical_brand_with_line_inference")
+
+  const garnierFructis = resolveBrandFromText("Garnier Fructis Aloe Hydra Bomb", catalog)
+  assert.equal(garnierFructis.match, "brand_line")
+  assert.equal(garnierFructis.brand?.id, "brand-garnier")
+  assert.equal(garnierFructis.productLine?.id, "line-fructis")
+  assert.equal(garnierFructis.reason, "canonical_brand_with_line_inference")
+
+  const fructisAlias = resolveBrandFromText("Fructis Aloe Hydra Bomb", catalog)
+  assert.equal(fructisAlias.match, "brand_line")
+  assert.equal(fructisAlias.brand?.id, "brand-garnier")
+  assert.equal(fructisAlias.productLine?.id, "line-fructis")
+  assert.equal(fructisAlias.reason, "brand_line_alias_exact")
+})
+
+test("unknown brand returns unresolved raw text with no confidence", () => {
+  const catalog = buildBrandResolutionCatalog({
+    brands: [{ id: "brand-garnier", canonical_name: "Garnier", normalized_name: "garnier" }],
+    productLines: [],
+    brandAliases: [],
+  })
+
+  const resolution = resolveBrandFromText("Unbekannte Pflegecreme", catalog)
+
+  assert.equal(resolution.match, "none")
+  assert.equal(resolution.confidence, "none")
+  assert.equal(resolution.reason, "unresolved")
+  assert.equal(resolution.unresolvedRawText, "Unbekannte Pflegecreme")
+})
+
+test("conflicting aliases are reported and excluded from usable alias resolution", () => {
+  const catalog = buildBrandResolutionCatalog({
+    brands: [
+      { id: "brand-first", canonical_name: "First", normalized_name: "first" },
+      { id: "brand-second", canonical_name: "Second", normalized_name: "second" },
+    ],
+    productLines: [],
+    brandAliases: [
+      {
+        brand_id: "brand-first",
+        product_line_id: null,
+        alias: "Shared",
+        normalized_alias: "shared",
+      },
+      {
+        brand_id: "brand-second",
+        product_line_id: null,
+        alias: "Shared",
+        normalized_alias: "shared",
+      },
+    ],
+  })
+
+  assert.deepEqual(
+    catalog.conflicts.map((conflict) => conflict.normalizedAlias),
+    ["shared"],
+  )
+
+  const resolution = resolveBrandFromText("Shared Shampoo", catalog)
+  assert.equal(resolution.match, "none")
+  assert.equal(resolution.reason, "unresolved")
+})
+
+test("resolver uses Phase 0 normalized brand and line fields for punctuation variants", () => {
+  const catalog = buildBrandResolutionCatalog({
+    brands: [
+      {
+        id: "brand-loreal-paris",
+        canonical_name: "Loreal Paris",
+        normalized_name: "loreal paris",
+      },
+    ],
+    productLines: [
+      {
+        id: "line-elvital",
+        brand_id: "brand-loreal-paris",
+        canonical_name: "Elvital",
+        normalized_name: "elvital",
+      },
+    ],
+    brandAliases: [],
+  })
+
+  const resolution = resolveBrandFromText("Loreal Paris Elvital Dream Length", catalog)
+
+  assert.equal(resolution.match, "brand_line")
+  assert.equal(resolution.brand?.id, "brand-loreal-paris")
+  assert.equal(resolution.productLine?.id, "line-elvital")
+  assert.equal(resolution.matchedText, "Loreal Paris Elvital")
+  assert.equal(resolution.reason, "canonical_brand_with_line_inference")
+
+  const apostropheResolution = resolveBrandFromText("L'Oréal Paris Elvital Dream Length", catalog)
+  assert.equal(apostropheResolution.match, "brand_line")
+  assert.equal(apostropheResolution.brand?.id, "brand-loreal-paris")
+  assert.equal(apostropheResolution.productLine?.id, "line-elvital")
+  assert.equal(apostropheResolution.matchedText, "L'Oréal Paris Elvital")
+  assert.equal(apostropheResolution.reason, "canonical_brand_with_line_inference")
+})
+
+test("alias collisions with canonical brand names are reported and excluded", () => {
+  const catalog = buildBrandResolutionCatalog({
+    brands: [
+      { id: "brand-garnier", canonical_name: "Garnier", normalized_name: "garnier" },
+      { id: "brand-fructis", canonical_name: "Fructis", normalized_name: "fructis" },
+    ],
+    productLines: [
+      {
+        id: "line-fructis",
+        brand_id: "brand-garnier",
+        canonical_name: "Fructis",
+        normalized_name: "fructis",
+      },
+    ],
+    brandAliases: [
+      {
+        brand_id: "brand-garnier",
+        product_line_id: "line-fructis",
+        alias: "Fructis",
+        normalized_alias: "fructis",
+      },
+    ],
+  })
+
+  assert.deepEqual(
+    catalog.conflicts.map((conflict) => conflict.normalizedAlias),
+    ["fructis"],
+  )
+
+  const resolution = resolveBrandFromText("Fructis Shampoo", catalog)
+  assert.equal(resolution.match, "brand")
+  assert.equal(resolution.brand?.id, "brand-fructis")
+  assert.equal(resolution.productLine, null)
+  assert.equal(resolution.reason, "canonical_brand_exact")
+})
+
+test("line-specific aliases with missing product lines are excluded", () => {
+  const catalog = buildBrandResolutionCatalog({
+    brands: [
+      {
+        id: "brand-loreal-paris",
+        canonical_name: "L'Oréal Paris",
+        normalized_name: "loreal paris",
+      },
+    ],
+    productLines: [],
+    brandAliases: [
+      {
+        brand_id: "brand-loreal-paris",
+        product_line_id: "line-elvital",
+        alias: "Elvital",
+        normalized_alias: "elvital",
+      },
+    ],
+  })
+
+  assert.equal(catalog.aliases.length, 0)
+
+  const resolution = resolveBrandFromText("Elvital Dream Length Shampoo", catalog)
+  assert.equal(resolution.match, "none")
+  assert.equal(resolution.reason, "unresolved")
 })
 
 test("detectBrandAliasConflicts reports duplicate normalized aliases with conflicting targets", () => {

--- a/tests/product-intake-matching.test.ts
+++ b/tests/product-intake-matching.test.ts
@@ -1,0 +1,704 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  matchProductIntake,
+  type ProductIntakeCatalog,
+} from "../src/lib/product-intake/product-matching"
+
+const catalog: ProductIntakeCatalog = {
+  products: [
+    {
+      id: "olaplex-leave-in",
+      name: "No. 5 Leave-In Conditioner",
+      brandId: "brand-olaplex",
+      productLineId: "line-no-5",
+      categoryKey: "leave_in",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+    {
+      id: "garnier-mask",
+      name: "Hair Food Aloe Maske",
+      brandId: "brand-garnier",
+      productLineId: "line-fructis",
+      categoryKey: "mask",
+      isActive: true,
+      isChaarlieRecommended: false,
+    },
+    {
+      id: "garnier-conditioner",
+      name: "Hair Food Aloe Conditioner",
+      brandId: "brand-garnier",
+      productLineId: "line-fructis",
+      categoryKey: "conditioner",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+    {
+      id: "pantene-shampoo-a",
+      name: "Repair & Care Shampoo",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      categoryKey: "shampoo",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+    {
+      id: "pantene-shampoo-b",
+      name: "Repair Care Shampoo",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      categoryKey: "shampoo",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+    {
+      id: "inactive-match",
+      name: "Inactive Shampoo",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      categoryKey: "shampoo",
+      isActive: false,
+      isChaarlieRecommended: true,
+    },
+  ],
+  identifiers: [
+    {
+      productId: "olaplex-leave-in",
+      identifierType: "ean",
+      identifierValue: "4000012345678",
+    },
+    {
+      productId: "garnier-mask",
+      identifierType: "gtin",
+      identifierValue: "4000099999999",
+    },
+    {
+      productId: "inactive-match",
+      identifierType: "ean",
+      identifierValue: "4000011111111",
+    },
+  ],
+}
+
+test("GTIN/EAN plus selected canonical category returns exact matched product when one active row exists", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      identifier: { type: "ean", value: "40000 12345678" },
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "matched")
+  assert.equal(result.matchedProduct?.id, "olaplex-leave-in")
+  assert.equal(result.reason, "identifier_category_exact")
+})
+
+test("GTIN/EAN without category or with a different category returns review candidates only", () => {
+  const missingCategory = matchProductIntake(
+    { identifier: { type: "ean", value: "4000012345678" } },
+    catalog,
+  )
+  assert.equal(missingCategory.status, "pending_review")
+  assert.equal(missingCategory.matchedProduct, null)
+  assert.deepEqual(
+    missingCategory.candidates.map((candidate) => candidate.product.id),
+    ["olaplex-leave-in"],
+  )
+  assert.equal(missingCategory.reason, "identifier_requires_category_review")
+
+  const categoryMismatch = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "ean", value: "4000012345678" },
+    },
+    catalog,
+  )
+  assert.equal(categoryMismatch.status, "pending_review")
+  assert.equal(categoryMismatch.matchedProduct, null)
+  assert.equal(categoryMismatch.candidates[0]?.product.id, "olaplex-leave-in")
+  assert.equal(categoryMismatch.reason, "identifier_category_mismatch_review")
+})
+
+test("identifier path ignores inactive products", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "ean", value: "4000011111111" },
+      brandId: "brand-pantene",
+      cleanProductName: "Inactive Shampoo",
+    },
+    catalog,
+  )
+
+  assert.notEqual(result.status, "matched")
+  assert.equal(result.matchedProduct, null)
+  assert.equal(
+    result.candidates.some((candidate) => candidate.product.id === "inactive-match"),
+    false,
+  )
+})
+
+test("GTIN/EAN with mixed-category exact evidence stays review-only", () => {
+  const mixedCategoryCatalog: ProductIntakeCatalog = {
+    products: [
+      ...catalog.products,
+      {
+        id: "olaplex-conditioner",
+        name: "No. 5 Leave-In Conditioner",
+        brandId: "brand-olaplex",
+        productLineId: "line-no-5",
+        categoryKey: "conditioner",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: [
+      ...(catalog.identifiers ?? []),
+      {
+        productId: "olaplex-conditioner",
+        identifierType: "gtin",
+        identifierValue: "4000012345678",
+      },
+    ],
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      identifier: { type: "barcode", value: "40000-12345678" },
+    },
+    mixedCategoryCatalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => candidate.product.id),
+    ["olaplex-leave-in", "olaplex-conditioner"],
+  )
+  assert.equal(result.reason, "identifier_category_mismatch_review")
+})
+
+test("ambiguous GTIN/EAN review candidates include cross-category exact evidence", () => {
+  const ambiguousCatalog: ProductIntakeCatalog = {
+    products: [
+      ...catalog.products,
+      {
+        id: "olaplex-leave-in-duplicate",
+        name: "No. 5 Leave-In Conditioner Duplicate",
+        brandId: "brand-olaplex",
+        productLineId: "line-no-5",
+        categoryKey: "leave_in",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+      {
+        id: "olaplex-conditioner",
+        name: "No. 5 Leave-In Conditioner",
+        brandId: "brand-olaplex",
+        productLineId: "line-no-5",
+        categoryKey: "conditioner",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: [
+      ...(catalog.identifiers ?? []),
+      {
+        productId: "olaplex-leave-in-duplicate",
+        identifierType: "gtin",
+        identifierValue: "4000012345678",
+      },
+      {
+        productId: "olaplex-conditioner",
+        identifierType: "barcode",
+        identifierValue: "4000012345678",
+      },
+    ],
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      identifier: { type: "ean", value: "4000012345678" },
+    },
+    ambiguousCatalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => [candidate.product.id, candidate.reason]),
+    [
+      ["olaplex-leave-in", "identifier_ambiguous_review"],
+      ["olaplex-leave-in-duplicate", "identifier_ambiguous_review"],
+      ["olaplex-conditioner", "identifier_category_mismatch_review"],
+    ],
+  )
+})
+
+test("retailer identifiers do not collapse punctuation into false exact matches", () => {
+  const retailerCatalog: ProductIntakeCatalog = {
+    products: [
+      {
+        id: "retailer-product",
+        name: "Retailer Shampoo",
+        brandId: "brand-retailer",
+        productLineId: null,
+        categoryKey: "shampoo",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: [
+      {
+        productId: "retailer-product",
+        identifierType: "retailer_sku",
+        identifierValue: "SKU-12",
+      },
+      {
+        productId: "retailer-product",
+        identifierType: "retailer_url",
+        identifierValue: "https://shop.example/products/a-b",
+      },
+    ],
+  }
+
+  const skuResult = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "retailer_sku", value: "SKU12" },
+    },
+    retailerCatalog,
+  )
+
+  assert.equal(skuResult.status, "needs_more_info")
+  assert.equal(skuResult.matchedProduct, null)
+  assert.equal(skuResult.candidates.length, 0)
+
+  const urlResult = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "retailer_url", value: "https://shop.example/products/ab" },
+    },
+    retailerCatalog,
+  )
+
+  assert.equal(urlResult.status, "needs_more_info")
+  assert.equal(urlResult.matchedProduct, null)
+  assert.equal(urlResult.candidates.length, 0)
+})
+
+test("retailer identifiers preserve diacritics for exact matching", () => {
+  const retailerCatalog: ProductIntakeCatalog = {
+    products: [
+      {
+        id: "retailer-product",
+        name: "Retailer Shampoo",
+        brandId: "brand-retailer",
+        productLineId: null,
+        categoryKey: "shampoo",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: [
+      {
+        productId: "retailer-product",
+        identifierType: "retailer_sku",
+        identifierValue: "Ä-12",
+        source: "dm",
+      },
+    ],
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "retailer_sku", value: "A-12", source: "dm" },
+    },
+    retailerCatalog,
+  )
+
+  assert.equal(result.status, "needs_more_info")
+  assert.equal(result.matchedProduct, null)
+  assert.equal(result.candidates.length, 0)
+})
+
+test("brand plus line plus clean name plus canonical category exact match returns matched", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      brandId: "brand-olaplex",
+      productLineId: "line-no-5",
+      cleanProductName: "No 5 Leave In Conditioner",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "matched")
+  assert.equal(result.matchedProduct?.id, "olaplex-leave-in")
+  assert.equal(result.reason, "brand_line_name_category_exact")
+})
+
+test("brand plus name fallback does not auto-link a different product line", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      brandId: "brand-olaplex",
+      productLineId: "line-no-6",
+      cleanProductName: "No 5 Leave In Conditioner",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.notEqual(result.reason, "brand_name_category_exact")
+})
+
+test("brand plus line plus name with mixed-category exact evidence stays review-only", () => {
+  const mixedCategoryCatalog: ProductIntakeCatalog = {
+    products: [
+      ...catalog.products,
+      {
+        id: "olaplex-conditioner",
+        name: "No. 5 Leave-In Conditioner",
+        brandId: "brand-olaplex",
+        productLineId: "line-no-5",
+        categoryKey: "conditioner",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: catalog.identifiers,
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      brandId: "brand-olaplex",
+      productLineId: "line-no-5",
+      cleanProductName: "No 5 Leave In Conditioner",
+    },
+    mixedCategoryCatalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => candidate.product.id),
+    ["olaplex-leave-in", "olaplex-conditioner"],
+  )
+  assert.equal(result.reason, "text_category_mismatch_review")
+})
+
+test("ambiguous brand plus line plus name candidates include cross-category exact evidence", () => {
+  const ambiguousCatalog: ProductIntakeCatalog = {
+    products: [
+      ...catalog.products,
+      {
+        id: "olaplex-leave-in-duplicate",
+        name: "No. 5 Leave-In Conditioner",
+        brandId: "brand-olaplex",
+        productLineId: "line-no-5",
+        categoryKey: "leave_in",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+      {
+        id: "olaplex-conditioner",
+        name: "No. 5 Leave-In Conditioner",
+        brandId: "brand-olaplex",
+        productLineId: "line-no-5",
+        categoryKey: "conditioner",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: catalog.identifiers,
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "leave_in",
+      brandId: "brand-olaplex",
+      productLineId: "line-no-5",
+      cleanProductName: "No 5 Leave In Conditioner",
+    },
+    ambiguousCatalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => [candidate.product.id, candidate.reason]),
+    [
+      ["olaplex-leave-in", "fuzzy_candidates_review"],
+      ["olaplex-leave-in-duplicate", "fuzzy_candidates_review"],
+      ["olaplex-conditioner", "text_category_mismatch_review"],
+    ],
+  )
+})
+
+test("existing non-recommended active product can match", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "mask",
+      brandId: "brand-garnier",
+      productLineId: "line-fructis",
+      cleanProductName: "Hair Food Aloe Maske",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "matched")
+  assert.equal(result.matchedProduct?.id, "garnier-mask")
+})
+
+test("brand plus clean name and category can match when no line exists", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "conditioner",
+      brandId: "brand-garnier",
+      cleanProductName: "Hair Food Aloe Conditioner",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "matched")
+  assert.equal(result.matchedProduct?.id, "garnier-conditioner")
+  assert.equal(result.reason, "brand_name_category_exact")
+})
+
+test("brand plus name with mixed-category exact evidence stays review-only", () => {
+  const mixedCategoryCatalog: ProductIntakeCatalog = {
+    products: [
+      ...catalog.products,
+      {
+        id: "garnier-leave-in",
+        name: "Hair Food Aloe Conditioner",
+        brandId: "brand-garnier",
+        productLineId: "line-fructis",
+        categoryKey: "leave_in",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: catalog.identifiers,
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "conditioner",
+      brandId: "brand-garnier",
+      cleanProductName: "Hair Food Aloe Conditioner",
+    },
+    mixedCategoryCatalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => candidate.product.id),
+    ["garnier-conditioner", "garnier-leave-in"],
+  )
+  assert.equal(result.reason, "text_category_mismatch_review")
+})
+
+test("ambiguous brand plus name candidates include cross-category exact evidence", () => {
+  const ambiguousCatalog: ProductIntakeCatalog = {
+    products: [
+      ...catalog.products,
+      {
+        id: "garnier-conditioner-duplicate",
+        name: "Hair Food Aloe Conditioner",
+        brandId: "brand-garnier",
+        productLineId: null,
+        categoryKey: "conditioner",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+      {
+        id: "garnier-leave-in",
+        name: "Hair Food Aloe Conditioner",
+        brandId: "brand-garnier",
+        productLineId: null,
+        categoryKey: "leave_in",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: catalog.identifiers,
+  }
+
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "conditioner",
+      brandId: "brand-garnier",
+      cleanProductName: "Hair Food Aloe Conditioner",
+    },
+    ambiguousCatalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => [candidate.product.id, candidate.reason]),
+    [
+      ["garnier-conditioner", "fuzzy_candidates_review"],
+      ["garnier-conditioner-duplicate", "fuzzy_candidates_review"],
+      ["garnier-leave-in", "text_category_mismatch_review"],
+    ],
+  )
+})
+
+test("multiple close candidates return ambiguous review without auto-linking", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      cleanProductName: "Repair Shampoo",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => candidate.product.id),
+    ["pantene-shampoo-a", "pantene-shampoo-b"],
+  )
+  assert.equal(result.reason, "fuzzy_candidates_review")
+})
+
+test("cross-category fuzzy candidates remain visible for review", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "conditioner",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      cleanProductName: "Repair Shampoo",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.deepEqual(
+    result.candidates.map((candidate) => [candidate.product.id, candidate.reason]),
+    [
+      ["pantene-shampoo-a", "text_category_mismatch_review"],
+      ["pantene-shampoo-b", "text_category_mismatch_review"],
+    ],
+  )
+})
+
+test("retailer SKU matching requires matching source before auto-linking", () => {
+  const retailerCatalog: ProductIntakeCatalog = {
+    products: [
+      {
+        id: "retailer-shampoo",
+        name: "Retailer Shampoo",
+        brandId: "brand-retailer",
+        productLineId: null,
+        categoryKey: "shampoo",
+        isActive: true,
+        isChaarlieRecommended: true,
+      },
+    ],
+    identifiers: [
+      {
+        productId: "retailer-shampoo",
+        identifierType: "retailer_sku",
+        identifierValue: "SKU-12",
+        source: "dm",
+      },
+    ],
+  }
+
+  const differentSource = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "retailer_sku", value: "SKU-12", source: "rossmann" },
+    },
+    retailerCatalog,
+  )
+  assert.equal(differentSource.status, "pending_review")
+  assert.equal(differentSource.matchedProduct, null)
+  assert.equal(differentSource.candidates[0]?.product.id, "retailer-shampoo")
+  assert.equal(differentSource.candidates[0]?.reason, "identifier_source_mismatch_review")
+  assert.equal(differentSource.reason, "identifier_source_mismatch_review")
+
+  const missingSource = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "retailer_sku", value: "SKU-12" },
+    },
+    retailerCatalog,
+  )
+  assert.equal(missingSource.status, "pending_review")
+  assert.equal(missingSource.matchedProduct, null)
+  assert.equal(missingSource.candidates[0]?.product.id, "retailer-shampoo")
+  assert.equal(missingSource.candidates[0]?.reason, "identifier_source_mismatch_review")
+  assert.equal(missingSource.reason, "identifier_source_mismatch_review")
+
+  const missingTypeAndSource = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { value: "SKU-12" },
+    },
+    retailerCatalog,
+  )
+  assert.equal(missingTypeAndSource.status, "pending_review")
+  assert.equal(missingTypeAndSource.matchedProduct, null)
+  assert.equal(missingTypeAndSource.candidates[0]?.product.id, "retailer-shampoo")
+  assert.equal(missingTypeAndSource.candidates[0]?.reason, "identifier_source_mismatch_review")
+  assert.equal(missingTypeAndSource.reason, "identifier_source_mismatch_review")
+
+  const sameSource = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      identifier: { type: "retailer_sku", value: "SKU-12", source: "dm" },
+    },
+    retailerCatalog,
+  )
+  assert.equal(sameSource.status, "matched")
+  assert.equal(sameSource.matchedProduct?.id, "retailer-shampoo")
+})
+
+test("missing category cannot match for usage from brand and name alone", () => {
+  const result = matchProductIntake(
+    {
+      brandId: "brand-olaplex",
+      productLineId: "line-no-5",
+      cleanProductName: "No 5 Leave In Conditioner",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "needs_more_info")
+  assert.equal(result.matchedProduct, null)
+  assert.equal(result.reason, "category_required")
+})
+
+test("category mismatch does not auto-link text matches", () => {
+  const result = matchProductIntake(
+    {
+      selectedCategoryKey: "shampoo",
+      brandId: "brand-olaplex",
+      productLineId: "line-no-5",
+      cleanProductName: "No 5 Leave In Conditioner",
+    },
+    catalog,
+  )
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matchedProduct, null)
+  assert.equal(result.candidates[0]?.product.id, "olaplex-leave-in")
+  assert.equal(result.reason, "text_category_mismatch_review")
+})


### PR DESCRIPTION
## Why

Phase 3 needs a deterministic, conservative matcher before intake routes can decide whether a user-entered product links to an existing catalog product or becomes a pending review submission.

## What changed

- Added product identity normalization helpers, including safer brand/product-name tokenization for apostrophe variants such as L'Oréal.
- Added Phase 0 shaped brand and product-line resolution with alias conflict handling.
- Added pure in-memory product intake matching with exact category-gated auto-linking and review-only ambiguous, fuzzy, or cross-category evidence.
- Added source-aware retailer SKU handling while keeping barcode-family matching tolerant.
- Added focused tests covering normalization, brand/line resolution, identifier matching, inactive products, non-recommended products, and conservative fallback behavior.

## Verification

- Focused Phase 2 tests passed: 37/37.
- `npm run typecheck` passed.
- `npm run test:node` passed: 713 tests.
- `npm run lint` passed with 5 existing unrelated warnings.
- `git diff --check` passed.
- Superpowers/fresh-context review passed after accepted fixes.
- Claude opus/high review found no in-scope correctness bug; accepted low-risk follow-ups were patched.

## Notes / residual risk

- Catalog normalization snapshots and validation outputs should be regenerated with the new apostrophe normalization behavior before relying on snapshot comparisons.
- This PR is stacked on Phase 1 (`codex/product-intake-phase-1`) and intentionally contains no API routes, UI, DB writes, or Supabase migration application.
