### PR TITLE
feat(onboarding): add no-towel profile option

### DIFF
--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -18,7 +18,7 @@ import {
   EXTRA_PRODUCT_OPTIONS,
   PRODUCT_CATEGORY_LABELS,
 } from "@/lib/onboarding/product-options"
-import { normalizeProductFrequency, type ProductFrequency } from "@/lib/vocabulary"
+import { normalizeProductFrequency } from "@/lib/vocabulary"
 import type { HeatStyling } from "@/lib/vocabulary"
 
 // Import all screens
@@ -62,6 +62,7 @@ const TOWEL_MATERIAL_ICONS: Record<string, IconName> = {
   mikrofaser: "towel-mikrofaser",
   tshirt: "towel-tshirt",
   turban_mikrofaser: "towel-turban",
+  no_towel: "drying-air",
 }
 
 const TOWEL_TECHNIQUE_ICONS: Record<string, IconName> = {
@@ -505,6 +506,7 @@ export function OnboardingFlow({
           case "towel_material": {
             await saveHairProfile({
               towel_material: state.towelMaterial,
+              ...(state.towelMaterial === "no_towel" ? { towel_technique: null } : {}),
             })
             break
           }
@@ -856,7 +858,11 @@ export function OnboardingFlow({
             options={towelMaterialWithIcon}
             selected={store.towelMaterial}
             onSelect={(val) => {
-              store.setTowelMaterial(val as TowelMaterial)
+              const towelMaterial = val as TowelMaterial
+              store.setTowelMaterial(towelMaterial)
+              if (towelMaterial === "no_towel") {
+                store.setTowelTechnique(null)
+              }
               handleStepComplete("towel_material")
             }}
             onBack={handleBack}
@@ -955,6 +961,7 @@ export function OnboardingFlow({
             currentDrilldownIndex={store.currentDrilldownIndex}
             drilldownCount={store.drilldownCategories().length}
             selectedHeatTools={store.selectedHeatTools}
+            towelMaterial={store.towelMaterial}
           />
         </div>
       )}

--- a/src/components/onboarding/onboarding-progress-bar.tsx
+++ b/src/components/onboarding/onboarding-progress-bar.tsx
@@ -2,6 +2,7 @@
 
 import type { OnboardingStep } from "@/lib/onboarding/store"
 import { buildOnboardingProgressState } from "@/lib/onboarding/progress"
+import type { TowelMaterial } from "@/lib/vocabulary/onboarding-care"
 
 const SECTION_LABELS = ["Produkte", "Styling", "Alltag"] as const
 
@@ -10,6 +11,7 @@ interface OnboardingProgressBarProps {
   currentDrilldownIndex: number
   drilldownCount: number
   selectedHeatTools: string[]
+  towelMaterial: TowelMaterial | null
 }
 
 export function OnboardingProgressBar({
@@ -17,12 +19,14 @@ export function OnboardingProgressBar({
   currentDrilldownIndex,
   drilldownCount,
   selectedHeatTools,
+  towelMaterial,
 }: OnboardingProgressBarProps) {
   const progress = buildOnboardingProgressState({
     currentStep,
     currentDrilldownIndex,
     drilldownCount,
     selectedHeatTools,
+    towelMaterial,
   })
 
   return (

--- a/src/lib/onboarding/progress.ts
+++ b/src/lib/onboarding/progress.ts
@@ -1,4 +1,6 @@
+import { getRoutineSteps } from "@/lib/onboarding/routine-steps"
 import type { OnboardingStep } from "./store"
+import type { TowelMaterial } from "@/lib/vocabulary/onboarding-care"
 
 const PRODUCTS_STEPS: OnboardingStep[] = ["products_basics", "products_extras"]
 const STYLING_STEPS: OnboardingStep[] = [
@@ -7,14 +9,6 @@ const STYLING_STEPS: OnboardingStep[] = [
   "heat_protection",
   "interstitial",
 ]
-const ROUTINE_STEPS: OnboardingStep[] = [
-  "towel_material",
-  "towel_technique",
-  "drying_method",
-  "brush_type",
-  "night_protection",
-]
-
 const STEP_LABELS: Record<OnboardingStep, string> = {
   welcome: "Willkommen",
   products_basics: "Produkte Basics",
@@ -37,6 +31,7 @@ export interface OnboardingProgressInput {
   currentDrilldownIndex: number
   drilldownCount: number
   selectedHeatTools: string[]
+  towelMaterial: TowelMaterial | null
 }
 
 export interface OnboardingProgressMilestone {
@@ -70,7 +65,11 @@ function buildDrilldownSteps(drilldownCount: number): string[] {
 export function buildOnboardingProgressPath({
   drilldownCount,
   selectedHeatTools,
-}: Pick<OnboardingProgressInput, "drilldownCount" | "selectedHeatTools">): string[] {
+  towelMaterial,
+}: Pick<
+  OnboardingProgressInput,
+  "drilldownCount" | "selectedHeatTools" | "towelMaterial"
+>): string[] {
   const hasHeatTools = selectedHeatTools.length > 0
 
   return [
@@ -79,7 +78,7 @@ export function buildOnboardingProgressPath({
     "heat_tools",
     ...(hasHeatTools ? ["heat_frequency", "heat_protection"] : []),
     ...STYLING_STEPS.slice(-1),
-    ...ROUTINE_STEPS,
+    ...getRoutineSteps({ towelMaterial }),
   ]
 }
 

--- a/src/lib/onboarding/routine-steps.ts
+++ b/src/lib/onboarding/routine-steps.ts
@@ -1,0 +1,20 @@
+import type { OnboardingStep } from "@/lib/onboarding/store"
+import type { TowelMaterial } from "@/lib/vocabulary/onboarding-care"
+
+export const ROUTINE_STEPS: OnboardingStep[] = [
+  "towel_material",
+  "towel_technique",
+  "drying_method",
+  "brush_type",
+  "night_protection",
+]
+
+export function getRoutineSteps({
+  towelMaterial,
+}: {
+  towelMaterial: TowelMaterial | null
+}): OnboardingStep[] {
+  return towelMaterial === "no_towel"
+    ? ROUTINE_STEPS.filter((step) => step !== "towel_technique")
+    : ROUTINE_STEPS
+}

--- a/src/lib/onboarding/store.ts
+++ b/src/lib/onboarding/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand"
+import { getRoutineSteps } from "@/lib/onboarding/routine-steps"
 import type { HeatStyling, ProductFrequency } from "@/lib/vocabulary/frequencies"
 import type {
   TowelMaterial,
@@ -60,16 +61,6 @@ const LINEAR_BEFORE_HEAT: OnboardingStep[] = [
 ]
 
 const HEAT_BRANCH: OnboardingStep[] = ["heat_frequency", "heat_protection"]
-
-const LINEAR_AFTER_HEAT: OnboardingStep[] = [
-  "interstitial",
-  "towel_material",
-  "towel_technique",
-  "drying_method",
-  "brush_type",
-  "night_protection",
-  "celebration",
-]
 
 /* ── State shape ── */
 
@@ -279,7 +270,17 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
 
 /* ── Build the full linear order including/excluding heat branch ── */
 
-function buildFullOrder(state: { selectedHeatTools: string[] }): OnboardingStep[] {
+function buildFullOrder(state: {
+  selectedHeatTools: string[]
+  towelMaterial: TowelMaterial | null
+}): OnboardingStep[] {
   const hasHeat = state.selectedHeatTools.length > 0
-  return [...LINEAR_BEFORE_HEAT, ...(hasHeat ? HEAT_BRANCH : []), ...LINEAR_AFTER_HEAT]
+
+  return [
+    ...LINEAR_BEFORE_HEAT,
+    ...(hasHeat ? HEAT_BRANCH : []),
+    "interstitial",
+    ...getRoutineSteps({ towelMaterial: state.towelMaterial }),
+    "celebration",
+  ]
 }

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -263,10 +263,16 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
     label: "Trocknungstechnik",
     sectionKey: "routine",
     editTarget: { kind: "onboarding", step: "towel_technique" },
-    getValue: (profile) =>
-      profile?.towel_technique
-        ? (TOWEL_TECHNIQUE_LABELS[profile.towel_technique] ?? profile.towel_technique)
-        : null,
+    getValue: (profile) => {
+      if (profile?.towel_technique) {
+        return TOWEL_TECHNIQUE_LABELS[profile.towel_technique] ?? profile.towel_technique
+      }
+      if (profile?.towel_material === "no_towel") {
+        return "Keine Trocknungstechnik"
+      }
+
+      return null
+    },
   },
   {
     key: "drying_method",

--- a/src/lib/vocabulary/onboarding-care.ts
+++ b/src/lib/vocabulary/onboarding-care.ts
@@ -1,5 +1,11 @@
 /* ── Towel material ── */
-export const TOWEL_MATERIALS = ["frottee", "mikrofaser", "tshirt", "turban_mikrofaser"] as const
+export const TOWEL_MATERIALS = [
+  "frottee",
+  "mikrofaser",
+  "tshirt",
+  "turban_mikrofaser",
+  "no_towel",
+] as const
 export type TowelMaterial = (typeof TOWEL_MATERIALS)[number]
 
 export const TOWEL_MATERIAL_LABELS = {
@@ -7,6 +13,7 @@ export const TOWEL_MATERIAL_LABELS = {
   mikrofaser: "Mikrofaser-Handtuch",
   tshirt: "T-Shirt / Baumwolltuch",
   turban_mikrofaser: "Turban (Mikrofaser)",
+  no_towel: "Kein Handtuch: Ich lasse meine Haare tropfnass trocknen",
 } as const satisfies Record<TowelMaterial, string>
 
 export const TOWEL_MATERIAL_OPTIONS = TOWEL_MATERIALS.map((value) => ({

--- a/supabase/migrations/20260615120000_add_no_towel_material.sql
+++ b/supabase/migrations/20260615120000_add_no_towel_material.sql
@@ -1,0 +1,28 @@
+DO $$
+DECLARE
+  constraint_name text;
+BEGIN
+  SELECT con.conname
+  INTO constraint_name
+  FROM pg_constraint con
+  JOIN pg_class rel ON rel.oid = con.conrelid
+  JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+  JOIN pg_attribute attr ON attr.attrelid = rel.oid
+    AND attr.attname = 'towel_material'
+    AND attr.attnum = ANY (con.conkey)
+  WHERE nsp.nspname = 'public'
+    AND rel.relname = 'hair_profiles'
+    AND con.contype = 'c'
+  LIMIT 1;
+
+  IF constraint_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.hair_profiles DROP CONSTRAINT %I', constraint_name);
+  END IF;
+END $$;
+
+ALTER TABLE public.hair_profiles
+  ADD CONSTRAINT hair_profiles_towel_material_check
+  CHECK (
+    towel_material IS NULL
+    OR towel_material IN ('frottee','mikrofaser','tshirt','turban_mikrofaser','no_towel')
+  );

--- a/tests/onboarding-care-vocabulary.test.ts
+++ b/tests/onboarding-care-vocabulary.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict"
 import test from "node:test"
 import {
   NIGHT_PROTECTIONS,
+  TOWEL_MATERIAL_LABELS,
+  TOWEL_MATERIALS,
   TOWEL_TECHNIQUES,
   normalizeNightProtectionValues,
   normalizeTowelTechniqueValue,
@@ -14,6 +16,20 @@ test("towel technique canonicalizes legacy German values", () => {
 
 test("towel technique options expose language-independent data keys", () => {
   assert.deepEqual(TOWEL_TECHNIQUES, ["rough_rubbing", "gentle_press"])
+})
+
+test("towel material options include no towel as the final explicit option", () => {
+  assert.deepEqual(TOWEL_MATERIALS, [
+    "frottee",
+    "mikrofaser",
+    "tshirt",
+    "turban_mikrofaser",
+    "no_towel",
+  ])
+  assert.equal(
+    TOWEL_MATERIAL_LABELS.no_towel,
+    "Kein Handtuch: Ich lasse meine Haare tropfnass trocknen",
+  )
 })
 
 test("night protection canonicalizes legacy loose braid and bun values", () => {

--- a/tests/onboarding-progress.test.ts
+++ b/tests/onboarding-progress.test.ts
@@ -9,6 +9,7 @@ test("product drilldowns count as individual progress steps", () => {
     currentDrilldownIndex: 2,
     drilldownCount: 3,
     selectedHeatTools: ["foehn"],
+    towelMaterial: null,
   })
 
   assert.equal(progress.totalSteps, 14)
@@ -28,6 +29,7 @@ test("heat branch disappears from the effective path when no tools are selected"
     currentDrilldownIndex: 1,
     drilldownCount: 2,
     selectedHeatTools: [],
+    towelMaterial: null,
   })
 
   assert.equal(progress.totalSteps, 11)
@@ -47,6 +49,7 @@ test("night protection reaches the end of the visible onboarding path", () => {
     currentDrilldownIndex: 0,
     drilldownCount: 1,
     selectedHeatTools: ["glätteisen"],
+    towelMaterial: null,
   })
 
   assert.equal(progress.currentLabel, "Nachtschutz")
@@ -55,4 +58,20 @@ test("night protection reaches the end of the visible onboarding path", () => {
   assert.equal(progress.progressPercent, 100)
   assert.equal(progress.milestones[2]?.label, "Alltag")
   assert.equal(progress.milestones[2]?.percent, 100)
+})
+
+test("no towel removes towel technique from the visible routine path", () => {
+  const progress = buildOnboardingProgressState({
+    currentStep: "drying_method",
+    currentDrilldownIndex: 0,
+    drilldownCount: 1,
+    selectedHeatTools: [],
+    towelMaterial: "no_towel",
+  })
+
+  assert.equal(progress.path.includes("towel_technique"), false)
+  assert.equal(progress.path.includes("towel_material"), true)
+  assert.equal(progress.path.includes("drying_method"), true)
+  assert.equal(progress.currentLabel, "Trocknen")
+  assert.equal(progress.currentSectionIndex, 2)
 })

--- a/tests/profile-section-config.test.ts
+++ b/tests/profile-section-config.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { PROFILE_FIELD_CONFIG } from "../src/lib/profile/section-config"
+import type { HairProfile } from "../src/lib/types"
+
+function makeProfile(overrides: Partial<HairProfile> = {}): HairProfile {
+  return {
+    id: "hp_test",
+    user_id: "user_test",
+    hair_texture: null,
+    thickness: null,
+    density: null,
+    concerns: [],
+    products_used: null,
+    shampoo_frequency: null,
+    heat_styling: null,
+    styling_tools: null,
+    goals: [],
+    cuticle_condition: null,
+    protein_moisture_balance: null,
+    scalp_type: null,
+    scalp_condition: null,
+    chemical_treatment: [],
+    desired_volume: null,
+    routine_preference: null,
+    current_routine_products: null,
+    towel_material: null,
+    towel_technique: null,
+    drying_method: null,
+    brush_type: null,
+    night_protection: null,
+    uses_heat_protection: false,
+    additional_notes: null,
+    conversation_memory: null,
+    created_at: "2026-06-15T00:00:00.000Z",
+    updated_at: "2026-06-15T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+test("profile shows no towel technique as an answered editable value", () => {
+  const towelTechniqueField = PROFILE_FIELD_CONFIG.find((field) => field.key === "towel_technique")
+
+  assert.ok(towelTechniqueField)
+  assert.deepEqual(towelTechniqueField.editTarget, {
+    kind: "onboarding",
+    step: "towel_technique",
+  })
+  assert.equal(
+    towelTechniqueField.getValue(
+      makeProfile({
+        towel_material: "no_towel",
+        towel_technique: null,
+      }),
+    ),
+    "Keine Trocknungstechnik",
+  )
+})

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -324,7 +324,24 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       })
       await page.getByRole("button", { name: /^Weiter$/i }).click()
 
-      // Towel material: select Frottee (single-select, auto-advances)
+      // Towel material: no towel skips technique, then back up and keep the normal Frottee path covered.
+      await expect(page.getByText("Womit trocknest du dein Haar?", { exact: false })).toBeVisible({
+        timeout: 10_000,
+      })
+      await page
+        .getByRole("button", {
+          name: /Kein Handtuch: Ich lasse meine Haare tropfnass trocknen/i,
+        })
+        .click()
+
+      await expect(
+        page.getByText("Wie trocknest du dein Haar hauptsächlich?", { exact: false }),
+      ).toBeVisible({
+        timeout: 10_000,
+      })
+      await expect(page.getByText("Wie trocknest du?", { exact: false })).toHaveCount(0)
+      await page.getByRole("button", { name: /^Zurück$/i }).click()
+
       await expect(page.getByText("Womit trocknest du dein Haar?", { exact: false })).toBeVisible({
         timeout: 10_000,
       })


### PR DESCRIPTION
## Summary
- Add canonical `towel_material = "no_towel"` with German profile/onboarding copy.
- Clear persisted `towel_technique` on normal no-towel selection and skip the technique step in onboarding navigation/progress.
- Keep the profile field visible/editable with display value `Keine Trocknungstechnik` for no-towel profiles.
- Add Supabase migration `20260615120000_add_no_towel_material.sql` to widen the `hair_profiles.towel_material` check constraint.

## Verification
- `npx tsx --test tests/onboarding-care-vocabulary.test.ts`
- `npx tsx --test tests/onboarding-progress.test.ts`
- `npx tsx --test tests/profile-section-config.test.ts`
- `npm run typecheck`
- `npm run ci:verify`
- Claude code review: medium profile-display finding fixed; no remaining blocking finding.
- `superpowers:requesting-code-review` / final focused review: no blocking findings.

## Migration / Release Notes
- Migration ID: `20260615120000`.
- Checked with `npx supabase migration list --linked`: `20260615120000` is local-only / not applied remotely.
- The DB-backed Playwright onboarding E2E reaches the no-towel click but cannot pass until this migration is applied; current remote constraint rejects `no_towel`.
- Do not merge into auto-deploying `main` until the migration application plan is explicit.

Linear: HAI-131