### PR TITLE
feat(product-intake): wire chat and onboarding intake

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "products:identity:validate": "tsx scripts/product-identity/validate-normalization.ts",
     "products:identity:validate-reviewed": "tsx scripts/product-identity/validate-normalization.ts --require-reviewed",
     "products:identity:apply": "tsx scripts/product-identity/apply-normalization.ts",
+    "product-intake:check-readiness": "tsx scripts/product-intake/check-readiness.ts",
+    "product-intake:cleanup-photos": "tsx scripts/product-intake/cleanup-photos.ts",
     "stress:smoke": "k6 run -e K6_PROFILE=smoke scripts/k6/launch-flow.js",
     "stress:average": "k6 run -e K6_PROFILE=average scripts/k6/launch-flow.js",
     "stress:spike": "k6 run -e K6_PROFILE=spike scripts/k6/launch-flow.js",

--- a/plans/2026-06-16-product-intake-phase-3-clawpatch-fixups.md
+++ b/plans/2026-06-16-product-intake-phase-3-clawpatch-fixups.md
@@ -1,0 +1,1003 @@
+# Product Intake Phase 3 Clawpatch Fixups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Patch the four Phase-3-relevant Clawpatch findings on PR #177 without mixing in unrelated profile/auth/product-identity/shampoo cleanup.
+
+**Architecture:** Keep the fix-up surgical. Product-intake cleanup becomes conservative by treating DB image references as protected storage paths; the product-intake client aligns submit readiness with payload shape; AgentV2 production orchestration gains a pipeline-level conversation ownership guard; `select_products` keeps parallel execution but no longer relies on a shared "latest result" variable.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Supabase service-role repositories, Node test runner via `tsx --test`, Clawpatch local review.
+
+---
+
+## Scope
+
+### In Scope
+
+- Fix Clawpatch finding `fnd_sig-feat-library-095071f340-4a60_680fbfd852`: cleanup script must not remove stale `tmp/...` storage objects that are still referenced by active or not-yet-cleaned `product_submissions`.
+- Fix Clawpatch finding `fnd_sig-feat-cli-command-8b2aeb085d-_da94465e61`: photo intake submit readiness and payload shape must agree when an existing pending onboarding usage reuses a committed front image.
+- Fix Clawpatch finding `fnd_sig-feat-library-036dec98b1-855d_672e9e5335`: AgentV2 production pipeline must verify `conversationId` belongs to `userId` before admin-client history/state reads.
+- Fix Clawpatch finding `fnd_sig-feat-library-036dec98b1-eda4_803266fcf0`: concurrent `select_products` calls must not share a mutable raw-result slot.
+- Re-run targeted tests and targeted Clawpatch revalidation.
+- Push one fix-up commit to `codex/product-intake-phase-3` to update draft PR #177 after verification.
+
+### Out Of Scope
+
+- Product identity apply transactionality and cross-type identifier conflicts.
+- Auth magic-link post-send cleanup.
+- Generic onboarding single-select delayed-back behavior.
+- Profile goals/subscription button findings.
+- Shampoo/conditioner helper findings.
+- Applying Supabase migrations or creating the production `product-intake` storage bucket.
+
+---
+
+## Current Branch And PR Context
+
+- Worktree: `/Users/nick/AI_work/hair_conscierge/.worktrees/product-intake-phase-3`
+- Branch: `codex/product-intake-phase-3`
+- PR: `https://github.com/NickRuppy/hair_concierge/pull/177`
+- Stack base: `origin/codex/product-intake-phase-2`
+- Current implementation commit before this fix-up: `9f3a084 feat(product-intake): wire chat and onboarding intake`
+- Keep `claude-code-review.md`, `.clawpatch/`, `clawpatch-report.md`, and `clawpatch-summary.md` out of the PR unless explicitly requested.
+
+---
+
+## Files To Modify
+
+- `scripts/product-intake/cleanup-photos.ts`
+  - Add a referenced-image-path loader for `product_submissions`.
+  - Pass protected paths into abandoned tmp cleanup.
+  - Export only the functions needed by tests.
+
+- `tests/product-intake-cleanup-photos.test.ts`
+  - Expand the fake Supabase client to distinguish `product_submissions` query shapes and storage list/remove calls.
+  - Add a regression test for stale tmp image referenced by pending submission.
+
+- `src/lib/product-intake/client.ts`
+  - Add `committedFrontImagePath?: string | null` to `buildProductIntakeSubmissionPayload`.
+  - Let committed front images make photo intake submittable only when paired with `existingUsageId`.
+  - For photo payloads, emit `front_image_path` only for current temporary uploads. Reuse committed images through `existing_usage_id`.
+
+- `src/hooks/use-onboarding-product-intake-controller.ts`
+  - Pass `drilldown.committedFrontImagePath` into `buildProductIntakeSubmissionPayload`.
+
+- `tests/product-intake-client-image-compression.test.ts`
+  - This file is currently the closest product-intake client unit test. Add payload/guard tests here or split to a new `tests/product-intake-client.test.ts` if the implementation would make this file semantically muddy. Prefer a new file if adding more than two payload tests.
+
+- `src/lib/agent-v2/production/conversation-history.ts`
+  - Add a pipeline ownership helper that uses the same query shape as the existing product-intake repository helper at `src/lib/product-intake/repository.ts:342`.
+  - Do not import product-intake repository code into AgentV2; match the prior-art query shape to avoid a cross-domain dependency.
+
+- `src/lib/chat-runtime/conversation-state-store.ts`
+  - Add an AgentV2 state loader that filters by both `conversation_id` and `user_id`, or accepts a `userId` parameter on `loadAgentV2ConversationState`.
+
+- `src/lib/agent-v2/production/chat-pipeline.ts`
+  - Update dependency signatures so tests can assert user-aware history/state loads.
+  - Load history/state through user-bound loaders before model/tool execution.
+  - Refactor `select_products` raw-result capture so each invocation owns its result.
+  - Replace the post-turn `deriveEngineArtifacts(latestSelectProductsResult)` consumer with the last append-only selected-product result.
+
+- `tests/agent-v2-production-chat-pipeline.spec.ts`
+  - Add conversation ownership regression.
+  - Add concurrent `select_products` out-of-order regression.
+  - Add `verifyConversationOwnership: async () => true` to the existing direct pipeline test setups so they do not call the real admin-client ownership helper.
+
+---
+
+## Task 1: Product-Intake Cleanup Protects Referenced Tmp Images
+
+**Files:**
+- Modify: `scripts/product-intake/cleanup-photos.ts`
+- Modify: `tests/product-intake-cleanup-photos.test.ts`
+
+- [ ] **Step 1: Write the failing cleanup test**
+
+Add a test to `tests/product-intake-cleanup-photos.test.ts` that proves apply-mode tmp cleanup skips old tmp files still referenced by `product_submissions`.
+
+The test should create:
+
+```ts
+const pendingReferencedTmp = "tmp/user-1/referenced-front.jpg"
+const orphanTmp = "tmp/user-1/orphan-front.jpg"
+```
+
+The fake Supabase storage list should return both files as stale under `tmp/user-1`. The fake `product_submissions` query should return one pending row:
+
+```ts
+{
+  id: "submission-1",
+  front_image_path: pendingReferencedTmp,
+  barcode_image_path: null,
+}
+```
+
+Expected result after `cleanupAbandonedTmpUploads(fake as never, true, cutoff, new Set([pendingReferencedTmp]))`:
+
+```ts
+assert.deepEqual(fake.removedPaths, [orphanTmp])
+assert.deepEqual(result, { objects: 1 })
+```
+
+The fake storage client needs both `list` and `remove`:
+
+```ts
+storage: {
+  from(bucket: string) {
+    return {
+      async list(path: string, options: { limit: number; offset: number }) {
+        calls.push(`list:${bucket}:${path}:${options.offset}`)
+        if (path === "tmp") {
+          return { data: [{ name: "user-1" }], error: null }
+        }
+        if (path === "tmp/user-1") {
+          return {
+            data: [
+              { name: "referenced-front.jpg", updated_at: "2026-06-14T00:00:00.000Z" },
+              { name: "orphan-front.jpg", updated_at: "2026-06-14T00:00:00.000Z" },
+            ],
+            error: null,
+          }
+        }
+        return { data: [], error: null }
+      },
+      async remove(paths: string[]) {
+        calls.push(`remove:${bucket}:${paths.join(",")}`)
+        removedPaths.push(...paths)
+        return { error: null }
+      },
+    }
+  },
+}
+```
+
+Export the function for tests:
+
+```ts
+export async function cleanupAbandonedTmpUploads(
+  supabase: SupabaseClient,
+  apply: boolean,
+  cutoff: Date,
+  protectedPaths: ReadonlySet<string> = new Set(),
+) {
+  // implementation in Step 3
+}
+```
+
+- [ ] **Step 2: Run the cleanup test and verify RED**
+
+Run:
+
+```bash
+npx tsx --test tests/product-intake-cleanup-photos.test.ts
+```
+
+Expected: FAIL because `cleanupAbandonedTmpUploads` either is not exported or removes both stale tmp paths.
+
+- [ ] **Step 3: Implement protected-path filtering**
+
+In `scripts/product-intake/cleanup-photos.ts`, add a referenced path loader:
+
+```ts
+type ReferencedSubmissionPhotoRow = {
+  front_image_path: string | null
+  barcode_image_path: string | null
+}
+
+export async function loadReferencedSubmissionImagePaths(
+  supabase: SupabaseClient,
+): Promise<Set<string>> {
+  const paths = new Set<string>()
+
+  for (let offset = 0; ; offset += SUBMISSION_BATCH_SIZE) {
+    const { data, error } = await supabase
+      .from("product_submissions")
+      .select("front_image_path, barcode_image_path")
+      .is("photos_deleted_at", null)
+      .range(offset, offset + SUBMISSION_BATCH_SIZE - 1)
+
+    if (error) {
+      throw new Error(`load referenced submission photos: ${error.message}`)
+    }
+
+    const rows = (data ?? []) as ReferencedSubmissionPhotoRow[]
+    for (const row of rows) {
+      for (const path of uniquePaths([row.front_image_path, row.barcode_image_path])) {
+        paths.add(path)
+      }
+    }
+
+    if (rows.length < SUBMISSION_BATCH_SIZE) break
+  }
+
+  return paths
+}
+```
+
+Change abandoned tmp cleanup to accept the set:
+
+```ts
+export async function cleanupAbandonedTmpUploads(
+  supabase: SupabaseClient,
+  apply: boolean,
+  cutoff: Date,
+  protectedPaths: ReadonlySet<string> = new Set(),
+) {
+  const users = await listAllStorageEntries(supabase, "tmp")
+  let totalObjects = 0
+
+  for (const userEntry of users) {
+    if (!userEntry.name) continue
+    const userPath = `tmp/${userEntry.name}`
+    const files = await listAllStorageEntries(supabase, userPath)
+    const stalePaths = files
+      .filter((file) => isOlderThan(file.updated_at ?? file.created_at, cutoff))
+      .map((file) => `${userPath}/${file.name}`)
+      .filter((path) => !protectedPaths.has(path))
+
+    totalObjects += await removeStorageObjects(supabase, stalePaths, apply)
+  }
+
+  return { objects: totalObjects }
+}
+```
+
+Add a direct loader test too, so the new database query is covered:
+
+```ts
+test("referenced submission image path loader paginates and collects both image columns", async () => {
+  const rows = [
+    { front_image_path: "tmp/user-1/front.jpg", barcode_image_path: null },
+    { front_image_path: null, barcode_image_path: "tmp/user-1/barcode.jpg" },
+  ]
+  const supabase = createCleanupSupabaseFake({ referencedRows: rows })
+
+  const paths = await loadReferencedSubmissionImagePaths(supabase as never)
+
+  assert.deepEqual([...paths].sort(), ["tmp/user-1/barcode.jpg", "tmp/user-1/front.jpg"])
+})
+```
+
+Change `main()` to avoid parallel cleanup:
+
+```ts
+const expiredSubmissions = await cleanupExpiredSubmissionPhotos(supabase, apply)
+const protectedPaths = await loadReferencedSubmissionImagePaths(supabase)
+const tmpUploads = await cleanupAbandonedTmpUploads(supabase, apply, tmpCutoff, protectedPaths)
+```
+
+Rationale: sequence this so expired/rejected rows can be stamped first in apply mode, then the tmp sweep uses the current DB reference set.
+
+Also update the existing summary `console.log` lines to read the sequential `expiredSubmissions` and `tmpUploads` constants. This is intentionally a small control-flow change, not a logging-format change.
+
+- [ ] **Step 4: Run cleanup tests and verify GREEN**
+
+Run:
+
+```bash
+npx tsx --test tests/product-intake-cleanup-photos.test.ts
+```
+
+Expected: PASS.
+
+---
+
+## Task 2: Committed Front Image Payload Reuse
+
+**Files:**
+- Modify: `src/lib/product-intake/client.ts`
+- Modify: `src/hooks/use-onboarding-product-intake-controller.ts`
+- Modify or create: `tests/product-intake-client.test.ts`
+
+- [ ] **Step 1: Write failing guard/payload consistency tests**
+
+Create `tests/product-intake-client.test.ts` if it does not exist.
+
+Add:
+
+```ts
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildProductIntakeSubmissionPayload,
+  canSubmitProductIntake,
+} from "../src/lib/product-intake/client"
+
+test("photo intake can submit with a committed front image only for an existing usage edit", () => {
+  const committedFrontImagePath = "user-1/submission-1/front.jpg"
+  const existingUsageId = "00000000-0000-4000-8000-000000000001"
+
+  assert.equal(
+    canSubmitProductIntake({
+      method: "photo",
+      category: "shampoo",
+      frequency: "weekly_1x",
+      brandText: "",
+      productName: "",
+      frontImagePath: null,
+      committedFrontImagePath,
+    }),
+    false,
+  )
+
+  assert.equal(
+    canSubmitProductIntake({
+      method: "photo",
+      category: "shampoo",
+      frequency: "weekly_1x",
+      brandText: "",
+      productName: "",
+      frontImagePath: null,
+      committedFrontImagePath,
+      existingUsageId,
+    }),
+    true,
+  )
+
+  const payload = buildProductIntakeSubmissionPayload({
+    method: "photo",
+    category: "shampoo",
+    frequency: "weekly_1x",
+    brandText: "",
+    productName: "",
+    frontImagePath: null,
+    committedFrontImagePath,
+    existingUsageId,
+    barcodeImagePath: null,
+  })
+
+  assert.equal(payload.front_image_path, undefined)
+  assert.equal(payload.existing_usage_id, existingUsageId)
+})
+```
+
+- [ ] **Step 2: Run the client test and verify RED**
+
+Run:
+
+```bash
+npx tsx --test tests/product-intake-client.test.ts
+```
+
+Expected: FAIL because `committedFrontImagePath` is not part of the builder/readiness contract for existing usage edits.
+
+Note: committed storage paths are not temporary upload paths. The desired payload shape for a same pending onboarding edit is `existing_usage_id` without `front_image_path`; the server then reuses the prior committed image.
+
+- [ ] **Step 3: Implement payload fallback**
+
+In `src/lib/product-intake/client.ts`, extend the builder params:
+
+```ts
+committedFrontImagePath?: string | null
+```
+
+Extend `canSubmitProductIntake` with:
+
+```ts
+existingUsageId?: string | null
+```
+
+For photo readiness, allow:
+
+```ts
+Boolean(params.frontImagePath || (params.committedFrontImagePath && params.existingUsageId))
+```
+
+In the photo payload branch, compute:
+
+```ts
+const frontImagePath = params.frontImagePath ?? null
+```
+
+Emit `front_image_path` only when `frontImagePath` is a current temporary upload. Do not serialize `committedFrontImagePath` into `front_image_path`; the server rejects committed `user/submission/...` paths as stale upload paths. Keep barcode behavior unchanged.
+
+- [ ] **Step 4: Pass the committed path from onboarding**
+
+In `src/hooks/use-onboarding-product-intake-controller.ts`, add:
+
+```ts
+committedFrontImagePath: drilldown.committedFrontImagePath,
+```
+
+to the existing `buildProductIntakeSubmissionPayload` call.
+
+Also pass `existingUsageId` into onboarding readiness checks so a committed-only photo can continue only for the same pending onboarding usage edit.
+
+Do not add `committedFrontImagePath` to the chat card. The chat card only has current tmp upload paths and no committed pending image path.
+
+- [ ] **Step 5: Run product-intake client tests and verify GREEN**
+
+Run:
+
+```bash
+npx tsx --test tests/product-intake-client.test.ts tests/product-intake-submissions.test.ts
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Pipeline-Level Conversation Ownership Guard
+
+**Files:**
+- Modify: `src/lib/agent-v2/production/conversation-history.ts`
+- Modify: `src/lib/chat-runtime/conversation-state-store.ts`
+- Modify: `src/lib/agent-v2/production/chat-pipeline.ts`
+- Modify: `tests/agent-v2-production-chat-pipeline.spec.ts`
+
+- [ ] **Step 1: Write failing ownership regression test**
+
+In `tests/agent-v2-production-chat-pipeline.spec.ts`, add a test near the existing production pipeline tests:
+
+```ts
+test("AgentV2 production pipeline rejects mismatched user and conversation before loading history or state", async () => {
+  let historyLoaded = false
+  let stateLoaded = false
+
+  await assert.rejects(
+    () =>
+      runAgentV2ProductionPipeline(
+        {
+          message: "Hallo",
+          conversationId: "conversation-owned-by-user-2",
+          userId: "user-1",
+          requestId: "request-ownership",
+        },
+        {
+          verifyConversationOwnership: async ({ conversationId, userId }) => {
+            assert.equal(conversationId, "conversation-owned-by-user-2")
+            assert.equal(userId, "user-1")
+            return false
+          },
+          loadConversationHistory: async () => {
+            historyLoaded = true
+            return []
+          },
+          loadConversationState: async () => {
+            stateLoaded = true
+            return createDefaultConversationState()
+          },
+          getUserContext: async () => ({
+            profile: createCompleteHairProfile(),
+            routine_inventory: [],
+            relevant_memory: [],
+            derived_signals: [],
+            suggested_overlays: [],
+            missing_profile: [],
+          }),
+          loadUserMemoryContext: async () => ({
+            enabled: true,
+            entries: [],
+            promptContext: null,
+            dislikedProductNames: [],
+          }),
+          runAgentV2ResponsesTurn: async () => createAgentV2Result(),
+        },
+      ),
+    /does not belong to user/i,
+  )
+
+  assert.equal(historyLoaded, false)
+  assert.equal(stateLoaded, false)
+})
+```
+
+This test introduces the dependency contract:
+
+```ts
+verifyConversationOwnership?: (params: {
+  conversationId: string
+  userId: string
+}) => Promise<boolean>
+```
+
+- [ ] **Step 2: Run the AgentV2 pipeline test and verify RED**
+
+Run:
+
+```bash
+npx tsx --test tests/agent-v2-production-chat-pipeline.spec.ts
+```
+
+Expected: FAIL because `verifyConversationOwnership` is not part of `ProductionAgentV2PipelineDeps` and/or the pipeline does not reject before history/state load.
+
+- [ ] **Step 3: Add ownership helper in conversation history module**
+
+In `src/lib/agent-v2/production/conversation-history.ts`, add:
+
+```ts
+type ConversationOwnershipQueryResult = {
+  data: { id: string } | null
+  error: unknown
+}
+
+type ConversationOwnershipClient = {
+  from(table: "conversations"): {
+    select(columns: string): {
+      eq(column: "id" | "user_id", value: string): {
+        eq(column: "id" | "user_id", value: string): {
+          maybeSingle(): Promise<ConversationOwnershipQueryResult>
+        }
+        maybeSingle(): Promise<ConversationOwnershipQueryResult>
+      }
+    }
+  }
+}
+
+export async function verifyAgentV2ProductionConversationOwnership(
+  params: { conversationId: string; userId: string },
+  client: unknown = createAdminClient(),
+): Promise<boolean> {
+  const admin = client as ConversationOwnershipClient
+  const { data, error } = await admin
+    .from("conversations")
+    .select("id")
+    .eq("id", params.conversationId)
+    .eq("user_id", params.userId)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to verify AgentV2 production conversation ownership:", error)
+    return false
+  }
+
+  return Boolean(data?.id)
+}
+```
+
+This intentionally matches the existing prior-art query in `src/lib/product-intake/repository.ts:342-353`, but keeps AgentV2 independent from product-intake repository code.
+
+If the local Supabase type shape makes the chained `eq` type awkward, prefer a small `unknown` cast inside this helper rather than spreading casts through the pipeline.
+
+- [ ] **Step 4: Wire guard into production pipeline**
+
+In `src/lib/agent-v2/production/chat-pipeline.ts`:
+
+1. Import the helper:
+
+```ts
+import {
+  loadAgentV2ProductionConversationHistory,
+  verifyAgentV2ProductionConversationOwnership,
+} from "@/lib/agent-v2/production/conversation-history"
+```
+
+2. Extend `ProductionAgentV2PipelineDeps`:
+
+```ts
+verifyConversationOwnership?: (params: {
+  conversationId: string
+  userId: string
+}) => Promise<boolean>
+```
+
+3. Before the current `Promise.all` that loads history/context/memory/state, add:
+
+```ts
+const ownsConversation = await (deps.verifyConversationOwnership ??
+  verifyAgentV2ProductionConversationOwnership)({ conversationId, userId })
+
+if (!ownsConversation) {
+  throw new Error("AgentV2 production conversation does not belong to user.")
+}
+```
+
+This must happen before `loadConversationHistory` and `loadConversationState`.
+
+- [ ] **Step 5: Update existing pipeline tests to stub the new guard**
+
+There are existing direct `runAgentV2ProductionPipeline(` calls in `tests/agent-v2-production-chat-pipeline.spec.ts` at these current line anchors:
+
+```text
+751, 908, 990, 1036, 1084, 1231, 1556, 1636, 1740, 1894, 1967, 2031, 2083
+```
+
+Each test dependency object that is meant to exercise normal successful pipeline behavior must add:
+
+```ts
+verifyConversationOwnership: async ({ conversationId, userId }) => {
+  assert.equal(typeof conversationId, "string")
+  assert.equal(typeof userId, "string")
+  return true
+},
+```
+
+Tests that intentionally exercise failure behavior can use the same stub unless the failure is ownership-specific. Do not let existing tests fall through to the real helper, because the real helper creates an admin Supabase client and will fail in unit tests without environment.
+
+- [ ] **Step 6: Make default state reads user-bound where practical**
+
+For default production code, the guard is the hard boundary. To make the state read less foot-gunny, also add a user-bound AgentV2 state loader in `src/lib/chat-runtime/conversation-state-store.ts`:
+
+```ts
+export async function loadAgentV2ConversationStateForUser(
+  supabase: SupabaseClient,
+  params: { conversationId: string | null | undefined; userId: string },
+): Promise<AgentV2ConversationStateV2> {
+  if (!params.conversationId) return normalizeAgentV2ConversationState(null)
+
+  const { data, error } = await supabase
+    .from("conversation_states")
+    .select("state")
+    .eq("conversation_id", params.conversationId)
+    .eq("user_id", params.userId)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to load AgentV2 conversation state:", error)
+    return normalizeAgentV2ConversationState(null)
+  }
+
+  return normalizeAgentV2ConversationState(data?.state)
+}
+```
+
+Then in the pipeline default state path use:
+
+```ts
+loadAgentV2ConversationStateForUser(createAdminClient(), { conversationId, userId })
+```
+
+This requires updating the import near the existing state-store import in `src/lib/agent-v2/production/chat-pipeline.ts`. Replace the current alias-only import shape:
+
+```ts
+import {
+  loadAgentV2ConversationState as loadPersistedConversationState,
+  saveAgentV2ConversationState,
+} from "@/lib/chat-runtime/conversation-state-store"
+```
+
+with an import that also brings in the new helper:
+
+```ts
+import {
+  loadAgentV2ConversationState as loadPersistedConversationState,
+  loadAgentV2ConversationStateForUser,
+  saveAgentV2ConversationState,
+} from "@/lib/chat-runtime/conversation-state-store"
+```
+
+Keep `deps.loadConversationState` available for tests, but update its signature to:
+
+```ts
+loadConversationState?: (params: { conversationId: string; userId: string }) => Promise<unknown>
+```
+
+Update the pipeline call site that currently passes a positional conversation id into `deps.loadConversationState`. The call must pass the new object:
+
+```ts
+deps.loadConversationState({ conversationId, userId })
+```
+
+Most existing test stubs use zero-argument async functions and remain assignable to this dependency type; do not churn those just for parameter shape. Only update stubs that inspect the argument or otherwise need the new object.
+
+- [ ] **Step 7: Run AgentV2 pipeline tests and verify GREEN**
+
+Run:
+
+```bash
+npx tsx --test tests/agent-v2-production-chat-pipeline.spec.ts
+```
+
+Expected: PASS.
+
+---
+
+## Task 4: Preserve Parallel `select_products` Without Shared Raw Result
+
+**Files:**
+- Modify: `src/lib/agent-v2/production/chat-pipeline.ts`
+- Modify: `tests/agent-v2-production-chat-pipeline.spec.ts`
+
+- [ ] **Step 1: Write failing out-of-order concurrency test**
+
+In `tests/agent-v2-production-chat-pipeline.spec.ts`, add a test that calls the runtime tool twice in parallel and resolves out of order.
+
+Use two `SelectProductsToolResult` objects:
+
+```ts
+const shampooSelection: SelectProductsToolResult = {
+  projection: { category: "shampoo", /* use same required fields as existing tests */ },
+  products: [createProduct("shampoo-product")],
+  effectiveHairProfile: hairProfile,
+  runtime: buildRecommendationEngineRuntimeForChat({
+    hairProfile,
+    routineItems: [],
+    productCategory: "shampoo",
+    message: "Vergleiche Shampoo und Conditioner.",
+  }),
+}
+
+const conditionerSelection: SelectProductsToolResult = {
+  projection: { category: "conditioner", /* use same required fields as existing tests */ },
+  products: [createProduct("conditioner-product")],
+  effectiveHairProfile: hairProfile,
+  runtime: buildRecommendationEngineRuntimeForChat({
+    hairProfile,
+    routineItems: [],
+    productCategory: "conditioner",
+    message: "Vergleiche Shampoo und Conditioner.",
+  }),
+}
+```
+
+The fake `createSelectProductsTool` should return promises controlled by the test:
+
+```ts
+const resolvers = new Map<string, (value: SelectProductsToolResult) => void>()
+
+createSelectProductsTool:
+  (options) =>
+  async (input: SelectProductsToolParams) =>
+    new Promise((resolve) => {
+      resolvers.set(input.category, (result) => {
+        options.onResult?.(result)
+        resolve(result.projection)
+      })
+    })
+```
+
+The fake must call `options.onResult?.(result)` before resolving and must resolve with `result.projection`, mirroring the real `select_products` tool. Without that callback, the current buggy shared `latestSelectProductsResult` slot is never populated and the test can pass for the wrong reason.
+
+The fake `runAgentV2ResponsesTurn` should:
+
+```ts
+const shampooPromise = params.tools.select_products({ category: "shampoo" })
+const conditionerPromise = params.tools.select_products({ category: "conditioner" })
+
+resolvers.get("conditioner")?.(conditionerSelection)
+resolvers.get("shampoo")?.(shampooSelection)
+
+const [shampooProjection, conditionerProjection] = await Promise.all([
+  shampooPromise,
+  conditionerPromise,
+])
+
+assert.equal(shampooProjection.category, "shampoo")
+assert.equal(conditionerProjection.category, "conditioner")
+```
+
+Expected under the current code: FAIL or flake because the first awaited projection can be derived from the out-of-order shared `latestSelectProductsResult` rather than from that invocation's raw result.
+
+- [ ] **Step 2: Run AgentV2 pipeline test and verify RED**
+
+Run:
+
+```bash
+npx tsx --test tests/agent-v2-production-chat-pipeline.spec.ts
+```
+
+Expected: FAIL on the new concurrency test.
+
+- [ ] **Step 3: Capture raw results per invocation in the pipeline**
+
+In `src/lib/agent-v2/production/chat-pipeline.ts`, remove this shared slot:
+
+```ts
+let latestSelectProductsResult: SelectProductsToolResult | null = null
+```
+
+Replace the single shared tool instance with a per-call wrapper. Inside `tools.select_products`, instantiate a tool with local capture:
+
+```ts
+let rawResult: SelectProductsToolResult | null = null
+const selectProductsForCall = (deps.createSelectProductsTool ?? createSelectProductsTool)({
+  onResult: (result) => {
+    rawResult = result
+  },
+})
+
+const projection = await selectProductsForCall({
+  category: input.category as Parameters<typeof selectProductsForCall>[0]["category"],
+  message: productToolMessage,
+  hairProfile: effectiveHairProfile,
+  memoryContext,
+  routineItems: effectiveRoutineItems,
+  effectiveCareContext,
+})
+```
+
+Then use the local value:
+
+```ts
+const resultForProjection =
+  rawResult ??
+  ({
+    projection,
+    products: [],
+    effectiveHairProfile,
+    runtime: {} as SelectProductsToolResult["runtime"],
+  } satisfies SelectProductsToolResult)
+
+selectedProductResults.push(resultForProjection)
+
+const agentProjection = projectSelectProductsForAgentV2(resultForProjection, {
+  includeCareBalanceContext: true,
+})
+selectedProductProjections.push(agentProjection)
+return agentProjection
+```
+
+Important: preserve `selectedProductResults` and `selectedProductProjections` as turn-level append-only arrays. Only the per-call capture becomes local.
+
+This intentionally pushes the local fallback result as well as real raw results. In production the real tool always calls `onResult`, so the fallback should only matter for defensive tests/fakes; keeping the append-only array populated makes the post-turn artifact source deterministic.
+
+Also delete the existing outer shared tool instance:
+
+```ts
+const selectProducts = (deps.createSelectProductsTool ?? createSelectProductsTool)({
+  onResult: (result) => {
+    latestSelectProductsResult = result
+    selectedProductResults.push(result)
+  },
+})
+```
+
+and delete the reset inside `tools.select_products`:
+
+```ts
+latestSelectProductsResult = null
+```
+
+Do not modify `src/lib/agent/tools/select-products.ts`. Its `onResult` callback already exists and already emits the raw result.
+
+- [ ] **Step 4: Replace post-turn engine artifact source**
+
+In `src/lib/agent-v2/production/chat-pipeline.ts`, replace:
+
+```ts
+const { categoryDecision, engineTrace } = deriveEngineArtifacts(latestSelectProductsResult)
+```
+
+with:
+
+```ts
+const { categoryDecision, engineTrace } = deriveEngineArtifacts(
+  selectedProductResults.at(-1) ?? null,
+)
+```
+
+This preserves the current "last selected product result drives exposed engine artifacts" behavior without a shared mutable slot.
+
+- [ ] **Step 5: Run AgentV2 pipeline tests and verify GREEN**
+
+Run:
+
+```bash
+npx tsx --test tests/agent-v2-production-chat-pipeline.spec.ts
+```
+
+Expected: PASS.
+
+---
+
+## Task 5: Verification And Targeted Clawpatch Revalidation
+
+**Files:**
+- No production files should be modified in this task.
+
+- [ ] **Step 1: Run focused test bundle**
+
+Run:
+
+```bash
+npx tsx --test \
+  tests/product-intake-cleanup-photos.test.ts \
+  tests/product-intake-client.test.ts \
+  tests/product-intake-client-image-compression.test.ts \
+  tests/product-intake-submissions.test.ts \
+  tests/product-intake-schema.test.ts \
+  tests/product-intake-lookup.test.ts \
+  tests/agent-v2-production-chat-pipeline.spec.ts \
+  tests/agent-v2-responses-runtime.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run repo checks**
+
+Run:
+
+```bash
+npm run typecheck
+npm run lint
+npm run build
+git diff --check
+```
+
+Expected:
+- `typecheck`: PASS
+- `lint`: PASS with only the known pre-existing warnings if still present
+- `build`: PASS
+- `git diff --check`: PASS
+
+For the final pre-push gate, prefer the repo aggregate command:
+
+```bash
+npm run ci:verify
+```
+
+Expected: PASS. This runs `typecheck && lint && build`.
+
+- [ ] **Step 3: Run targeted Clawpatch revalidation**
+
+Run:
+
+```bash
+npm run clawpatch:revalidate -- --finding fnd_sig-feat-library-095071f340-4a60_680fbfd852
+npm run clawpatch:revalidate -- --finding fnd_sig-feat-cli-command-8b2aeb085d-_da94465e61
+npm run clawpatch:revalidate -- --finding fnd_sig-feat-library-036dec98b1-855d_672e9e5335
+npm run clawpatch:revalidate -- --finding fnd_sig-feat-library-036dec98b1-eda4_803266fcf0
+```
+
+Expected: each finding is closed, downgraded to non-actionable, or produces a narrower remaining issue that is triaged before shipping.
+
+The flag is valid for the current Clawpatch CLI (`clawpatch revalidate --help` lists `--finding <id>`).
+
+- [ ] **Step 4: Generate updated Clawpatch report**
+
+Run:
+
+```bash
+npm run clawpatch:report -- --output clawpatch-report.md
+npm run clawpatch:summary -- --output clawpatch-summary.md --base origin/codex/product-intake-phase-2
+```
+
+Expected: report reflects targeted finding status. Keep generated report files out of git unless Nick explicitly asks to include them.
+
+- [ ] **Step 5: Commit and push fix-up**
+
+After Nick approves the patched diff:
+
+```bash
+git status --short --branch
+git add scripts/product-intake/cleanup-photos.ts \
+  src/lib/product-intake/client.ts \
+  src/hooks/use-onboarding-product-intake-controller.ts \
+  src/lib/agent-v2/production/conversation-history.ts \
+  src/lib/chat-runtime/conversation-state-store.ts \
+  src/lib/agent-v2/production/chat-pipeline.ts \
+  tests/product-intake-cleanup-photos.test.ts \
+  tests/product-intake-client.test.ts \
+  tests/agent-v2-production-chat-pipeline.spec.ts
+git commit -m "fix(product-intake): address phase 3 review findings"
+git push
+```
+
+Do not stage:
+
+```text
+claude-code-review.md
+clawpatch-report.md
+clawpatch-summary.md
+.clawpatch/
+```
+
+- [ ] **Step 6: Update PR #177 notes**
+
+Update the PR body or add a PR comment summarizing:
+
+- the four targeted Clawpatch findings patched
+- verification commands and results
+- remaining Clawpatch findings intentionally deferred because they are outside PR #177 scope
+- Supabase migration/storage bucket still unapplied to production
+
+---
+
+## Verification Matrix
+
+| Risk | Regression Test | Runtime Check |
+| --- | --- | --- |
+| Cleanup deletes reviewed image | `tests/product-intake-cleanup-photos.test.ts` referenced tmp test | `npm run clawpatch:revalidate` for cleanup finding |
+| UI can submit without a reusable image reference | `tests/product-intake-client.test.ts` committed path existing-usage test | product-intake focused bundle |
+| Cross-user chat history/state load | `tests/agent-v2-production-chat-pipeline.spec.ts` ownership mismatch test | Clawpatch revalidation for ownership finding |
+| Parallel tool result mix-up | `tests/agent-v2-production-chat-pipeline.spec.ts` out-of-order parallel tool test | Clawpatch revalidation for concurrency finding |
+
+---
+
+## Open Risks And Notes
+
+- The cleanup script will be more conservative. If old tmp paths are referenced by active rows, they will be skipped. That can retain extra storage temporarily, which is preferable to losing review evidence.
+- The pipeline ownership guard introduces a new failure mode: a mismatched `userId`/`conversationId` throws before assistant execution. This should surface as a server error unless the API route maps it. If tests reveal poor UX, add a route-level controlled response, but keep the pipeline guard.
+- The `select_products` per-call refactor should preserve existing matched-products output because `selectedProductResults` remains append-only for the turn.
+- Do not address non-Phase-3 Clawpatch findings in this PR unless they block the targeted tests or revalidation.

--- a/scripts/product-intake/check-readiness.ts
+++ b/scripts/product-intake/check-readiness.ts
@@ -1,0 +1,277 @@
+import { config as loadEnv } from "dotenv"
+import { existsSync } from "node:fs"
+import { join, sep } from "node:path"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+type CheckStatus = "pass" | "fail"
+
+type ReadinessCheck = {
+  label: string
+  run: () => Promise<void>
+}
+
+type CheckResult = {
+  label: string
+  status: CheckStatus
+  detail: string
+}
+
+const REQUIRED_BUCKET_ID = "product-intake"
+const REQUIRED_BUCKET_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+]
+const MAX_PRODUCT_INTAKE_UPLOAD_BYTES = 10 * 1024 * 1024
+
+const TABLE_COLUMN_CHECKS = [
+  {
+    table: "product_categories",
+    columns: ["key", "display_name_de", "is_catalog_supported", "is_intake_supported"],
+    reason: "category support gating",
+  },
+  {
+    table: "brands",
+    columns: ["id", "canonical_name", "normalized_name"],
+    reason: "brand resolution",
+  },
+  {
+    table: "product_lines",
+    columns: ["id", "brand_id", "canonical_name", "normalized_name"],
+    reason: "brand/product-line resolution",
+  },
+  {
+    table: "brand_aliases",
+    columns: ["brand_id", "product_line_id", "alias", "normalized_alias"],
+    reason: "brand alias resolution",
+  },
+  {
+    table: "products",
+    columns: [
+      "id",
+      "name",
+      "brand_id",
+      "product_line_id",
+      "category_key",
+      "is_active",
+      "is_chaarlie_recommended",
+    ],
+    reason: "catalog matching",
+  },
+  {
+    table: "product_identifiers",
+    columns: [
+      "product_id",
+      "identifier_type",
+      "identifier_value",
+      "normalized_identifier_value",
+      "source",
+    ],
+    reason: "identifier/barcode matching",
+  },
+  {
+    table: "user_product_usage",
+    columns: [
+      "id",
+      "user_id",
+      "category",
+      "product_name",
+      "frequency_range",
+      "brand_text",
+      "product_id",
+      "product_submission_id",
+      "match_status",
+      "intake_method",
+      "source",
+      "front_image_path",
+    ],
+    reason: "user inventory intake/link state",
+  },
+  {
+    table: "product_submissions",
+    columns: [
+      "id",
+      "user_id",
+      "user_product_usage_id",
+      "source",
+      "source_conversation_id",
+      "intake_method",
+      "category",
+      "brand_text",
+      "product_name_text",
+      "frequency_range",
+      "front_image_path",
+      "barcode_image_path",
+      "front_image_validation_status",
+      "front_image_validation_metadata",
+      "barcode_image_validation_status",
+      "barcode_image_validation_metadata",
+      "previous_product_id",
+      "previous_product_snapshot",
+      "status",
+      "researched_payload",
+      "intake_history",
+      "approved_product_id",
+      "reviewed_at",
+      "reviewed_by",
+      "review_notes",
+      "user_facing_resolution_reason",
+      "user_facing_next_step",
+      "user_facing_missing_fields",
+      "notification_sent_at",
+      "cleanup_after",
+      "photos_deleted_at",
+      "created_at",
+      "updated_at",
+    ],
+    reason: "operator review queue",
+  },
+] as const
+
+function createSupabaseClientFromEnv(): SupabaseClient {
+  loadLocalEnv()
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+function loadLocalEnv() {
+  for (const envPath of envCandidatePaths()) {
+    if (existsSync(envPath)) {
+      loadEnv({ path: envPath })
+    }
+  }
+}
+
+function envCandidatePaths(): string[] {
+  const cwd = process.cwd()
+  const candidates = [join(cwd, ".env.local")]
+  const worktreeIndex = cwd.indexOf(`${sep}.worktrees${sep}`)
+
+  if (worktreeIndex >= 0) {
+    candidates.push(join(cwd.slice(0, worktreeIndex), ".env.local"))
+  }
+
+  return [...new Set(candidates)]
+}
+
+function targetLabel(): string {
+  const rawUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (!rawUrl) return "unknown Supabase URL"
+
+  try {
+    const url = new URL(rawUrl)
+    return url.hostname
+  } catch {
+    return "configured Supabase URL"
+  }
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  return "unknown error"
+}
+
+async function expectColumns(
+  supabase: SupabaseClient,
+  table: string,
+  columns: readonly string[],
+  reason: string,
+) {
+  const { error } = await supabase.from(table).select(columns.join(",")).limit(1)
+
+  if (error) {
+    throw new Error(`${table}: missing or inaccessible primitives for ${reason}: ${error.message}`)
+  }
+}
+
+async function expectProductIntakeBucket(supabase: SupabaseClient) {
+  const { data, error } = await supabase.storage.getBucket(REQUIRED_BUCKET_ID)
+
+  if (error || !data) {
+    throw new Error(
+      `storage bucket "${REQUIRED_BUCKET_ID}" is missing or inaccessible: ${
+        error?.message ?? "no bucket returned"
+      }`,
+    )
+  }
+
+  if (data.public) {
+    throw new Error(`storage bucket "${REQUIRED_BUCKET_ID}" must not be public`)
+  }
+
+  const configuredLimit = data.file_size_limit ?? 0
+  if (configuredLimit < MAX_PRODUCT_INTAKE_UPLOAD_BYTES) {
+    throw new Error(
+      `storage bucket "${REQUIRED_BUCKET_ID}" file_size_limit is ${configuredLimit}; expected at least ${MAX_PRODUCT_INTAKE_UPLOAD_BYTES}`,
+    )
+  }
+
+  const mimeTypes = data.allowed_mime_types ?? []
+  const missingMimeTypes = REQUIRED_BUCKET_MIME_TYPES.filter(
+    (mimeType) => !mimeTypes.includes(mimeType),
+  )
+  if (missingMimeTypes.length > 0) {
+    throw new Error(
+      `storage bucket "${REQUIRED_BUCKET_ID}" missing allowed MIME types: ${missingMimeTypes.join(", ")}`,
+    )
+  }
+}
+
+async function runCheck(check: ReadinessCheck): Promise<CheckResult> {
+  try {
+    await check.run()
+    return { label: check.label, status: "pass", detail: "ready" }
+  } catch (error) {
+    return { label: check.label, status: "fail", detail: formatError(error) }
+  }
+}
+
+async function main() {
+  const supabase = createSupabaseClientFromEnv()
+  const checks: ReadinessCheck[] = [
+    {
+      label: `storage bucket: ${REQUIRED_BUCKET_ID}`,
+      run: () => expectProductIntakeBucket(supabase),
+    },
+    ...TABLE_COLUMN_CHECKS.map((check) => ({
+      label: `table columns: ${check.table}`,
+      run: () => expectColumns(supabase, check.table, check.columns, check.reason),
+    })),
+  ]
+
+  console.log(`Product Intake readiness target: ${targetLabel()}`)
+  console.log("Checking schema/storage primitives only; empty tables are acceptable.")
+
+  const results = await Promise.all(checks.map(runCheck))
+
+  for (const result of results) {
+    const marker = result.status === "pass" ? "PASS" : "FAIL"
+    console.log(`${marker} ${result.label} - ${result.detail}`)
+  }
+
+  const failures = results.filter((result) => result.status === "fail")
+  if (failures.length > 0) {
+    console.error(`Product Intake readiness failed: ${failures.length} critical check(s) failed.`)
+    process.exitCode = 1
+    return
+  }
+
+  console.log("Product Intake readiness passed.")
+}
+
+main().catch((error) => {
+  console.error(`Product Intake readiness check crashed: ${formatError(error)}`)
+  process.exitCode = 1
+})

--- a/scripts/product-intake/cleanup-photos.ts
+++ b/scripts/product-intake/cleanup-photos.ts
@@ -15,6 +15,11 @@ type ProductSubmissionPhotoRow = {
   barcode_image_path: string | null
 }
 
+type ReferencedSubmissionPhotoRow = {
+  front_image_path: string | null
+  barcode_image_path: string | null
+}
+
 function loadLocalEnv() {
   for (const envPath of envCandidatePaths()) {
     if (existsSync(envPath)) {
@@ -136,6 +141,35 @@ export async function cleanupExpiredSubmissionPhotos(supabase: SupabaseClient, a
   return { rows: totalRows, objects: totalObjects }
 }
 
+export async function loadReferencedSubmissionImagePaths(
+  supabase: SupabaseClient,
+): Promise<Set<string>> {
+  const paths = new Set<string>()
+
+  for (let offset = 0; ; offset += SUBMISSION_BATCH_SIZE) {
+    const { data, error } = await supabase
+      .from("product_submissions")
+      .select("front_image_path, barcode_image_path")
+      .is("photos_deleted_at", null)
+      .range(offset, offset + SUBMISSION_BATCH_SIZE - 1)
+
+    if (error) {
+      throw new Error(`load referenced submission photos: ${error.message}`)
+    }
+
+    const rows = (data ?? []) as ReferencedSubmissionPhotoRow[]
+    for (const row of rows) {
+      for (const path of uniquePaths([row.front_image_path, row.barcode_image_path])) {
+        paths.add(path)
+      }
+    }
+
+    if (rows.length < SUBMISSION_BATCH_SIZE) break
+  }
+
+  return paths
+}
+
 async function listStoragePage(supabase: SupabaseClient, path: string, offset: number) {
   const { data, error } = await supabase.storage.from(PRODUCT_INTAKE_BUCKET).list(path, {
     limit: STORAGE_PAGE_SIZE,
@@ -160,7 +194,12 @@ async function listAllStorageEntries(supabase: SupabaseClient, path: string) {
   return entries
 }
 
-async function cleanupAbandonedTmpUploads(supabase: SupabaseClient, apply: boolean, cutoff: Date) {
+export async function cleanupAbandonedTmpUploads(
+  supabase: SupabaseClient,
+  apply: boolean,
+  cutoff: Date,
+  protectedPaths: ReadonlySet<string> = new Set(),
+) {
   const users = await listAllStorageEntries(supabase, "tmp")
   let totalObjects = 0
 
@@ -171,6 +210,7 @@ async function cleanupAbandonedTmpUploads(supabase: SupabaseClient, apply: boole
     const stalePaths = files
       .filter((file) => isOlderThan(file.updated_at ?? file.created_at, cutoff))
       .map((file) => `${userPath}/${file.name}`)
+      .filter((path) => !protectedPaths.has(path))
 
     totalObjects += await removeStorageObjects(supabase, stalePaths, apply)
   }
@@ -186,10 +226,9 @@ async function main() {
   console.log(`Product Intake photo cleanup mode: ${apply ? "apply" : "dry-run"}`)
   console.log(`Temporary upload cutoff: ${tmpCutoff.toISOString()}`)
 
-  const [expiredSubmissions, tmpUploads] = await Promise.all([
-    cleanupExpiredSubmissionPhotos(supabase, apply),
-    cleanupAbandonedTmpUploads(supabase, apply, tmpCutoff),
-  ])
+  const expiredSubmissions = await cleanupExpiredSubmissionPhotos(supabase, apply)
+  const protectedPaths = await loadReferencedSubmissionImagePaths(supabase)
+  const tmpUploads = await cleanupAbandonedTmpUploads(supabase, apply, tmpCutoff, protectedPaths)
 
   console.log(
     `Expired submission rows: ${expiredSubmissions.rows}; committed objects ${

--- a/scripts/product-intake/cleanup-photos.ts
+++ b/scripts/product-intake/cleanup-photos.ts
@@ -1,0 +1,211 @@
+import { config as loadEnv } from "dotenv"
+import { existsSync } from "node:fs"
+import { join, sep } from "node:path"
+import { pathToFileURL } from "node:url"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+
+const PRODUCT_INTAKE_BUCKET = "product-intake"
+const DEFAULT_TMP_MAX_AGE_HOURS = 24
+const SUBMISSION_BATCH_SIZE = 100
+const STORAGE_PAGE_SIZE = 100
+
+type ProductSubmissionPhotoRow = {
+  id: string
+  front_image_path: string | null
+  barcode_image_path: string | null
+}
+
+function loadLocalEnv() {
+  for (const envPath of envCandidatePaths()) {
+    if (existsSync(envPath)) {
+      loadEnv({ path: envPath })
+    }
+  }
+}
+
+function envCandidatePaths(): string[] {
+  const cwd = process.cwd()
+  const candidates = [join(cwd, ".env.local")]
+  const worktreeIndex = cwd.indexOf(`${sep}.worktrees${sep}`)
+
+  if (worktreeIndex >= 0) {
+    candidates.push(join(cwd.slice(0, worktreeIndex), ".env.local"))
+  }
+
+  return [...new Set(candidates)]
+}
+
+function createSupabaseClientFromEnv(): SupabaseClient {
+  loadLocalEnv()
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+function hasApplyFlag() {
+  return process.argv.includes("--apply")
+}
+
+function tmpMaxAgeHours() {
+  const raw = process.env.PRODUCT_INTAKE_TMP_MAX_AGE_HOURS
+  if (!raw) return DEFAULT_TMP_MAX_AGE_HOURS
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TMP_MAX_AGE_HOURS
+}
+
+function cutoffDate(hours: number) {
+  return new Date(Date.now() - hours * 60 * 60 * 1000)
+}
+
+function isOlderThan(value: string | null | undefined, cutoff: Date) {
+  if (!value) return false
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) && date < cutoff
+}
+
+function uniquePaths(paths: Array<string | null | undefined>) {
+  return [...new Set(paths.filter((path): path is string => Boolean(path)))]
+}
+
+async function removeStorageObjects(
+  supabase: SupabaseClient,
+  paths: string[],
+  apply: boolean,
+): Promise<number> {
+  if (paths.length === 0) return 0
+  if (!apply) return paths.length
+
+  const { error } = await supabase.storage.from(PRODUCT_INTAKE_BUCKET).remove(paths)
+  if (error) {
+    throw new Error(`remove product intake photos: ${error.message}`)
+  }
+  return paths.length
+}
+
+export async function cleanupExpiredSubmissionPhotos(supabase: SupabaseClient, apply: boolean) {
+  let totalRows = 0
+  let totalObjects = 0
+  let offset = 0
+
+  while (true) {
+    const { data, error } = await supabase
+      .from("product_submissions")
+      .select("id, front_image_path, barcode_image_path")
+      .in("status", ["cancelled_by_user", "rejected"])
+      .lte("cleanup_after", new Date().toISOString())
+      .is("photos_deleted_at", null)
+      .range(offset, offset + SUBMISSION_BATCH_SIZE - 1)
+
+    if (error) {
+      throw new Error(`load expired submission photos: ${error.message}`)
+    }
+
+    const rows = (data ?? []) as ProductSubmissionPhotoRow[]
+    if (rows.length === 0) break
+
+    for (const row of rows) {
+      const paths = uniquePaths([row.front_image_path, row.barcode_image_path])
+      totalObjects += await removeStorageObjects(supabase, paths, apply)
+
+      if (apply) {
+        const { error: updateError } = await supabase
+          .from("product_submissions")
+          .update({ photos_deleted_at: new Date().toISOString() })
+          .eq("id", row.id)
+
+        if (updateError) {
+          throw new Error(`stamp photos_deleted_at for ${row.id}: ${updateError.message}`)
+        }
+      }
+
+      totalRows += 1
+    }
+
+    if (rows.length < SUBMISSION_BATCH_SIZE) break
+    if (!apply) offset += rows.length
+  }
+
+  return { rows: totalRows, objects: totalObjects }
+}
+
+async function listStoragePage(supabase: SupabaseClient, path: string, offset: number) {
+  const { data, error } = await supabase.storage.from(PRODUCT_INTAKE_BUCKET).list(path, {
+    limit: STORAGE_PAGE_SIZE,
+    offset,
+    sortBy: { column: "name", order: "asc" },
+  })
+
+  if (error) {
+    throw new Error(`list storage path ${path}: ${error.message}`)
+  }
+
+  return data ?? []
+}
+
+async function listAllStorageEntries(supabase: SupabaseClient, path: string) {
+  const entries = []
+  for (let offset = 0; ; offset += STORAGE_PAGE_SIZE) {
+    const page = await listStoragePage(supabase, path, offset)
+    entries.push(...page)
+    if (page.length < STORAGE_PAGE_SIZE) break
+  }
+  return entries
+}
+
+async function cleanupAbandonedTmpUploads(supabase: SupabaseClient, apply: boolean, cutoff: Date) {
+  const users = await listAllStorageEntries(supabase, "tmp")
+  let totalObjects = 0
+
+  for (const userEntry of users) {
+    if (!userEntry.name) continue
+    const userPath = `tmp/${userEntry.name}`
+    const files = await listAllStorageEntries(supabase, userPath)
+    const stalePaths = files
+      .filter((file) => isOlderThan(file.updated_at ?? file.created_at, cutoff))
+      .map((file) => `${userPath}/${file.name}`)
+
+    totalObjects += await removeStorageObjects(supabase, stalePaths, apply)
+  }
+
+  return { objects: totalObjects }
+}
+
+async function main() {
+  const apply = hasApplyFlag()
+  const supabase = createSupabaseClientFromEnv()
+  const tmpCutoff = cutoffDate(tmpMaxAgeHours())
+
+  console.log(`Product Intake photo cleanup mode: ${apply ? "apply" : "dry-run"}`)
+  console.log(`Temporary upload cutoff: ${tmpCutoff.toISOString()}`)
+
+  const [expiredSubmissions, tmpUploads] = await Promise.all([
+    cleanupExpiredSubmissionPhotos(supabase, apply),
+    cleanupAbandonedTmpUploads(supabase, apply, tmpCutoff),
+  ])
+
+  console.log(
+    `Expired submission rows: ${expiredSubmissions.rows}; committed objects ${
+      apply ? "removed" : "eligible"
+    }: ${expiredSubmissions.objects}`,
+  )
+  console.log(`Temporary objects ${apply ? "removed" : "eligible"}: ${tmpUploads.objects}`)
+
+  if (!apply) {
+    console.log("Dry-run only. Re-run with --apply to delete objects and stamp reviewed rows.")
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : "Product Intake cleanup failed")
+    process.exitCode = 1
+  })
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -12,6 +12,7 @@ import {
 import { classifyOpenAIError } from "@/lib/openai/errors"
 import { sanitizeLangfuseText } from "@/lib/langfuse/masking"
 import { ERR_UNAUTHORIZED, fehler } from "@/lib/vocabulary"
+import { isProductIntakeEnabled } from "@/lib/product-intake/config"
 import { NextResponse } from "next/server"
 import type { ConversationStatePersistenceTrace } from "@/lib/types"
 import type { PipelineTraceDraft } from "@/lib/chat-runtime/debug-trace"
@@ -305,6 +306,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
         debugTrace,
         visibleFailure,
         answerMode,
+        productIntakeOffer: pipelineProductIntakeOffer,
       } = await deps.otelContext.with(parentContext, async () =>
         deps.propagateAttributes(
           {
@@ -325,6 +327,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
               conversationId: activeConversationId,
               userId: user.id,
               requestId,
+              productIntakeEnabled: isProductIntakeEnabled(),
             }),
         ),
       )
@@ -338,6 +341,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
         : routerDecision
       const routeCategoryDecision = isVisibleFailure ? undefined : categoryDecision
       const routeEngineTrace = isVisibleFailure ? null : engineTrace
+      const productIntakeOffer = isVisibleFailure ? null : (pipelineProductIntakeOffer ?? null)
 
       // Save user message
       const { data: userMessageRow, error: userMessageError } = await admin
@@ -423,6 +427,8 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                 matchedProducts.length > 0
                   ? matchedProducts.slice(0, 3)
                   : []
+              const productIntakeOfferToSend = productIntakeOffer
+              const responseSources = productIntakeOfferToSend ? [] : sources
               const langfuseTraceUrl = traceUrlPromise ? await traceUrlPromise : null
               if (productsToSend.length > 0) {
                 controller.enqueue(
@@ -432,9 +438,22 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                 )
               }
 
-              if (sources.length > 0) {
+              if (responseSources.length > 0) {
                 controller.enqueue(
-                  encoder.encode(`data: ${JSON.stringify({ type: "sources", data: sources })}\n\n`),
+                  encoder.encode(
+                    `data: ${JSON.stringify({ type: "sources", data: responseSources })}\n\n`,
+                  ),
+                )
+              }
+
+              if (productIntakeOfferToSend) {
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({
+                      type: "product_intake_offer",
+                      data: productIntakeOfferToSend,
+                    })}\n\n`,
+                  ),
                 )
               }
 
@@ -445,10 +464,11 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                   role: "assistant",
                   content: fullContent,
                   rag_context: buildAssistantDecisionContext(
-                    sources,
+                    responseSources,
                     routeCategoryDecision,
                     routeEngineTrace,
                     routerDecision.response_mode,
+                    productIntakeOfferToSend,
                   ),
                   product_recommendations: productsToSend.length > 0 ? productsToSend : null,
                   langfuse_trace_id: langfuseTraceId,
@@ -463,16 +483,23 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
 
               let conversationStatePersistence: ConversationStatePersistenceTrace = {
                 status: "skipped",
-                error: isVisibleFailure
-                  ? "visible_failure_no_state_mutation"
-                  : skipsAgentV2StateMutation
-                    ? "answer_mode_no_state_mutation"
-                    : assistantMessageError
-                      ? "assistant_message_not_persisted"
-                      : "assistant_message_id_missing",
+                error: productIntakeOfferToSend
+                  ? "product_intake_deferred_no_state_mutation"
+                  : isVisibleFailure
+                    ? "visible_failure_no_state_mutation"
+                    : skipsAgentV2StateMutation
+                      ? "answer_mode_no_state_mutation"
+                      : assistantMessageError
+                        ? "assistant_message_not_persisted"
+                        : "assistant_message_id_missing",
               }
 
-              if (isVisibleFailure) {
+              if (productIntakeOfferToSend) {
+                conversationStatePersistence = {
+                  status: "skipped",
+                  error: "product_intake_deferred_no_state_mutation",
+                }
+              } else if (isVisibleFailure) {
                 conversationStatePersistence = {
                   status: "skipped",
                   error: "visible_failure_no_state_mutation",
@@ -525,7 +552,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
                 })
                 .eq("id", activeConversationId)
 
-              if (!isVisibleFailure && !skipsAgentV2StateMutation) {
+              if (!isVisibleFailure && !skipsAgentV2StateMutation && !productIntakeOfferToSend) {
                 extractConversationMemory(activeConversationId, user.id, {
                   requestId,
                 }).catch(() => {})
@@ -546,7 +573,7 @@ export function createChatPostHandler(overrides: ChatPostHandlerDeps = {}) {
 
               const completedTrace = finalizeChatTurnTrace(routeDebugTrace, {
                 assistant_content: fullContent,
-                sources,
+                sources: responseSources,
                 product_count: productsToSend.length,
                 status: isVisibleFailure ? "failed" : "completed",
                 stream_read_ms: Math.round(deps.now() - streamReadStart),

--- a/src/app/api/product-intake/brand-options/route.ts
+++ b/src/app/api/product-intake/brand-options/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server"
+import { normalizeIdentityText } from "@/lib/product-identity"
+import { isProductIntakeEnabled } from "@/lib/product-intake/config"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { createClient } from "@/lib/supabase/server"
+import { ERR_UNAUTHORIZED } from "@/lib/vocabulary"
+
+type BrandRow = {
+  id: string
+  canonical_name: string
+  normalized_name: string | null
+}
+
+type ProductLineRow = {
+  id: string
+  brand_id: string
+  canonical_name: string
+  normalized_name: string | null
+}
+
+type BrandAliasRow = {
+  brand_id: string
+  product_line_id: string | null
+  alias: string
+  normalized_alias: string | null
+}
+
+type BrandOption = {
+  id: string
+  type: "brand" | "alias"
+  label: string
+  brand_id: string
+  product_line_id: string | null
+}
+
+function optionSearchText(option: BrandOption): string {
+  return normalizeIdentityText(option.label)
+}
+
+function addOption(options: BrandOption[], seen: Set<string>, option: BrandOption, query: string) {
+  const normalized = optionSearchText(option)
+  if (query && !normalized.includes(query)) return
+
+  const key = `${option.brand_id}:${option.product_line_id ?? ""}:${normalized}`
+  if (seen.has(key)) return
+  seen.add(key)
+  options.push(option)
+}
+
+export async function GET(request: Request) {
+  if (!isProductIntakeEnabled()) {
+    return NextResponse.json(
+      { error: "Produktaufnahme ist aktuell deaktiviert.", code: "product_intake_disabled" },
+      { status: 503 },
+    )
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(request.url)
+  const query = normalizeIdentityText(searchParams.get("q") ?? "")
+  const requestedLimit = Number.parseInt(searchParams.get("limit") ?? "20", 10)
+  const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 20, 1), 50)
+  const admin = createAdminClient()
+
+  const [brandsResult, linesResult, aliasesResult] = await Promise.all([
+    admin.from("brands").select("id, canonical_name, normalized_name"),
+    admin.from("product_lines").select("id, brand_id, canonical_name, normalized_name"),
+    admin.from("brand_aliases").select("brand_id, product_line_id, alias, normalized_alias"),
+  ])
+
+  if (brandsResult.error || linesResult.error || aliasesResult.error) {
+    return NextResponse.json({ error: "Marken konnten nicht geladen werden." }, { status: 500 })
+  }
+
+  const brands = (brandsResult.data ?? []) as BrandRow[]
+  const productLines = (linesResult.data ?? []) as ProductLineRow[]
+  const aliases = (aliasesResult.data ?? []) as BrandAliasRow[]
+  const linesByBrandId = new Map<string, ProductLineRow[]>()
+
+  for (const line of productLines) {
+    const current = linesByBrandId.get(line.brand_id) ?? []
+    current.push(line)
+    linesByBrandId.set(line.brand_id, current)
+  }
+
+  const options: BrandOption[] = []
+  const seen = new Set<string>()
+
+  for (const brand of brands) {
+    addOption(
+      options,
+      seen,
+      {
+        id: `brand:${brand.id}`,
+        type: "brand",
+        label: brand.canonical_name,
+        brand_id: brand.id,
+        product_line_id: null,
+      },
+      query,
+    )
+
+    for (const line of linesByBrandId.get(brand.id) ?? []) {
+      addOption(
+        options,
+        seen,
+        {
+          id: `line:${line.id}`,
+          type: "brand",
+          label: `${brand.canonical_name} ${line.canonical_name}`,
+          brand_id: brand.id,
+          product_line_id: line.id,
+        },
+        query,
+      )
+    }
+  }
+
+  for (const alias of aliases) {
+    addOption(
+      options,
+      seen,
+      {
+        id: `alias:${alias.brand_id}:${alias.product_line_id ?? "brand"}:${normalizeIdentityText(
+          alias.alias,
+        )}`,
+        type: "alias",
+        label: alias.alias,
+        brand_id: alias.brand_id,
+        product_line_id: alias.product_line_id,
+      },
+      query,
+    )
+  }
+
+  options.sort((left, right) => left.label.localeCompare(right.label, "de"))
+
+  return NextResponse.json({ options: options.slice(0, limit) })
+}

--- a/src/app/api/product-intake/chat/route.ts
+++ b/src/app/api/product-intake/chat/route.ts
@@ -1,0 +1,3 @@
+import { createProductIntakePostHandler } from "@/lib/product-intake/route-handlers"
+
+export const POST = createProductIntakePostHandler("chat")

--- a/src/app/api/product-intake/onboarding/cancel/route.ts
+++ b/src/app/api/product-intake/onboarding/cancel/route.ts
@@ -1,0 +1,3 @@
+import { createProductIntakeCancelHandler } from "@/lib/product-intake/route-handlers"
+
+export const POST = createProductIntakeCancelHandler()

--- a/src/app/api/product-intake/onboarding/route.ts
+++ b/src/app/api/product-intake/onboarding/route.ts
@@ -1,0 +1,3 @@
+import { createProductIntakePostHandler } from "@/lib/product-intake/route-handlers"
+
+export const POST = createProductIntakePostHandler("onboarding")

--- a/src/app/api/product-intake/upload/route.ts
+++ b/src/app/api/product-intake/upload/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server"
+import {
+  PRODUCT_INTAKE_BUCKET,
+  ProductIntakeImageValidationError,
+  validateProductIntakeImageFile,
+  type ProductIntakeImageKind,
+} from "@/lib/product-intake/image-validation"
+import { isProductIntakeEnabled } from "@/lib/product-intake/config"
+import { checkRateLimit } from "@/lib/rate-limit"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { createClient } from "@/lib/supabase/server"
+import { ERR_UNAUTHORIZED } from "@/lib/vocabulary"
+
+const PRODUCT_INTAKE_UPLOAD_RATE_LIMIT = {
+  prefix: "product-intake-upload",
+  limit: 20,
+  windowMs: 60 * 60_000,
+}
+
+function parseImageKind(value: FormDataEntryValue | null): ProductIntakeImageKind {
+  return value === "barcode" ? "barcode" : "front"
+}
+
+export async function POST(request: Request) {
+  if (!isProductIntakeEnabled()) {
+    return NextResponse.json(
+      { error: "Produktaufnahme ist aktuell deaktiviert.", code: "product_intake_disabled" },
+      { status: 503 },
+    )
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+  }
+
+  const rateCheck = await checkRateLimit(user.id, PRODUCT_INTAKE_UPLOAD_RATE_LIMIT)
+  if (!rateCheck.allowed) {
+    return NextResponse.json(
+      {
+        error:
+          rateCheck.error === "service_unavailable"
+            ? "Bildupload ist gerade nicht verfügbar. Bitte versuche es gleich erneut."
+            : "Du hast gerade viele Bilder hochgeladen. Bitte warte kurz und versuche es dann erneut.",
+        code: rateCheck.error === "service_unavailable" ? "rate_limit_unavailable" : "rate_limited",
+      },
+      { status: rateCheck.error === "service_unavailable" ? 503 : 429 },
+    )
+  }
+
+  const formData = await request.formData()
+  const file = formData.get("file")
+  const kind = parseImageKind(formData.get("kind"))
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: "Bitte lade ein Bild hoch.", code: "missing_file" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const image = await validateProductIntakeImageFile(file, kind)
+    const path = `tmp/${user.id}/${crypto.randomUUID()}.${image.extension}`
+    const admin = createAdminClient()
+    const { error } = await admin.storage
+      .from(PRODUCT_INTAKE_BUCKET)
+      .upload(path, Buffer.from(image.bytes), {
+        contentType: image.mimeType,
+        upsert: false,
+        cacheControl: "3600",
+        metadata: {
+          user_id: user.id,
+          image_kind: kind,
+          validation: image.validationMetadata.validation,
+        },
+      })
+
+    if (error) {
+      console.error("[product-intake] image upload failed", error)
+      return NextResponse.json({ error: "Bild konnte nicht gespeichert werden." }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      bucket: PRODUCT_INTAKE_BUCKET,
+      path,
+      image_kind: kind,
+      mime_type: image.mimeType,
+      size_bytes: image.size,
+      validation_status: image.validationStatus,
+      validation_metadata: image.validationMetadata,
+    })
+  } catch (error) {
+    if (error instanceof ProductIntakeImageValidationError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: 400 })
+    }
+
+    console.error("[product-intake] image validation failed", error)
+    return NextResponse.json({ error: "Bild konnte nicht verarbeitet werden." }, { status: 500 })
+  }
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { OnboardingFlow } from "@/components/onboarding/onboarding-flow"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import { getOnboardingEditScope, type OnboardingStep } from "@/lib/onboarding/store"
 import { resolveIntakeState } from "@/lib/auth/intake-state"
+import { isProductIntakeEnabled } from "@/lib/product-intake/config"
 
 interface OnboardingPageProps {
   searchParams: Promise<{
@@ -135,6 +136,7 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
       initialDrilldownCategory={
         forcedStep === "product_drilldown" ? initialDrilldownCategory : null
       }
+      productIntakeEnabled={isProductIntakeEnabled()}
       allowCompletionFallback={!forcedStep && profileRow?.onboarding_step === "celebration"}
     />
   )

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -12,6 +12,7 @@ import { CitationBadge } from "./citation-badge"
 import { ProductPopover } from "./product-popover"
 import { CombIcon } from "@/components/ui/comb-icon"
 import { ProductCard } from "./product-card"
+import { ProductIntakeCard } from "./product-intake-card"
 
 /**
  * Renumbers [N] citation markers in content so they appear as [1], [2], [3]
@@ -341,6 +342,13 @@ export function ChatMessage({
             </ul>
           </details>
         )}
+
+        {message.rag_context?.product_intake_offer && !isUser ? (
+          <ProductIntakeCard
+            offer={message.rag_context.product_intake_offer}
+            conversationId={message.conversation_id}
+          />
+        ) : null}
 
         {/* Product recommendation cards */}
         {products.length > 0 && onProductClick && (

--- a/src/components/chat/product-intake-card.tsx
+++ b/src/components/chat/product-intake-card.tsx
@@ -1,0 +1,243 @@
+"use client"
+
+import { useId, useMemo, useState } from "react"
+import {
+  PRODUCT_CATEGORY_DISPLAY_LABELS,
+  SUPPORTED_PRODUCT_CATEGORY_KEYS,
+} from "@/lib/product-identity"
+import {
+  ProductIntakeBrandProductFields,
+  ProductIntakeImageFields,
+  ProductIntakeMethodToggle,
+} from "@/components/product-intake/product-intake-form-fields"
+import {
+  buildProductIntakeSubmissionPayload,
+  canSubmitProductIntake,
+  selectedProductIntakeBrandOptionForText,
+  uploadProductIntakeImage,
+  type ProductIntakeImageKind,
+  type ProductIntakeMethod,
+  type ProductIntakeResponseBody,
+} from "@/lib/product-intake/client"
+import { PRODUCT_FREQUENCY_OPTIONS, type ProductFrequency } from "@/lib/vocabulary"
+import { useProductIntakeBrandOptions } from "@/hooks/use-product-intake-brand-options"
+import type { ProductIntakeCategoryKey, ProductIntakeOffer } from "@/lib/types"
+
+type ProductIntakeCardProps = {
+  offer: ProductIntakeOffer
+  conversationId: string
+}
+
+export function ProductIntakeCard({ offer, conversationId }: ProductIntakeCardProps) {
+  const brandListId = useId()
+  const [method, setMethod] = useState<ProductIntakeMethod>("photo")
+  const [category, setCategory] = useState<ProductIntakeCategoryKey | "">(offer.category)
+  const [frequency, setFrequency] = useState<ProductFrequency | "">("")
+  const [brandText, setBrandText] = useState(offer.extracted_identity?.brand_text ?? "")
+  const [selectedBrandId, setSelectedBrandId] = useState<string | null>(null)
+  const [selectedProductLineId, setSelectedProductLineId] = useState<string | null>(null)
+  const [productName, setProductName] = useState(offer.extracted_identity?.product_name_text ?? "")
+  const [frontImagePath, setFrontImagePath] = useState<string | null>(null)
+  const [barcodeImagePath, setBarcodeImagePath] = useState<string | null>(null)
+  const [frontImageValidationStatus, setFrontImageValidationStatus] = useState<string | null>(null)
+  const [frontImageValidationMetadata, setFrontImageValidationMetadata] = useState<
+    Record<string, unknown>
+  >({})
+  const [barcodeImageValidationStatus, setBarcodeImageValidationStatus] = useState<string | null>(
+    null,
+  )
+  const [barcodeImageValidationMetadata, setBarcodeImageValidationMetadata] = useState<
+    Record<string, unknown>
+  >({})
+  const brandOptions = useProductIntakeBrandOptions(brandText)
+  const [busy, setBusy] = useState<ProductIntakeImageKind | "submit" | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const ready = useMemo(
+    () =>
+      canSubmitProductIntake({
+        method,
+        category,
+        frequency,
+        brandText,
+        productName,
+        frontImagePath,
+      }),
+    [brandText, category, frequency, frontImagePath, method, productName],
+  )
+
+  function handleBrandTextChange(value: string) {
+    setBrandText(value)
+    const selectedOption = selectedProductIntakeBrandOptionForText(brandOptions, value)
+    setSelectedBrandId(selectedOption?.brand_id ?? null)
+    setSelectedProductLineId(selectedOption?.product_line_id ?? null)
+  }
+
+  async function uploadImage(kind: ProductIntakeImageKind, file: File | undefined) {
+    if (!file) return
+    setBusy(kind)
+    setError(null)
+    setStatus(null)
+
+    try {
+      const upload = await uploadProductIntakeImage(kind, file)
+
+      if (kind === "front") {
+        setFrontImagePath(upload.path)
+        setFrontImageValidationStatus(upload.validationStatus)
+        setFrontImageValidationMetadata(upload.validationMetadata)
+      } else {
+        setBarcodeImagePath(upload.path)
+        setBarcodeImageValidationStatus(upload.validationStatus)
+        setBarcodeImageValidationMetadata(upload.validationMetadata)
+      }
+    } catch (uploadError) {
+      setError(
+        uploadError instanceof Error
+          ? uploadError.message
+          : "Bild konnte nicht hochgeladen werden.",
+      )
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function submit(replaceExistingConfirmed = false): Promise<void> {
+    if (!ready || busy) return
+    setBusy("submit")
+    setError(null)
+    setStatus(null)
+
+    if (!category || !frequency) {
+      setBusy(null)
+      return
+    }
+
+    const payload = buildProductIntakeSubmissionPayload({
+      method,
+      category,
+      frequency,
+      brandText,
+      brandId: selectedBrandId,
+      productLineId: selectedProductLineId,
+      productName,
+      frontImagePath,
+      frontImageValidationStatus,
+      frontImageValidationMetadata,
+      barcodeImagePath,
+      barcodeImageValidationStatus,
+      barcodeImageValidationMetadata,
+      sourceConversationId: conversationId,
+      replaceExistingConfirmed,
+    })
+
+    try {
+      const response = await fetch("/api/product-intake/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+      const body = (await response.json().catch(() => ({}))) as ProductIntakeResponseBody
+
+      if (response.status === 409 && body.code === "product_category_already_filled") {
+        const confirmed = window.confirm(
+          body.error ??
+            "Du hast für diese Kategorie bereits ein Produkt hinterlegt. Möchtest du es ersetzen?",
+        )
+        if (confirmed) {
+          await submit(true)
+        }
+        return
+      }
+
+      if (!response.ok) {
+        throw new Error(body.error ?? "Produkt konnte nicht gespeichert werden.")
+      }
+
+      setStatus(
+        body.status === "matched"
+          ? "Produkt gespeichert. Du kannst dazu direkt weiterfragen."
+          : "Danke, wir prüfen dein Produkt und melden uns hier im Chat.",
+      )
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error
+          ? submitError.message
+          : "Produkt konnte nicht gespeichert werden.",
+      )
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="w-full min-w-0 rounded-xl border border-border bg-background p-3 shadow-sm">
+      <p className="mb-3 text-sm leading-relaxed text-foreground">
+        Danke für dein Produkt. Wir haben es noch nicht sicher in unserer Datenbank und prüfen es
+        gerne konkret für dich.
+      </p>
+      <ProductIntakeMethodToggle value={method} onChange={setMethod} />
+
+      <div className="space-y-3">
+        <select
+          value={category}
+          onChange={(event) => setCategory(event.target.value as ProductIntakeCategoryKey)}
+          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground"
+        >
+          <option value="">Kategorie</option>
+          {SUPPORTED_PRODUCT_CATEGORY_KEYS.map((key) => (
+            <option key={key} value={key}>
+              {PRODUCT_CATEGORY_DISPLAY_LABELS[key]}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={frequency}
+          onChange={(event) => setFrequency(event.target.value as ProductFrequency)}
+          className="w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground"
+        >
+          <option value="">Häufigkeit</option>
+          {PRODUCT_FREQUENCY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+
+        {method === "photo" ? (
+          <ProductIntakeImageFields
+            frontReady={Boolean(frontImagePath)}
+            barcodeReady={Boolean(barcodeImagePath)}
+            uploading={busy === "front" || busy === "barcode" ? busy : null}
+            onUpload={uploadImage}
+          />
+        ) : null}
+
+        <ProductIntakeBrandProductFields
+          brandText={brandText}
+          productName={productName}
+          brandOptions={brandOptions}
+          brandListId={brandListId}
+          brandPlaceholder={method === "manual" ? "Marke" : "Marke optional"}
+          productPlaceholder={method === "manual" ? "Produktname" : "Produktname optional"}
+          onBrandTextChange={handleBrandTextChange}
+          onProductNameChange={setProductName}
+        />
+
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        {status ? <p className="text-xs text-emerald-700">{status}</p> : null}
+
+        <button
+          type="button"
+          onClick={() => submit()}
+          disabled={!ready || busy !== null || Boolean(status)}
+          className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {busy === "submit" ? "Speichern..." : "Produkt einreichen"}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/onboarding/onboarding-display-config.ts
+++ b/src/components/onboarding/onboarding-display-config.ts
@@ -1,0 +1,40 @@
+import type { IconName } from "@/components/ui/icon"
+
+export const TOWEL_MATERIAL_ICONS: Record<string, IconName> = {
+  frottee: "towel-frottee",
+  mikrofaser: "towel-mikrofaser",
+  tshirt: "towel-tshirt",
+  turban_mikrofaser: "towel-turban",
+}
+
+export const TOWEL_TECHNIQUE_ICONS: Record<string, IconName> = {
+  rough_rubbing: "technique-rough-rubbing",
+  gentle_press: "technique-gentle-press",
+}
+
+export const DRYING_METHOD_ICONS: Record<string, IconName> = {
+  air_dry: "drying-air",
+  blow_dry: "drying-blow",
+  blow_dry_diffuser: "drying-diffuser",
+}
+
+export const BRUSH_TYPE_ICONS: Record<string, IconName> = {
+  wide_tooth_comb: "brush-wide-tooth",
+  detangling: "brush-detangling",
+  paddle: "brush-paddle",
+  round: "brush-round",
+  boar_bristle: "brush-boar-bristle",
+  fingers: "brush-fingers",
+  none_regular: "brush-none",
+}
+
+export const NIGHT_PROTECTION_ICONS: Record<string, IconName> = {
+  silk_satin_pillow: "night-silk-pillow",
+  silk_satin_bonnet: "night-silk-bonnet",
+  loose_tied: "night-loose-braid",
+  pineapple: "night-pineapple",
+}
+
+export const CATEGORY_SUBTITLES: Record<string, string> = {
+  peeling: "Nutzt du ein Serum oder Scrub für deine Kopfhaut? Welches Produkt und wie oft?",
+}

--- a/src/components/onboarding/onboarding-flow-navigation.ts
+++ b/src/components/onboarding/onboarding-flow-navigation.ts
@@ -1,0 +1,65 @@
+import type { OnboardingEditScope, OnboardingStep } from "@/lib/onboarding/store"
+
+type OnboardingNavigationSnapshot = {
+  currentDrilldownIndex: number
+  drilldownCategories: () => unknown[]
+  selectedHeatTools: string[]
+}
+
+export function shouldReturnAfterScopeStep(
+  completedStep: OnboardingStep,
+  state: OnboardingNavigationSnapshot,
+  editScope: OnboardingEditScope | null,
+) {
+  switch (editScope) {
+    case "products": {
+      const lastDrilldownIndex = state.drilldownCategories().length - 1
+      return (
+        completedStep === "product_drilldown" && state.currentDrilldownIndex >= lastDrilldownIndex
+      )
+    }
+    case "styling":
+      return (
+        (completedStep === "heat_tools" && state.selectedHeatTools.length === 0) ||
+        completedStep === "heat_protection"
+      )
+    case "routine":
+      return completedStep === "night_protection"
+    default:
+      return false
+  }
+}
+
+export function getFinalContinueLabel(
+  currentStep: OnboardingStep,
+  state: OnboardingNavigationSnapshot,
+  editScope: OnboardingEditScope | null,
+  singleStepEdit: boolean,
+  returnTo: string | null,
+) {
+  if (!returnTo) return "Weiter"
+
+  if (
+    singleStepEdit &&
+    (currentStep === "product_drilldown" ||
+      currentStep === "heat_tools" ||
+      currentStep === "drying_method" ||
+      currentStep === "night_protection")
+  ) {
+    return "Speichern und zurück zum Profil"
+  }
+
+  if (currentStep === "night_protection" && editScope === "routine") {
+    return "Speichern und zurück zum Profil"
+  }
+
+  if (
+    currentStep === "product_drilldown" &&
+    editScope === "products" &&
+    shouldReturnAfterScopeStep(currentStep, state, editScope)
+  ) {
+    return "Speichern und zurück zum Profil"
+  }
+
+  return "Weiter"
+}

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -706,6 +706,7 @@ export function OnboardingFlow({
             frequency={currentDrilldown.frequency}
             frontImagePath={currentDrilldown.frontImagePath}
             committedFrontImagePath={currentDrilldown.committedFrontImagePath}
+            existingUsageId={currentDrilldown.existingUsageId}
             barcodeImagePath={currentDrilldown.barcodeImagePath}
             isSupportedIntakeCategory={productIntake.isSupportedCategory(currentCategory)}
             productIntakeEnabled={productIntakeEnabled}

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -4,21 +4,32 @@ import { useEffect, useRef, useState, useCallback } from "react"
 import { trackAppEvent } from "@/lib/analytics/track-app-event"
 import { useToast } from "@/providers/toast-provider"
 import { createClient } from "@/lib/supabase/client"
-import { useOnboardingStore } from "@/lib/onboarding/store"
+import { emptyProductDrilldown, useOnboardingStore } from "@/lib/onboarding/store"
 import type { OnboardingEditScope, OnboardingStep } from "@/lib/onboarding/store"
 import { shouldHydrateStoredHeatProtection } from "@/lib/onboarding/heat-protection-hydration"
 import { buildProductUsagePayloads } from "@/lib/onboarding/product-usage-save"
-import {
-  isUnselectedShampooFallbackItem,
-  SHAMPOO_CATEGORY,
-} from "@/lib/product-usage/shampoo-fallback"
+import { isUnselectedShampooFallbackItem } from "@/lib/product-usage/shampoo-fallback"
+import { useOnboardingProductIntakeController } from "@/hooks/use-onboarding-product-intake-controller"
 import { OnboardingProgressBar } from "@/components/onboarding/onboarding-progress-bar"
+import { ProductReplacementDialog } from "@/components/onboarding/product-replacement-dialog"
+import {
+  BRUSH_TYPE_ICONS,
+  CATEGORY_SUBTITLES,
+  DRYING_METHOD_ICONS,
+  NIGHT_PROTECTION_ICONS,
+  TOWEL_MATERIAL_ICONS,
+  TOWEL_TECHNIQUE_ICONS,
+} from "@/components/onboarding/onboarding-display-config"
+import {
+  getFinalContinueLabel,
+  shouldReturnAfterScopeStep,
+} from "@/components/onboarding/onboarding-flow-navigation"
 import {
   BASIC_PRODUCT_OPTIONS,
   EXTRA_PRODUCT_OPTIONS,
   PRODUCT_CATEGORY_LABELS,
 } from "@/lib/onboarding/product-options"
-import { normalizeProductFrequency, type ProductFrequency } from "@/lib/vocabulary"
+import { normalizeProductFrequency } from "@/lib/vocabulary"
 import type { HeatStyling } from "@/lib/vocabulary"
 
 // Import all screens
@@ -55,61 +66,19 @@ import type {
 
 import type { IconName } from "@/components/ui/icon"
 
-/* ── Care habit icon maps ── */
-
-const TOWEL_MATERIAL_ICONS: Record<string, IconName> = {
-  frottee: "towel-frottee",
-  mikrofaser: "towel-mikrofaser",
-  tshirt: "towel-tshirt",
-  turban_mikrofaser: "towel-turban",
-}
-
-const TOWEL_TECHNIQUE_ICONS: Record<string, IconName> = {
-  rough_rubbing: "technique-rough-rubbing",
-  gentle_press: "technique-gentle-press",
-}
-
-const DRYING_METHOD_ICONS: Record<string, IconName> = {
-  air_dry: "drying-air",
-  blow_dry: "drying-blow",
-  blow_dry_diffuser: "drying-diffuser",
-}
-
-const BRUSH_TYPE_ICONS: Record<string, IconName> = {
-  wide_tooth_comb: "brush-wide-tooth",
-  detangling: "brush-detangling",
-  paddle: "brush-paddle",
-  round: "brush-round",
-  boar_bristle: "brush-boar-bristle",
-  fingers: "brush-fingers",
-  none_regular: "brush-none",
-}
-
-const NIGHT_PROTECTION_ICONS: Record<string, IconName> = {
-  silk_satin_pillow: "night-silk-pillow",
-  silk_satin_bonnet: "night-silk-bonnet",
-  loose_tied: "night-loose-braid",
-  pineapple: "night-pineapple",
-}
-
-/* ── Label map for drilldown categories ── */
-
-/* ── Custom subtitle overrides for drilldown screens ── */
-
-const CATEGORY_SUBTITLES: Record<string, string> = {
-  peeling: "Nutzt du ein Serum oder Scrub für deine Kopfhaut? Welches Produkt und wie oft?",
-}
-
 const SAVE_TIMEOUT_MS = 15_000
 const SAVE_TIMEOUT_MESSAGE =
   "Speichern dauert zu lange. Bitte pruefe deine Verbindung und versuche es erneut."
 const SAVE_ERROR_MESSAGE = "Fehler beim Speichern. Bitte versuche es erneut."
-
 class SaveTimeoutError extends Error {
   constructor() {
     super(SAVE_TIMEOUT_MESSAGE)
     this.name = "SaveTimeoutError"
   }
+}
+
+type ProductReplacementConflict = {
+  step: "product_drilldown"
 }
 
 /* ── Props ── */
@@ -124,67 +93,8 @@ interface OnboardingFlowProps {
   editScope?: OnboardingEditScope | null
   singleStepEdit?: boolean
   initialDrilldownCategory?: string | null
+  productIntakeEnabled?: boolean
   allowCompletionFallback?: boolean
-}
-
-type OnboardingStateSnapshot = ReturnType<typeof useOnboardingStore.getState>
-
-function shouldReturnAfterScopeStep(
-  completedStep: OnboardingStep,
-  state: OnboardingStateSnapshot,
-  editScope: OnboardingEditScope | null,
-) {
-  switch (editScope) {
-    case "products": {
-      const lastDrilldownIndex = state.drilldownCategories().length - 1
-      return (
-        completedStep === "product_drilldown" && state.currentDrilldownIndex >= lastDrilldownIndex
-      )
-    }
-    case "styling":
-      return (
-        (completedStep === "heat_tools" && state.selectedHeatTools.length === 0) ||
-        completedStep === "heat_protection"
-      )
-    case "routine":
-      return completedStep === "night_protection"
-    default:
-      return false
-  }
-}
-
-function getFinalContinueLabel(
-  currentStep: OnboardingStep,
-  state: OnboardingStateSnapshot,
-  editScope: OnboardingEditScope | null,
-  singleStepEdit: boolean,
-  returnTo: string | null,
-) {
-  if (!returnTo) return "Weiter"
-
-  if (
-    singleStepEdit &&
-    (currentStep === "product_drilldown" ||
-      currentStep === "heat_tools" ||
-      currentStep === "drying_method" ||
-      currentStep === "night_protection")
-  ) {
-    return "Speichern und zurück zum Profil"
-  }
-
-  if (currentStep === "night_protection" && editScope === "routine") {
-    return "Speichern und zurück zum Profil"
-  }
-
-  if (
-    currentStep === "product_drilldown" &&
-    editScope === "products" &&
-    shouldReturnAfterScopeStep(currentStep, state, editScope)
-  ) {
-    return "Speichern und zurück zum Profil"
-  }
-
-  return "Weiter"
 }
 
 /* ── Component ── */
@@ -199,12 +109,16 @@ export function OnboardingFlow({
   editScope = null,
   singleStepEdit = false,
   initialDrilldownCategory = null,
+  productIntakeEnabled = false,
   allowCompletionFallback = false,
 }: OnboardingFlowProps) {
   const { toast } = useToast()
   const store = useOnboardingStore()
+  const productIntake = useOnboardingProductIntakeController(productIntakeEnabled)
   const [hydrated, setHydrated] = useState(false)
   const [savingStep, setSavingStep] = useState<OnboardingStep | null>(null)
+  const [productReplacementConflict, setProductReplacementConflict] =
+    useState<ProductReplacementConflict | null>(null)
   const initRef = useRef(false)
   const savingStepsRef = useRef<Set<OnboardingStep>>(new Set())
   const stepSaveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
@@ -296,10 +210,10 @@ export function OnboardingFlow({
         else if (extraValues.includes(cat)) extras.push(cat)
 
         if (row.product_name || row.frequency_range) {
-          store.setProductDrilldown(cat, {
-            productName: productName ?? "",
-            frequency,
-          })
+          store.setProductDrilldown(
+            cat,
+            productIntake.drilldownFromUsageRow(row, productName ?? "", frequency),
+          )
         }
       }
 
@@ -382,21 +296,19 @@ export function OnboardingFlow({
         }
       }
 
-      // Delete deselected categories
-      const toDelete = (existing ?? [])
-        .filter((r: Record<string, unknown>) => {
-          const category = r.category as string
-          return category !== SHAMPOO_CATEGORY && !categories.includes(category)
-        })
-        .map((r: Record<string, unknown>) => r.id as string)
+      const directDeleteIds = await productIntake.cancelDeselectedCategories(
+        existing ?? [],
+        categories,
+        signal,
+      )
 
-      if (toDelete.length > 0) {
-        const deleteQuery = supabase.from("user_product_usage").delete().in("id", toDelete)
+      if (directDeleteIds.length > 0) {
+        const deleteQuery = supabase.from("user_product_usage").delete().in("id", directDeleteIds)
         const { error: deleteError } = await withAbortSignal(deleteQuery, signal)
         if (deleteError) throw deleteError
       }
     },
-    [userId],
+    [productIntake, userId],
   )
 
   const saveHairProfile = useCallback(
@@ -424,7 +336,7 @@ export function OnboardingFlow({
   // ── Step completion handler ──
 
   const handleStepComplete = useCallback(
-    async (completedStep: OnboardingStep) => {
+    async (completedStep: OnboardingStep, options: { replaceExistingConfirmed?: boolean } = {}) => {
       if (savingStepsRef.current.has(completedStep)) return
       savingStepsRef.current.add(completedStep)
       setSavingStep(completedStep)
@@ -453,17 +365,40 @@ export function OnboardingFlow({
             const drilldown = state.productDrilldowns[currentCat]
             if (!drilldown) break
 
-            // Update the specific product usage row
-            const { error: productUsageError } = await supabase
-              .from("user_product_usage")
-              .update({
-                product_name: drilldown.productName,
-                frequency_range: drilldown.frequency,
-              })
-              .eq("user_id", userId)
-              .eq("category", currentCat)
+            if (!productIntakeEnabled || !productIntake.isSupportedCategory(currentCat)) {
+              const { error: productUsageError } = await supabase
+                .from("user_product_usage")
+                .update({
+                  product_name: drilldown.productName,
+                  frequency_range: drilldown.frequency,
+                })
+                .eq("user_id", userId)
+                .eq("category", currentCat)
 
-            if (productUsageError) throw productUsageError
+              if (productUsageError) throw productUsageError
+              break
+            }
+
+            const productIntakeResult = await withSaveTimeout((signal) =>
+              productIntake.submitDrilldown(
+                currentCat,
+                drilldown,
+                options.replaceExistingConfirmed,
+                signal,
+              ),
+            )
+            if (!productIntakeResult) break
+            if (productIntakeResult.status === "replace_conflict") {
+              setProductReplacementConflict({ step: "product_drilldown" })
+              return
+            }
+            if (productIntakeResult.usageId) {
+              useOnboardingStore.getState().setProductDrilldown(currentCat, {
+                existingUsageId: productIntakeResult.usageId,
+                frontImagePath: null,
+                committedFrontImagePath: productIntakeResult.frontImagePath,
+              })
+            }
 
             break
           }
@@ -618,6 +553,8 @@ export function OnboardingFlow({
       saveProductUsage,
       saveHairProfile,
       saveOnboardingStep,
+      productIntake,
+      productIntakeEnabled,
       returnTo,
       editScope,
       singleStepEdit,
@@ -705,8 +642,8 @@ export function OnboardingFlow({
   const drilldownCategories = store.drilldownCategories()
   const currentCategory = drilldownCategories[store.currentDrilldownIndex]
   const currentDrilldown = currentCategory
-    ? (store.productDrilldowns[currentCategory] ?? { productName: "", frequency: null })
-    : { productName: "", frequency: null }
+    ? (store.productDrilldowns[currentCategory] ?? emptyProductDrilldown())
+    : emptyProductDrilldown()
   const backTarget = singleStepEdit && returnTo ? returnTo : null
 
   function handleBack() {
@@ -763,8 +700,30 @@ export function OnboardingFlow({
             category={currentCategory}
             categoryLabel={PRODUCT_CATEGORY_LABELS[currentCategory] ?? currentCategory}
             subtitle={CATEGORY_SUBTITLES[currentCategory]}
+            intakeMethod={currentDrilldown.intakeMethod}
             productName={currentDrilldown.productName}
+            brandText={currentDrilldown.brandText}
             frequency={currentDrilldown.frequency}
+            frontImagePath={currentDrilldown.frontImagePath}
+            committedFrontImagePath={currentDrilldown.committedFrontImagePath}
+            barcodeImagePath={currentDrilldown.barcodeImagePath}
+            isSupportedIntakeCategory={productIntake.isSupportedCategory(currentCategory)}
+            productIntakeEnabled={productIntakeEnabled}
+            isSaving={savingStep === "product_drilldown"}
+            onIntakeMethodChange={(method) =>
+              store.setProductDrilldown(currentCategory, {
+                ...currentDrilldown,
+                intakeMethod: method,
+              })
+            }
+            onBrandTextChange={({ brandText, brandId, productLineId }) =>
+              store.setProductDrilldown(currentCategory, {
+                ...currentDrilldown,
+                brandText,
+                brandId,
+                productLineId,
+              })
+            }
             onProductNameChange={(name) =>
               store.setProductDrilldown(currentCategory, {
                 ...currentDrilldown,
@@ -777,6 +736,13 @@ export function OnboardingFlow({
                 frequency: freq,
               })
             }
+            onUploadImage={async (kind, file) => {
+              const uploadPatch = await productIntake.uploadImagePatch(kind, file)
+              store.setProductDrilldown(currentCategory, {
+                ...useOnboardingStore.getState().productDrilldowns[currentCategory],
+                ...uploadPatch,
+              })
+            }}
             onContinue={() => handleStepComplete("product_drilldown")}
             onBack={handleBack}
             continueLabel={getFinalContinueLabel(
@@ -959,6 +925,17 @@ export function OnboardingFlow({
         </div>
       )}
       {renderScreen()}
+      {productReplacementConflict ? (
+        <ProductReplacementDialog
+          disabled={savingStep !== null}
+          onCancel={() => setProductReplacementConflict(null)}
+          onConfirm={() => {
+            const conflict = productReplacementConflict
+            setProductReplacementConflict(null)
+            void handleStepComplete(conflict.step, { replaceExistingConfirmed: true })
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/onboarding/product-replacement-dialog.tsx
+++ b/src/components/onboarding/product-replacement-dialog.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+export function ProductReplacementDialog({
+  disabled,
+  onCancel,
+  onConfirm,
+}: {
+  disabled: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/35 px-4 py-6 sm:items-center">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="product-replacement-title"
+        className="w-full max-w-md rounded-xl border border-border bg-background p-5 shadow-xl"
+      >
+        <h2 id="product-replacement-title" className="mb-2 text-lg font-semibold text-foreground">
+          Produkt ersetzen?
+        </h2>
+        <p className="mb-5 text-sm leading-relaxed text-[var(--text-sub)]">
+          Du hast für diese Kategorie bereits ein Produkt hinterlegt. Wenn du fortfährst, ersetzen
+          wir den bisherigen Eintrag durch dieses Produkt.
+        </p>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={disabled}
+            className="min-h-[44px] rounded-full border border-border px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-40"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={disabled}
+            className="quiz-btn-primary disabled:opacity-40"
+          >
+            Produkt ersetzen
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/onboarding/screens/product-drilldown-screen.tsx
+++ b/src/components/onboarding/screens/product-drilldown-screen.tsx
@@ -1,33 +1,149 @@
 "use client"
 
+import { useId, useMemo, useState } from "react"
 import { ArrowLeft } from "lucide-react"
+import {
+  ProductIntakeBrandProductFields,
+  ProductIntakeImageFields,
+  ProductIntakeMethodToggle,
+} from "@/components/product-intake/product-intake-form-fields"
 import { PRODUCT_FREQUENCY_OPTIONS } from "@/lib/vocabulary"
 import type { ProductFrequency } from "@/lib/vocabulary"
+import {
+  canSubmitProductIntake,
+  selectedProductIntakeBrandOptionForText,
+  type ProductIntakeImageKind,
+} from "@/lib/product-intake/client"
+import { useProductIntakeBrandOptions } from "@/hooks/use-product-intake-brand-options"
+import type { OnboardingProductIntakeMethod } from "@/lib/onboarding/store"
 
 interface ProductDrilldownScreenProps {
   category: string
   categoryLabel: string
   subtitle?: string
+  intakeMethod: OnboardingProductIntakeMethod | null
   productName: string
+  brandText: string
   frequency: ProductFrequency | null
+  frontImagePath: string | null
+  committedFrontImagePath: string | null
+  barcodeImagePath: string | null
+  isSupportedIntakeCategory: boolean
+  productIntakeEnabled: boolean
+  isSaving?: boolean
+  onIntakeMethodChange: (method: OnboardingProductIntakeMethod) => void
+  onBrandTextChange: (value: {
+    brandText: string
+    brandId: string | null
+    productLineId: string | null
+  }) => void
   onProductNameChange: (name: string) => void
   onFrequencyChange: (freq: ProductFrequency) => void
+  onUploadImage: (kind: ProductIntakeImageKind, file: File) => Promise<void>
   onContinue: () => void
   onBack: () => void
   continueLabel?: string
 }
 
+function hasRequiredFields(params: {
+  intakeMethod: OnboardingProductIntakeMethod | null
+  brandText: string
+  productName: string
+  frequency: ProductFrequency | null
+  frontImagePath: string | null
+  committedFrontImagePath: string | null
+  isSupportedIntakeCategory: boolean
+}) {
+  if (!params.frequency) return false
+  if (!params.isSupportedIntakeCategory) return params.productName.trim().length > 0
+  return canSubmitProductIntake({
+    method: params.intakeMethod,
+    category: params.isSupportedIntakeCategory ? "supported" : null,
+    frequency: params.frequency,
+    brandText: params.brandText,
+    productName: params.productName,
+    frontImagePath: params.frontImagePath,
+    committedFrontImagePath: params.committedFrontImagePath,
+  })
+}
+
 export function ProductDrilldownScreen({
+  category,
   categoryLabel,
   subtitle,
+  intakeMethod,
   productName,
+  brandText,
   frequency,
+  frontImagePath,
+  committedFrontImagePath,
+  barcodeImagePath,
+  isSupportedIntakeCategory,
+  productIntakeEnabled,
+  isSaving = false,
+  onIntakeMethodChange,
+  onBrandTextChange,
   onProductNameChange,
   onFrequencyChange,
+  onUploadImage,
   onContinue,
   onBack,
   continueLabel = "Weiter",
 }: ProductDrilldownScreenProps) {
+  const brandListId = useId()
+  const [uploading, setUploading] = useState<ProductIntakeImageKind | null>(null)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const shouldUseProductIntake = productIntakeEnabled && isSupportedIntakeCategory
+  const selectedMethod = shouldUseProductIntake ? intakeMethod : "manual"
+  const brandOptions = useProductIntakeBrandOptions(brandText, shouldUseProductIntake)
+
+  const canContinue = useMemo(
+    () =>
+      hasRequiredFields({
+        intakeMethod: selectedMethod,
+        brandText,
+        productName,
+        frequency,
+        frontImagePath,
+        committedFrontImagePath,
+        isSupportedIntakeCategory: shouldUseProductIntake,
+      }),
+    [
+      brandText,
+      committedFrontImagePath,
+      frequency,
+      frontImagePath,
+      productName,
+      selectedMethod,
+      shouldUseProductIntake,
+    ],
+  )
+
+  async function handleUpload(kind: ProductIntakeImageKind, file: File | undefined) {
+    if (!file) return
+    setUploading(kind)
+    setUploadError(null)
+
+    try {
+      await onUploadImage(kind, file)
+    } catch (error) {
+      setUploadError(
+        error instanceof Error ? error.message : "Bild konnte nicht hochgeladen werden.",
+      )
+    } finally {
+      setUploading(null)
+    }
+  }
+
+  function handleBrandTextChange(value: string) {
+    const selectedOption = selectedProductIntakeBrandOptionForText(brandOptions, value)
+    onBrandTextChange({
+      brandText: value,
+      brandId: selectedOption?.brand_id ?? null,
+      productLineId: selectedOption?.product_line_id ?? null,
+    })
+  }
+
   return (
     <div>
       <button
@@ -49,18 +165,71 @@ export function ProductDrilldownScreen({
         {subtitle ?? "Welches Produkt nutzt du und wie oft?"}
       </p>
 
-      {/* Product name input */}
-      <div className="animate-fade-in-up mb-6" style={{ animationDelay: "100ms" }}>
-        <input
-          type="text"
-          value={productName}
-          onChange={(e) => onProductNameChange(e.target.value)}
-          placeholder="z.B. Produktname oder Marke"
-          className="w-full rounded-xl border border-border bg-muted px-4 py-3 text-base text-foreground placeholder:text-[var(--text-caption)] focus:border-[var(--brand-plum)]/50 focus:outline-none focus:ring-1 focus:ring-[var(--brand-plum)]/30 transition-colors"
+      {shouldUseProductIntake ? (
+        <ProductIntakeMethodToggle
+          value={selectedMethod}
+          onChange={onIntakeMethodChange}
+          className="animate-fade-in-up mb-5 grid grid-cols-2 gap-2"
+          buttonClassName="flex min-h-[52px] items-center justify-center gap-2 rounded-xl border px-3 text-sm font-medium transition-colors"
         />
-      </div>
+      ) : null}
 
-      {/* Frequency pills */}
+      {selectedMethod === "photo" && shouldUseProductIntake ? (
+        <div className="animate-fade-in-up space-y-3 mb-6" style={{ animationDelay: "120ms" }}>
+          <ProductIntakeImageFields
+            frontReady={Boolean(frontImagePath || committedFrontImagePath)}
+            barcodeReady={Boolean(barcodeImagePath)}
+            uploading={uploading}
+            uploadError={uploadError}
+            onUpload={handleUpload}
+            labelClassName="block rounded-xl border border-border bg-muted p-4 text-sm font-medium text-foreground"
+            inputClassName="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-full file:border-0 file:bg-secondary file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-secondary-foreground"
+            statusClassName="flex items-center gap-2 text-sm text-[var(--text-sub)]"
+            errorClassName="text-sm text-destructive"
+          />
+
+          <ProductIntakeBrandProductFields
+            brandText={brandText}
+            productName={productName}
+            brandOptions={brandOptions}
+            brandListId={brandListId}
+            brandPlaceholder="Marke optional"
+            productPlaceholder="Produktname optional"
+            onBrandTextChange={handleBrandTextChange}
+            onProductNameChange={onProductNameChange}
+            wrapperClassName="grid gap-3 sm:grid-cols-2"
+            inputClassName="w-full rounded-xl border border-border bg-muted px-4 py-3 text-base text-foreground placeholder:text-[var(--text-caption)] focus:border-[var(--brand-plum)]/50 focus:outline-none focus:ring-1 focus:ring-[var(--brand-plum)]/30 transition-colors"
+          />
+        </div>
+      ) : null}
+
+      {selectedMethod === "manual" || !isSupportedIntakeCategory ? (
+        <div className="animate-fade-in-up space-y-3 mb-6" style={{ animationDelay: "120ms" }}>
+          {shouldUseProductIntake ? (
+            <ProductIntakeBrandProductFields
+              brandText={brandText}
+              productName={productName}
+              brandOptions={brandOptions}
+              brandListId={brandListId}
+              brandPlaceholder="Marke"
+              productPlaceholder="Produktname"
+              onBrandTextChange={handleBrandTextChange}
+              onProductNameChange={onProductNameChange}
+              wrapperClassName="space-y-3"
+              inputClassName="w-full rounded-xl border border-border bg-muted px-4 py-3 text-base text-foreground placeholder:text-[var(--text-caption)] focus:border-[var(--brand-plum)]/50 focus:outline-none focus:ring-1 focus:ring-[var(--brand-plum)]/30 transition-colors"
+            />
+          ) : (
+            <input
+              type="text"
+              value={productName}
+              onChange={(event) => onProductNameChange(event.target.value)}
+              placeholder="z.B. Produktname oder Marke"
+              className="w-full rounded-xl border border-border bg-muted px-4 py-3 text-base text-foreground placeholder:text-[var(--text-caption)] focus:border-[var(--brand-plum)]/50 focus:outline-none focus:ring-1 focus:ring-[var(--brand-plum)]/30 transition-colors"
+            />
+          )}
+        </div>
+      ) : null}
+
       <div className="animate-fade-in-up mb-8" style={{ animationDelay: "160ms" }}>
         <p className="text-sm text-[var(--text-sub)] mb-3">Wie oft?</p>
         <div className="flex flex-wrap gap-2">
@@ -84,12 +253,14 @@ export function ProductDrilldownScreen({
       <div className="animate-fade-in-up" style={{ animationDelay: "220ms" }}>
         <button
           onClick={onContinue}
-          disabled={!frequency}
+          disabled={!canContinue || isSaving || uploading !== null}
           className="quiz-btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {continueLabel}
+          {isSaving ? "Speichern..." : continueLabel}
         </button>
       </div>
+
+      <input type="hidden" name="product-category" value={category} />
     </div>
   )
 }

--- a/src/components/onboarding/screens/product-drilldown-screen.tsx
+++ b/src/components/onboarding/screens/product-drilldown-screen.tsx
@@ -27,6 +27,7 @@ interface ProductDrilldownScreenProps {
   frequency: ProductFrequency | null
   frontImagePath: string | null
   committedFrontImagePath: string | null
+  existingUsageId: string | null
   barcodeImagePath: string | null
   isSupportedIntakeCategory: boolean
   productIntakeEnabled: boolean
@@ -52,6 +53,7 @@ function hasRequiredFields(params: {
   frequency: ProductFrequency | null
   frontImagePath: string | null
   committedFrontImagePath: string | null
+  existingUsageId: string | null
   isSupportedIntakeCategory: boolean
 }) {
   if (!params.frequency) return false
@@ -64,6 +66,7 @@ function hasRequiredFields(params: {
     productName: params.productName,
     frontImagePath: params.frontImagePath,
     committedFrontImagePath: params.committedFrontImagePath,
+    existingUsageId: params.existingUsageId,
   })
 }
 
@@ -77,6 +80,7 @@ export function ProductDrilldownScreen({
   frequency,
   frontImagePath,
   committedFrontImagePath,
+  existingUsageId,
   barcodeImagePath,
   isSupportedIntakeCategory,
   productIntakeEnabled,
@@ -106,11 +110,13 @@ export function ProductDrilldownScreen({
         frequency,
         frontImagePath,
         committedFrontImagePath,
+        existingUsageId,
         isSupportedIntakeCategory: shouldUseProductIntake,
       }),
     [
       brandText,
       committedFrontImagePath,
+      existingUsageId,
       frequency,
       frontImagePath,
       productName,

--- a/src/components/product-intake/product-intake-form-fields.tsx
+++ b/src/components/product-intake/product-intake-form-fields.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import { Check, ImageUp, Keyboard, Loader2 } from "lucide-react"
+import type { ProductIntakeImageKind, ProductIntakeMethod } from "@/lib/product-intake/client"
+import type { ProductIntakeBrandOption } from "@/lib/product-intake/client"
+
+export function ProductIntakeMethodToggle({
+  value,
+  onChange,
+  className = "mb-3 grid grid-cols-2 gap-2",
+  buttonClassName = "flex min-h-[44px] items-center justify-center gap-2 rounded-lg border px-2 text-sm font-medium transition-colors",
+}: {
+  value: ProductIntakeMethod | null
+  onChange: (method: ProductIntakeMethod) => void
+  className?: string
+  buttonClassName?: string
+}) {
+  return (
+    <div className={className}>
+      {[
+        { value: "photo" as const, label: "Foto hochladen", icon: ImageUp },
+        { value: "manual" as const, label: "Daten eingeben", icon: Keyboard },
+      ].map((option) => {
+        const Icon = option.icon
+        const active = value === option.value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={`${buttonClassName} ${
+              active
+                ? "border-secondary bg-secondary text-secondary-foreground"
+                : "border-border bg-background text-foreground hover:border-[var(--brand-plum)]/40"
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+            <span>{option.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export function ProductIntakeImageFields({
+  frontReady,
+  barcodeReady,
+  uploading,
+  uploadError,
+  onUpload,
+  labelClassName = "block rounded-lg border border-border bg-muted p-3 text-sm",
+  inputClassName = "sr-only",
+  statusClassName = "flex items-center gap-2 text-xs text-muted-foreground",
+  errorClassName = "text-xs text-destructive",
+}: {
+  frontReady: boolean
+  barcodeReady: boolean
+  uploading: ProductIntakeImageKind | null
+  uploadError?: string | null
+  onUpload: (kind: ProductIntakeImageKind, file: File | undefined) => void
+  labelClassName?: string
+  inputClassName?: string
+  statusClassName?: string
+  errorClassName?: string
+}) {
+  return (
+    <div className="space-y-2">
+      <ProductIntakeImageField
+        label="Vorderseite"
+        ready={frontReady}
+        kind="front"
+        onUpload={onUpload}
+        labelClassName={labelClassName}
+        inputClassName={inputClassName}
+      />
+      <ProductIntakeImageField
+        label="Barcode"
+        ready={barcodeReady}
+        kind="barcode"
+        onUpload={onUpload}
+        labelClassName={labelClassName}
+        inputClassName={inputClassName}
+      />
+
+      {uploading ? (
+        <div className={statusClassName}>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Bild wird hochgeladen
+        </div>
+      ) : null}
+      {uploadError ? <p className={errorClassName}>{uploadError}</p> : null}
+    </div>
+  )
+}
+
+function ProductIntakeImageField({
+  label,
+  ready,
+  kind,
+  onUpload,
+  labelClassName,
+  inputClassName,
+}: {
+  label: string
+  ready: boolean
+  kind: ProductIntakeImageKind
+  onUpload: (kind: ProductIntakeImageKind, file: File | undefined) => void
+  labelClassName: string
+  inputClassName: string
+}) {
+  return (
+    <label className={labelClassName}>
+      <span className="mb-2 flex items-center justify-between gap-3">
+        {label}
+        {ready ? <Check className="h-4 w-4 text-emerald-600" /> : null}
+      </span>
+      <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <span className="rounded-full bg-secondary px-3 py-1.5 font-medium text-secondary-foreground">
+          {ready ? "Foto ersetzen" : "Foto auswählen"}
+        </span>
+        <span>{ready ? "Bild hochgeladen" : "Noch kein Bild ausgewählt"}</span>
+      </span>
+      <input
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+        onChange={(event) => onUpload(kind, event.target.files?.[0])}
+        className={inputClassName}
+      />
+    </label>
+  )
+}
+
+export function ProductIntakeBrandProductFields({
+  brandText,
+  productName,
+  brandOptions,
+  brandListId,
+  brandPlaceholder,
+  productPlaceholder,
+  onBrandTextChange,
+  onProductNameChange,
+  wrapperClassName = "grid gap-2 sm:grid-cols-2",
+  inputClassName = "w-full rounded-lg border border-border bg-muted px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground",
+}: {
+  brandText: string
+  productName: string
+  brandOptions: ProductIntakeBrandOption[]
+  brandListId: string
+  brandPlaceholder: string
+  productPlaceholder: string
+  onBrandTextChange: (value: string) => void
+  onProductNameChange: (value: string) => void
+  wrapperClassName?: string
+  inputClassName?: string
+}) {
+  return (
+    <>
+      <div className={wrapperClassName}>
+        <input
+          type="text"
+          value={brandText}
+          onChange={(event) => onBrandTextChange(event.target.value)}
+          placeholder={brandPlaceholder}
+          list={brandListId}
+          className={inputClassName}
+        />
+        <input
+          type="text"
+          value={productName}
+          onChange={(event) => onProductNameChange(event.target.value)}
+          placeholder={productPlaceholder}
+          className={inputClassName}
+        />
+      </div>
+      <datalist id={brandListId}>
+        {brandOptions.map((option) => (
+          <option key={option.id} value={option.label} />
+        ))}
+      </datalist>
+    </>
+  )
+}

--- a/src/hooks/use-chat.ts
+++ b/src/hooks/use-chat.ts
@@ -200,6 +200,13 @@ export function useChat(): UseChatReturn {
               switch (event.type) {
                 case "conversation_id":
                   setCurrentConversationId(event.data)
+                  setMessages((prev) =>
+                    prev.map((message) =>
+                      message.conversation_id
+                        ? message
+                        : { ...message, conversation_id: event.data },
+                    ),
+                  )
                   break
                 case "content_delta":
                   setMessages((prev) => {
@@ -235,6 +242,22 @@ export function useChat(): UseChatReturn {
                       updated[updated.length - 1] = {
                         ...last,
                         product_recommendations: event.data,
+                      }
+                    }
+                    return updated
+                  })
+                  break
+                case "product_intake_offer":
+                  setMessages((prev) => {
+                    const updated = [...prev]
+                    const last = updated[updated.length - 1]
+                    if (last?.role === "assistant") {
+                      updated[updated.length - 1] = {
+                        ...last,
+                        rag_context: {
+                          ...(last.rag_context ?? { sources: [], category_decision: null }),
+                          product_intake_offer: event.data,
+                        },
                       }
                     }
                     return updated
@@ -282,6 +305,7 @@ export function useChat(): UseChatReturn {
                         rag_context: {
                           sources: last.rag_context?.sources ?? [],
                           category_decision: event.data?.category_decision ?? null,
+                          product_intake_offer: last.rag_context?.product_intake_offer ?? null,
                         },
                       }
                     }

--- a/src/hooks/use-onboarding-product-intake-controller.ts
+++ b/src/hooks/use-onboarding-product-intake-controller.ts
@@ -136,6 +136,7 @@ export function useOnboardingProductIntakeController(productIntakeEnabled: boole
         productLineId: drilldown.productLineId,
         productName: drilldown.productName,
         frontImagePath: drilldown.frontImagePath,
+        committedFrontImagePath: drilldown.committedFrontImagePath,
         frontImageValidationStatus: drilldown.frontImageValidationStatus,
         frontImageValidationMetadata: drilldown.frontImageValidationMetadata,
         barcodeImagePath: drilldown.barcodeImagePath,

--- a/src/hooks/use-onboarding-product-intake-controller.ts
+++ b/src/hooks/use-onboarding-product-intake-controller.ts
@@ -1,0 +1,173 @@
+"use client"
+
+import { useCallback } from "react"
+import { SUPPORTED_PRODUCT_CATEGORY_KEYS } from "@/lib/product-identity"
+import {
+  buildProductIntakeSubmissionPayload,
+  cancelOnboardingProductIntakeCategories,
+  submitOnboardingProductIntake,
+  uploadProductIntakeImage,
+  type ProductIntakeImageKind,
+} from "@/lib/product-intake/client"
+import type {
+  OnboardingProductDrilldown,
+  OnboardingProductIntakeBarcodeImageValidationStatus,
+  OnboardingProductIntakeFrontImageValidationStatus,
+} from "@/lib/onboarding/store"
+import type { ProductFrequency } from "@/lib/vocabulary"
+
+const SUPPORTED_PRODUCT_INTAKE_CATEGORY_SET = new Set<string>(SUPPORTED_PRODUCT_CATEGORY_KEYS)
+
+type ProductUsageRowLike = Record<string, unknown>
+
+function temporaryUploadPath(path: unknown): string | null {
+  return typeof path === "string" && path.startsWith("tmp/") ? path : null
+}
+
+function committedUploadPath(path: unknown): string | null {
+  return typeof path === "string" && path.length > 0 && !path.startsWith("tmp/") ? path : null
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function frontValidationStatus(
+  value: unknown,
+): OnboardingProductIntakeFrontImageValidationStatus | null {
+  return value === "valid_product_front" ||
+    value === "uncertain" ||
+    value === "not_a_product_photo" ||
+    value === "unsafe_or_inappropriate"
+    ? value
+    : null
+}
+
+function barcodeValidationStatus(
+  value: unknown,
+): OnboardingProductIntakeBarcodeImageValidationStatus | null {
+  return value === "valid_barcode" ||
+    value === "uncertain" ||
+    value === "not_a_product_photo" ||
+    value === "unsafe_or_inappropriate"
+    ? value
+    : null
+}
+
+export function useOnboardingProductIntakeController(productIntakeEnabled: boolean) {
+  const isSupportedCategory = useCallback(
+    (category: string) => SUPPORTED_PRODUCT_INTAKE_CATEGORY_SET.has(category),
+    [],
+  )
+
+  const drilldownFromUsageRow = useCallback(
+    (row: ProductUsageRowLike, productName: string, frequency: ProductFrequency | null) => {
+      const rowIntakeMethod =
+        row.intake_method === "photo" || row.front_image_path ? "photo" : "manual"
+
+      return {
+        intakeMethod: rowIntakeMethod,
+        productName,
+        existingUsageId: typeof row.id === "string" ? row.id : null,
+        brandText: typeof row.brand_text === "string" ? row.brand_text : "",
+        brandId: null,
+        productLineId: null,
+        frequency,
+        frontImagePath: temporaryUploadPath(row.front_image_path),
+        committedFrontImagePath: committedUploadPath(row.front_image_path),
+        barcodeImagePath: temporaryUploadPath(row.barcode_image_path),
+        frontImageValidationStatus: frontValidationStatus(row.front_image_validation_status),
+        frontImageValidationMetadata: metadataRecord(row.front_image_validation_metadata),
+        barcodeImageValidationStatus: barcodeValidationStatus(row.barcode_image_validation_status),
+        barcodeImageValidationMetadata: metadataRecord(row.barcode_image_validation_metadata),
+      } satisfies Partial<OnboardingProductDrilldown>
+    },
+    [],
+  )
+
+  const cancelDeselectedCategories = useCallback(
+    async (
+      existingRows: ProductUsageRowLike[],
+      selectedCategories: string[],
+      signal?: AbortSignal,
+    ) => {
+      const toDeleteRows = existingRows.filter((row) => {
+        const category = row.category as string
+        return category !== "shampoo" && !selectedCategories.includes(category)
+      })
+      const intakeCancelCategories = toDeleteRows
+        .map((row) => row.category as string)
+        .filter((category) => isSupportedCategory(category))
+      const directDeleteIds = toDeleteRows
+        .filter((row) => {
+          const category = row.category as string
+          return !productIntakeEnabled || !isSupportedCategory(category)
+        })
+        .map((row) => row.id as string)
+
+      if (productIntakeEnabled && intakeCancelCategories.length > 0) {
+        await cancelOnboardingProductIntakeCategories(intakeCancelCategories, signal)
+      }
+
+      return directDeleteIds
+    },
+    [isSupportedCategory, productIntakeEnabled],
+  )
+
+  const submitDrilldown = useCallback(
+    (
+      category: string,
+      drilldown: OnboardingProductDrilldown,
+      replaceExistingConfirmed: boolean | undefined,
+      signal?: AbortSignal,
+    ) => {
+      if (!drilldown.intakeMethod || !drilldown.frequency) {
+        return Promise.resolve(null)
+      }
+
+      const payload = buildProductIntakeSubmissionPayload({
+        method: drilldown.intakeMethod,
+        category,
+        frequency: drilldown.frequency,
+        brandText: drilldown.brandText,
+        brandId: drilldown.brandId,
+        productLineId: drilldown.productLineId,
+        productName: drilldown.productName,
+        frontImagePath: drilldown.frontImagePath,
+        frontImageValidationStatus: drilldown.frontImageValidationStatus,
+        frontImageValidationMetadata: drilldown.frontImageValidationMetadata,
+        barcodeImagePath: drilldown.barcodeImagePath,
+        barcodeImageValidationStatus: drilldown.barcodeImageValidationStatus,
+        barcodeImageValidationMetadata: drilldown.barcodeImageValidationMetadata,
+        existingUsageId: drilldown.existingUsageId,
+        replaceExistingConfirmed,
+      })
+
+      return submitOnboardingProductIntake(payload, signal)
+    },
+    [],
+  )
+
+  const uploadImagePatch = useCallback(async (kind: ProductIntakeImageKind, file: File) => {
+    const upload = await uploadProductIntakeImage(kind, file)
+    return {
+      [kind === "front" ? "frontImagePath" : "barcodeImagePath"]: upload.path,
+      ...(kind === "front" ? { committedFrontImagePath: null } : {}),
+      [kind === "front" ? "frontImageValidationStatus" : "barcodeImageValidationStatus"]:
+        upload.validationStatus,
+      [kind === "front" ? "frontImageValidationMetadata" : "barcodeImageValidationMetadata"]:
+        upload.validationMetadata,
+      intakeMethod: "photo" as const,
+    } satisfies Partial<OnboardingProductDrilldown>
+  }, [])
+
+  return {
+    isSupportedCategory,
+    drilldownFromUsageRow,
+    cancelDeselectedCategories,
+    submitDrilldown,
+    uploadImagePatch,
+  }
+}

--- a/src/hooks/use-product-intake-brand-options.ts
+++ b/src/hooks/use-product-intake-brand-options.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import type { ProductIntakeBrandOption } from "@/lib/product-intake/client"
+
+export function useProductIntakeBrandOptions(query: string, enabled = true) {
+  const [brandOptions, setBrandOptions] = useState<ProductIntakeBrandOption[]>([])
+  const trimmedQuery = query.trim()
+  const shouldFetch = enabled && trimmedQuery.length >= 2
+
+  useEffect(() => {
+    if (!shouldFetch) {
+      return
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => {
+      fetch(`/api/product-intake/brand-options?q=${encodeURIComponent(trimmedQuery)}`, {
+        signal: controller.signal,
+      })
+        .then((response) => (response.ok ? response.json() : null))
+        .then((body: { options?: ProductIntakeBrandOption[] } | null) => {
+          setBrandOptions(body?.options ?? [])
+        })
+        .catch((error) => {
+          if ((error as Error).name !== "AbortError") setBrandOptions([])
+        })
+    }, 180)
+
+    return () => {
+      clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [shouldFetch, trimmedQuery])
+
+  return shouldFetch ? brandOptions : []
+}

--- a/src/lib/agent-v2/compare/run-agent-v2.ts
+++ b/src/lib/agent-v2/compare/run-agent-v2.ts
@@ -759,6 +759,14 @@ export async function runAgentV2ComparisonForUser(
       safetyMode,
       tools: {
         load_advisor_guidance: async (input) => loadAgentV2AdvisorGuidance(input),
+        lookup_product_candidate: async () => ({
+          status: "insufficient_identity",
+          category: null,
+          product: null,
+          candidates: [],
+          missing_fields: ["category"],
+          intake_offer: null,
+        }),
         select_products: async (input, executionContext?: AgentV2RuntimeToolExecutionContext) => {
           latestSelectProductsResult = null
           const effectiveCareContext =

--- a/src/lib/agent-v2/production/chat-pipeline.ts
+++ b/src/lib/agent-v2/production/chat-pipeline.ts
@@ -6,7 +6,10 @@ import {
   createSelectProductsTool,
   type SelectProductsToolResult,
 } from "@/lib/agent/tools/select-products"
-import { loadAgentV2ProductionConversationHistory } from "@/lib/agent-v2/production/conversation-history"
+import {
+  loadAgentV2ProductionConversationHistory,
+  verifyAgentV2ProductionConversationOwnership,
+} from "@/lib/agent-v2/production/conversation-history"
 import {
   buildAgentV2GenerationMetadata,
   isAgentV2LangfuseObservationEnabled,
@@ -59,7 +62,7 @@ import {
   type AgentV2ConversationStateTransition,
   type AgentV2ConversationStateV2,
 } from "@/lib/agent-v2/production/persisted-session-state"
-import { loadAgentV2ConversationState as loadPersistedConversationState } from "@/lib/chat-runtime/conversation-state-store"
+import { loadAgentV2ConversationStateForUser } from "@/lib/chat-runtime/conversation-state-store"
 import { buildPipelineTraceDraft, type PipelineTraceDraft } from "@/lib/chat-runtime/debug-trace"
 import { loadUserMemoryContext, type UserMemoryContext } from "@/lib/chat-runtime/user-memory"
 import {
@@ -131,10 +134,14 @@ export interface PipelineResult {
 
 interface ProductionAgentV2PipelineDeps {
   client?: AgentV2ResponsesClient
+  verifyConversationOwnership?: (params: {
+    conversationId: string
+    userId: string
+  }) => Promise<boolean>
   loadConversationHistory?: (conversationId: string) => Promise<Message[]>
   getUserContext?: (userId: string) => Promise<UserContextProjection>
   loadUserMemoryContext?: (userId: string) => Promise<UserMemoryContext>
-  loadConversationState?: (conversationId: string) => Promise<unknown>
+  loadConversationState?: (params: { conversationId: string; userId: string }) => Promise<unknown>
   createSelectProductsTool?: typeof createSelectProductsTool
   createBuildOrFixRoutineTool?: typeof createBuildOrFixRoutineTool
   runAgentV2ResponsesTurn?: typeof runAgentV2ResponsesTurn
@@ -452,6 +459,14 @@ export async function runAgentV2ProductionPipeline(
   }
 
   const startedAt = new Date().toISOString()
+  const ownsConversation = await (
+    deps.verifyConversationOwnership ?? verifyAgentV2ProductionConversationOwnership
+  )({ conversationId, userId })
+
+  if (!ownsConversation) {
+    throw new Error("AgentV2 production conversation does not belong to user.")
+  }
+
   const [
     { result: conversationHistory, durationMs: historyLoadMs },
     { result: userContext, durationMs: contextLoadMs },
@@ -465,8 +480,8 @@ export async function runAgentV2ProductionPipeline(
     measureAsync(() => (deps.loadUserMemoryContext ?? loadUserMemoryContext)(userId)),
     measureAsync(() =>
       deps.loadConversationState
-        ? deps.loadConversationState(conversationId)
-        : loadPersistedConversationState(createAdminClient(), conversationId),
+        ? deps.loadConversationState({ conversationId, userId })
+        : loadAgentV2ConversationStateForUser(createAdminClient(), { conversationId, userId }),
     ),
   ])
 
@@ -478,15 +493,8 @@ export async function runAgentV2ProductionPipeline(
   )
   const selectedProductResults: SelectProductsToolResult[] = []
   const selectedProductProjections: ReturnType<typeof projectSelectProductsForAgentV2>[] = []
-  let latestSelectProductsResult: SelectProductsToolResult | null = null
   let latestProductLookupResult: ProductLookupResult | null = null
   let latestRoutineProjection: AgentV2RoutineProjection | null = null
-  const selectProducts = (deps.createSelectProductsTool ?? createSelectProductsTool)({
-    onResult: (result) => {
-      latestSelectProductsResult = result
-      selectedProductResults.push(result)
-    },
-  })
   const buildRoutine = (deps.createBuildOrFixRoutineTool ?? createBuildOrFixRoutineTool)()
   const routineThreadContext = buildRoutineThreadContextFromConversationState(conversationState)
   const priorSelectedProductProjections =
@@ -584,7 +592,6 @@ export async function runAgentV2ProductionPipeline(
         return result
       },
       select_products: async (input, executionContext?: AgentV2RuntimeToolExecutionContext) => {
-        latestSelectProductsResult = null
         const effectiveCareContext =
           executionContext?.effectiveCareContext ?? readAgentV2EffectiveCareContext(input)
         const effectiveHairProfile = buildAgentV2EffectiveHairProfile(
@@ -599,23 +606,30 @@ export async function runAgentV2ProductionPipeline(
           latestMessage: message,
           recentMessages,
         })
-        const projection = await selectProducts({
-          category: input.category as Parameters<typeof selectProducts>[0]["category"],
+        let rawResult: SelectProductsToolResult | null = null
+        const selectProductsForCall = (deps.createSelectProductsTool ?? createSelectProductsTool)({
+          onResult: (result) => {
+            rawResult = result
+          },
+        })
+        const projection = await selectProductsForCall({
+          category: input.category as Parameters<typeof selectProductsForCall>[0]["category"],
           message: productToolMessage,
           hairProfile: effectiveHairProfile,
           memoryContext,
           routineItems: effectiveRoutineItems,
           effectiveCareContext,
         })
-        const rawResult =
-          latestSelectProductsResult ??
+        const resultForProjection =
+          rawResult ??
           ({
             projection,
             products: [],
             effectiveHairProfile,
             runtime: {} as SelectProductsToolResult["runtime"],
           } satisfies SelectProductsToolResult)
-        const agentProjection = projectSelectProductsForAgentV2(rawResult, {
+        selectedProductResults.push(resultForProjection)
+        const agentProjection = projectSelectProductsForAgentV2(resultForProjection, {
           includeCareBalanceContext: true,
         })
         selectedProductProjections.push(agentProjection)
@@ -682,7 +696,9 @@ export async function runAgentV2ProductionPipeline(
   const matchedProducts = visibleFailure
     ? []
     : deriveMatchedProducts({ answer, selectedProductResults })
-  const { categoryDecision, engineTrace } = deriveEngineArtifacts(latestSelectProductsResult)
+  const { categoryDecision, engineTrace } = deriveEngineArtifacts(
+    selectedProductResults.at(-1) ?? null,
+  )
   const exposedCategoryDecision = visibleFailure ? undefined : categoryDecision
   const exposedEngineTrace = visibleFailure ? undefined : engineTrace
   const attachmentMode = matchedProducts.length > 0 ? "cards" : "text_only"

--- a/src/lib/agent-v2/production/chat-pipeline.ts
+++ b/src/lib/agent-v2/production/chat-pipeline.ts
@@ -24,6 +24,13 @@ import {
 import { runAgentV2ResponsesTurn } from "@/lib/agent-v2/runtime/responses-agent"
 import { loadAgentV2AdvisorGuidance } from "@/lib/agent-v2/tools/guidance-tool"
 import {
+  lookupProductCandidate,
+  type ProductLookupCatalog,
+  type ProductLookupResult,
+} from "@/lib/product-intake/product-lookup"
+import { createSupabaseProductIntakeRepository } from "@/lib/product-intake/repository"
+import type { BrandResolutionCatalogInput } from "@/lib/product-identity/brand-resolution"
+import {
   projectRoutineForAgentV2,
   type AgentV2RoutineProjection,
 } from "@/lib/agent-v2/tools/routine-projection"
@@ -100,6 +107,7 @@ export interface PipelineParams {
   conversationId?: string
   userId: string
   requestId: string
+  productIntakeEnabled?: boolean
 }
 
 export interface PipelineResult {
@@ -118,6 +126,7 @@ export interface PipelineResult {
   debugTrace: PipelineTraceDraft
   visibleFailure?: boolean
   answerMode: AgentV2AnswerMode
+  productIntakeOffer?: import("@/lib/types").ProductIntakeOffer | null
 }
 
 interface ProductionAgentV2PipelineDeps {
@@ -133,6 +142,7 @@ interface ProductionAgentV2PipelineDeps {
   getObservedOpenAI?: typeof getObservedOpenAI
   getManagedTextPromptTemplate?: typeof getManagedTextPromptTemplate
   observeAgentV2ToolCall?: typeof observeAgentV2ToolCall
+  createProductIntakeRepository?: typeof createSupabaseProductIntakeRepository
 }
 
 const ROUTINE_PRODUCT_CATEGORY_VALUES = new Set<RoutineProduct>([
@@ -469,6 +479,7 @@ export async function runAgentV2ProductionPipeline(
   const selectedProductResults: SelectProductsToolResult[] = []
   const selectedProductProjections: ReturnType<typeof projectSelectProductsForAgentV2>[] = []
   let latestSelectProductsResult: SelectProductsToolResult | null = null
+  let latestProductLookupResult: ProductLookupResult | null = null
   let latestRoutineProjection: AgentV2RoutineProjection | null = null
   const selectProducts = (deps.createSelectProductsTool ?? createSelectProductsTool)({
     onResult: (result) => {
@@ -482,6 +493,23 @@ export async function runAgentV2ProductionPipeline(
     conversationState.agent_v2.prior_selected_product_projections
   const sessionMemory = conversationState.agent_v2.session_memory
   const runTurn = deps.runAgentV2ResponsesTurn ?? runAgentV2ResponsesTurn
+  const productIntakeEnabled = params.productIntakeEnabled === true
+  let productLookupCatalogPromise: Promise<{
+    catalog: ProductLookupCatalog
+    brandCatalog: BrandResolutionCatalogInput
+  }> | null = null
+  const loadProductLookupCatalogs = () => {
+    productLookupCatalogPromise ??= (async () => {
+      const repository =
+        deps.createProductIntakeRepository?.() ?? createSupabaseProductIntakeRepository()
+      const [catalog, brandCatalog] = await Promise.all([
+        repository.loadCatalog(),
+        repository.loadBrandResolutionCatalog(),
+      ])
+      return { catalog, brandCatalog }
+    })()
+    return productLookupCatalogPromise
+  }
   const safetyMode = classifyAgentV2ProductionSafetyMode(message)
   const managedPrompt = await (deps.getManagedTextPromptTemplate ?? getManagedTextPromptTemplate)(
     LANGFUSE_PROMPTS.agentV2ResponsesCareBalance,
@@ -531,10 +559,30 @@ export async function runAgentV2ProductionPipeline(
     routineThreadContext,
     priorSelectedProductProjections,
     safetyMode,
+    productIntakeEnabled,
     langfuseMode: "enabled",
     observeToolCall: deps.observeAgentV2ToolCall ?? observeAgentV2ToolCall,
     tools: {
       load_advisor_guidance: async (input) => loadAgentV2AdvisorGuidance(input),
+      lookup_product_candidate: async (input) => {
+        if (!productIntakeEnabled) {
+          throw new Error("product intake lookup tool is disabled")
+        }
+        const { catalog, brandCatalog } = await loadProductLookupCatalogs()
+        const result = lookupProductCandidate({
+          input: {
+            category: typeof input.category === "string" ? input.category : null,
+            brand_text: typeof input.brand_text === "string" ? input.brand_text : null,
+            product_name_text:
+              typeof input.product_name_text === "string" ? input.product_name_text : null,
+          },
+          catalog,
+          brandCatalog,
+          offerId: `product-intake-${requestId}`,
+        })
+        latestProductLookupResult = result
+        return result
+      },
       select_products: async (input, executionContext?: AgentV2RuntimeToolExecutionContext) => {
         latestSelectProductsResult = null
         const effectiveCareContext =
@@ -617,6 +665,11 @@ export async function runAgentV2ProductionPipeline(
 
   const answer = result.final_answer
   const visibleFailure = result.trace.failure_stage !== null
+  const productLookupResult = latestProductLookupResult as ProductLookupResult | null
+  const productIntakeOffer =
+    productIntakeEnabled && !visibleFailure && productLookupResult?.status === "not_found"
+      ? productLookupResult.intake_offer
+      : null
   const intent = deriveIntent(answer)
   const productCategory = visibleFailure ? null : deriveProductCategory(answer)
   const routerDecision = buildAgentV2RouterDecision({ answer, visibleFailure })
@@ -758,5 +811,6 @@ export async function runAgentV2ProductionPipeline(
     debugTrace,
     visibleFailure,
     answerMode: answer.answer_mode,
+    productIntakeOffer,
   }
 }

--- a/src/lib/agent-v2/production/conversation-history.ts
+++ b/src/lib/agent-v2/production/conversation-history.ts
@@ -24,6 +24,30 @@ type ConversationHistoryClient = {
   }
 }
 
+type ConversationOwnershipQueryResult = {
+  data: { id: string } | null
+  error: unknown
+}
+
+type ConversationOwnershipClient = {
+  from(table: "conversations"): {
+    select(columns: string): {
+      eq(
+        column: "id" | "user_id",
+        value: string,
+      ): {
+        eq(
+          column: "id" | "user_id",
+          value: string,
+        ): {
+          maybeSingle(): Promise<ConversationOwnershipQueryResult>
+        }
+        maybeSingle(): Promise<ConversationOwnershipQueryResult>
+      }
+    }
+  }
+}
+
 export async function loadAgentV2ProductionConversationHistory(
   conversationId: string,
   client: unknown = createAdminClient(),
@@ -42,4 +66,24 @@ export async function loadAgentV2ProductionConversationHistory(
   }
 
   return ((data as Message[]) ?? []).slice().reverse()
+}
+
+export async function verifyAgentV2ProductionConversationOwnership(
+  params: { conversationId: string; userId: string },
+  client: unknown = createAdminClient(),
+): Promise<boolean> {
+  const admin = client as ConversationOwnershipClient
+  const { data, error } = await admin
+    .from("conversations")
+    .select("id")
+    .eq("id", params.conversationId)
+    .eq("user_id", params.userId)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to verify AgentV2 production conversation ownership:", error)
+    return false
+  }
+
+  return Boolean(data?.id)
 }

--- a/src/lib/agent-v2/runtime/responses-agent.ts
+++ b/src/lib/agent-v2/runtime/responses-agent.ts
@@ -28,6 +28,7 @@ import type { CareBalanceToolContext } from "@/lib/agent/tools/care-balance-cont
 import {
   BuildOrFixRoutineToolInputSchema,
   ClassifyTurnGateToolParametersSchema,
+  LookupProductCandidateToolInputSchema,
   type CurrentCareFactInput,
   SelectProductsToolInputSchema,
   buildAgentV2ResponsesTools,
@@ -57,6 +58,7 @@ type AgentV2ToolName =
   | "classify_turn_gate"
   | "load_advisor_guidance"
   | "set_current_care_context"
+  | "lookup_product_candidate"
   | "select_products"
   | "build_or_fix_routine"
 type AgentV2RuntimeToolName = keyof AgentV2RuntimeTools
@@ -91,6 +93,10 @@ interface AgentV2RuntimeTools {
     executionContext?: AgentV2RuntimeToolExecutionContext,
   ) => Promise<unknown>
   select_products: (
+    input: Record<string, unknown>,
+    executionContext?: AgentV2RuntimeToolExecutionContext,
+  ) => Promise<unknown>
+  lookup_product_candidate: (
     input: Record<string, unknown>,
     executionContext?: AgentV2RuntimeToolExecutionContext,
   ) => Promise<unknown>
@@ -202,6 +208,7 @@ export async function runAgentV2ResponsesTurn(params: {
   priorSelectedProductProjections?: readonly Partial<AgentV2SelectProductsProjection>[]
   tools: AgentV2RuntimeTools
   safetyMode?: AgentV2SafetyMode
+  productIntakeEnabled?: boolean
   policyOverrides?: Partial<AgentV2ModelPolicy>
   langfuseMode?: "disabled" | "enabled"
   observeToolCall?: <T>(params: {
@@ -211,6 +218,7 @@ export async function runAgentV2ResponsesTurn(params: {
   }) => Promise<T>
 }): Promise<AgentV2ResponsesTurnResult> {
   const safetyMode = params.safetyMode ?? "normal"
+  const productIntakeEnabled = params.productIntakeEnabled === true
   const policy = { ...getAgentV2ModelPolicy(), ...params.policyOverrides }
   const routineThreadContext = normalizeRoutineThreadContext(params.routineThreadContext ?? null)
   const trace = createAgentV2Trace({
@@ -246,7 +254,11 @@ export async function runAgentV2ResponsesTurn(params: {
     routineThreadContext,
   })
   const turnGateEnabled = policy.turn_gate_enabled
-  const toolDefinitions = buildAgentV2ResponsesTools({ safetyMode, turnGateEnabled })
+  const toolDefinitions = buildAgentV2ResponsesTools({
+    safetyMode,
+    turnGateEnabled,
+    productIntakeEnabled,
+  })
   const allowedExecutableTools = new Set(
     toolDefinitions
       .map((tool) => tool.name)
@@ -277,6 +289,7 @@ export async function runAgentV2ResponsesTurn(params: {
     routineToolPolicy,
     turnGateEnabled,
     namedProductContext,
+    productIntakeEnabled,
   )
   const buildCurrentClarificationFallback = () =>
     isNonProceedTurnGate(turnGateAuthorized)
@@ -821,6 +834,7 @@ function buildInputItems(
   routineToolPolicy: RoutineToolPolicy,
   turnGateEnabled: boolean,
   namedProductContext: AgentV2NamedProductContext | null,
+  productIntakeEnabled: boolean,
 ): unknown[] {
   const items: unknown[] = [
     {
@@ -895,7 +909,7 @@ function buildInputItems(
   if (namedProductContext) {
     items.push({
       role: "system",
-      content: buildNamedProductContextGuidance(namedProductContext),
+      content: buildNamedProductContextGuidance(namedProductContext, { productIntakeEnabled }),
     })
   }
 
@@ -922,13 +936,29 @@ function buildInputItems(
   return items
 }
 
-function buildNamedProductContextGuidance(context: AgentV2NamedProductContext): string {
-  return [
+function buildNamedProductContextGuidance(
+  context: AgentV2NamedProductContext,
+  params: { productIntakeEnabled: boolean },
+): string {
+  const guidance = [
     `Current user named a plausible exact product: "${context.display_name}" (${context.category}). Treat it as user-provided but not catalog-verified.`,
     "For product_detail, still call select_products before the terminal answer.",
     "If select_products returns no exact or supported product_detail match, do not ask for the exact name again and do not substitute unrelated catalog alternatives as the answer.",
-    "Use constraint_blocked or a cautious non-evaluative answer: say it is not a verified catalog hit, cannot be evaluated exactly, and only discuss category-level plausibility or limitations if useful.",
-  ].join(" ")
+  ]
+
+  if (params.productIntakeEnabled) {
+    guidance.push(
+      "Also call lookup_product_candidate when the product identity and category/use are specific enough; use its result to distinguish found_exact, ambiguous, unsupported_category, insufficient_identity, and not_found.",
+      "If lookup_product_candidate returns not_found, write a natural German answer saying the product is not yet in the database and can be added for review; the app will render the intake card from structured metadata.",
+      "Use constraint_blocked or a cautious non-evaluative answer when lookup is ambiguous, unsupported, or missing category/identity: say it is not a verified catalog hit, cannot be evaluated exactly, and only discuss category-level plausibility or limitations if useful.",
+    )
+  } else {
+    guidance.push(
+      "If select_products cannot verify an exact catalog hit, answer cautiously without offering product intake: say it is not a verified catalog hit and ask for the exact product/category only when needed.",
+    )
+  }
+
+  return guidance.join(" ")
 }
 
 function normalizeRoutineThreadContext(
@@ -1593,6 +1623,11 @@ function validateExecutableToolArguments(
     return parsed.success ? { ok: true, value: parsed.data } : { ok: false }
   }
 
+  if (name === "lookup_product_candidate") {
+    const parsed = LookupProductCandidateToolInputSchema.safeParse(value)
+    return parsed.success ? { ok: true, value: parsed.data } : { ok: false }
+  }
+
   if (name === "build_or_fix_routine") {
     const parsed = BuildOrFixRoutineToolInputSchema.safeParse(value)
     return parsed.success ? { ok: true, value: parsed.data } : { ok: false }
@@ -1626,6 +1661,7 @@ function isExecutableToolName(name: string): name is AgentV2ToolName {
     name === "classify_turn_gate" ||
     name === "load_advisor_guidance" ||
     name === "set_current_care_context" ||
+    name === "lookup_product_candidate" ||
     name === "select_products" ||
     name === "build_or_fix_routine"
   )

--- a/src/lib/agent-v2/tools/tool-definitions.ts
+++ b/src/lib/agent-v2/tools/tool-definitions.ts
@@ -61,6 +61,7 @@ export interface AgentV2ResponsesToolDefinition {
 export function buildAgentV2ResponsesTools(params: {
   safetyMode: "normal" | "restricted" | "hard_short_circuit"
   turnGateEnabled?: boolean
+  productIntakeEnabled?: boolean
 }): AgentV2ResponsesToolDefinition[] {
   if (params.safetyMode === "hard_short_circuit") {
     throw new Error("Hard short circuit bypasses the AgentV2 tool loop")
@@ -114,7 +115,20 @@ export function buildAgentV2ResponsesTools(params: {
   )
 
   if (params.safetyMode === "normal") {
-    tools.splice(1, 0, {
+    const productTools: AgentV2ResponsesToolDefinition[] = []
+
+    if (params.productIntakeEnabled === true) {
+      productTools.push({
+        type: "function",
+        name: "lookup_product_candidate",
+        description:
+          "Look up a named product candidate in the product catalog when the user wants Chaarlie to work with that specific product: e.g. evaluate their own product, ask whether it suits them, add it to their routine, or clarify a named product. Use this for precise product identity checks before offering product intake. The lookup needs the product category/use when known from the message, context, or product name; if category is unclear, pass null and ask a natural clarification from the result. Do not call this for broad recommendation asks like 'welches Shampoo empfiehlst du?' unless the user names a specific product candidate. If the lookup returns not_found for a supported category, the app may offer the product intake card; if it returns ambiguous, ask which exact product; if unsupported_category, explain that this product category cannot be added yet.",
+        strict: true,
+        parameters: toStrictJsonSchema(LookupProductCandidateToolInputSchema),
+      })
+    }
+
+    productTools.push({
       type: "function",
       name: "select_products",
       description:
@@ -122,10 +136,22 @@ export function buildAgentV2ResponsesTools(params: {
       strict: true,
       parameters: toStrictJsonSchema(SelectProductsToolInputSchema),
     })
+
+    tools.splice(1, 0, ...productTools)
   }
 
   return tools
 }
+
+export const LookupProductCandidateToolInputSchema = z.strictObject({
+  category: z.string().nullable(),
+  brand_text: z.string().nullable(),
+  product_name_text: z.string().nullable(),
+  reason: z.string(),
+  evidence_quote: z.string().min(1),
+})
+
+export type LookupProductCandidateToolInput = z.infer<typeof LookupProductCandidateToolInputSchema>
 
 export const SelectProductsToolInputSchema = z.strictObject({
   category: AgentV2GuidanceCategorySchema.describe(

--- a/src/lib/chat-runtime/conversation-state-store.ts
+++ b/src/lib/chat-runtime/conversation-state-store.ts
@@ -73,6 +73,27 @@ export async function loadAgentV2ConversationState(
   return normalizeAgentV2ConversationState(data?.state)
 }
 
+export async function loadAgentV2ConversationStateForUser(
+  supabase: SupabaseClient,
+  params: { conversationId: string | null | undefined; userId: string },
+): Promise<AgentV2ConversationStateV2> {
+  if (!params.conversationId) return normalizeAgentV2ConversationState(null)
+
+  const { data, error } = await supabase
+    .from("conversation_states")
+    .select("state")
+    .eq("conversation_id", params.conversationId)
+    .eq("user_id", params.userId)
+    .maybeSingle()
+
+  if (error) {
+    console.error("Failed to load AgentV2 conversation state:", error)
+    return normalizeAgentV2ConversationState(null)
+  }
+
+  return normalizeAgentV2ConversationState(data?.state)
+}
+
 export async function persistConversationStateTransition(
   supabase: SupabaseClient,
   params: {

--- a/src/lib/chat-runtime/stream-events.ts
+++ b/src/lib/chat-runtime/stream-events.ts
@@ -2,6 +2,7 @@ import type {
   ChatCategoryDecision,
   IntentType,
   MessageRagContext,
+  ProductIntakeOffer,
   RecommendationEngineTrace,
   ResponseMode,
   RouterDecision,
@@ -13,8 +14,15 @@ export function buildAssistantDecisionContext(
   categoryDecision?: ChatCategoryDecision,
   engineTrace?: RecommendationEngineTrace | null,
   responseMode?: ResponseMode,
+  productIntakeOffer?: ProductIntakeOffer | null,
 ): MessageRagContext | null {
-  if (sources.length === 0 && !categoryDecision && !engineTrace && !responseMode) {
+  if (
+    sources.length === 0 &&
+    !categoryDecision &&
+    !engineTrace &&
+    !responseMode &&
+    !productIntakeOffer
+  ) {
     return null
   }
 
@@ -23,6 +31,7 @@ export function buildAssistantDecisionContext(
     category_decision: categoryDecision ?? null,
     engine_trace: engineTrace ?? null,
     response_mode: responseMode ?? null,
+    product_intake_offer: productIntakeOffer ?? null,
   }
 }
 

--- a/src/lib/onboarding/store.ts
+++ b/src/lib/onboarding/store.ts
@@ -27,6 +27,33 @@ export type OnboardingStep =
   | "celebration"
 
 export type OnboardingEditScope = "products" | "styling" | "routine"
+export type OnboardingProductIntakeMethod = "manual" | "photo"
+export type OnboardingProductIntakeFrontImageValidationStatus =
+  | "valid_product_front"
+  | "uncertain"
+  | "not_a_product_photo"
+  | "unsafe_or_inappropriate"
+export type OnboardingProductIntakeBarcodeImageValidationStatus =
+  | "valid_barcode"
+  | "uncertain"
+  | "not_a_product_photo"
+  | "unsafe_or_inappropriate"
+export type OnboardingProductDrilldown = {
+  intakeMethod: OnboardingProductIntakeMethod | null
+  productName: string
+  existingUsageId: string | null
+  brandText: string
+  brandId: string | null
+  productLineId: string | null
+  frequency: ProductFrequency | null
+  frontImagePath: string | null
+  committedFrontImagePath: string | null
+  barcodeImagePath: string | null
+  frontImageValidationStatus: OnboardingProductIntakeFrontImageValidationStatus | null
+  frontImageValidationMetadata: Record<string, unknown>
+  barcodeImageValidationStatus: OnboardingProductIntakeBarcodeImageValidationStatus | null
+  barcodeImageValidationMetadata: Record<string, unknown>
+}
 
 export function getOnboardingEditScope(step: OnboardingStep): OnboardingEditScope | null {
   switch (step) {
@@ -79,7 +106,7 @@ interface OnboardingState {
   // Product usage
   selectedBasicProducts: string[]
   selectedExtraProducts: string[]
-  productDrilldowns: Record<string, { productName: string; frequency: ProductFrequency | null }>
+  productDrilldowns: Record<string, OnboardingProductDrilldown>
   currentDrilldownIndex: number
 
   // Heat styling
@@ -102,10 +129,7 @@ interface OnboardingState {
   // Setters
   setSelectedBasicProducts: (products: string[]) => void
   setSelectedExtraProducts: (products: string[]) => void
-  setProductDrilldown: (
-    category: string,
-    data: { productName: string; frequency: ProductFrequency | null },
-  ) => void
+  setProductDrilldown: (category: string, data: Partial<OnboardingProductDrilldown>) => void
   setCurrentDrilldownIndex: (index: number) => void
   setSelectedHeatTools: (tools: string[]) => void
   setHeatFrequency: (freq: HeatStyling | null) => void
@@ -146,10 +170,7 @@ const initialData = {
 
   selectedBasicProducts: [] as string[],
   selectedExtraProducts: [] as string[],
-  productDrilldowns: {} as Record<
-    string,
-    { productName: string; frequency: ProductFrequency | null }
-  >,
+  productDrilldowns: {} as Record<string, OnboardingProductDrilldown>,
   currentDrilldownIndex: 0,
 
   selectedHeatTools: [] as string[],
@@ -161,6 +182,25 @@ const initialData = {
   dryingMethod: null as DryingMethod | null,
   brushType: null as BrushType | null,
   nightProtection: [] as NightProtection[],
+}
+
+export function emptyProductDrilldown(): OnboardingProductDrilldown {
+  return {
+    intakeMethod: null,
+    productName: "",
+    existingUsageId: null,
+    brandText: "",
+    brandId: null,
+    productLineId: null,
+    frequency: null,
+    frontImagePath: null,
+    committedFrontImagePath: null,
+    barcodeImagePath: null,
+    frontImageValidationStatus: null,
+    frontImageValidationMetadata: {},
+    barcodeImageValidationStatus: null,
+    barcodeImageValidationMetadata: {},
+  }
 }
 
 /* ── Store ── */
@@ -257,7 +297,14 @@ export const useOnboardingStore = create<OnboardingState>((set, get) => ({
   setSelectedExtraProducts: (products) => set({ selectedExtraProducts: products }),
   setProductDrilldown: (category, data) =>
     set((s) => ({
-      productDrilldowns: { ...s.productDrilldowns, [category]: data },
+      productDrilldowns: {
+        ...s.productDrilldowns,
+        [category]: {
+          ...emptyProductDrilldown(),
+          ...(s.productDrilldowns[category] ?? {}),
+          ...data,
+        },
+      },
     })),
   setCurrentDrilldownIndex: (index) => set({ currentDrilldownIndex: index }),
   setSelectedHeatTools: (tools) => set({ selectedHeatTools: tools }),

--- a/src/lib/product-intake/client-image-compression.ts
+++ b/src/lib/product-intake/client-image-compression.ts
@@ -1,0 +1,142 @@
+"use client"
+
+import { PRODUCT_INTAKE_MAX_IMAGE_BYTES } from "@/lib/product-intake/image-validation"
+
+export const PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES = 4 * 1024 * 1024
+export const PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE = 1800
+export const PRODUCT_INTAKE_CLIENT_IMAGE_QUALITY = 0.82
+
+export class ProductIntakeClientImageCompressionError extends Error {
+  constructor(
+    message = "Das Bild ist zu groß. Bitte lade ein kleineres oder schärfer zugeschnittenes Bild hoch.",
+  ) {
+    super(message)
+    this.name = "ProductIntakeClientImageCompressionError"
+  }
+}
+
+function isBrowserImageCompressionAvailable() {
+  return typeof document !== "undefined" && typeof Image !== "undefined"
+}
+
+function compressedFileName(fileName: string) {
+  const baseName = fileName.replace(/\.[^.]*$/, "") || "produktfoto"
+  return `${baseName}.jpg`
+}
+
+function shouldBypassCanvasDecode(file: File) {
+  const type = file.type.toLowerCase()
+  return type === "image/heic" || type === "image/heif"
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    const objectUrl = URL.createObjectURL(file)
+
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl)
+      resolve(image)
+    }
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      reject(new ProductIntakeClientImageCompressionError())
+    }
+    image.src = objectUrl
+  })
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob)
+          return
+        }
+        reject(new ProductIntakeClientImageCompressionError())
+      },
+      type,
+      quality,
+    )
+  })
+}
+
+export function getProductIntakeClientScaledImageDimensions(width: number, height: number) {
+  const longestEdge = Math.max(width, height)
+  if (longestEdge <= PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE) {
+    return { width, height }
+  }
+
+  const scale = PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE / longestEdge
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  }
+}
+
+export function shouldPrepareProductIntakeImageForUpload(params: {
+  fileSizeBytes: number
+  width: number
+  height: number
+}) {
+  return (
+    params.fileSizeBytes > PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES ||
+    Math.max(params.width, params.height) > PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE
+  )
+}
+
+export async function prepareProductIntakeImageForUpload(file: File): Promise<File> {
+  if (shouldBypassCanvasDecode(file)) {
+    if (file.size > PRODUCT_INTAKE_MAX_IMAGE_BYTES) {
+      throw new ProductIntakeClientImageCompressionError()
+    }
+    return file
+  }
+
+  if (
+    file.size <= PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES &&
+    !isBrowserImageCompressionAvailable()
+  ) {
+    return file
+  }
+
+  if (!isBrowserImageCompressionAvailable()) {
+    throw new ProductIntakeClientImageCompressionError()
+  }
+
+  const image = await loadImage(file)
+  const imageWidth = image.naturalWidth || image.width
+  const imageHeight = image.naturalHeight || image.height
+  if (
+    !shouldPrepareProductIntakeImageForUpload({
+      fileSizeBytes: file.size,
+      width: imageWidth,
+      height: imageHeight,
+    })
+  ) {
+    return file
+  }
+
+  const dimensions = getProductIntakeClientScaledImageDimensions(imageWidth, imageHeight)
+  const canvas = document.createElement("canvas")
+  canvas.width = dimensions.width
+  canvas.height = dimensions.height
+
+  const context = canvas.getContext("2d")
+  if (!context) {
+    throw new ProductIntakeClientImageCompressionError()
+  }
+
+  context.drawImage(image, 0, 0, dimensions.width, dimensions.height)
+
+  const compressed = await canvasToBlob(canvas, "image/jpeg", PRODUCT_INTAKE_CLIENT_IMAGE_QUALITY)
+  if (compressed.size > PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES) {
+    throw new ProductIntakeClientImageCompressionError()
+  }
+
+  return new File([compressed], compressedFileName(file.name), {
+    type: "image/jpeg",
+    lastModified: Date.now(),
+  })
+}

--- a/src/lib/product-intake/client.ts
+++ b/src/lib/product-intake/client.ts
@@ -87,10 +87,13 @@ export function canSubmitProductIntake(params: {
   productName: string
   frontImagePath?: string | null
   committedFrontImagePath?: string | null
+  existingUsageId?: string | null
 }) {
   if (!params.category || !params.frequency) return false
   if (params.method === "photo") {
-    return Boolean(params.frontImagePath || params.committedFrontImagePath)
+    return Boolean(
+      params.frontImagePath || (params.committedFrontImagePath && params.existingUsageId),
+    )
   }
   if (params.method === "manual") {
     return params.brandText.trim().length > 0 && params.productName.trim().length > 0
@@ -107,6 +110,7 @@ export function buildProductIntakeSubmissionPayload(params: {
   productLineId?: string | null
   productName: string
   frontImagePath?: string | null
+  committedFrontImagePath?: string | null
   frontImageValidationStatus?: string | null
   frontImageValidationMetadata?: ProductIntakeValidationMetadata
   barcodeImagePath?: string | null
@@ -127,12 +131,14 @@ export function buildProductIntakeSubmissionPayload(params: {
   }
 
   if (params.method === "photo") {
+    const frontImagePath = params.frontImagePath ?? null
+
     return {
       intake_method: "photo",
       ...common,
-      ...(params.frontImagePath
+      ...(frontImagePath
         ? {
-            front_image_path: params.frontImagePath,
+            front_image_path: frontImagePath,
             front_image_validation_status: params.frontImageValidationStatus ?? "uncertain",
             front_image_validation_metadata: params.frontImageValidationMetadata ?? {},
           }

--- a/src/lib/product-intake/client.ts
+++ b/src/lib/product-intake/client.ts
@@ -1,0 +1,202 @@
+"use client"
+
+import { prepareProductIntakeImageForUpload } from "@/lib/product-intake/client-image-compression"
+import type { ProductFrequency } from "@/lib/vocabulary"
+import type { ProductIntakeCategoryKey } from "@/lib/types"
+
+export type ProductIntakeMethod = "photo" | "manual"
+export type ProductIntakeImageKind = "front" | "barcode"
+export type ProductIntakeValidationMetadata = Record<string, unknown>
+
+export type ProductIntakeBrandOption = {
+  id: string
+  label: string
+  brand_id: string
+  product_line_id: string | null
+}
+
+export type ProductIntakeResponseBody = {
+  code?: string
+  error?: string
+  path?: string
+  status?: "matched" | "pending_review"
+  validation_status?: string
+  validation_metadata?: ProductIntakeValidationMetadata
+  usage?: {
+    id?: string
+    front_image_path?: string | null
+  }
+}
+
+export type ProductIntakeUploadResult = {
+  path: string
+  validationStatus: string
+  validationMetadata: ProductIntakeValidationMetadata
+}
+
+export type OnboardingProductIntakeSubmitResult =
+  | { status: "saved"; usageId: string | null; frontImagePath: string | null }
+  | { status: "replace_conflict" }
+
+export const PRODUCT_INTAKE_REPLACE_CODE = "product_category_already_filled"
+
+export function selectedProductIntakeBrandOptionForText(
+  options: ProductIntakeBrandOption[],
+  text: string,
+): ProductIntakeBrandOption | null {
+  const normalizedText = text.trim().toLocaleLowerCase("de")
+  if (!normalizedText) return null
+
+  const matches = options.filter(
+    (option) => option.label.trim().toLocaleLowerCase("de") === normalizedText,
+  )
+  return matches.length === 1 ? matches[0] : null
+}
+
+export async function uploadProductIntakeImage(
+  kind: ProductIntakeImageKind,
+  file: File,
+): Promise<ProductIntakeUploadResult> {
+  const uploadFile = await prepareProductIntakeImageForUpload(file)
+  const formData = new FormData()
+  formData.set("kind", kind)
+  formData.set("file", uploadFile)
+
+  const response = await fetch("/api/product-intake/upload", {
+    method: "POST",
+    body: formData,
+  })
+  const body = (await response.json().catch(() => ({}))) as ProductIntakeResponseBody
+
+  if (!response.ok || !body.path) {
+    throw new Error(body.error ?? "Bild konnte nicht hochgeladen werden.")
+  }
+
+  return {
+    path: body.path,
+    validationStatus: body.validation_status ?? "uncertain",
+    validationMetadata: body.validation_metadata ?? {},
+  }
+}
+
+export function canSubmitProductIntake(params: {
+  method: ProductIntakeMethod | null
+  category?: ProductIntakeCategoryKey | string | null
+  frequency: ProductFrequency | "" | null
+  brandText: string
+  productName: string
+  frontImagePath?: string | null
+  committedFrontImagePath?: string | null
+}) {
+  if (!params.category || !params.frequency) return false
+  if (params.method === "photo") {
+    return Boolean(params.frontImagePath || params.committedFrontImagePath)
+  }
+  if (params.method === "manual") {
+    return params.brandText.trim().length > 0 && params.productName.trim().length > 0
+  }
+  return false
+}
+
+export function buildProductIntakeSubmissionPayload(params: {
+  method: ProductIntakeMethod
+  category: ProductIntakeCategoryKey | string
+  frequency: ProductFrequency
+  brandText: string
+  brandId?: string | null
+  productLineId?: string | null
+  productName: string
+  frontImagePath?: string | null
+  frontImageValidationStatus?: string | null
+  frontImageValidationMetadata?: ProductIntakeValidationMetadata
+  barcodeImagePath?: string | null
+  barcodeImageValidationStatus?: string | null
+  barcodeImageValidationMetadata?: ProductIntakeValidationMetadata
+  sourceConversationId?: string | null
+  existingUsageId?: string | null
+  replaceExistingConfirmed?: boolean
+}): Record<string, unknown> {
+  const common = {
+    category: params.category,
+    frequency_range: params.frequency,
+    ...(params.brandId ? { brand_id: params.brandId } : {}),
+    ...(params.productLineId ? { product_line_id: params.productLineId } : {}),
+    ...(params.sourceConversationId ? { source_conversation_id: params.sourceConversationId } : {}),
+    ...(params.existingUsageId ? { existing_usage_id: params.existingUsageId } : {}),
+    ...(params.replaceExistingConfirmed ? { replace_existing_confirmed: true } : {}),
+  }
+
+  if (params.method === "photo") {
+    return {
+      intake_method: "photo",
+      ...common,
+      ...(params.frontImagePath
+        ? {
+            front_image_path: params.frontImagePath,
+            front_image_validation_status: params.frontImageValidationStatus ?? "uncertain",
+            front_image_validation_metadata: params.frontImageValidationMetadata ?? {},
+          }
+        : {}),
+      ...(params.barcodeImagePath ? { barcode_image_path: params.barcodeImagePath } : {}),
+      ...(params.barcodeImagePath
+        ? {
+            barcode_image_validation_status: params.barcodeImageValidationStatus ?? "uncertain",
+            barcode_image_validation_metadata: params.barcodeImageValidationMetadata ?? {},
+          }
+        : {}),
+      ...(params.brandText.trim() ? { brand_text: params.brandText.trim() } : {}),
+      ...(params.productName.trim() ? { product_name_text: params.productName.trim() } : {}),
+    }
+  }
+
+  return {
+    intake_method: "manual",
+    ...common,
+    brand_text: params.brandText.trim(),
+    product_name_text: params.productName.trim(),
+  }
+}
+
+export async function submitOnboardingProductIntake(
+  payload: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<OnboardingProductIntakeSubmitResult> {
+  const response = await fetch("/api/product-intake/onboarding", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal,
+  })
+  const body = (await response.json().catch(() => ({}))) as ProductIntakeResponseBody
+
+  if (response.status === 409 && body.code === PRODUCT_INTAKE_REPLACE_CODE) {
+    return { status: "replace_conflict" }
+  }
+
+  if (!response.ok) {
+    throw new Error(body.error ?? "Fehler beim Speichern. Bitte versuche es erneut.")
+  }
+
+  return {
+    status: "saved",
+    usageId: body.usage?.id ?? null,
+    frontImagePath: body.usage?.front_image_path ?? null,
+  }
+}
+
+export async function cancelOnboardingProductIntakeCategories(
+  categories: string[],
+  signal?: AbortSignal,
+) {
+  const response = await fetch("/api/product-intake/onboarding/cancel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ categories }),
+    signal,
+  })
+  const body = (await response.json().catch(() => ({}))) as ProductIntakeResponseBody
+
+  if (!response.ok) {
+    throw new Error(body.error ?? "Fehler beim Speichern. Bitte versuche es erneut.")
+  }
+}

--- a/src/lib/product-intake/config.ts
+++ b/src/lib/product-intake/config.ts
@@ -1,0 +1,18 @@
+type ProductIntakeEnv = Partial<
+  Pick<NodeJS.ProcessEnv, "NODE_ENV" | "PRODUCT_INTAKE_ENABLED" | "VERCEL_ENV">
+>
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"])
+const FALSE_VALUES = new Set(["0", "false", "no", "off"])
+
+export function isProductIntakeEnabled(env: ProductIntakeEnv = process.env): boolean {
+  const explicit = env.PRODUCT_INTAKE_ENABLED?.trim().toLowerCase()
+
+  if (explicit) {
+    if (TRUE_VALUES.has(explicit)) return true
+    if (FALSE_VALUES.has(explicit)) return false
+  }
+
+  const deploymentEnv = env.VERCEL_ENV ?? env.NODE_ENV
+  return deploymentEnv !== "production"
+}

--- a/src/lib/product-intake/errors.ts
+++ b/src/lib/product-intake/errors.ts
@@ -1,0 +1,28 @@
+export class ProductIntakePersistenceError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "ProductIntakePersistenceError"
+  }
+}
+
+export class ProductIntakeUserInputError extends Error {
+  readonly status: number
+  readonly code: string
+
+  constructor(message: string, options: { status?: number; code?: string } = {}) {
+    super(message)
+    this.name = "ProductIntakeUserInputError"
+    this.status = options.status ?? 400
+    this.code = options.code ?? "product_intake_invalid_input"
+  }
+}
+
+export class ProductIntakeUploadExpiredError extends ProductIntakeUserInputError {
+  constructor(message = "Upload nicht gefunden oder abgelaufen.") {
+    super(message, {
+      status: 410,
+      code: "product_intake_upload_expired",
+    })
+    this.name = "ProductIntakeUploadExpiredError"
+  }
+}

--- a/src/lib/product-intake/image-validation.ts
+++ b/src/lib/product-intake/image-validation.ts
@@ -1,0 +1,138 @@
+export const PRODUCT_INTAKE_BUCKET = "product-intake"
+export const PRODUCT_INTAKE_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+const MIME_EXTENSIONS = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/heic": "heic",
+  "image/heif": "heif",
+} as const
+
+export type ProductIntakeImageKind = "front" | "barcode"
+export type ProductIntakeValidatedImage = {
+  bytes: Uint8Array
+  mimeType: keyof typeof MIME_EXTENSIONS
+  extension: (typeof MIME_EXTENSIONS)[keyof typeof MIME_EXTENSIONS]
+  size: number
+  validationStatus: "uncertain"
+  validationMetadata: {
+    kind: ProductIntakeImageKind
+    validation: "file_signature_only"
+    mime_type: keyof typeof MIME_EXTENSIONS
+    size_bytes: number
+  }
+}
+
+export class ProductIntakeImageValidationError extends Error {
+  readonly code:
+    | "missing_file"
+    | "file_too_large"
+    | "unsupported_image_type"
+    | "invalid_image_signature"
+
+  constructor(
+    code: ProductIntakeImageValidationError["code"],
+    message = "Bild konnte nicht validiert werden.",
+  ) {
+    super(message)
+    this.name = "ProductIntakeImageValidationError"
+    this.code = code
+  }
+}
+
+function detectMimeType(bytes: Uint8Array): keyof typeof MIME_EXTENSIONS | null {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg"
+  }
+
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png"
+  }
+
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp"
+  }
+
+  if (
+    bytes.length >= 12 &&
+    bytes[4] === 0x66 &&
+    bytes[5] === 0x74 &&
+    bytes[6] === 0x79 &&
+    bytes[7] === 0x70
+  ) {
+    const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]).toLowerCase()
+    if (brand.startsWith("hei") || brand.startsWith("mif")) {
+      return brand === "heic" || brand === "heix" ? "image/heic" : "image/heif"
+    }
+  }
+
+  return null
+}
+
+export async function validateProductIntakeImageFile(
+  file: File | null | undefined,
+  kind: ProductIntakeImageKind,
+): Promise<ProductIntakeValidatedImage> {
+  if (!file) {
+    throw new ProductIntakeImageValidationError("missing_file", "Bitte lade ein Bild hoch.")
+  }
+
+  if (file.size > PRODUCT_INTAKE_MAX_IMAGE_BYTES) {
+    throw new ProductIntakeImageValidationError(
+      "file_too_large",
+      "Das Bild ist zu groß. Bitte lade ein kleineres Bild hoch.",
+    )
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer())
+  const detectedMime = detectMimeType(bytes)
+
+  if (!detectedMime) {
+    throw new ProductIntakeImageValidationError(
+      "invalid_image_signature",
+      "Bitte lade ein JPG-, PNG-, WebP-, HEIC- oder HEIF-Bild hoch.",
+    )
+  }
+
+  if (file.type && file.type !== detectedMime) {
+    throw new ProductIntakeImageValidationError(
+      "unsupported_image_type",
+      "Der Dateityp passt nicht zum Bildinhalt.",
+    )
+  }
+
+  return {
+    bytes,
+    mimeType: detectedMime,
+    extension: MIME_EXTENSIONS[detectedMime],
+    size: bytes.length,
+    validationStatus: "uncertain",
+    validationMetadata: {
+      kind,
+      validation: "file_signature_only",
+      mime_type: detectedMime,
+      size_bytes: bytes.length,
+    },
+  }
+}

--- a/src/lib/product-intake/product-lookup.ts
+++ b/src/lib/product-intake/product-lookup.ts
@@ -1,0 +1,329 @@
+import { cleanProductDisplayName, normalizeCategoryKey } from "@/lib/product-identity"
+import { tokenizeProductName } from "@/lib/product-identity/normalize"
+import {
+  buildBrandResolutionCatalog,
+  resolveBrandFromText,
+  type BrandResolutionCatalogInput,
+  type ProductIdentityBrand,
+  type ProductIdentityProductLine,
+} from "@/lib/product-identity/brand-resolution"
+import {
+  matchProductIntake,
+  type ProductIntakeCatalog,
+  type ProductIntakeCatalogProduct,
+  type ProductIntakeMatchCandidate,
+} from "@/lib/product-intake/product-matching"
+import { SUPPORTED_PRODUCT_CATEGORY_KEYS } from "@/lib/product-identity"
+import type { ProductIntakeCategoryKey, ProductIntakeOffer } from "@/lib/types"
+
+export type ProductLookupCatalog = ProductIntakeCatalog
+
+export type ProductLookupStatus =
+  | "found_exact"
+  | "ambiguous"
+  | "not_found"
+  | "insufficient_identity"
+  | "unsupported_category"
+
+export type ProductLookupInput = {
+  category?: string | null
+  brand_id?: string | null
+  brand_text?: string | null
+  product_line_id?: string | null
+  product_name_text?: string | null
+}
+
+export type ProductLookupResult = {
+  status: ProductLookupStatus
+  category: ProductIntakeCategoryKey | string | null
+  product: ProductLookupProduct | null
+  candidates: ProductIntakeMatchCandidate[]
+  missing_fields: string[]
+  intake_offer: ProductIntakeOffer | null
+}
+
+export type ProductLookupProduct = {
+  id: string
+  name: string
+  category_key: string | null
+  is_chaarlie_recommended: boolean | null
+}
+
+export type LookupProductCandidateParams = {
+  input: ProductLookupInput
+  catalog: ProductLookupCatalog
+  brandCatalog?: BrandResolutionCatalogInput | null
+  offerId?: string
+}
+
+const SUPPORTED_CATEGORY_SET = new Set<string>(SUPPORTED_PRODUCT_CATEGORY_KEYS)
+const LOW_VALUE_PRODUCT_TOKENS = new Set([
+  "shampoo",
+  "shampo",
+  "shampoing",
+  "conditioner",
+  "spulung",
+  "spuelung",
+  "maske",
+  "mask",
+  "kur",
+  "haarkur",
+  "leave",
+  "in",
+  "ol",
+  "oel",
+  "oil",
+  "trockenshampoo",
+  "dry",
+  "deep",
+  "cleansing",
+  "tiefenreinigungsshampoo",
+  "bondbuilder",
+  "pflege",
+  "produkt",
+  "product",
+])
+
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ""
+  return trimmed || null
+}
+
+function brandId(brand: ProductIdentityBrand | null): string | null {
+  return brand?.id ?? brand?.key ?? null
+}
+
+function brandName(brand: ProductIdentityBrand | null): string | null {
+  return brand?.canonicalName ?? brand?.canonical_name ?? brand?.name ?? brand?.key ?? null
+}
+
+function lineId(line: ProductIdentityProductLine | null): string | null {
+  return line?.id ?? line?.key ?? null
+}
+
+function lineName(line: ProductIdentityProductLine | null): string | null {
+  return line?.canonicalName ?? line?.canonical_name ?? line?.name ?? line?.key ?? null
+}
+
+function productCategoryKey(product: ProductIntakeCatalogProduct): string | null {
+  return product.categoryKey ?? product.category_key ?? null
+}
+
+function productCleanName(product: ProductIntakeCatalogProduct): string {
+  return product.cleanName ?? product.name
+}
+
+function productChaarlieRecommended(product: ProductIntakeCatalogProduct): boolean | null {
+  return product.isChaarlieRecommended ?? product.is_chaarlie_recommended ?? null
+}
+
+function toLookupProduct(product: ProductIntakeCatalogProduct): ProductLookupProduct {
+  return {
+    id: product.id,
+    name: product.name,
+    category_key: productCategoryKey(product),
+    is_chaarlie_recommended: productChaarlieRecommended(product),
+  }
+}
+
+function emptyResult(params: {
+  status: ProductLookupStatus
+  category: ProductLookupResult["category"]
+  missingFields?: string[]
+}): ProductLookupResult {
+  return {
+    status: params.status,
+    category: params.category,
+    product: null,
+    candidates: [],
+    missing_fields: params.missingFields ?? [],
+    intake_offer: null,
+  }
+}
+
+function buildIntakeOffer(params: {
+  offerId: string
+  category: ProductIntakeCategoryKey
+  brandText: string | null
+  productNameText: string | null
+}): ProductIntakeOffer {
+  return {
+    id: params.offerId,
+    source: "chat",
+    reason: "product_lookup_not_found",
+    category: params.category,
+    extracted_identity: {
+      ...(params.brandText ? { brand_text: params.brandText } : {}),
+      ...(params.productNameText ? { product_name_text: params.productNameText } : {}),
+    },
+  }
+}
+
+function meaningfulTokenOverlap(left: string, right: string): number {
+  const leftTokens = new Set(
+    tokenizeProductName(left).filter((token) => !LOW_VALUE_PRODUCT_TOKENS.has(token)),
+  )
+  if (leftTokens.size === 0) return 0
+
+  return tokenizeProductName(right).filter(
+    (token) => !LOW_VALUE_PRODUCT_TOKENS.has(token) && leftTokens.has(token),
+  ).length
+}
+
+function meaningfulProductTokens(value: string): string[] {
+  return tokenizeProductName(value).filter(
+    (token) => token.length > 1 && !LOW_VALUE_PRODUCT_TOKENS.has(token),
+  )
+}
+
+function hasPreciseProductIdentity(value: string): boolean {
+  return meaningfulProductTokens(value).length > 0
+}
+
+function meaningfulCandidates(params: {
+  candidates: ProductIntakeMatchCandidate[]
+  productNameText: string
+}): ProductIntakeMatchCandidate[] {
+  return params.candidates.filter(
+    (candidate) =>
+      candidate.confidence === "exact" ||
+      meaningfulTokenOverlap(params.productNameText, productCleanName(candidate.product)) > 0,
+  )
+}
+
+export function lookupProductCandidate(params: LookupProductCandidateParams): ProductLookupResult {
+  const rawCategory = trimToNull(params.input.category)
+  const normalizedCategory = normalizeCategoryKey(rawCategory)
+  if (!normalizedCategory) {
+    return emptyResult({
+      status: "insufficient_identity",
+      category: null,
+      missingFields: ["category"],
+    })
+  }
+
+  if (!SUPPORTED_CATEGORY_SET.has(normalizedCategory)) {
+    return emptyResult({
+      status: "unsupported_category",
+      category: normalizedCategory,
+    })
+  }
+
+  const category = normalizedCategory as ProductIntakeCategoryKey
+  const productNameText = trimToNull(params.input.product_name_text)
+  const providedBrandId = trimToNull(params.input.brand_id)
+  const providedLineId = trimToNull(params.input.product_line_id)
+  const brandText = trimToNull(params.input.brand_text)
+
+  if (!productNameText) {
+    return emptyResult({
+      status: "insufficient_identity",
+      category,
+      missingFields: ["productNameText"],
+    })
+  }
+
+  const resolved =
+    !providedBrandId && brandText && params.brandCatalog
+      ? resolveBrandFromText(brandText, buildBrandResolutionCatalog(params.brandCatalog))
+      : null
+  const resolvedBrandId = providedBrandId ?? brandId(resolved?.brand ?? null)
+  const resolvedLineId = providedLineId ?? lineId(resolved?.productLine ?? null)
+
+  if (!resolvedBrandId && !brandText) {
+    return emptyResult({
+      status: "insufficient_identity",
+      category,
+      missingFields: ["brandText"],
+    })
+  }
+
+  const cleanProductName = cleanProductDisplayName(productNameText, {
+    brand: brandName(resolved?.brand ?? null) ?? brandText,
+    productLine: lineName(resolved?.productLine ?? null),
+  })
+
+  if (!hasPreciseProductIdentity(cleanProductName)) {
+    return emptyResult({
+      status: "insufficient_identity",
+      category,
+      missingFields: ["productNameText"],
+    })
+  }
+
+  if (!resolvedBrandId) {
+    return {
+      status: "not_found",
+      category,
+      product: null,
+      candidates: [],
+      missing_fields: [],
+      intake_offer: buildIntakeOffer({
+        offerId: params.offerId ?? crypto.randomUUID(),
+        category,
+        brandText,
+        productNameText,
+      }),
+    }
+  }
+
+  const match = matchProductIntake(
+    {
+      selectedCategoryKey: category,
+      brandId: resolvedBrandId,
+      productLineId: resolvedLineId,
+      cleanProductName,
+      productName: productNameText,
+    },
+    params.catalog,
+  )
+
+  if (match.status === "matched" && match.matchedProduct) {
+    return {
+      status: "found_exact",
+      category,
+      product: toLookupProduct(match.matchedProduct),
+      candidates: match.candidates,
+      missing_fields: [],
+      intake_offer: null,
+    }
+  }
+
+  const candidates = meaningfulCandidates({
+    candidates: match.candidates,
+    productNameText,
+  })
+
+  if (candidates.length > 0) {
+    return {
+      status: "ambiguous",
+      category,
+      product: null,
+      candidates,
+      missing_fields: [],
+      intake_offer: null,
+    }
+  }
+
+  if (match.status === "needs_more_info" || match.status === "rejected") {
+    return emptyResult({
+      status: "insufficient_identity",
+      category,
+      missingFields: match.missingFields,
+    })
+  }
+
+  return {
+    status: "not_found",
+    category,
+    product: null,
+    candidates: [],
+    missing_fields: [],
+    intake_offer: buildIntakeOffer({
+      offerId: params.offerId ?? crypto.randomUUID(),
+      category,
+      brandText,
+      productNameText,
+    }),
+  }
+}

--- a/src/lib/product-intake/repository-types.ts
+++ b/src/lib/product-intake/repository-types.ts
@@ -1,0 +1,158 @@
+import type { BrandResolutionCatalogInput } from "@/lib/product-identity/brand-resolution"
+import type { ProductIntakeCatalog } from "@/lib/product-intake/product-matching"
+import type {
+  ProductFrequency,
+  ProductIntakeCategoryKey,
+  ProductSubmissionSource,
+  ProductUsageMatchStatus,
+} from "@/lib/types"
+
+export type JsonRecord = Record<string, unknown>
+
+export type ProductIntakeUsageRow = {
+  id: string
+  user_id: string
+  category: ProductIntakeCategoryKey
+  product_name: string | null
+  frequency_range: ProductFrequency | null
+  brand_text: string | null
+  product_id: string | null
+  product_submission_id: string | null
+  match_status: ProductUsageMatchStatus
+  intake_method: "manual" | "photo" | null
+  source: "onboarding" | "chat" | "profile" | "script" | null
+  front_image_path: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export type ProductIntakeSubmissionRow = {
+  id: string
+  user_id: string
+  user_product_usage_id: string | null
+  source: ProductSubmissionSource
+  source_conversation_id: string | null
+  intake_method: "manual" | "photo"
+  category: ProductIntakeCategoryKey
+  brand_text: string | null
+  product_name_text: string | null
+  frequency_range: ProductFrequency
+  front_image_path: string | null
+  barcode_image_path: string | null
+  front_image_validation_status:
+    | "valid_product_front"
+    | "uncertain"
+    | "not_a_product_photo"
+    | "unsafe_or_inappropriate"
+    | null
+  front_image_validation_metadata: JsonRecord
+  barcode_image_validation_status:
+    | "valid_barcode"
+    | "uncertain"
+    | "not_a_product_photo"
+    | "unsafe_or_inappropriate"
+    | null
+  barcode_image_validation_metadata: JsonRecord
+  previous_product_id: string | null
+  previous_product_snapshot: JsonRecord
+  status:
+    | "pending_review"
+    | "researching"
+    | "ready_for_review"
+    | "needs_more_info"
+    | "matched_existing"
+    | "approved"
+    | "rejected"
+    | "cancelled_by_user"
+  researched_payload: JsonRecord
+  intake_history: JsonRecord[]
+  approved_product_id: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export type ProductIntakeRepository = {
+  loadCatalog: () => Promise<ProductIntakeCatalog>
+  loadBrandResolutionCatalog: () => Promise<BrandResolutionCatalogInput>
+  findUserProductUsage: (
+    userId: string,
+    category: ProductIntakeCategoryKey,
+  ) => Promise<ProductIntakeUsageRow | null>
+  insertUserProductUsage: (
+    row: Partial<ProductIntakeUsageRow> & {
+      user_id: string
+      category: ProductIntakeCategoryKey
+      frequency_range: ProductFrequency
+    },
+  ) => Promise<ProductIntakeUsageRow>
+  updateUserProductUsage: (
+    id: string,
+    patch: Partial<ProductIntakeUsageRow>,
+  ) => Promise<ProductIntakeUsageRow>
+  deleteUserProductUsage: (id: string) => Promise<void>
+  replaceUsageWithMatchedProduct: (params: {
+    userId: string
+    category: ProductIntakeCategoryKey
+    existingUsageId: string | null
+    productId: string
+    productName: string | null
+    frequencyRange: ProductFrequency
+    brandText: string | null
+    intakeMethod: "manual" | "photo"
+    source: ProductSubmissionSource
+    now: string
+  }) => Promise<ProductIntakeUsageRow>
+  replaceUsageWithPendingSubmission: (params: {
+    userId: string
+    category: ProductIntakeCategoryKey
+    existingUsageId: string | null
+    submissionId: string
+    productName: string | null
+    frequencyRange: ProductFrequency
+    brandText: string | null
+    intakeMethod: "manual" | "photo"
+    source: ProductSubmissionSource
+    frontImagePath: string | null
+    now: string
+  }) => Promise<{
+    usage: ProductIntakeUsageRow
+    submission: ProductIntakeSubmissionRow
+  }>
+  cancelProductIntakeUsageForCategory: (params: {
+    userId: string
+    category: ProductIntakeCategoryKey
+    now: string
+  }) => Promise<{
+    category: ProductIntakeCategoryKey
+    usage_id: string | null
+    submission_id: string | null
+  }>
+  findProductSubmission: (id: string, userId: string) => Promise<ProductIntakeSubmissionRow | null>
+  insertProductSubmission: (
+    row: Partial<ProductIntakeSubmissionRow> & {
+      user_id: string
+      source: ProductSubmissionSource
+      intake_method: "manual" | "photo"
+      category: ProductIntakeCategoryKey
+      frequency_range: ProductFrequency
+    },
+  ) => Promise<ProductIntakeSubmissionRow>
+  updateProductSubmission: (
+    id: string,
+    patch: Partial<ProductIntakeSubmissionRow>,
+  ) => Promise<ProductIntakeSubmissionRow>
+  deleteProductSubmission: (id: string) => Promise<void>
+  verifyUploadedImage: (params: {
+    sourcePath: string
+    userId: string
+    kind: "front" | "barcode"
+  }) => Promise<boolean>
+  commitUploadedImage: (params: {
+    sourcePath: string
+    userId: string
+    submissionId: string
+    kind: "front" | "barcode"
+  }) => Promise<string>
+  removeCommittedImages: (paths: readonly string[]) => Promise<void>
+  verifyConversationOwnership: (conversationId: string, userId: string) => Promise<boolean>
+}

--- a/src/lib/product-intake/repository.ts
+++ b/src/lib/product-intake/repository.ts
@@ -1,0 +1,356 @@
+import { randomUUID } from "node:crypto"
+
+import { createAdminClient } from "@/lib/supabase/admin"
+import { PRODUCT_INTAKE_BUCKET } from "@/lib/product-intake/image-validation"
+import { ProductIntakePersistenceError } from "@/lib/product-intake/errors"
+import { assertTemporaryUploadPathBelongsToUser } from "@/lib/product-intake/upload-paths"
+import type {
+  ProductIntakeCatalog,
+  ProductIntakeCatalogProduct,
+} from "@/lib/product-intake/product-matching"
+import type {
+  ProductIntakeRepository,
+  ProductIntakeSubmissionRow,
+  ProductIntakeUsageRow,
+} from "@/lib/product-intake/repository-types"
+import type { ProductIntakeCategoryKey } from "@/lib/types"
+
+function requireData<T>(
+  result: { data: T | null; error: { message?: string } | null },
+  label: string,
+): T {
+  if (result.error) {
+    throw new ProductIntakePersistenceError(`${label}: ${result.error.message ?? "unknown error"}`)
+  }
+  if (!result.data) {
+    throw new ProductIntakePersistenceError(`${label}: no data returned`)
+  }
+  return result.data
+}
+
+function optionalData<T>(
+  result: { data: T | null; error: { code?: string; message?: string } | null },
+  label: string,
+): T | null {
+  if (!result.error) return result.data ?? null
+  if (result.error.code === "PGRST116") return null
+  throw new ProductIntakePersistenceError(`${label}: ${result.error.message ?? "unknown error"}`)
+}
+
+function extensionFromPath(path: string): string {
+  const filename = path.split("/").pop() ?? ""
+  const extension = filename.includes(".") ? filename.split(".").pop()?.toLowerCase() : null
+  return extension && /^[a-z0-9]+$/.test(extension) ? extension : "jpg"
+}
+
+type StorageErrorLike = {
+  message?: string
+  status?: number
+  statusCode?: string
+  code?: string
+  error?: string
+}
+
+function storageErrorStatus(error: StorageErrorLike): number | null {
+  if (typeof error.status === "number") return error.status
+  if (typeof error.statusCode === "string" && /^\d+$/.test(error.statusCode)) {
+    return Number.parseInt(error.statusCode, 10)
+  }
+  return null
+}
+
+export function isMissingProductIntakeUploadError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const storageError = error as StorageErrorLike
+  const status = storageErrorStatus(storageError)
+  const signature = [
+    storageError.statusCode,
+    storageError.code,
+    storageError.error,
+    storageError.message,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase()
+
+  if (signature.includes("bucket")) return false
+
+  return (
+    status === 404 &&
+    (signature.includes("object") ||
+      signature.includes("key") ||
+      signature.includes("resource") ||
+      signature.includes("not found") ||
+      signature.includes("nosuchkey"))
+  )
+}
+
+export function createSupabaseProductIntakeRepository(
+  admin = createAdminClient(),
+): ProductIntakeRepository {
+  return {
+    async loadCatalog() {
+      const [productsResult, identifiersResult] = await Promise.all([
+        admin
+          .from("products")
+          .select(
+            "id, name, brand_id, product_line_id, category_key, is_active, is_chaarlie_recommended",
+          ),
+        admin
+          .from("product_identifiers")
+          .select(
+            "product_id, identifier_type, identifier_value, normalized_identifier_value, source",
+          ),
+      ])
+
+      const products = requireData<ProductIntakeCatalogProduct[]>(
+        productsResult,
+        "load products for intake matching",
+      )
+      const identifiers = requireData<ProductIntakeCatalog["identifiers"]>(
+        identifiersResult,
+        "load product identifiers for intake matching",
+      )
+
+      return { products, identifiers }
+    },
+
+    async loadBrandResolutionCatalog() {
+      const [brandsResult, linesResult, aliasesResult] = await Promise.all([
+        admin.from("brands").select("id, canonical_name, normalized_name"),
+        admin.from("product_lines").select("id, brand_id, canonical_name, normalized_name"),
+        admin.from("brand_aliases").select("brand_id, product_line_id, alias, normalized_alias"),
+      ])
+
+      return {
+        brands: requireData(brandsResult, "load brands for intake"),
+        productLines: requireData(linesResult, "load product lines for intake"),
+        brandAliases: requireData(aliasesResult, "load brand aliases for intake"),
+      }
+    },
+
+    async findUserProductUsage(userId, category) {
+      return optionalData<ProductIntakeUsageRow>(
+        await admin
+          .from("user_product_usage")
+          .select("*")
+          .eq("user_id", userId)
+          .eq("category", category)
+          .maybeSingle(),
+        "load user product usage",
+      )
+    },
+
+    async insertUserProductUsage(row) {
+      return requireData<ProductIntakeUsageRow>(
+        await admin.from("user_product_usage").insert(row).select("*").single(),
+        "insert user product usage",
+      )
+    },
+
+    async updateUserProductUsage(id, patch) {
+      return requireData<ProductIntakeUsageRow>(
+        await admin.from("user_product_usage").update(patch).eq("id", id).select("*").single(),
+        "update user product usage",
+      )
+    },
+
+    async deleteUserProductUsage(id) {
+      const { error } = await admin.from("user_product_usage").delete().eq("id", id)
+      if (error) {
+        throw new ProductIntakePersistenceError(
+          `delete user product usage: ${error.message ?? "unknown error"}`,
+        )
+      }
+    },
+
+    async replaceUsageWithMatchedProduct({
+      userId,
+      category,
+      existingUsageId,
+      productId,
+      productName,
+      frequencyRange,
+      brandText,
+      intakeMethod,
+      source,
+      now,
+    }) {
+      return requireData<ProductIntakeUsageRow>(
+        await admin.rpc("product_intake_replace_usage_with_matched_product", {
+          p_user_id: userId,
+          p_category: category,
+          p_existing_usage_id: existingUsageId,
+          p_product_id: productId,
+          p_product_name: productName,
+          p_frequency_range: frequencyRange,
+          p_brand_text: brandText,
+          p_intake_method: intakeMethod,
+          p_source: source,
+          p_updated_at: now,
+        }),
+        "replace product usage with matched product",
+      )
+    },
+
+    async replaceUsageWithPendingSubmission({
+      userId,
+      category,
+      existingUsageId,
+      submissionId,
+      productName,
+      frequencyRange,
+      brandText,
+      intakeMethod,
+      source,
+      frontImagePath,
+      now,
+    }) {
+      const payload = requireData<{
+        usage?: ProductIntakeUsageRow
+        submission?: ProductIntakeSubmissionRow
+      }>(
+        await admin.rpc("product_intake_replace_usage_with_pending_submission", {
+          p_user_id: userId,
+          p_category: category,
+          p_existing_usage_id: existingUsageId,
+          p_submission_id: submissionId,
+          p_product_name: productName,
+          p_frequency_range: frequencyRange,
+          p_brand_text: brandText,
+          p_intake_method: intakeMethod,
+          p_source: source,
+          p_front_image_path: frontImagePath,
+          p_updated_at: now,
+        }),
+        "replace product usage with pending submission",
+      )
+
+      if (!payload.usage || !payload.submission) {
+        throw new ProductIntakePersistenceError(
+          "replace product usage with pending submission: incomplete payload",
+        )
+      }
+
+      return { usage: payload.usage, submission: payload.submission }
+    },
+
+    async cancelProductIntakeUsageForCategory({ userId, category, now }) {
+      return requireData(
+        await admin
+          .rpc("product_intake_cancel_usage_for_category", {
+            p_user_id: userId,
+            p_category: category,
+            p_updated_at: now,
+          })
+          .single(),
+        "cancel product intake usage",
+      ) as {
+        category: ProductIntakeCategoryKey
+        usage_id: string | null
+        submission_id: string | null
+      }
+    },
+
+    async findProductSubmission(id, userId) {
+      return optionalData<ProductIntakeSubmissionRow>(
+        await admin
+          .from("product_submissions")
+          .select("*")
+          .eq("id", id)
+          .eq("user_id", userId)
+          .maybeSingle(),
+        "load product submission",
+      )
+    },
+
+    async insertProductSubmission(row) {
+      return requireData<ProductIntakeSubmissionRow>(
+        await admin.from("product_submissions").insert(row).select("*").single(),
+        "insert product submission",
+      )
+    },
+
+    async updateProductSubmission(id, patch) {
+      return requireData<ProductIntakeSubmissionRow>(
+        await admin.from("product_submissions").update(patch).eq("id", id).select("*").single(),
+        "update product submission",
+      )
+    },
+
+    async deleteProductSubmission(id) {
+      const { error } = await admin.from("product_submissions").delete().eq("id", id)
+      if (error) {
+        throw new ProductIntakePersistenceError(
+          `delete failed product submission: ${error.message ?? "unknown error"}`,
+        )
+      }
+    },
+
+    async verifyUploadedImage({ sourcePath, userId, kind }) {
+      assertTemporaryUploadPathBelongsToUser(sourcePath, userId)
+      const { data, error } = await admin.storage.from(PRODUCT_INTAKE_BUCKET).info(sourcePath)
+
+      if (error) {
+        if (isMissingProductIntakeUploadError(error)) return false
+        throw new ProductIntakePersistenceError(
+          `verify product intake image: ${error.message ?? "unknown error"}`,
+        )
+      }
+      if (!data) return false
+
+      const metadata = data.metadata as Record<string, unknown> | null | undefined
+      if (metadata?.user_id && metadata.user_id !== userId) return false
+      if (metadata?.image_kind && metadata.image_kind !== kind) return false
+
+      return true
+    },
+
+    async commitUploadedImage({ sourcePath, userId, submissionId, kind }) {
+      assertTemporaryUploadPathBelongsToUser(sourcePath, userId)
+      const destinationPath = `${userId}/${submissionId}/${kind}-${randomUUID()}.${extensionFromPath(sourcePath)}`
+      const { error } = await admin.storage
+        .from(PRODUCT_INTAKE_BUCKET)
+        .copy(sourcePath, destinationPath)
+
+      if (error) {
+        throw new ProductIntakePersistenceError(
+          `commit product intake image: ${error.message ?? "unknown error"}`,
+        )
+      }
+
+      const { error: removeError } = await admin.storage
+        .from(PRODUCT_INTAKE_BUCKET)
+        .remove([sourcePath])
+      if (removeError) {
+        console.warn("[product-intake] committed image tmp cleanup failed", removeError)
+      }
+
+      return destinationPath
+    },
+
+    async removeCommittedImages(paths) {
+      if (paths.length === 0) return
+      const { error } = await admin.storage.from(PRODUCT_INTAKE_BUCKET).remove([...paths])
+      if (error) {
+        throw new ProductIntakePersistenceError(
+          `remove failed product intake images: ${error.message ?? "unknown error"}`,
+        )
+      }
+    },
+
+    async verifyConversationOwnership(conversationId, userId) {
+      const row = await optionalData<{ id: string }>(
+        await admin
+          .from("conversations")
+          .select("id")
+          .eq("id", conversationId)
+          .eq("user_id", userId)
+          .maybeSingle(),
+        "verify conversation ownership",
+      )
+
+      return Boolean(row)
+    },
+  }
+}

--- a/src/lib/product-intake/route-handlers.ts
+++ b/src/lib/product-intake/route-handlers.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { ERR_INVALID_DATA, ERR_UNAUTHORIZED } from "@/lib/vocabulary"
+import { isProductIntakeEnabled } from "@/lib/product-intake/config"
+import {
+  chatProductIntakeSubmissionSchema,
+  onboardingProductIntakeCancelSchema,
+  onboardingProductIntakeSubmissionSchema,
+} from "@/lib/product-intake/schemas"
+import {
+  cancelProductIntakeUsage,
+  ProductIntakeConflictError,
+  ProductIntakeOwnershipError,
+  submitProductIntake,
+  type ProductIntakeRepository,
+} from "@/lib/product-intake/submissions"
+import { createSupabaseProductIntakeRepository } from "@/lib/product-intake/repository"
+import { ProductIntakeUserInputError } from "@/lib/product-intake/errors"
+
+type ProductIntakeRouteSource = "onboarding" | "chat"
+
+type ProductIntakePostHandlerDeps = {
+  createServerClient?: typeof createClient
+  createAdminClient?: typeof createAdminClient
+  isEnabled?: () => boolean
+  createRepository?: (admin: ReturnType<typeof createAdminClient>) => ProductIntakeRepository
+}
+
+const DISABLED_RESPONSE = {
+  error: "Produktaufnahme ist aktuell deaktiviert.",
+  code: "product_intake_disabled",
+}
+
+export function createProductIntakePostHandler(
+  source: ProductIntakeRouteSource,
+  overrides: ProductIntakePostHandlerDeps = {},
+) {
+  const deps = {
+    createServerClient: createClient,
+    createAdminClient,
+    isEnabled: isProductIntakeEnabled,
+    createRepository: createSupabaseProductIntakeRepository,
+    ...overrides,
+  }
+
+  return async function productIntakePostHandler(request: Request) {
+    if (!deps.isEnabled()) {
+      return NextResponse.json(DISABLED_RESPONSE, { status: 503 })
+    }
+
+    const supabase = await deps.createServerClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const schema =
+      source === "chat"
+        ? chatProductIntakeSubmissionSchema
+        : onboardingProductIntakeSubmissionSchema
+    const parsed = schema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: ERR_INVALID_DATA, details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    const admin = deps.createAdminClient()
+    const repository = deps.createRepository(admin)
+
+    try {
+      const result = await submitProductIntake({
+        userId: user.id,
+        source,
+        input: parsed.data,
+        repository,
+      })
+
+      return NextResponse.json(result, { status: result.status === "matched" ? 200 : 202 })
+    } catch (error) {
+      if (error instanceof ProductIntakeConflictError) {
+        return NextResponse.json(
+          {
+            error: error.message,
+            code: "product_category_already_filled",
+            category: error.category,
+            existing_usage_id: error.existingUsageId,
+          },
+          { status: 409 },
+        )
+      }
+
+      if (error instanceof ProductIntakeOwnershipError) {
+        return NextResponse.json({ error: error.message }, { status: 404 })
+      }
+
+      if (error instanceof ProductIntakeUserInputError) {
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: error.status },
+        )
+      }
+
+      console.error("[product-intake] submission failed", error)
+      return NextResponse.json(
+        { error: "Produkt konnte nicht gespeichert werden." },
+        { status: 500 },
+      )
+    }
+  }
+}
+
+export function createProductIntakeCancelHandler(overrides: ProductIntakePostHandlerDeps = {}) {
+  const deps = {
+    createServerClient: createClient,
+    createAdminClient,
+    isEnabled: isProductIntakeEnabled,
+    createRepository: createSupabaseProductIntakeRepository,
+    ...overrides,
+  }
+
+  return async function productIntakeCancelHandler(request: Request) {
+    if (!deps.isEnabled()) {
+      return NextResponse.json(DISABLED_RESPONSE, { status: 503 })
+    }
+
+    const supabase = await deps.createServerClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: ERR_UNAUTHORIZED }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const parsed = onboardingProductIntakeCancelSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: ERR_INVALID_DATA, details: parsed.error.flatten() },
+        { status: 400 },
+      )
+    }
+
+    const admin = deps.createAdminClient()
+    const repository = deps.createRepository(admin)
+
+    try {
+      const cancelled = []
+      for (const category of parsed.data.categories) {
+        cancelled.push(
+          await cancelProductIntakeUsage({
+            userId: user.id,
+            category,
+            repository,
+          }),
+        )
+      }
+
+      return NextResponse.json({ cancelled }, { status: 200 })
+    } catch (error) {
+      console.error("[product-intake] usage cancellation failed", error)
+      return NextResponse.json({ error: "Produkt konnte nicht entfernt werden." }, { status: 500 })
+    }
+  }
+}

--- a/src/lib/product-intake/schemas.ts
+++ b/src/lib/product-intake/schemas.ts
@@ -1,0 +1,128 @@
+import { z } from "zod"
+import type { ProductFrequency } from "@/lib/types"
+import { SUPPORTED_PRODUCT_CATEGORY_KEYS } from "@/lib/product-identity"
+import { PRODUCT_FREQUENCIES, normalizeProductFrequency } from "@/lib/vocabulary/frequencies"
+
+const trimmedString = z.preprocess(
+  (value) => (typeof value === "string" ? value.trim() : value),
+  z.string(),
+)
+
+const optionalTrimmedString = z.preprocess((value) => {
+  if (typeof value !== "string") return value
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}, z.string().optional())
+
+export const productIntakeFrequencySchema = z.preprocess((value) => {
+  if (typeof value !== "string") return value
+  return normalizeProductFrequency(value) ?? value
+}, z.enum(PRODUCT_FREQUENCIES))
+
+export const productIntakeCategorySchema = z.enum(SUPPORTED_PRODUCT_CATEGORY_KEYS)
+
+const uuidString = z.string().uuid()
+const uploadPathString = trimmedString.pipe(z.string().min(1).max(500))
+const validationMetadataSchema = z.record(z.string(), z.unknown())
+
+const frontImageValidationStatusSchema = z.enum([
+  "valid_product_front",
+  "uncertain",
+  "not_a_product_photo",
+  "unsafe_or_inappropriate",
+])
+
+const barcodeImageValidationStatusSchema = z.enum([
+  "valid_barcode",
+  "uncertain",
+  "not_a_product_photo",
+  "unsafe_or_inappropriate",
+])
+
+const manualProductIntakeBaseSchema = z
+  .object({
+    intake_method: z.literal("manual").default("manual"),
+    category: productIntakeCategorySchema,
+    frequency_range: productIntakeFrequencySchema,
+    brand_text: optionalTrimmedString,
+    brand_id: uuidString.optional(),
+    product_line_id: uuidString.nullable().optional(),
+    product_name_text: trimmedString.pipe(z.string().min(1).max(240)),
+    replace_existing_confirmed: z.boolean().default(false),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.brand_text && !value.brand_id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["brand_text"],
+        message: "Marke ist erforderlich.",
+      })
+    }
+  })
+
+const photoProductIntakeBaseSchema = z.object({
+  intake_method: z.literal("photo"),
+  category: productIntakeCategorySchema,
+  frequency_range: productIntakeFrequencySchema,
+  front_image_path: uploadPathString,
+  front_image_validation_status: frontImageValidationStatusSchema.default("uncertain"),
+  front_image_validation_metadata: validationMetadataSchema.default({}),
+  barcode_image_path: uploadPathString.optional(),
+  barcode_image_validation_status: barcodeImageValidationStatusSchema.optional(),
+  barcode_image_validation_metadata: validationMetadataSchema.default({}),
+  brand_text: optionalTrimmedString,
+  brand_id: uuidString.optional(),
+  product_line_id: uuidString.nullable().optional(),
+  product_name_text: optionalTrimmedString.pipe(z.string().max(240).optional()),
+  replace_existing_confirmed: z.boolean().default(false),
+})
+
+export const onboardingProductIntakeSubmissionSchema = z
+  .discriminatedUnion("intake_method", [
+    manualProductIntakeBaseSchema.extend({
+      existing_usage_id: uuidString.optional(),
+    }),
+    photoProductIntakeBaseSchema.extend({
+      front_image_path: uploadPathString.optional(),
+      existing_usage_id: uuidString.optional(),
+    }),
+  ])
+  .superRefine((value, ctx) => {
+    if (value.intake_method === "photo" && !value.front_image_path && !value.existing_usage_id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["front_image_path"],
+        message: "Vorderseitenfoto ist erforderlich.",
+      })
+    }
+  })
+
+export const chatProductIntakeSubmissionSchema = z.discriminatedUnion("intake_method", [
+  manualProductIntakeBaseSchema.extend({
+    source_conversation_id: uuidString.optional(),
+  }),
+  photoProductIntakeBaseSchema.extend({
+    source_conversation_id: uuidString.optional(),
+  }),
+])
+
+export const onboardingProductIntakeCancelSchema = z.object({
+  categories: z
+    .array(productIntakeCategorySchema)
+    .min(1)
+    .max(SUPPORTED_PRODUCT_CATEGORY_KEYS.length),
+})
+
+export type OnboardingProductIntakeSubmissionInput = z.infer<
+  typeof onboardingProductIntakeSubmissionSchema
+> & {
+  frequency_range: ProductFrequency
+}
+
+export type ChatProductIntakeSubmissionInput = z.infer<typeof chatProductIntakeSubmissionSchema> & {
+  frequency_range: ProductFrequency
+}
+
+export type ProductIntakeSubmissionInput =
+  | OnboardingProductIntakeSubmissionInput
+  | ChatProductIntakeSubmissionInput

--- a/src/lib/product-intake/submissions.ts
+++ b/src/lib/product-intake/submissions.ts
@@ -1,0 +1,871 @@
+import { randomUUID } from "node:crypto"
+
+import { cleanProductDisplayName } from "@/lib/product-identity"
+import {
+  buildBrandResolutionCatalog,
+  resolveBrandFromText,
+  type BrandResolutionCatalog,
+  type ProductIdentityBrand,
+  type ProductIdentityProductLine,
+} from "@/lib/product-identity/brand-resolution"
+import { matchProductIntake } from "@/lib/product-intake/product-matching"
+import {
+  ProductIntakePersistenceError,
+  ProductIntakeUploadExpiredError,
+} from "@/lib/product-intake/errors"
+import { assertTemporaryUploadPathBelongsToUser } from "@/lib/product-intake/upload-paths"
+import type {
+  JsonRecord,
+  ProductIntakeRepository,
+  ProductIntakeSubmissionRow,
+  ProductIntakeUsageRow,
+} from "@/lib/product-intake/repository-types"
+import type { ProductIntakeCategoryKey, ProductSubmissionSource } from "@/lib/types"
+import type { ProductIntakeSubmissionInput } from "@/lib/product-intake/schemas"
+import type { ProductIntakeSubmissionResult } from "@/lib/product-intake/types"
+
+export type {
+  ProductIntakeRepository,
+  ProductIntakeSubmissionRow,
+  ProductIntakeUsageRow,
+} from "@/lib/product-intake/repository-types"
+
+const REPLACEMENT_CONFLICT_MESSAGE =
+  "Du hast für diese Kategorie bereits ein Produkt hinterlegt. Möchtest du es durch dieses Produkt ersetzen?"
+
+const OPEN_SUBMISSION_STATUSES = [
+  "pending_review",
+  "researching",
+  "ready_for_review",
+  "needs_more_info",
+] as const
+
+export class ProductIntakeConflictError extends Error {
+  readonly category: ProductIntakeCategoryKey
+  readonly existingUsageId: string
+
+  constructor(category: ProductIntakeCategoryKey, existingUsageId: string) {
+    super(REPLACEMENT_CONFLICT_MESSAGE)
+    this.name = "ProductIntakeConflictError"
+    this.category = category
+    this.existingUsageId = existingUsageId
+  }
+}
+
+export class ProductIntakeOwnershipError extends Error {
+  constructor() {
+    super("Unterhaltung nicht gefunden")
+    this.name = "ProductIntakeOwnershipError"
+  }
+}
+
+export type SubmitProductIntakeParams = {
+  userId: string
+  source: ProductSubmissionSource
+  input: ProductIntakeSubmissionInput
+  repository: ProductIntakeRepository
+  now?: () => string
+}
+
+function brandId(brand: ProductIdentityBrand | null): string | null {
+  return brand?.id ?? brand?.key ?? null
+}
+
+function brandName(brand: ProductIdentityBrand | null): string | null {
+  return brand?.canonicalName ?? brand?.canonical_name ?? brand?.name ?? brand?.key ?? null
+}
+
+function lineId(line: ProductIdentityProductLine | null): string | null {
+  return line?.id ?? line?.key ?? null
+}
+
+function lineName(line: ProductIdentityProductLine | null): string | null {
+  return line?.canonicalName ?? line?.canonical_name ?? line?.name ?? line?.key ?? null
+}
+
+function isTrackedUsage(row: ProductIntakeUsageRow): boolean {
+  return Boolean(
+    row.product_name?.trim() ||
+    row.frequency_range ||
+    row.brand_text?.trim() ||
+    row.product_id ||
+    row.product_submission_id ||
+    row.match_status !== "text_only" ||
+    row.intake_method ||
+    row.source ||
+    row.front_image_path,
+  )
+}
+
+function previousSnapshot(row: ProductIntakeUsageRow | null): JsonRecord {
+  if (!row) return {}
+
+  return {
+    id: row.id,
+    category: row.category,
+    product_name: row.product_name,
+    frequency_range: row.frequency_range,
+    brand_text: row.brand_text,
+    product_id: row.product_id,
+    product_submission_id: row.product_submission_id,
+    match_status: row.match_status,
+    intake_method: row.intake_method,
+    source: row.source,
+    front_image_path: row.front_image_path,
+  }
+}
+
+function restoreUsagePatch(params: {
+  userId: string
+  category: ProductIntakeCategoryKey
+  previousUsage: ProductIntakeUsageRow | null
+  now: string
+}): Partial<ProductIntakeUsageRow> & { user_id: string; category: ProductIntakeCategoryKey } {
+  const previous = params.previousUsage
+  return {
+    user_id: params.userId,
+    category: params.category,
+    product_name: previous?.product_name ?? null,
+    frequency_range: previous?.frequency_range ?? null,
+    brand_text: previous?.brand_text ?? null,
+    product_id: previous?.product_id ?? null,
+    product_submission_id: previous?.product_submission_id ?? null,
+    match_status: previous?.match_status ?? "text_only",
+    intake_method: previous?.intake_method ?? null,
+    source: previous?.source ?? null,
+    front_image_path: previous?.front_image_path ?? null,
+    updated_at: params.now,
+  }
+}
+
+async function commitSubmissionImages(params: {
+  repository: ProductIntakeRepository
+  userId: string
+  submissionId: string
+  frontImagePath: string | null
+  barcodeImagePath: string | null
+  onCommitted?: (path: string) => void
+}): Promise<{ frontImagePath: string | null; barcodeImagePath: string | null }> {
+  const frontImagePath = params.frontImagePath
+    ? await params.repository.commitUploadedImage({
+        sourcePath: params.frontImagePath,
+        userId: params.userId,
+        submissionId: params.submissionId,
+        kind: "front",
+      })
+    : null
+  if (frontImagePath) params.onCommitted?.(frontImagePath)
+
+  const barcodeImagePath = params.barcodeImagePath
+    ? await params.repository.commitUploadedImage({
+        sourcePath: params.barcodeImagePath,
+        userId: params.userId,
+        submissionId: params.submissionId,
+        kind: "barcode",
+      })
+    : null
+  if (barcodeImagePath) params.onCommitted?.(barcodeImagePath)
+
+  return { frontImagePath, barcodeImagePath }
+}
+
+async function cleanupFailedPendingSubmission(params: {
+  repository: ProductIntakeRepository
+  submissionId: string | null
+  committedImagePaths: readonly string[]
+  linkedUsageId: string | null
+  restoreUsagePatch:
+    | (Partial<ProductIntakeUsageRow> & {
+        user_id: string
+        category: ProductIntakeCategoryKey
+      })
+    | null
+}) {
+  if (params.linkedUsageId && params.restoreUsagePatch) {
+    try {
+      await params.repository.updateUserProductUsage(params.linkedUsageId, params.restoreUsagePatch)
+    } catch (error) {
+      console.warn("[product-intake] failed submission usage rollback failed", error)
+      return
+    }
+  }
+
+  if (params.submissionId) {
+    try {
+      await params.repository.deleteProductSubmission(params.submissionId)
+    } catch (error) {
+      console.warn("[product-intake] failed submission row cleanup failed", error)
+      return
+    }
+  }
+
+  if (params.committedImagePaths.length > 0) {
+    try {
+      await params.repository.removeCommittedImages(params.committedImagePaths)
+    } catch (error) {
+      console.warn("[product-intake] failed submission image cleanup failed", error)
+    }
+  }
+}
+
+async function cleanupTemporarySubmissionImages(params: {
+  repository: ProductIntakeRepository
+  frontImagePath: string | null
+  barcodeImagePath: string | null
+}) {
+  const paths = [params.frontImagePath, params.barcodeImagePath].filter((path): path is string =>
+    Boolean(path),
+  )
+  if (paths.length === 0) return
+
+  try {
+    await params.repository.removeCommittedImages(paths)
+  } catch (error) {
+    console.warn("[product-intake] matched submission tmp image cleanup failed", error)
+  }
+}
+
+async function verifySubmissionImages(params: {
+  repository: ProductIntakeRepository
+  userId: string
+  frontImagePath: string | null
+  barcodeImagePath: string | null
+}) {
+  if (params.frontImagePath) {
+    const exists = await params.repository.verifyUploadedImage({
+      sourcePath: params.frontImagePath,
+      userId: params.userId,
+      kind: "front",
+    })
+    if (!exists) {
+      throw new ProductIntakeUploadExpiredError()
+    }
+  }
+
+  if (params.barcodeImagePath) {
+    const exists = await params.repository.verifyUploadedImage({
+      sourcePath: params.barcodeImagePath,
+      userId: params.userId,
+      kind: "barcode",
+    })
+    if (!exists) {
+      throw new ProductIntakeUploadExpiredError()
+    }
+  }
+}
+
+async function verifyAndCleanupMatchedPhotoUploads(params: {
+  repository: ProductIntakeRepository
+  userId: string
+  input: ProductIntakeSubmissionInput
+}) {
+  if (params.input.intake_method !== "photo") return
+
+  const frontImagePath =
+    "front_image_path" in params.input ? (params.input.front_image_path ?? null) : null
+  const barcodeImagePath =
+    "barcode_image_path" in params.input ? (params.input.barcode_image_path ?? null) : null
+
+  await verifySubmissionImages({
+    repository: params.repository,
+    userId: params.userId,
+    frontImagePath,
+    barcodeImagePath,
+  })
+  await cleanupTemporarySubmissionImages({
+    repository: params.repository,
+    frontImagePath,
+    barcodeImagePath,
+  })
+}
+
+function toSubmittedUsage(row: ProductIntakeUsageRow) {
+  return {
+    id: row.id,
+    category: row.category,
+    product_id: row.product_id,
+    product_submission_id: row.product_submission_id,
+    match_status: row.match_status,
+    front_image_path: row.front_image_path,
+  }
+}
+
+function committedSubmissionImagePath(params: {
+  path: string | null
+  userId: string
+  submissionId: string
+}) {
+  return Boolean(params.path?.startsWith(`${params.userId}/${params.submissionId}/`))
+}
+
+function collectObsoleteCommittedImagePaths(params: {
+  userId: string
+  submissionId: string
+  previousPaths: readonly (string | null)[]
+  nextPaths: readonly (string | null)[]
+}) {
+  const nextPaths = new Set(params.nextPaths.filter((path): path is string => Boolean(path)))
+  const previousPaths = params.previousPaths.filter((path): path is string => Boolean(path))
+  return Array.from(
+    new Set(
+      previousPaths.filter(
+        (path) =>
+          committedSubmissionImagePath({
+            path,
+            userId: params.userId,
+            submissionId: params.submissionId,
+          }) && !nextPaths.has(path),
+      ),
+    ),
+  )
+}
+
+function isSameOnboardingUsageEdit(params: {
+  source: ProductSubmissionSource
+  input: ProductIntakeSubmissionInput
+  existingUsage: ProductIntakeUsageRow | null
+}) {
+  return Boolean(
+    params.source === "onboarding" &&
+    params.existingUsage &&
+    "existing_usage_id" in params.input &&
+    params.input.existing_usage_id === params.existingUsage.id,
+  )
+}
+
+function buildIntakeHistory(
+  input: ProductIntakeSubmissionInput,
+  source: ProductSubmissionSource,
+  now: string,
+) {
+  return [
+    {
+      at: now,
+      source,
+      intake_method: input.intake_method,
+      category: input.category,
+      frequency_range: input.frequency_range,
+      fields: {
+        brand_text: input.brand_text ?? null,
+        brand_id: input.brand_id ?? null,
+        product_line_id: input.product_line_id ?? null,
+        product_name_text: input.product_name_text ?? null,
+        front_image_path: "front_image_path" in input ? input.front_image_path : null,
+        barcode_image_path:
+          "barcode_image_path" in input ? (input.barcode_image_path ?? null) : null,
+        front_image_validation_status:
+          "front_image_validation_status" in input ? "uncertain" : null,
+        barcode_image_validation_status:
+          "barcode_image_validation_status" in input && input.barcode_image_path
+            ? "uncertain"
+            : null,
+        source_conversation_id:
+          "source_conversation_id" in input ? (input.source_conversation_id ?? null) : null,
+      },
+    },
+  ]
+}
+
+async function updatePendingSubmissionInPlace(params: {
+  repository: ProductIntakeRepository
+  userId: string
+  source: ProductSubmissionSource
+  input: ProductIntakeSubmissionInput
+  existingUsage: ProductIntakeUsageRow
+  now: string
+  sourceConversationId: string | null
+  frontUploadPath: string | null
+  barcodeUploadPath: string | null
+}): Promise<{
+  submission: ProductIntakeSubmissionRow
+  usage: ProductIntakeUsageRow
+} | null> {
+  const submissionId = params.existingUsage.product_submission_id
+  if (!submissionId) return null
+
+  const previousSubmission = await params.repository.findProductSubmission(
+    submissionId,
+    params.userId,
+  )
+  if (!previousSubmission || previousSubmission.status !== "pending_review") {
+    return null
+  }
+
+  if (params.input.intake_method === "photo") {
+    await verifySubmissionImages({
+      repository: params.repository,
+      userId: params.userId,
+      frontImagePath: params.frontUploadPath,
+      barcodeImagePath: params.barcodeUploadPath,
+    })
+  }
+
+  const committedImagePaths: string[] = []
+  const previousUsage = params.existingUsage
+  let usageUpdated = false
+  let submissionUpdated = false
+
+  try {
+    const committedImages =
+      params.input.intake_method === "photo"
+        ? await commitSubmissionImages({
+            repository: params.repository,
+            userId: params.userId,
+            submissionId,
+            frontImagePath: params.frontUploadPath,
+            barcodeImagePath: params.barcodeUploadPath,
+            onCommitted: (path) => committedImagePaths.push(path),
+          })
+        : { frontImagePath: null, barcodeImagePath: null }
+
+    const frontImagePath =
+      params.input.intake_method === "photo"
+        ? (committedImages.frontImagePath ??
+          previousSubmission.front_image_path ??
+          previousUsage.front_image_path)
+        : null
+    const barcodeImagePath =
+      params.input.intake_method === "photo"
+        ? (committedImages.barcodeImagePath ?? previousSubmission.barcode_image_path)
+        : null
+
+    if (params.input.intake_method === "photo" && !frontImagePath) {
+      throw new ProductIntakePersistenceError("Vorderseitenfoto fehlt.")
+    }
+
+    const usage = await params.repository.updateUserProductUsage(previousUsage.id, {
+      user_id: params.userId,
+      category: params.input.category,
+      product_name: params.input.product_name_text ?? null,
+      frequency_range: params.input.frequency_range,
+      brand_text: params.input.brand_text ?? null,
+      product_id: null,
+      product_submission_id: submissionId,
+      match_status: "pending_review",
+      intake_method: params.input.intake_method,
+      source: params.source,
+      front_image_path: frontImagePath,
+      updated_at: params.now,
+    })
+    usageUpdated = true
+
+    const submission = await params.repository.updateProductSubmission(submissionId, {
+      user_product_usage_id: usage.id,
+      source: params.source,
+      source_conversation_id: params.sourceConversationId,
+      intake_method: params.input.intake_method,
+      category: params.input.category,
+      brand_text: params.input.brand_text ?? null,
+      product_name_text: params.input.product_name_text ?? null,
+      frequency_range: params.input.frequency_range,
+      front_image_path: frontImagePath,
+      barcode_image_path: barcodeImagePath,
+      front_image_validation_status: params.input.intake_method === "photo" ? "uncertain" : null,
+      front_image_validation_metadata: {},
+      barcode_image_validation_status:
+        params.input.intake_method === "photo" && barcodeImagePath ? "uncertain" : null,
+      barcode_image_validation_metadata: {},
+      status: "pending_review",
+      intake_history: [
+        ...(Array.isArray(previousSubmission.intake_history)
+          ? previousSubmission.intake_history
+          : []),
+        ...buildIntakeHistory(params.input, params.source, params.now),
+      ],
+      updated_at: params.now,
+    })
+    submissionUpdated = true
+
+    const obsoleteImagePaths =
+      params.input.intake_method === "photo"
+        ? collectObsoleteCommittedImagePaths({
+            userId: params.userId,
+            submissionId,
+            previousPaths: [
+              committedImages.frontImagePath ? previousSubmission.front_image_path : null,
+              committedImages.frontImagePath ? previousUsage.front_image_path : null,
+              committedImages.barcodeImagePath ? previousSubmission.barcode_image_path : null,
+            ],
+            nextPaths: [frontImagePath, barcodeImagePath],
+          })
+        : []
+
+    if (obsoleteImagePaths.length > 0) {
+      try {
+        await params.repository.removeCommittedImages(obsoleteImagePaths)
+      } catch (removeError) {
+        console.warn("[product-intake] old pending edit image cleanup failed", removeError)
+      }
+    }
+
+    return { submission, usage }
+  } catch (error) {
+    if (submissionUpdated) {
+      try {
+        await params.repository.updateProductSubmission(submissionId, previousSubmission)
+      } catch (restoreError) {
+        console.warn("[product-intake] pending submission rollback failed", restoreError)
+      }
+    }
+    if (usageUpdated) {
+      try {
+        await params.repository.updateUserProductUsage(
+          previousUsage.id,
+          restoreUsagePatch({
+            userId: params.userId,
+            category: params.input.category,
+            previousUsage,
+            now: params.now,
+          }),
+        )
+      } catch (restoreError) {
+        console.warn("[product-intake] pending usage rollback failed", restoreError)
+      }
+    }
+    if (committedImagePaths.length > 0) {
+      try {
+        await params.repository.removeCommittedImages(committedImagePaths)
+      } catch (removeError) {
+        console.warn("[product-intake] pending edit image cleanup failed", removeError)
+      }
+    }
+    throw error
+  }
+}
+
+function resolveInputIdentity(params: {
+  input: ProductIntakeSubmissionInput
+  brandCatalog: BrandResolutionCatalog
+}): {
+  brandId: string | null
+  productLineId: string | null
+  cleanProductName: string
+} {
+  if (params.input.brand_id) {
+    const brand =
+      params.brandCatalog.brands.find(
+        (candidate) => brandId(candidate) === params.input.brand_id,
+      ) ?? null
+    const productLine =
+      params.input.product_line_id && params.brandCatalog.productLines
+        ? (params.brandCatalog.productLines.find(
+            (candidate) => lineId(candidate.line) === params.input.product_line_id,
+          )?.line ?? null)
+        : null
+
+    return {
+      brandId: params.input.brand_id,
+      productLineId: params.input.product_line_id ?? null,
+      cleanProductName: params.input.product_name_text
+        ? cleanProductDisplayName(params.input.product_name_text, {
+            brand: brandName(brand),
+            productLine: lineName(productLine),
+          })
+        : "",
+    }
+  }
+
+  const resolved = params.input.brand_text
+    ? resolveBrandFromText(params.input.brand_text, params.brandCatalog)
+    : null
+
+  return {
+    brandId: brandId(resolved?.brand ?? null),
+    productLineId: params.input.product_line_id ?? lineId(resolved?.productLine ?? null),
+    cleanProductName: params.input.product_name_text
+      ? cleanProductDisplayName(params.input.product_name_text, {
+          brand: brandName(resolved?.brand ?? null),
+          productLine: lineName(resolved?.productLine ?? null),
+        })
+      : "",
+  }
+}
+
+async function upsertMatchedUsage(params: {
+  repository: ProductIntakeRepository
+  userId: string
+  source: ProductSubmissionSource
+  input: ProductIntakeSubmissionInput
+  existingUsage: ProductIntakeUsageRow | null
+  productId: string
+  now: string
+}): Promise<ProductIntakeUsageRow> {
+  return params.repository.replaceUsageWithMatchedProduct({
+    userId: params.userId,
+    category: params.input.category,
+    existingUsageId: params.existingUsage?.id ?? null,
+    productId: params.productId,
+    productName: params.input.product_name_text ?? null,
+    frequencyRange: params.input.frequency_range,
+    brandText: params.input.brand_text ?? null,
+    intakeMethod: params.input.intake_method,
+    source: params.source,
+    now: params.now,
+  })
+}
+
+async function createPendingSubmission(params: {
+  repository: ProductIntakeRepository
+  userId: string
+  source: ProductSubmissionSource
+  input: ProductIntakeSubmissionInput
+  existingUsage: ProductIntakeUsageRow | null
+  now: string
+}): Promise<{
+  submission: ProductIntakeSubmissionRow
+  usage: ProductIntakeUsageRow
+}> {
+  const sourceConversationId =
+    params.source === "chat" && "source_conversation_id" in params.input
+      ? (params.input.source_conversation_id ?? null)
+      : null
+  const frontUploadPath =
+    "front_image_path" in params.input ? (params.input.front_image_path ?? null) : null
+  const barcodeUploadPath =
+    "barcode_image_path" in params.input ? (params.input.barcode_image_path ?? null) : null
+
+  if (
+    params.existingUsage &&
+    isSameOnboardingUsageEdit({
+      source: params.source,
+      input: params.input,
+      existingUsage: params.existingUsage,
+    })
+  ) {
+    const updated = await updatePendingSubmissionInPlace({
+      repository: params.repository,
+      userId: params.userId,
+      source: params.source,
+      input: params.input,
+      existingUsage: params.existingUsage,
+      now: params.now,
+      sourceConversationId,
+      frontUploadPath: frontUploadPath ?? null,
+      barcodeUploadPath,
+    })
+    if (updated) return updated
+  }
+
+  if (params.input.intake_method === "photo" && !frontUploadPath) {
+    throw new ProductIntakePersistenceError("Vorderseitenfoto fehlt.")
+  }
+
+  if (params.input.intake_method === "photo") {
+    await verifySubmissionImages({
+      repository: params.repository,
+      userId: params.userId,
+      frontImagePath: frontUploadPath,
+      barcodeImagePath: barcodeUploadPath,
+    })
+  }
+
+  const submissionId = randomUUID()
+  const committedImagePaths: string[] = []
+  let insertedSubmissionId: string | null = null
+
+  try {
+    const committedImages =
+      params.input.intake_method === "photo"
+        ? await commitSubmissionImages({
+            repository: params.repository,
+            userId: params.userId,
+            submissionId,
+            frontImagePath: frontUploadPath,
+            barcodeImagePath: barcodeUploadPath,
+            onCommitted: (path) => committedImagePaths.push(path),
+          })
+        : { frontImagePath: null, barcodeImagePath: null }
+
+    const submission = await params.repository.insertProductSubmission({
+      id: submissionId,
+      user_id: params.userId,
+      user_product_usage_id: null,
+      source: params.source,
+      source_conversation_id: sourceConversationId,
+      intake_method: params.input.intake_method,
+      category: params.input.category,
+      brand_text: params.input.brand_text ?? null,
+      product_name_text: params.input.product_name_text ?? null,
+      frequency_range: params.input.frequency_range,
+      front_image_path: committedImages.frontImagePath,
+      barcode_image_path: committedImages.barcodeImagePath,
+      front_image_validation_status: params.input.intake_method === "photo" ? "uncertain" : null,
+      front_image_validation_metadata: {},
+      barcode_image_validation_status:
+        params.input.intake_method === "photo" && barcodeUploadPath ? "uncertain" : null,
+      barcode_image_validation_metadata: {},
+      previous_product_id: params.existingUsage?.product_id ?? null,
+      previous_product_snapshot: previousSnapshot(params.existingUsage),
+      status: "pending_review",
+      researched_payload: {},
+      intake_history: buildIntakeHistory(params.input, params.source, params.now),
+      approved_product_id: null,
+    })
+    insertedSubmissionId = submission.id
+
+    const { usage, submission: linkedSubmission } =
+      await params.repository.replaceUsageWithPendingSubmission({
+        userId: params.userId,
+        category: params.input.category,
+        existingUsageId: params.existingUsage?.id ?? null,
+        submissionId: submission.id,
+        productName: params.input.product_name_text ?? null,
+        frequencyRange: params.input.frequency_range,
+        brandText: params.input.brand_text ?? null,
+        intakeMethod: params.input.intake_method,
+        source: params.source,
+        frontImagePath: committedImages.frontImagePath,
+        now: params.now,
+      })
+
+    return { submission: linkedSubmission, usage }
+  } catch (error) {
+    await cleanupFailedPendingSubmission({
+      repository: params.repository,
+      submissionId: insertedSubmissionId,
+      committedImagePaths,
+      linkedUsageId: null,
+      restoreUsagePatch: null,
+    })
+    throw error
+  }
+}
+
+export async function submitProductIntake(
+  params: SubmitProductIntakeParams,
+): Promise<ProductIntakeSubmissionResult> {
+  if ("front_image_path" in params.input) {
+    assertTemporaryUploadPathBelongsToUser(params.input.front_image_path, params.userId)
+  }
+  if ("barcode_image_path" in params.input) {
+    assertTemporaryUploadPathBelongsToUser(params.input.barcode_image_path, params.userId)
+  }
+
+  if (
+    params.source === "chat" &&
+    "source_conversation_id" in params.input &&
+    params.input.source_conversation_id
+  ) {
+    const ownsConversation = await params.repository.verifyConversationOwnership(
+      params.input.source_conversation_id,
+      params.userId,
+    )
+    if (!ownsConversation) throw new ProductIntakeOwnershipError()
+  }
+
+  const [catalog, brandCatalogInput, existingUsage] = await Promise.all([
+    params.repository.loadCatalog(),
+    params.repository.loadBrandResolutionCatalog(),
+    params.repository.findUserProductUsage(params.userId, params.input.category),
+  ])
+
+  if (
+    existingUsage &&
+    isTrackedUsage(existingUsage) &&
+    !(
+      params.source === "onboarding" &&
+      "existing_usage_id" in params.input &&
+      params.input.existing_usage_id === existingUsage.id
+    ) &&
+    params.input.replace_existing_confirmed !== true
+  ) {
+    throw new ProductIntakeConflictError(params.input.category, existingUsage.id)
+  }
+
+  const identity = resolveInputIdentity({
+    input: params.input,
+    brandCatalog: buildBrandResolutionCatalog(brandCatalogInput),
+  })
+
+  const match = matchProductIntake(
+    {
+      selectedCategoryKey: params.input.category,
+      brandId: identity.brandId,
+      productLineId: identity.productLineId,
+      cleanProductName: identity.cleanProductName,
+      productName: params.input.product_name_text ?? null,
+    },
+    catalog,
+  )
+
+  const now = params.now?.() ?? new Date().toISOString()
+
+  if (match.status === "matched" && match.productId) {
+    await verifyAndCleanupMatchedPhotoUploads({
+      repository: params.repository,
+      userId: params.userId,
+      input: params.input,
+    })
+
+    const usage = await upsertMatchedUsage({
+      repository: params.repository,
+      userId: params.userId,
+      source: params.source,
+      input: params.input,
+      existingUsage,
+      productId: match.productId,
+      now,
+    })
+
+    return {
+      status: "matched",
+      source: params.source,
+      intake_method: params.input.intake_method,
+      category: params.input.category,
+      frequency_range: params.input.frequency_range,
+      usage: toSubmittedUsage(usage),
+      submission: null,
+      matched_product_id: match.productId,
+      match,
+    }
+  }
+
+  const { submission, usage } = await createPendingSubmission({
+    repository: params.repository,
+    userId: params.userId,
+    source: params.source,
+    input: params.input,
+    existingUsage,
+    now,
+  })
+
+  return {
+    status: "pending_review",
+    source: params.source,
+    intake_method: params.input.intake_method,
+    category: params.input.category,
+    frequency_range: params.input.frequency_range,
+    usage: toSubmittedUsage(usage),
+    submission: {
+      id: submission.id,
+      status: "pending_review",
+      category: submission.category,
+    },
+    matched_product_id: null,
+    match,
+  }
+}
+
+export async function cancelProductIntakeUsage(params: {
+  userId: string
+  category: ProductIntakeCategoryKey
+  repository: ProductIntakeRepository
+  now?: () => string
+}): Promise<{
+  category: ProductIntakeCategoryKey
+  usage_id: string | null
+  submission_id: string | null
+}> {
+  const now = params.now?.() ?? new Date().toISOString()
+  const result = await params.repository.cancelProductIntakeUsageForCategory({
+    userId: params.userId,
+    category: params.category,
+    now,
+  })
+
+  return result
+}
+
+export function isOpenProductSubmissionStatus(status: string): boolean {
+  return OPEN_SUBMISSION_STATUSES.includes(status as (typeof OPEN_SUBMISSION_STATUSES)[number])
+}

--- a/src/lib/product-intake/types.ts
+++ b/src/lib/product-intake/types.ts
@@ -1,0 +1,44 @@
+import type {
+  ProductFrequency,
+  ProductIntakeCategoryKey,
+  ProductIntakeMethod,
+  ProductSubmissionSource,
+  ProductUsageMatchStatus,
+} from "@/lib/types"
+import type { ProductIntakeMatchResult } from "@/lib/product-intake/product-matching"
+
+export type ProductIntakeSubmissionStatus = "matched" | "pending_review"
+
+export type ProductIntakeSubmittedUsage = {
+  id: string
+  category: ProductIntakeCategoryKey
+  product_id: string | null
+  product_submission_id: string | null
+  match_status: ProductUsageMatchStatus
+  front_image_path: string | null
+}
+
+export type ProductIntakeSubmittedSubmission = {
+  id: string
+  status: "pending_review"
+  category: ProductIntakeCategoryKey
+}
+
+export type ProductIntakeSubmissionResult = {
+  status: ProductIntakeSubmissionStatus
+  source: ProductSubmissionSource
+  intake_method: ProductIntakeMethod
+  category: ProductIntakeCategoryKey
+  frequency_range: ProductFrequency
+  usage: ProductIntakeSubmittedUsage
+  submission: ProductIntakeSubmittedSubmission | null
+  matched_product_id: string | null
+  match: ProductIntakeMatchResult
+}
+
+export type ProductIntakeConflict = {
+  code: "product_category_already_filled"
+  message: string
+  category: ProductIntakeCategoryKey
+  existing_usage_id: string
+}

--- a/src/lib/product-intake/upload-paths.ts
+++ b/src/lib/product-intake/upload-paths.ts
@@ -1,0 +1,23 @@
+import { ProductIntakeUserInputError } from "@/lib/product-intake/errors"
+
+export function assertTemporaryUploadPathBelongsToUser(
+  path: string | null | undefined,
+  userId: string,
+) {
+  if (!path) return
+  const normalized = path.trim()
+  if (normalized.startsWith(`tmp/${userId}/`) && !normalized.includes("..")) {
+    return
+  }
+
+  if (normalized.startsWith(`${userId}/`)) {
+    throw new ProductIntakeUserInputError(
+      "Bitte verwende den temporären Upload-Pfad aus dem aktuellen Upload.",
+      { code: "product_intake_stale_upload_path" },
+    )
+  }
+
+  throw new ProductIntakeUserInputError("Bildpfad gehört nicht zu diesem Nutzer.", {
+    code: "product_intake_upload_owner_mismatch",
+  })
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -123,7 +123,7 @@ export async function updateSession(request: NextRequest) {
   }
 
   // --- Subscription paywall ---------------------------------------------
-  const SUB_REQUIRED_PREFIXES = ["/onboarding", "/chat", "/api/chat"]
+  const SUB_REQUIRED_PREFIXES = ["/onboarding", "/chat", "/api/chat", "/api/product-intake"]
   const needsSub = SUB_REQUIRED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
 
   if (needsSub) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -819,9 +819,21 @@ export interface MessageRagContext {
   category_decision?: ChatCategoryDecision | null
   engine_trace?: RecommendationEngineTrace | null
   response_mode?: ResponseMode | null
+  product_intake_offer?: ProductIntakeOffer | null
 }
 
 export type MessageDecisionContext = MessageRagContext
+
+export interface ProductIntakeOffer {
+  id: string
+  source: "chat"
+  reason: "product_lookup_not_found"
+  category: ProductIntakeCategoryKey
+  extracted_identity?: {
+    brand_text?: string
+    product_name_text?: string
+  }
+}
 
 export interface ChatPromptMessageSnapshot {
   role: "system" | "user" | "assistant"
@@ -1278,6 +1290,7 @@ export interface ChatSSEEvent {
     | "conversation_id"
     | "content_delta"
     | "product_recommendations"
+    | "product_intake_offer"
     | "sources"
     | "confidence"
     | "retrieval_debug"

--- a/supabase/migrations/20260616120000_product_intake_lifecycle_functions.sql
+++ b/supabase/migrations/20260616120000_product_intake_lifecycle_functions.sql
@@ -1,0 +1,307 @@
+-- Product intake lifecycle helpers.
+-- These keep user_product_usage/product_submissions cross-row state changes
+-- trigger-safe and atomic while storage cleanup remains app-side.
+
+CREATE OR REPLACE FUNCTION public.product_intake_cancel_usage_for_category(
+  p_user_id uuid,
+  p_category text,
+  p_updated_at timestamptz DEFAULT now()
+)
+RETURNS TABLE(category text, usage_id uuid, submission_id uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  usage_row public.user_product_usage%ROWTYPE;
+BEGIN
+  SELECT *
+  INTO usage_row
+  FROM public.user_product_usage AS usage
+  WHERE usage.user_id = p_user_id
+    AND usage.category = p_category
+  FOR UPDATE;
+
+  category := p_category;
+  usage_id := usage_row.id;
+  submission_id := usage_row.product_submission_id;
+
+  IF usage_row.id IS NULL THEN
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  IF submission_id IS NOT NULL THEN
+    PERFORM 1
+    FROM public.product_submissions AS submission
+    WHERE submission.id = submission_id
+      AND submission.user_id = p_user_id
+      AND submission.category = p_category
+    FOR UPDATE;
+  END IF;
+
+  DELETE FROM public.user_product_usage
+  WHERE id = usage_row.id;
+
+  IF submission_id IS NOT NULL THEN
+    UPDATE public.product_submissions AS submission
+    SET status = 'cancelled_by_user',
+        user_product_usage_id = NULL,
+        cleanup_after = COALESCE(cleanup_after, p_updated_at + interval '30 days'),
+        updated_at = p_updated_at
+    WHERE submission.id = submission_id
+      AND submission.user_id = p_user_id
+      AND submission.category = p_category
+      AND submission.status IN ('pending_review', 'researching', 'ready_for_review', 'needs_more_info');
+  END IF;
+
+  RETURN NEXT;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.product_intake_replace_usage_with_matched_product(
+  p_user_id uuid,
+  p_category text,
+  p_existing_usage_id uuid,
+  p_product_id uuid,
+  p_product_name text,
+  p_frequency_range text,
+  p_brand_text text,
+  p_intake_method text,
+  p_source text,
+  p_updated_at timestamptz DEFAULT now()
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  usage_row public.user_product_usage%ROWTYPE;
+  old_submission_id uuid;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.products AS product
+    WHERE product.id = p_product_id
+      AND product.category_key = p_category
+  ) THEN
+    RAISE EXCEPTION 'matched product must belong to usage category';
+  END IF;
+
+  IF p_existing_usage_id IS NOT NULL THEN
+    SELECT *
+    INTO usage_row
+    FROM public.user_product_usage AS usage
+    WHERE usage.id = p_existing_usage_id
+      AND usage.user_id = p_user_id
+      AND usage.category = p_category
+    FOR UPDATE;
+
+    IF usage_row.id IS NULL THEN
+      RAISE EXCEPTION 'existing product usage not found for matched replacement';
+    END IF;
+
+    old_submission_id := usage_row.product_submission_id;
+
+    UPDATE public.user_product_usage AS usage
+    SET product_name = p_product_name,
+        frequency_range = p_frequency_range,
+        brand_text = p_brand_text,
+        product_id = p_product_id,
+        product_submission_id = NULL,
+        match_status = 'matched',
+        intake_method = p_intake_method,
+        source = p_source,
+        front_image_path = NULL,
+        updated_at = p_updated_at
+    WHERE usage.id = usage_row.id
+    RETURNING * INTO usage_row;
+  ELSE
+    INSERT INTO public.user_product_usage (
+      user_id,
+      category,
+      product_name,
+      frequency_range,
+      brand_text,
+      product_id,
+      product_submission_id,
+      match_status,
+      intake_method,
+      source,
+      front_image_path,
+      updated_at
+    )
+    VALUES (
+      p_user_id,
+      p_category,
+      p_product_name,
+      p_frequency_range,
+      p_brand_text,
+      p_product_id,
+      NULL,
+      'matched',
+      p_intake_method,
+      p_source,
+      NULL,
+      p_updated_at
+    )
+    RETURNING * INTO usage_row;
+  END IF;
+
+  IF old_submission_id IS NOT NULL THEN
+    UPDATE public.product_submissions AS submission
+    SET status = 'cancelled_by_user',
+        user_product_usage_id = NULL,
+        cleanup_after = COALESCE(cleanup_after, p_updated_at + interval '30 days'),
+        updated_at = p_updated_at
+    WHERE submission.id = old_submission_id
+      AND submission.user_id = p_user_id
+      AND submission.category = p_category
+      AND submission.status IN ('pending_review', 'researching', 'ready_for_review', 'needs_more_info');
+  END IF;
+
+  RETURN to_jsonb(usage_row);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.product_intake_replace_usage_with_pending_submission(
+  p_user_id uuid,
+  p_category text,
+  p_existing_usage_id uuid,
+  p_submission_id uuid,
+  p_product_name text,
+  p_frequency_range text,
+  p_brand_text text,
+  p_intake_method text,
+  p_source text,
+  p_front_image_path text,
+  p_updated_at timestamptz DEFAULT now()
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  usage_row public.user_product_usage%ROWTYPE;
+  submission_row public.product_submissions%ROWTYPE;
+  old_submission_id uuid;
+BEGIN
+  SELECT *
+  INTO submission_row
+  FROM public.product_submissions AS submission
+  WHERE submission.id = p_submission_id
+    AND submission.user_id = p_user_id
+    AND submission.category = p_category
+  FOR UPDATE;
+
+  IF submission_row.id IS NULL THEN
+    RAISE EXCEPTION 'pending product submission not found for usage replacement';
+  END IF;
+
+  IF submission_row.status <> 'pending_review' THEN
+    RAISE EXCEPTION 'usage replacement requires a pending product submission';
+  END IF;
+
+  IF p_existing_usage_id IS NOT NULL THEN
+    SELECT *
+    INTO usage_row
+    FROM public.user_product_usage AS usage
+    WHERE usage.id = p_existing_usage_id
+      AND usage.user_id = p_user_id
+      AND usage.category = p_category
+    FOR UPDATE;
+
+    IF usage_row.id IS NULL THEN
+      RAISE EXCEPTION 'existing product usage not found for pending replacement';
+    END IF;
+
+    old_submission_id := usage_row.product_submission_id;
+
+    UPDATE public.user_product_usage AS usage
+    SET product_name = p_product_name,
+        frequency_range = p_frequency_range,
+        brand_text = p_brand_text,
+        product_id = NULL,
+        product_submission_id = p_submission_id,
+        match_status = 'pending_review',
+        intake_method = p_intake_method,
+        source = p_source,
+        front_image_path = p_front_image_path,
+        updated_at = p_updated_at
+    WHERE usage.id = usage_row.id
+    RETURNING * INTO usage_row;
+  ELSE
+    INSERT INTO public.user_product_usage (
+      user_id,
+      category,
+      product_name,
+      frequency_range,
+      brand_text,
+      product_id,
+      product_submission_id,
+      match_status,
+      intake_method,
+      source,
+      front_image_path,
+      updated_at
+    )
+    VALUES (
+      p_user_id,
+      p_category,
+      p_product_name,
+      p_frequency_range,
+      p_brand_text,
+      NULL,
+      p_submission_id,
+      'pending_review',
+      p_intake_method,
+      p_source,
+      p_front_image_path,
+      p_updated_at
+    )
+    RETURNING * INTO usage_row;
+  END IF;
+
+  IF old_submission_id IS NOT NULL
+      AND old_submission_id IS DISTINCT FROM p_submission_id THEN
+    UPDATE public.product_submissions AS submission
+    SET status = 'cancelled_by_user',
+        user_product_usage_id = NULL,
+        cleanup_after = COALESCE(cleanup_after, p_updated_at + interval '30 days'),
+        updated_at = p_updated_at
+    WHERE submission.id = old_submission_id
+      AND submission.user_id = p_user_id
+      AND submission.category = p_category
+      AND submission.status IN ('pending_review', 'researching', 'ready_for_review', 'needs_more_info');
+  END IF;
+
+  UPDATE public.product_submissions AS submission
+  SET user_product_usage_id = usage_row.id,
+      updated_at = p_updated_at
+  WHERE submission.id = p_submission_id
+    AND submission.user_id = p_user_id
+    AND submission.category = p_category
+  RETURNING * INTO submission_row;
+
+  RETURN jsonb_build_object(
+    'usage', to_jsonb(usage_row),
+    'submission', to_jsonb(submission_row)
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.product_intake_cancel_usage_for_category(uuid, text, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.product_intake_replace_usage_with_matched_product(uuid, text, uuid, uuid, text, text, text, text, text, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.product_intake_replace_usage_with_pending_submission(uuid, text, uuid, uuid, text, text, text, text, text, text, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.product_intake_cancel_usage_for_category(uuid, text, timestamptz)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.product_intake_replace_usage_with_matched_product(uuid, text, uuid, uuid, text, text, text, text, text, timestamptz)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.product_intake_replace_usage_with_pending_submission(uuid, text, uuid, uuid, text, text, text, text, text, text, timestamptz)
+  TO service_role;

--- a/tests/agent-v2-current-care-context.spec.ts
+++ b/tests/agent-v2-current-care-context.spec.ts
@@ -380,6 +380,7 @@ test("AgentV2 runtime applies current-turn facts to the same effective context f
         downstreamContexts.push(executionContext?.effectiveCareContext)
         return { valid_product_ids: [], products: [] }
       },
+      lookup_product_candidate: async () => ({ status: "insufficient_identity" }),
       build_or_fix_routine: async (
         _input,
         executionContext?: { effectiveCareContext?: unknown },
@@ -557,6 +558,7 @@ function fakeAgentV2Tools() {
   return {
     load_advisor_guidance: async () => ({ loaded_package_ids: [] }),
     select_products: async () => ({ valid_product_ids: [], products: [] }),
+    lookup_product_candidate: async () => ({ status: "insufficient_identity" }),
     build_or_fix_routine: async () => ({ routine_layer: "basics", visible_steps: [] }),
   }
 }

--- a/tests/agent-v2-production-chat-pipeline.spec.ts
+++ b/tests/agent-v2-production-chat-pipeline.spec.ts
@@ -131,6 +131,269 @@ function createTextStream(text: string): ReadableStream<Uint8Array> {
   })
 }
 
+test("chat product intake offer is driven by structured pipeline metadata and preserves model copy", async () => {
+  const modelAnswer =
+    "Danke dir. Dieses konkrete Pantene-Shampoo kenne ich noch nicht sicher in unserer Produktdatenbank. Damit ich es wirklich passend zu deiner Routine einschätzen kann, kannst du es kurz hinzufügen."
+  const productIntakeOffer = {
+    id: "offer-1",
+    source: "chat",
+    reason: "product_lookup_not_found",
+    category: "shampoo",
+    extracted_identity: {
+      brand_text: "Pantene",
+      product_name_text: "Pro-V Repair & Care Shampoo",
+    },
+  }
+  const messageRows: Array<Record<string, unknown>> = []
+  const conversationUpdates: Array<Record<string, unknown>> = []
+  const statePersistenceCalls: unknown[] = []
+  const memoryExtractionCalls: unknown[] = []
+  const traceRows: Array<Record<string, unknown>> = []
+  let decisionContextProductIntakeOffer: unknown = null
+  const admin = createFakeChatAdminClient({ messageRows, conversationUpdates })
+
+  const handler = createChatPostHandler({
+    createClient: async () =>
+      ({
+        auth: {
+          getUser: async () => ({ data: { user: { id: "user-1" } } }),
+        },
+      }) as never,
+    checkRateLimit: async () => ({ allowed: true }) as never,
+    ensureLangfuseTracing: () => null,
+    flushLangfuseClient: async () => {},
+    getLangfuseClient: () =>
+      ({
+        getTraceUrl: async () => "https://langfuse.test/trace/trace-1",
+      }) as never,
+    getLangfuseRelease: () => "test-release",
+    resolveLangfuseTraceId: () => "trace-1",
+    startObservation: () =>
+      ({
+        otelSpan: {},
+        update: () => {},
+        end: () => {},
+      }) as never,
+    propagateAttributes: ((_attributes: unknown, fn: () => unknown) => fn()) as never,
+    otelContext: {
+      active: () => ({}),
+      with: async (_context: unknown, fn: () => unknown) => fn(),
+    } as never,
+    otelTrace: {
+      setSpan: () => ({}),
+    } as never,
+    loadRuntimeDeps: async () =>
+      ({
+        createAdminClient: () => admin,
+        runAgentV2ProductionPipeline: async () => ({
+          stream: createTextStream(modelAnswer),
+          intent: "product_question",
+          matchedProducts: [],
+          sources: [{ title: "Source that should not be shown" }],
+          retrievalSummary: { final_context_count: 0 },
+          routerDecision: {
+            confidence: 0.8,
+            retrieval_mode: "semantic",
+            response_mode: "answer",
+          },
+          conversationStateTransition: { next_state: "should_not_persist" },
+          categoryDecision: undefined,
+          engineTrace: undefined,
+          debugTrace: {},
+          visibleFailure: false,
+          answerMode: "product_recommendation",
+          productIntakeOffer,
+        }),
+        buildAssistantDecisionContext: (
+          _sources: unknown,
+          _categoryDecision: unknown,
+          _engineTrace: unknown,
+          _responseMode: unknown,
+          productIntakeOffer: unknown,
+        ) => {
+          decisionContextProductIntakeOffer = productIntakeOffer
+          return { product_intake_offer: productIntakeOffer }
+        },
+        buildDoneEventData: ({ intent }: { intent: string }) => ({ intent }),
+        extractConversationMemory: (...args: unknown[]) => {
+          memoryExtractionCalls.push(args)
+          return Promise.resolve()
+        },
+        buildRetrievalDebugEventData: () => ({ route_debug: true }),
+        finalizeChatTurnTrace: (_trace: unknown, params: Record<string, unknown>) => ({
+          response_composition: {},
+          decision_context: {
+            engine_trace: null,
+            matched_products: [],
+          },
+          conversation_state_persistence: params.conversation_state_persistence,
+        }),
+        summarizeEngineTraceForLangfuse: () => null,
+        summarizeProductsForLangfuse: () => [],
+        summarizeAgentV2TraceForLangfuse: () => null,
+        persistConversationStateTransition: async (...args: unknown[]) => {
+          statePersistenceCalls.push(args)
+          return { status: "persisted", error: null }
+        },
+        chatMessageSchema: {
+          safeParse: (value: unknown) => ({ success: true, data: value }),
+        },
+        generateConversationTitle: async () => {},
+      }) as never,
+    persistConversationTurnTrace: async (row) => {
+      traceRows.push(row)
+    },
+    randomUUID: () => "offer-1",
+    now: () => 0,
+  })
+
+  const response = await handler(
+    new Request("https://example.test/api/chat", {
+      method: "POST",
+      body: JSON.stringify({
+        message: "Ich benutze Pantene Pro-V Shampoo. Passt das gut zu mir?",
+        conversation_id: "conversation-1",
+      }),
+    }),
+  )
+  const responseText = await response.text()
+
+  assert.equal(response.status, 200)
+  assert.match(responseText, /product_intake_offer/)
+  assert.match(responseText, new RegExp(modelAnswer))
+  assert.equal(messageRows[1]?.content, modelAnswer)
+  assert.deepEqual(decisionContextProductIntakeOffer, productIntakeOffer)
+  assert.deepEqual(
+    (messageRows[1]?.rag_context as { product_intake_offer?: unknown } | undefined)
+      ?.product_intake_offer,
+    productIntakeOffer,
+  )
+  assert.equal(statePersistenceCalls.length, 0)
+  assert.equal(memoryExtractionCalls.length, 0)
+  assert.equal(traceRows.length, 1)
+})
+
+test("chat route does not infer product intake offer from raw user message", async () => {
+  const modelAnswer =
+    "Ich kann das konkrete Produkt nur bewerten, wenn es in der Produktdatenbank sicher gefunden wurde."
+  const messageRows: Array<Record<string, unknown>> = []
+  const conversationUpdates: Array<Record<string, unknown>> = []
+  const statePersistenceCalls: unknown[] = []
+  const memoryExtractionCalls: unknown[] = []
+  const traceRows: Array<Record<string, unknown>> = []
+  const admin = createFakeChatAdminClient({ messageRows, conversationUpdates })
+
+  const handler = createChatPostHandler({
+    createClient: async () =>
+      ({
+        auth: {
+          getUser: async () => ({ data: { user: { id: "user-1" } } }),
+        },
+      }) as never,
+    checkRateLimit: async () => ({ allowed: true }) as never,
+    ensureLangfuseTracing: () => null,
+    flushLangfuseClient: async () => {},
+    getLangfuseClient: () =>
+      ({
+        getTraceUrl: async () => "https://langfuse.test/trace/trace-1",
+      }) as never,
+    getLangfuseRelease: () => "test-release",
+    resolveLangfuseTraceId: () => "trace-1",
+    startObservation: () =>
+      ({
+        otelSpan: {},
+        update: () => {},
+        end: () => {},
+      }) as never,
+    propagateAttributes: ((_attributes: unknown, fn: () => unknown) => fn()) as never,
+    otelContext: {
+      active: () => ({}),
+      with: async (_context: unknown, fn: () => unknown) => fn(),
+    } as never,
+    otelTrace: {
+      setSpan: () => ({}),
+    } as never,
+    loadRuntimeDeps: async () =>
+      ({
+        createAdminClient: () => admin,
+        runAgentV2ProductionPipeline: async () => ({
+          stream: createTextStream(modelAnswer),
+          intent: "routine_question",
+          matchedProducts: [],
+          sources: [],
+          retrievalSummary: { final_context_count: 0 },
+          routerDecision: {
+            confidence: 0.8,
+            retrieval_mode: "semantic",
+            response_mode: "answer",
+          },
+          conversationStateTransition: { next_state: "persist" },
+          categoryDecision: undefined,
+          engineTrace: undefined,
+          debugTrace: {},
+          visibleFailure: false,
+          answerMode: "product_recommendation",
+        }),
+        buildAssistantDecisionContext: (
+          _sources: unknown,
+          _categoryDecision: unknown,
+          _engineTrace: unknown,
+          _responseMode: unknown,
+          productIntakeOffer: unknown,
+        ) => ({ product_intake_offer: productIntakeOffer }),
+        buildDoneEventData: ({ intent }: { intent: string }) => ({ intent }),
+        extractConversationMemory: (...args: unknown[]) => {
+          memoryExtractionCalls.push(args)
+          return Promise.resolve()
+        },
+        buildRetrievalDebugEventData: () => ({ route_debug: true }),
+        finalizeChatTurnTrace: (_trace: unknown, params: Record<string, unknown>) => ({
+          response_composition: {},
+          decision_context: {
+            engine_trace: null,
+            matched_products: [],
+          },
+          conversation_state_persistence: params.conversation_state_persistence,
+        }),
+        summarizeEngineTraceForLangfuse: () => null,
+        summarizeProductsForLangfuse: () => [],
+        summarizeAgentV2TraceForLangfuse: () => null,
+        persistConversationStateTransition: async (...args: unknown[]) => {
+          statePersistenceCalls.push(args)
+          return { status: "persisted", error: null }
+        },
+        chatMessageSchema: {
+          safeParse: (value: unknown) => ({ success: true, data: value }),
+        },
+        generateConversationTitle: async () => {},
+      }) as never,
+    persistConversationTurnTrace: async (row) => {
+      traceRows.push(row)
+    },
+    randomUUID: () => "offer-1",
+    now: () => 0,
+  })
+
+  const response = await handler(
+    new Request("https://example.test/api/chat", {
+      method: "POST",
+      body: JSON.stringify({
+        message: "Ich benutze Pantene Pro-V Shampoo. Passt das gut zu mir?",
+        conversation_id: "conversation-1",
+      }),
+    }),
+  )
+  const responseText = await response.text()
+
+  assert.equal(response.status, 200)
+  assert.doesNotMatch(responseText, /product_intake_offer/)
+  assert.match(responseText, new RegExp(modelAnswer))
+  assert.equal(messageRows[1]?.content, modelAnswer)
+  assert.equal(statePersistenceCalls.length, 1)
+  assert.equal(memoryExtractionCalls.length, 1)
+  assert.equal(traceRows.length, 1)
+})
+
 function createFakeChatAdminClient(params: {
   messageRows: Array<Record<string, unknown>>
   conversationUpdates: Array<Record<string, unknown>>
@@ -606,6 +869,286 @@ test("AgentV2 production pipeline returns cards, trace, and CareBalance context"
   })
   assert.equal(failedDebugEvent.agent_v2_visible_failure, true)
   assert.equal(failedDebugEvent.visible_failure, true)
+})
+
+test("AgentV2 production pipeline surfaces product intake offer from lookup result", async () => {
+  const hairProfile = createCompleteHairProfile()
+  const agentResult = createAgentV2Result()
+  agentResult.final_answer = {
+    ...agentResult.final_answer,
+    answer_mode: "general_advice",
+    interpreted_intent: "User asks about their own named product.",
+    request_interpretation: {
+      primary_intent: "general_advice",
+      product_request_kind: "none",
+      routine_intent: "none",
+      care_category: "shampoo",
+      requested_product_count: null,
+      count_policy: "none",
+      evidence_quote: "Pantene Pro-V Volume Pur Shampoo",
+      confidence: 0.88,
+    },
+    tool_grounding: {
+      used_guidance_package_ids: ["base.advisor_rules.v1"],
+      used_product_tool: false,
+      used_routine_tool: false,
+      product_ids: [],
+      routine_step_ids: [],
+      hard_rule_ids: [],
+    },
+    payload: {
+      user_facing_answer_de:
+        "Danke dir. Dieses konkrete Shampoo kenne ich noch nicht sicher in unserer Produktdatenbank. Du kannst es kurz hinzufügen, dann prüfen wir es sauber.",
+      category_or_topic: "shampoo",
+      key_points_de: [],
+      next_step_offer_de: null,
+    },
+  }
+
+  const result = await runAgentV2ProductionPipeline(
+    {
+      message: "Ich nutze Pantene Pro-V Volume Pur Shampoo. Passt das zu mir?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-lookup",
+      productIntakeEnabled: true,
+    },
+    {
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: hairProfile,
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async (): Promise<ConversationState> =>
+        createDefaultConversationState(),
+      client: {
+        responses: {
+          create: async () => ({ output: [] }),
+        },
+      },
+      createProductIntakeRepository: () =>
+        ({
+          loadCatalog: async () => ({ products: [], identifiers: [] }),
+          loadBrandResolutionCatalog: async () => ({
+            brands: [{ id: "brand-pantene", canonical_name: "Pantene" }],
+            productLines: [
+              { id: "line-pro-v", brand_id: "brand-pantene", canonical_name: "Pro-V" },
+            ],
+            brandAliases: [
+              {
+                brand_id: "brand-pantene",
+                product_line_id: "line-pro-v",
+                alias: "Pantene Pro-V",
+              },
+            ],
+          }),
+        }) as never,
+      runAgentV2ResponsesTurn: async (params) => {
+        await params.tools.lookup_product_candidate({
+          category: "shampoo",
+          brand_text: "Pantene Pro-V",
+          product_name_text: "Volume Pur Shampoo",
+          reason: "User asks whether their own named product suits them.",
+          evidence_quote: "Pantene Pro-V Volume Pur Shampoo",
+        })
+        return agentResult
+      },
+    },
+  )
+
+  assert.deepEqual(result.productIntakeOffer, {
+    id: "product-intake-request-lookup",
+    source: "chat",
+    reason: "product_lookup_not_found",
+    category: "shampoo",
+    extracted_identity: {
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Volume Pur Shampoo",
+    },
+  })
+  assert.equal(
+    await readStream(result.stream),
+    agentResult.final_answer.payload.user_facing_answer_de,
+  )
+})
+
+test("AgentV2 production pipeline defaults product intake lookup off", async () => {
+  const hairProfile = createCompleteHairProfile()
+  const agentResult = createAgentV2Result()
+  let observedProductIntakeEnabled: boolean | undefined
+
+  const result = await runAgentV2ProductionPipeline(
+    {
+      message: "Ich nutze Pantene Pro-V Volume Pur Shampoo. Passt das zu mir?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-default-disabled-lookup",
+    },
+    {
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: hairProfile,
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async (): Promise<ConversationState> =>
+        createDefaultConversationState(),
+      client: {
+        responses: {
+          create: async () => ({ output: [] }),
+        },
+      },
+      runAgentV2ResponsesTurn: async (params) => {
+        observedProductIntakeEnabled = params.productIntakeEnabled
+        return agentResult
+      },
+    },
+  )
+
+  assert.equal(observedProductIntakeEnabled, false)
+  assert.equal(result.productIntakeOffer, null)
+})
+
+test("AgentV2 production pipeline disables product intake lookup when feature flag is off", async () => {
+  const hairProfile = createCompleteHairProfile()
+  const agentResult = createAgentV2Result()
+  let observedProductIntakeEnabled: boolean | undefined
+
+  const result = await runAgentV2ProductionPipeline(
+    {
+      message: "Ich nutze Pantene Pro-V Volume Pur Shampoo. Passt das zu mir?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-disabled-lookup",
+      productIntakeEnabled: false,
+    },
+    {
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: hairProfile,
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async (): Promise<ConversationState> =>
+        createDefaultConversationState(),
+      client: {
+        responses: {
+          create: async () => ({ output: [] }),
+        },
+      },
+      runAgentV2ResponsesTurn: async (params) => {
+        observedProductIntakeEnabled = params.productIntakeEnabled
+        return agentResult
+      },
+    },
+  )
+
+  assert.equal(observedProductIntakeEnabled, false)
+  assert.equal(result.productIntakeOffer, null)
+})
+
+test("AgentV2 production pipeline memoizes product lookup catalogs per turn", async () => {
+  const hairProfile = createCompleteHairProfile()
+  const agentResult = createAgentV2Result()
+  let loadCatalogCalls = 0
+  let loadBrandCatalogCalls = 0
+
+  await runAgentV2ProductionPipeline(
+    {
+      message: "Ich nutze Pantene Pro-V Volume Pur Shampoo. Passt das zu mir?",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-lookup-cache",
+      productIntakeEnabled: true,
+    },
+    {
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: hairProfile,
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async (): Promise<ConversationState> =>
+        createDefaultConversationState(),
+      client: {
+        responses: {
+          create: async () => ({ output: [] }),
+        },
+      },
+      createProductIntakeRepository: () =>
+        ({
+          loadCatalog: async () => {
+            loadCatalogCalls += 1
+            return { products: [], identifiers: [] }
+          },
+          loadBrandResolutionCatalog: async () => {
+            loadBrandCatalogCalls += 1
+            return {
+              brands: [{ id: "brand-pantene", canonical_name: "Pantene" }],
+              productLines: [],
+              brandAliases: [],
+            }
+          },
+        }) as never,
+      runAgentV2ResponsesTurn: async (params) => {
+        await params.tools.lookup_product_candidate({
+          category: "shampoo",
+          brand_text: "Pantene",
+          product_name_text: "Volume Pur Shampoo",
+          reason: "First check.",
+          evidence_quote: "Pantene Pro-V Volume Pur Shampoo",
+        })
+        await params.tools.lookup_product_candidate({
+          category: "shampoo",
+          brand_text: "Pantene",
+          product_name_text: "Volume Pur Shampoo",
+          reason: "Second check.",
+          evidence_quote: "Pantene Pro-V Volume Pur Shampoo",
+        })
+        return agentResult
+      },
+    },
+  )
+
+  assert.equal(loadCatalogCalls, 1)
+  assert.equal(loadBrandCatalogCalls, 1)
 })
 
 test("AgentV2 production pipeline exposes boundary answer mode without products", async () => {

--- a/tests/agent-v2-production-chat-pipeline.spec.ts
+++ b/tests/agent-v2-production-chat-pipeline.spec.ts
@@ -31,6 +31,18 @@ import { buildRetrievalDebugEventData } from "../src/lib/chat-runtime/debug-trac
 
 type SelectProductsToolParams = Parameters<ReturnType<typeof createSelectProductsTool>>[0]
 
+const verifyConversationOwnership = async ({
+  conversationId,
+  userId,
+}: {
+  conversationId: string
+  userId: string
+}) => {
+  assert.equal(typeof conversationId, "string")
+  assert.equal(typeof userId, "string")
+  return true
+}
+
 function createProduct(id: string): Product & { similarity: number } {
   return {
     id,
@@ -708,6 +720,57 @@ test("AgentV2 persisted state recovers from malformed persisted state", () => {
   assert.equal(state.agent_v2.routine_thread_context, null)
 })
 
+test("AgentV2 production pipeline rejects mismatched user and conversation before loading history or state", async () => {
+  let historyLoaded = false
+  let stateLoaded = false
+
+  await assert.rejects(
+    () =>
+      runAgentV2ProductionPipeline(
+        {
+          message: "Hallo",
+          conversationId: "conversation-owned-by-user-2",
+          userId: "user-1",
+          requestId: "request-ownership",
+        },
+        {
+          verifyConversationOwnership: async ({ conversationId, userId }) => {
+            assert.equal(conversationId, "conversation-owned-by-user-2")
+            assert.equal(userId, "user-1")
+            return false
+          },
+          loadConversationHistory: async () => {
+            historyLoaded = true
+            return []
+          },
+          getUserContext: async () => ({
+            profile: createCompleteHairProfile(),
+            routine_inventory: [],
+            relevant_memory: [],
+            derived_signals: [],
+            suggested_overlays: [],
+            missing_profile: [],
+          }),
+          loadUserMemoryContext: async () => ({
+            enabled: true,
+            entries: [],
+            promptContext: null,
+            dislikedProductNames: [],
+          }),
+          loadConversationState: async () => {
+            stateLoaded = true
+            return createDefaultConversationState()
+          },
+          runAgentV2ResponsesTurn: async () => createAgentV2Result(),
+        },
+      ),
+    /does not belong to user/i,
+  )
+
+  assert.equal(historyLoaded, false)
+  assert.equal(stateLoaded, false)
+})
+
 test("AgentV2 production pipeline returns cards, trace, and CareBalance context", async () => {
   const primaryProduct = createProduct("primary")
   const fallbackProduct = createProduct("fallback")
@@ -756,6 +819,7 @@ test("AgentV2 production pipeline returns cards, trace, and CareBalance context"
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () =>
         [
           {
@@ -871,6 +935,137 @@ test("AgentV2 production pipeline returns cards, trace, and CareBalance context"
   assert.equal(failedDebugEvent.visible_failure, true)
 })
 
+test("AgentV2 production pipeline keeps parallel select_products results isolated", async () => {
+  const hairProfile = createCompleteHairProfile()
+  const shampooProduct = createProduct("shampoo-product")
+  const conditionerProduct = createProduct("conditioner-product")
+  const shampooSelection: SelectProductsToolResult = {
+    projection: {
+      category: "shampoo",
+      decision: "recommended",
+      product_response_policy: "recommend",
+      policy_reason: "Explicit shampoo comparison.",
+      profile_basis: [],
+      category_guidance: "Shampoo passt als konkrete Produktempfehlung.",
+      products: [
+        {
+          rank: 1,
+          product_id: shampooProduct.id,
+          name: shampooProduct.name,
+          brand: shampooProduct.brand,
+          price_eur: shampooProduct.price_eur,
+          currency: shampooProduct.currency,
+          fit_reason: "Passt als Shampoo.",
+          caveat: null,
+          supported_claims: [],
+          unsupported_requested_signals: [],
+        },
+      ],
+      comparison_facts: null,
+      missing_info: [],
+      unsupported_requested_signals: [],
+    },
+    products: [shampooProduct],
+    effectiveHairProfile: hairProfile,
+    runtime: buildRecommendationEngineRuntimeForChat({
+      hairProfile,
+      routineItems: [],
+      productCategory: "shampoo",
+      message: "Vergleiche Shampoo und Conditioner.",
+    }),
+  }
+  const conditionerSelection: SelectProductsToolResult = {
+    projection: {
+      category: "conditioner",
+      decision: "recommended",
+      product_response_policy: "recommend",
+      policy_reason: "Explicit conditioner comparison.",
+      profile_basis: [],
+      category_guidance: "Conditioner passt als konkrete Produktempfehlung.",
+      products: [
+        {
+          rank: 1,
+          product_id: conditionerProduct.id,
+          name: conditionerProduct.name,
+          brand: conditionerProduct.brand,
+          price_eur: conditionerProduct.price_eur,
+          currency: conditionerProduct.currency,
+          fit_reason: "Passt als Conditioner.",
+          caveat: null,
+          supported_claims: [],
+          unsupported_requested_signals: [],
+        },
+      ],
+      comparison_facts: null,
+      missing_info: [],
+      unsupported_requested_signals: [],
+    },
+    products: [conditionerProduct],
+    effectiveHairProfile: hairProfile,
+    runtime: buildRecommendationEngineRuntimeForChat({
+      hairProfile,
+      routineItems: [],
+      productCategory: "conditioner",
+      message: "Vergleiche Shampoo und Conditioner.",
+    }),
+  }
+  const resolvers = new Map<string, (value: SelectProductsToolResult) => void>()
+
+  await runAgentV2ProductionPipeline(
+    {
+      message: "Vergleiche Shampoo und Conditioner.",
+      conversationId: "conversation-1",
+      userId: "user-1",
+      requestId: "request-parallel-select-products",
+    },
+    {
+      verifyConversationOwnership,
+      loadConversationHistory: async () => [],
+      getUserContext: async () => ({
+        profile: hairProfile,
+        routine_inventory: [],
+        relevant_memory: [],
+        derived_signals: [],
+        suggested_overlays: [],
+        missing_profile: [],
+      }),
+      loadUserMemoryContext: async () => ({
+        enabled: true,
+        entries: [],
+        promptContext: null,
+        dislikedProductNames: [],
+      }),
+      loadConversationState: async (): Promise<ConversationState> =>
+        createDefaultConversationState(),
+      createSelectProductsTool:
+        (options = {}) =>
+        async (input: SelectProductsToolParams) =>
+          new Promise((resolve) => {
+            resolvers.set(input.category, (result) => {
+              options.onResult?.(result)
+              resolve(result.projection)
+            })
+          }),
+      runAgentV2ResponsesTurn: async (params) => {
+        const shampooPromise = params.tools.select_products({ category: "shampoo" })
+        const conditionerPromise = params.tools.select_products({ category: "conditioner" })
+
+        resolvers.get("conditioner")?.(conditionerSelection)
+        resolvers.get("shampoo")?.(shampooSelection)
+
+        const [shampooProjection, conditionerProjection] = (await Promise.all([
+          shampooPromise,
+          conditionerPromise,
+        ])) as [AgentV2SelectProductsProjection, AgentV2SelectProductsProjection]
+
+        assert.equal(shampooProjection.category, "shampoo")
+        assert.equal(conditionerProjection.category, "conditioner")
+        return createAgentV2Result()
+      },
+    },
+  )
+})
+
 test("AgentV2 production pipeline surfaces product intake offer from lookup result", async () => {
   const hairProfile = createCompleteHairProfile()
   const agentResult = createAgentV2Result()
@@ -914,6 +1109,7 @@ test("AgentV2 production pipeline surfaces product intake offer from lookup resu
       productIntakeEnabled: true,
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: hairProfile,
@@ -995,6 +1191,7 @@ test("AgentV2 production pipeline defaults product intake lookup off", async () 
       requestId: "request-default-disabled-lookup",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: hairProfile,
@@ -1042,6 +1239,7 @@ test("AgentV2 production pipeline disables product intake lookup when feature fl
       productIntakeEnabled: false,
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: hairProfile,
@@ -1090,6 +1288,7 @@ test("AgentV2 production pipeline memoizes product lookup catalogs per turn", as
       productIntakeEnabled: true,
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: hairProfile,
@@ -1236,6 +1435,7 @@ test("AgentV2 production pipeline exposes boundary answer mode without products"
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: hairProfile,
@@ -1561,6 +1761,7 @@ test("AgentV2 production pipeline uses observed OpenAI and managed prompt refs b
         requestId: "request-1",
       },
       {
+        verifyConversationOwnership,
         loadConversationHistory: async () => [],
         getUserContext: async () => ({
           profile: createCompleteHairProfile(),
@@ -1641,6 +1842,7 @@ test("AgentV2 production pipeline can disable observed OpenAI via rollback flag"
         requestId: "request-1",
       },
       {
+        verifyConversationOwnership,
         loadConversationHistory: async () => [],
         getUserContext: async () => ({
           profile: createCompleteHairProfile(),
@@ -1745,6 +1947,7 @@ test("AgentV2 production pipeline treats any runtime failure stage as visible fa
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: hairProfile,
@@ -1899,6 +2102,7 @@ test("AgentV2 production pipeline carries persisted routine thread context into 
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: createCompleteHairProfile(),
@@ -1972,6 +2176,7 @@ test("AgentV2 production pipeline carries persisted surfaced product facts into 
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: createCompleteHairProfile(),
@@ -2036,6 +2241,7 @@ test("AgentV2 production pipeline carries session memory through conversation st
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: createCompleteHairProfile(),
@@ -2088,6 +2294,7 @@ test("AgentV2 production pipeline ignores legacy V1 routine fields without flat 
       requestId: "request-1",
     },
     {
+      verifyConversationOwnership,
       loadConversationHistory: async () => [],
       getUserContext: async () => ({
         profile: createCompleteHairProfile(),

--- a/tests/agent-v2-responses-runtime.spec.ts
+++ b/tests/agent-v2-responses-runtime.spec.ts
@@ -28,6 +28,63 @@ test("AgentV2 exposes only the V0 advisor toolset", () => {
   }
 })
 
+test("AgentV2 exposes product intake lookup only when explicitly enabled", () => {
+  const tools = buildAgentV2ResponsesTools({
+    safetyMode: "normal",
+    productIntakeEnabled: true,
+  })
+  const names = tools.map((tool) => tool.name).sort()
+
+  assert.deepEqual(names, [
+    "build_or_fix_routine",
+    "load_advisor_guidance",
+    "lookup_product_candidate",
+    "select_products",
+    "set_current_care_context",
+    "submit_final_answer",
+  ])
+})
+
+test("AgentV2 omits product intake lookup tool when product intake is disabled", () => {
+  const tools = buildAgentV2ResponsesTools({
+    safetyMode: "normal",
+    productIntakeEnabled: false,
+  })
+  const names = tools.map((tool) => tool.name).sort()
+
+  assert.deepEqual(names, [
+    "build_or_fix_routine",
+    "load_advisor_guidance",
+    "select_products",
+    "set_current_care_context",
+    "submit_final_answer",
+  ])
+})
+
+test("AgentV2 disabled product intake guidance does not promise an intake card", async () => {
+  const client = fakeResponsesClientWithOutputs([terminalGeneralAdvice("call_1")])
+
+  await runAgentV2ResponsesTurn({
+    client,
+    message: "Kannst du den Moisture Mist Conditioner von Urban Alchemy bewerten?",
+    recentMessages: [],
+    userContext: { hairProfile: null, routineInventory: [], sessionMemory: [] },
+    productIntakeEnabled: false,
+    tools: fakeAgentV2Tools(),
+  })
+
+  const firstInput = getInputItems(client.requests[0])
+  const namedProductContextItem = firstInput
+    .map(asRecord)
+    .find((item) =>
+      String(item?.content ?? "").includes("Current user named a plausible exact product"),
+    )
+  const content = String(namedProductContextItem?.content ?? "")
+  assert.doesNotMatch(content, /lookup_product_candidate/)
+  assert.doesNotMatch(content, /intake card/i)
+  assert.match(content, /without offering product intake/)
+})
+
 test("AgentV2 restricted safety toolset omits product selection", () => {
   const names = buildAgentV2ResponsesTools({ safetyMode: "restricted" })
     .map((tool) => tool.name)
@@ -92,7 +149,10 @@ test("AgentV2 product and guidance tool descriptions route bond repair brands to
 })
 
 test("AgentV2 strict tool schemas avoid open records and root unions", () => {
-  const tools = buildAgentV2ResponsesTools({ safetyMode: "normal" })
+  const tools = buildAgentV2ResponsesTools({
+    safetyMode: "normal",
+    productIntakeEnabled: true,
+  })
 
   for (const tool of tools) {
     const serialized = JSON.stringify(tool.parameters)
@@ -120,6 +180,13 @@ test("AgentV2 strict tool schemas avoid open records and root unions", () => {
     "product_request_kind",
     "requested_product_count",
     "count_policy",
+    "evidence_quote",
+  ])
+  assertRequiredToolFields(tools, "lookup_product_candidate", [
+    "category",
+    "brand_text",
+    "product_name_text",
+    "reason",
     "evidence_quote",
   ])
   assertRequiredToolFields(tools, "build_or_fix_routine", [
@@ -1380,6 +1447,7 @@ function fakeAgentV2Tools() {
       markdown_brief: "Guidance.",
     }),
     select_products: async () => ({ valid_product_ids: [] }),
+    lookup_product_candidate: async () => ({ status: "insufficient_identity" }),
     build_or_fix_routine: async () => ({ visible_steps: [] }),
   }
 }
@@ -1453,6 +1521,51 @@ test("AgentV2 runtime executes tool call then terminal answer", async () => {
         asRecord(item)?.type === "function_call_output" && asRecord(item)?.call_id === "call_1",
     ),
   )
+})
+
+test("AgentV2 runtime executes product candidate lookup tool", async () => {
+  const client = fakeResponsesClientWithOutputs([
+    functionCall("call_1", "lookup_product_candidate", {
+      category: "shampoo",
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Volume Pur Shampoo",
+      reason: "The user asks whether their own named product suits them.",
+      evidence_quote: "Pantene Pro-V Volume Pur Shampoo",
+    }),
+    terminalGeneralAdvice("call_2"),
+  ])
+  const toolInputs: Record<string, unknown>[] = []
+  const result = await runAgentV2ResponsesTurn({
+    client,
+    message: "Ich nutze Pantene Pro-V Volume Pur Shampoo. Passt das zu mir?",
+    recentMessages: [],
+    userContext: { hairProfile: null, routineInventory: [], sessionMemory: [] },
+    productIntakeEnabled: true,
+    tools: {
+      ...fakeAgentV2Tools(),
+      lookup_product_candidate: async (input) => {
+        toolInputs.push(input)
+        return {
+          status: "not_found",
+          category: "shampoo",
+          intake_offer: {
+            id: "offer-1",
+            source: "chat",
+            reason: "product_lookup_not_found",
+            category: "shampoo",
+            extracted_identity: {
+              brand_text: "Pantene Pro-V",
+              product_name_text: "Volume Pur Shampoo",
+            },
+          },
+        }
+      },
+    },
+  })
+
+  assert.equal(toolInputs.length, 1)
+  assert.equal(toolInputs[0]?.category, "shampoo")
+  assert.ok(result.trace.tool_calls.some((call) => call.name === "lookup_product_candidate"))
 })
 
 test("AgentV2 turn gate must run before advisor tools when enabled", async () => {
@@ -1690,6 +1803,7 @@ test("AgentV2 runtime injects named product context for plausible off-catalog pr
     message: "Kannst du den Moisture Mist Conditioner von Urban Alchemy bewerten?",
     recentMessages: [],
     userContext: { hairProfile: null, routineInventory: [], sessionMemory: [] },
+    productIntakeEnabled: true,
     tools: fakeAgentV2Tools(),
   })
 
@@ -1703,6 +1817,8 @@ test("AgentV2 runtime injects named product context for plausible off-catalog pr
   assert.match(content, /Urban Alchemy Moisture Mist Conditioner/)
   assert.match(content, /conditioner/)
   assert.match(content, /not catalog-verified/)
+  assert.match(content, /lookup_product_candidate/)
+  assert.match(content, /not_found/)
   assert.match(content, /constraint_blocked/)
   assert.deepEqual(result.trace.named_product_context, {
     display_name: "Urban Alchemy Moisture Mist Conditioner",
@@ -5276,6 +5392,9 @@ test("AgentV2 hard short circuit bypasses model and product tools", async () => 
       },
       select_products: async () => {
         throw new Error("products should not be called")
+      },
+      lookup_product_candidate: async () => {
+        throw new Error("lookup should not be called")
       },
       build_or_fix_routine: async () => {
         throw new Error("routine should not be called")

--- a/tests/product-intake-cleanup-photos.test.ts
+++ b/tests/product-intake-cleanup-photos.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import { cleanupExpiredSubmissionPhotos } from "../scripts/product-intake/cleanup-photos"
+import {
+  cleanupAbandonedTmpUploads,
+  cleanupExpiredSubmissionPhotos,
+  loadReferencedSubmissionImagePaths,
+} from "../scripts/product-intake/cleanup-photos"
 
 type PhotoRow = {
   id: string
@@ -9,10 +13,20 @@ type PhotoRow = {
   barcode_image_path: string | null
 }
 
-function createCleanupSupabaseFake(rows: PhotoRow[]) {
+type ReferencedPhotoRow = {
+  front_image_path: string | null
+  barcode_image_path: string | null
+}
+
+function createCleanupSupabaseFake(
+  input: PhotoRow[] | { expiredRows?: PhotoRow[]; referencedRows?: ReferencedPhotoRow[] },
+) {
+  const expiredRows = Array.isArray(input) ? input : (input.expiredRows ?? [])
+  const referencedRows = Array.isArray(input) ? [] : (input.referencedRows ?? [])
   const calls: string[] = []
   const removedPaths: string[] = []
   let nextRange: { from: number; to: number } | null = null
+  let selectedColumns = ""
 
   return {
     calls,
@@ -31,7 +45,9 @@ function createCleanupSupabaseFake(rows: PhotoRow[]) {
     from(table: string) {
       calls.push(`from:${table}`)
       return {
-        select() {
+        select(columns: string) {
+          selectedColumns = columns
+          calls.push(`select:${columns}`)
           return this
         },
         in() {
@@ -40,7 +56,8 @@ function createCleanupSupabaseFake(rows: PhotoRow[]) {
         lte() {
           return this
         },
-        is() {
+        is(column: string, value: unknown) {
+          calls.push(`is:${column}:${String(value)}`)
           return this
         },
         range(from: number, to: number) {
@@ -53,7 +70,13 @@ function createCleanupSupabaseFake(rows: PhotoRow[]) {
           calls.push(`limit:${count}`)
           return this
         },
-        async then(resolve: (value: { data: PhotoRow[]; error: null }) => unknown) {
+        async then(
+          resolve: (value: { data: Array<PhotoRow | ReferencedPhotoRow>; error: null }) => unknown,
+        ) {
+          const rows =
+            selectedColumns === "front_image_path, barcode_image_path"
+              ? referencedRows
+              : expiredRows
           const range = nextRange ?? { from: 0, to: rows.length - 1 }
           nextRange = null
           return resolve({ data: rows.slice(range.from, range.to + 1), error: null })
@@ -67,6 +90,43 @@ function createCleanupSupabaseFake(rows: PhotoRow[]) {
           }
         },
       }
+    },
+  }
+}
+
+function createTmpCleanupSupabaseFake() {
+  const calls: string[] = []
+  const removedPaths: string[] = []
+
+  return {
+    calls,
+    removedPaths,
+    storage: {
+      from(bucket: string) {
+        return {
+          async list(path: string, options: { limit: number; offset: number }) {
+            calls.push(`list:${bucket}:${path}:${options.offset}`)
+            if (path === "tmp") {
+              return { data: [{ name: "user-1" }], error: null }
+            }
+            if (path === "tmp/user-1") {
+              return {
+                data: [
+                  { name: "referenced-front.jpg", updated_at: "2026-06-14T00:00:00.000Z" },
+                  { name: "orphan-front.jpg", updated_at: "2026-06-14T00:00:00.000Z" },
+                ],
+                error: null,
+              }
+            }
+            return { data: [], error: null }
+          },
+          async remove(paths: string[]) {
+            calls.push(`remove:${bucket}:${paths.join(",")}`)
+            removedPaths.push(...paths)
+            return { error: null }
+          },
+        }
+      },
     },
   }
 }
@@ -90,5 +150,48 @@ test("expired submission photo cleanup dry-run paginates instead of rereading fi
   assert.equal(
     supabase.calls.some((call) => call.startsWith("update:")),
     false,
+  )
+})
+
+test("abandoned tmp cleanup keeps stale tmp images referenced by active submissions", async () => {
+  const pendingReferencedTmp = "tmp/user-1/referenced-front.jpg"
+  const orphanTmp = "tmp/user-1/orphan-front.jpg"
+  const supabase = createTmpCleanupSupabaseFake()
+  const cutoff = new Date("2026-06-15T00:00:00.000Z")
+
+  const result = await cleanupAbandonedTmpUploads(
+    supabase as never,
+    true,
+    cutoff,
+    new Set([pendingReferencedTmp]),
+  )
+
+  assert.deepEqual(supabase.removedPaths, [orphanTmp])
+  assert.deepEqual(result, { objects: 1 })
+})
+
+test("referenced submission image path loader collects both image columns", async () => {
+  const supabase = createCleanupSupabaseFake({
+    referencedRows: [
+      { front_image_path: "tmp/user-1/front.jpg", barcode_image_path: null },
+      { front_image_path: null, barcode_image_path: "tmp/user-1/barcode.jpg" },
+      { front_image_path: "tmp/user-1/front.jpg", barcode_image_path: null },
+    ],
+  })
+
+  const paths = await loadReferencedSubmissionImagePaths(supabase as never)
+
+  assert.deepEqual([...paths].sort(), ["tmp/user-1/barcode.jpg", "tmp/user-1/front.jpg"])
+  assert.deepEqual(
+    supabase.calls.filter((call) => call.startsWith("select:")),
+    ["select:front_image_path, barcode_image_path"],
+  )
+  assert.deepEqual(
+    supabase.calls.filter((call) => call.startsWith("is:")),
+    ["is:photos_deleted_at:null"],
+  )
+  assert.deepEqual(
+    supabase.calls.filter((call) => call.startsWith("range:")),
+    ["range:0:99"],
   )
 })

--- a/tests/product-intake-cleanup-photos.test.ts
+++ b/tests/product-intake-cleanup-photos.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { cleanupExpiredSubmissionPhotos } from "../scripts/product-intake/cleanup-photos"
+
+type PhotoRow = {
+  id: string
+  front_image_path: string | null
+  barcode_image_path: string | null
+}
+
+function createCleanupSupabaseFake(rows: PhotoRow[]) {
+  const calls: string[] = []
+  const removedPaths: string[] = []
+  let nextRange: { from: number; to: number } | null = null
+
+  return {
+    calls,
+    removedPaths,
+    storage: {
+      from(bucket: string) {
+        return {
+          async remove(paths: string[]) {
+            calls.push(`remove:${bucket}:${paths.join(",")}`)
+            removedPaths.push(...paths)
+            return { error: null }
+          },
+        }
+      },
+    },
+    from(table: string) {
+      calls.push(`from:${table}`)
+      return {
+        select() {
+          return this
+        },
+        in() {
+          return this
+        },
+        lte() {
+          return this
+        },
+        is() {
+          return this
+        },
+        range(from: number, to: number) {
+          nextRange = { from, to }
+          calls.push(`range:${from}:${to}`)
+          return this
+        },
+        limit(count: number) {
+          nextRange = { from: 0, to: count - 1 }
+          calls.push(`limit:${count}`)
+          return this
+        },
+        async then(resolve: (value: { data: PhotoRow[]; error: null }) => unknown) {
+          const range = nextRange ?? { from: 0, to: rows.length - 1 }
+          nextRange = null
+          return resolve({ data: rows.slice(range.from, range.to + 1), error: null })
+        },
+        update() {
+          return {
+            eq(idColumn: string, id: string) {
+              calls.push(`update:${idColumn}:${id}`)
+              return Promise.resolve({ error: null })
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+test("expired submission photo cleanup dry-run paginates instead of rereading first full page", async () => {
+  const rows = Array.from({ length: 101 }, (_, index) => ({
+    id: `submission-${index}`,
+    front_image_path: `user/submission-${index}/front.jpg`,
+    barcode_image_path: null,
+  }))
+  const supabase = createCleanupSupabaseFake(rows)
+
+  const result = await cleanupExpiredSubmissionPhotos(supabase as never, false)
+
+  assert.deepEqual(result, { rows: 101, objects: 101 })
+  assert.deepEqual(
+    supabase.calls.filter((call) => call.startsWith("range:")),
+    ["range:0:99", "range:100:199"],
+  )
+  assert.deepEqual(supabase.removedPaths, [])
+  assert.equal(
+    supabase.calls.some((call) => call.startsWith("update:")),
+    false,
+  )
+})

--- a/tests/product-intake-client-image-compression.test.ts
+++ b/tests/product-intake-client-image-compression.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE,
+  PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES,
+  ProductIntakeClientImageCompressionError,
+  getProductIntakeClientScaledImageDimensions,
+  prepareProductIntakeImageForUpload,
+  shouldPrepareProductIntakeImageForUpload,
+} from "../src/lib/product-intake/client-image-compression"
+
+test("product intake client image preparation keeps small files untouched without browser APIs", async () => {
+  const file = new File([new Uint8Array([1, 2, 3])], "front.jpg", { type: "image/jpeg" })
+
+  const prepared = await prepareProductIntakeImageForUpload(file)
+
+  assert.equal(prepared, file)
+})
+
+test("product intake client image preparation rejects oversized files without browser APIs", async () => {
+  const file = new File([new Uint8Array(PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES + 1)], "front.jpg", {
+    type: "image/jpeg",
+  })
+
+  await assert.rejects(
+    () => prepareProductIntakeImageForUpload(file),
+    ProductIntakeClientImageCompressionError,
+  )
+})
+
+test("product intake client image preparation keeps HEIC files untouched without browser decode", async () => {
+  const file = new File(
+    [new Uint8Array(PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES + 1)],
+    "front.heic",
+    { type: "image/heic" },
+  )
+
+  const prepared = await prepareProductIntakeImageForUpload(file)
+
+  assert.equal(prepared, file)
+})
+
+test("product intake client image preparation decides from size or dimensions", () => {
+  assert.equal(
+    shouldPrepareProductIntakeImageForUpload({
+      fileSizeBytes: PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES - 1,
+      width: PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE,
+      height: PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE,
+    }),
+    false,
+  )
+  assert.equal(
+    shouldPrepareProductIntakeImageForUpload({
+      fileSizeBytes: PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES + 1,
+      width: 800,
+      height: 800,
+    }),
+    true,
+  )
+  assert.equal(
+    shouldPrepareProductIntakeImageForUpload({
+      fileSizeBytes: PRODUCT_INTAKE_CLIENT_MAX_UPLOAD_BYTES - 1,
+      width: PRODUCT_INTAKE_CLIENT_MAX_IMAGE_EDGE + 1,
+      height: 800,
+    }),
+    true,
+  )
+})
+
+test("product intake client image scaling preserves aspect ratio", () => {
+  assert.deepEqual(getProductIntakeClientScaledImageDimensions(1200, 800), {
+    width: 1200,
+    height: 800,
+  })
+  assert.deepEqual(getProductIntakeClientScaledImageDimensions(3600, 2400), {
+    width: 1800,
+    height: 1200,
+  })
+  assert.deepEqual(getProductIntakeClientScaledImageDimensions(2400, 3600), {
+    width: 1200,
+    height: 1800,
+  })
+})

--- a/tests/product-intake-client.test.ts
+++ b/tests/product-intake-client.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildProductIntakeSubmissionPayload,
+  canSubmitProductIntake,
+} from "../src/lib/product-intake/client"
+
+test("photo intake can submit with a committed front image only for an existing usage edit", () => {
+  const committedFrontImagePath = "user-1/submission-1/front-front.jpg"
+  const existingUsageId = "00000000-0000-4000-8000-000000000001"
+
+  assert.equal(
+    canSubmitProductIntake({
+      method: "photo",
+      category: "mask",
+      frequency: "weekly_1x",
+      brandText: "",
+      productName: "",
+      frontImagePath: null,
+      committedFrontImagePath,
+    }),
+    false,
+  )
+
+  assert.equal(
+    canSubmitProductIntake({
+      method: "photo",
+      category: "mask",
+      frequency: "weekly_1x",
+      brandText: "",
+      productName: "",
+      frontImagePath: null,
+      committedFrontImagePath,
+      existingUsageId,
+    }),
+    true,
+  )
+
+  const payload = buildProductIntakeSubmissionPayload({
+    method: "photo",
+    category: "mask",
+    frequency: "weekly_1x",
+    brandText: "",
+    productName: "",
+    frontImagePath: null,
+    committedFrontImagePath,
+    existingUsageId,
+  })
+
+  assert.equal(payload.front_image_path, undefined)
+  assert.equal(payload.existing_usage_id, existingUsageId)
+})

--- a/tests/product-intake-lookup.test.ts
+++ b/tests/product-intake-lookup.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  lookupProductCandidate,
+  type ProductLookupCatalog,
+} from "../src/lib/product-intake/product-lookup"
+import type { BrandResolutionCatalogInput } from "../src/lib/product-identity/brand-resolution"
+
+const catalog: ProductLookupCatalog = {
+  products: [
+    {
+      id: "garnier-mask",
+      name: "Hair Food Aloe Maske",
+      brandId: "brand-garnier",
+      productLineId: "line-fructis",
+      categoryKey: "mask",
+      isActive: true,
+      isChaarlieRecommended: false,
+    },
+    {
+      id: "garnier-conditioner",
+      name: "Hair Food Aloe Conditioner",
+      brandId: "brand-garnier",
+      productLineId: "line-fructis",
+      categoryKey: "conditioner",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+    {
+      id: "pantene-shampoo-a",
+      name: "Repair & Care Shampoo",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      categoryKey: "shampoo",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+    {
+      id: "pantene-shampoo-b",
+      name: "Repair Care Shampoo",
+      brandId: "brand-pantene",
+      productLineId: "line-pro-v",
+      categoryKey: "shampoo",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+  ],
+  identifiers: [],
+}
+
+const brandCatalog: BrandResolutionCatalogInput = {
+  brands: [
+    { id: "brand-garnier", canonical_name: "Garnier" },
+    { id: "brand-pantene", canonical_name: "Pantene" },
+  ],
+  productLines: [
+    { id: "line-fructis", brand_id: "brand-garnier", canonical_name: "Fructis" },
+    { id: "line-pro-v", brand_id: "brand-pantene", canonical_name: "Pro-V" },
+  ],
+  brandAliases: [
+    {
+      brand_id: "brand-garnier",
+      product_line_id: "line-fructis",
+      alias: "Garnier Fructis",
+    },
+    {
+      brand_id: "brand-pantene",
+      product_line_id: "line-pro-v",
+      alias: "Pantene Pro-V",
+    },
+  ],
+}
+
+test("lookup returns exact catalog hit even when product is not Chaarlie recommended", () => {
+  const result = lookupProductCandidate({
+    input: {
+      category: "mask",
+      brand_text: "Garnier Fructis",
+      product_name_text: "Hair Food Aloe Maske",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(result.status, "found_exact")
+  assert.equal(result.product?.id, "garnier-mask")
+  assert.equal(result.product?.is_chaarlie_recommended, false)
+  assert.equal(result.intake_offer, null)
+})
+
+test("lookup needs category before it can make a conclusive product decision", () => {
+  const result = lookupProductCandidate({
+    input: {
+      brand_text: "Garnier Fructis",
+      product_name_text: "Hair Food Aloe Maske",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(result.status, "insufficient_identity")
+  assert.deepEqual(result.missing_fields, ["category"])
+  assert.equal(result.intake_offer, null)
+})
+
+test("lookup rejects unsupported categories without offering intake", () => {
+  const result = lookupProductCandidate({
+    input: {
+      category: "peeling",
+      brand_text: "Some Brand",
+      product_name_text: "Scalp Peeling",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(result.status, "unsupported_category")
+  assert.equal(result.category, "peeling")
+  assert.equal(result.intake_offer, null)
+})
+
+test("lookup returns ambiguous when matching evidence points to multiple products", () => {
+  const result = lookupProductCandidate({
+    input: {
+      category: "shampoo",
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Repair Care",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(result.status, "ambiguous")
+  assert.deepEqual(
+    result.candidates.map((candidate) => candidate.product.id),
+    ["pantene-shampoo-a", "pantene-shampoo-b"],
+  )
+  assert.equal(result.intake_offer, null)
+})
+
+test("lookup offers product intake only for a precise supported product not found in catalog", () => {
+  const result = lookupProductCandidate({
+    input: {
+      category: "shampoo",
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Volume Pur Shampoo",
+    },
+    catalog,
+    brandCatalog,
+    offerId: "offer-1",
+  })
+
+  assert.equal(result.status, "not_found")
+  assert.deepEqual(result.intake_offer, {
+    id: "offer-1",
+    source: "chat",
+    reason: "product_lookup_not_found",
+    category: "shampoo",
+    extracted_identity: {
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Volume Pur Shampoo",
+    },
+  })
+})
+
+test("lookup asks for more identity before offering intake for generic brand category mentions", () => {
+  const pantene = lookupProductCandidate({
+    input: {
+      category: "shampoo",
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Shampoo",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(pantene.status, "insufficient_identity")
+  assert.deepEqual(pantene.missing_fields, ["productNameText"])
+  assert.equal(pantene.intake_offer, null)
+
+  const garnier = lookupProductCandidate({
+    input: {
+      category: "mask",
+      brand_text: "Garnier",
+      product_name_text: "Maske",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(garnier.status, "insufficient_identity")
+  assert.deepEqual(garnier.missing_fields, ["productNameText"])
+  assert.equal(garnier.intake_offer, null)
+
+  const redundantBrand = lookupProductCandidate({
+    input: {
+      category: "shampoo",
+      brand_text: "Pantene Pro-V",
+      product_name_text: "Pantene Pro-V Shampoo",
+    },
+    catalog,
+    brandCatalog,
+  })
+
+  assert.equal(redundantBrand.status, "insufficient_identity")
+  assert.deepEqual(redundantBrand.missing_fields, ["productNameText"])
+  assert.equal(redundantBrand.intake_offer, null)
+})

--- a/tests/product-intake-schema.test.ts
+++ b/tests/product-intake-schema.test.ts
@@ -4,13 +4,14 @@ import { join } from "node:path"
 import test from "node:test"
 
 const migrationsDir = join(process.cwd(), "supabase", "migrations")
-const migrationFile = readdirSync(migrationsDir).find((file) =>
-  file.endsWith("_product_intake_submissions.sql"),
-)
+const migrationFiles = readdirSync(migrationsDir).filter((file) => file.includes("product_intake"))
 
-assert.ok(migrationFile, "product intake submissions migration is missing")
+assert.ok(migrationFiles.length > 0, "product intake migrations are missing")
 
-const migrationSql = readFileSync(join(migrationsDir, migrationFile), "utf8")
+const migrationSql = migrationFiles
+  .sort()
+  .map((file) => readFileSync(join(migrationsDir, file), "utf8"))
+  .join("\n")
 const normalizedSql = migrationSql.replace(/\s+/g, " ").toLowerCase()
 
 function assertIncludes(fragment: string) {
@@ -198,6 +199,24 @@ test("product intake migration enforces ownership and current pending-link integ
   assertIncludes("coalesce(current_setting('request.jwt.claims', true), '') = ''")
   assertIncludes("profiles.is_admin = true")
   assertIncludes("create or replace function public.validate_product_submission_status_link()")
+  assertIncludes("create or replace function public.product_intake_cancel_usage_for_category")
+  assertIncludes("delete from public.user_product_usage")
+  assertIncludes("status = 'cancelled_by_user'")
+  assertIncludes("cleanup_after = coalesce(cleanup_after, p_updated_at + interval '30 days')")
+  assertIncludes(
+    "create or replace function public.product_intake_replace_usage_with_matched_product",
+  )
+  assertIncludes("product_submission_id = null")
+  assertIncludes("match_status = 'matched'")
+  assertIncludes(
+    "create or replace function public.product_intake_replace_usage_with_pending_submission",
+  )
+  assertIncludes("product_submission_id = p_submission_id")
+  assertIncludes("match_status = 'pending_review'")
+  assertIncludes("jsonb_build_object")
+  assertIncludes(
+    "grant execute on function public.product_intake_replace_usage_with_pending_submission",
+  )
   assertIncludes("successful product submissions require approved_product_id")
   assertIncludes("from public.products")
   assertIncludes("category_key = new.category")

--- a/tests/product-intake-submissions.test.ts
+++ b/tests/product-intake-submissions.test.ts
@@ -1,0 +1,1320 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { isProductIntakeEnabled } from "../src/lib/product-intake/config"
+import { ProductIntakePersistenceError } from "../src/lib/product-intake/errors"
+import { validateProductIntakeImageFile } from "../src/lib/product-intake/image-validation"
+import { isMissingProductIntakeUploadError } from "../src/lib/product-intake/repository"
+import { createProductIntakePostHandler } from "../src/lib/product-intake/route-handlers"
+import {
+  chatProductIntakeSubmissionSchema,
+  onboardingProductIntakeSubmissionSchema,
+} from "../src/lib/product-intake/schemas"
+import {
+  cancelProductIntakeUsage,
+  ProductIntakeConflictError,
+  ProductIntakeOwnershipError,
+  submitProductIntake,
+  type ProductIntakeRepository,
+  type ProductIntakeSubmissionRow,
+  type ProductIntakeUsageRow,
+} from "../src/lib/product-intake/submissions"
+import type { ProductIntakeCatalog } from "../src/lib/product-intake/product-matching"
+import type { BrandResolutionCatalogInput } from "../src/lib/product-identity/brand-resolution"
+import type { ProductFrequency, ProductIntakeCategoryKey } from "../src/lib/types"
+
+const USER_ID = "11111111-1111-4111-8111-111111111111"
+const CONVERSATION_ID = "22222222-2222-4222-8222-222222222222"
+const OTHER_CONVERSATION_ID = "33333333-3333-4333-8333-333333333333"
+const EXISTING_USAGE_ID = "44444444-4444-4444-8444-444444444444"
+const OTHER_USAGE_ID = "55555555-5555-4555-8555-555555555555"
+
+const catalog: ProductIntakeCatalog = {
+  products: [
+    {
+      id: "product-garnier-mask",
+      name: "Hair Food Aloe Maske",
+      brandId: "brand-garnier",
+      productLineId: "line-fructis",
+      categoryKey: "mask",
+      isActive: true,
+      isChaarlieRecommended: true,
+    },
+  ],
+  identifiers: [],
+}
+
+const brandCatalog: BrandResolutionCatalogInput = {
+  brands: [
+    {
+      id: "brand-garnier",
+      canonical_name: "Garnier",
+    },
+  ],
+  productLines: [
+    {
+      id: "line-fructis",
+      brand_id: "brand-garnier",
+      canonical_name: "Fructis",
+    },
+  ],
+  brandAliases: [
+    {
+      brand_id: "brand-garnier",
+      product_line_id: "line-fructis",
+      alias: "Garnier Fructis",
+    },
+  ],
+}
+
+type FakeRepoOptions = {
+  usage?: ProductIntakeUsageRow | null
+  conversationIds?: string[]
+  uploadedPaths?: string[]
+  failCommitKinds?: Array<"front" | "barcode">
+  failSubmissionLink?: boolean
+  submissions?: ProductIntakeSubmissionRow[]
+}
+
+function makeUsage(
+  overrides: Partial<ProductIntakeUsageRow> & { id?: string; category?: ProductIntakeCategoryKey },
+): ProductIntakeUsageRow {
+  return {
+    id: overrides.id ?? "usage-1",
+    user_id: USER_ID,
+    category: overrides.category ?? "mask",
+    product_name: null,
+    frequency_range: null,
+    brand_text: null,
+    product_id: null,
+    product_submission_id: null,
+    match_status: "text_only",
+    intake_method: null,
+    source: null,
+    front_image_path: null,
+    ...overrides,
+  }
+}
+
+function makeSubmission(
+  overrides: Partial<ProductIntakeSubmissionRow> & { id?: string },
+): ProductIntakeSubmissionRow {
+  return {
+    id: overrides.id ?? "submission-1",
+    user_id: USER_ID,
+    user_product_usage_id: null,
+    source: "onboarding",
+    source_conversation_id: null,
+    intake_method: "manual",
+    category: "mask",
+    brand_text: null,
+    product_name_text: null,
+    frequency_range: "weekly_1x",
+    front_image_path: null,
+    barcode_image_path: null,
+    front_image_validation_status: null,
+    front_image_validation_metadata: {},
+    barcode_image_validation_status: null,
+    barcode_image_validation_metadata: {},
+    previous_product_id: null,
+    previous_product_snapshot: {},
+    status: "pending_review",
+    researched_payload: {},
+    intake_history: [],
+    approved_product_id: null,
+    ...overrides,
+  }
+}
+
+function createFakeRepository(options: FakeRepoOptions = {}) {
+  let usage = options.usage ?? null
+  const submissions = new Map<string, ProductIntakeSubmissionRow>(
+    (options.submissions ?? []).map((submission) => [submission.id, submission]),
+  )
+  let nextSubmission = 1
+  let nextUsage = 1
+  const calls: string[] = []
+  const openStatuses = new Set([
+    "pending_review",
+    "researching",
+    "ready_for_review",
+    "needs_more_info",
+  ])
+
+  function closeOpenSubmission(id: string, now = "2026-06-13T10:00:00.000Z") {
+    const current = submissions.get(id)
+    if (!current || !openStatuses.has(current.status)) return
+    if (usage?.product_submission_id === id) {
+      throw new Error("trigger violation: close unsuccessful submission after unlinking usage")
+    }
+    calls.push(`rpc_cancel_submission:${id}`)
+    submissions.set(id, {
+      ...current,
+      status: "cancelled_by_user",
+      user_product_usage_id: null,
+      updated_at: now,
+    })
+  }
+
+  const repository: ProductIntakeRepository = {
+    async loadCatalog() {
+      return catalog
+    },
+    async loadBrandResolutionCatalog() {
+      return brandCatalog
+    },
+    async findUserProductUsage() {
+      return usage
+    },
+    async insertUserProductUsage(row) {
+      calls.push("insert_usage")
+      usage = makeUsage({
+        id: `usage-new-${nextUsage++}`,
+        ...row,
+      })
+      return usage
+    },
+    async updateUserProductUsage(id, patch) {
+      calls.push(`update_usage:${id}`)
+      assert.ok(usage, "expected existing usage")
+      usage = { ...usage, ...patch, id }
+      return usage
+    },
+    async deleteUserProductUsage(id) {
+      calls.push(`delete_usage:${id}`)
+      if (usage?.id === id) usage = null
+    },
+    async replaceUsageWithMatchedProduct(params) {
+      calls.push(`replace_usage_matched:${params.productId}`)
+      const oldSubmissionId = usage?.product_submission_id ?? null
+      const usagePatch = {
+        user_id: params.userId,
+        category: params.category,
+        product_name: params.productName,
+        frequency_range: params.frequencyRange,
+        brand_text: params.brandText,
+        product_id: params.productId,
+        product_submission_id: null,
+        match_status: "matched" as const,
+        intake_method: params.intakeMethod,
+        source: params.source,
+        front_image_path: null,
+        updated_at: params.now,
+      }
+
+      if (params.existingUsageId) {
+        assert.equal(usage?.id, params.existingUsageId)
+        usage = { ...usage, ...usagePatch, id: params.existingUsageId }
+      } else {
+        usage = makeUsage({
+          id: `usage-new-${nextUsage++}`,
+          ...usagePatch,
+        })
+      }
+
+      if (oldSubmissionId) closeOpenSubmission(oldSubmissionId, params.now)
+      return usage
+    },
+    async replaceUsageWithPendingSubmission(params) {
+      calls.push(`replace_usage_pending:${params.submissionId}`)
+      if (options.failSubmissionLink) {
+        throw new Error("failed submission link")
+      }
+
+      const submission = submissions.get(params.submissionId)
+      assert.ok(submission, "expected pending submission")
+      assert.equal(submission.user_id, params.userId)
+      assert.equal(submission.category, params.category)
+      assert.equal(submission.status, "pending_review")
+
+      const oldSubmissionId = usage?.product_submission_id ?? null
+      const usagePatch = {
+        user_id: params.userId,
+        category: params.category,
+        product_name: params.productName,
+        frequency_range: params.frequencyRange,
+        brand_text: params.brandText,
+        product_id: null,
+        product_submission_id: params.submissionId,
+        match_status: "pending_review" as const,
+        intake_method: params.intakeMethod,
+        source: params.source,
+        front_image_path: params.frontImagePath,
+        updated_at: params.now,
+      }
+
+      if (params.existingUsageId) {
+        assert.equal(usage?.id, params.existingUsageId)
+        usage = { ...usage, ...usagePatch, id: params.existingUsageId }
+      } else {
+        usage = makeUsage({
+          id: `usage-new-${nextUsage++}`,
+          ...usagePatch,
+        })
+      }
+
+      if (oldSubmissionId && oldSubmissionId !== params.submissionId) {
+        closeOpenSubmission(oldSubmissionId, params.now)
+      }
+
+      const linkedSubmission = {
+        ...submission,
+        user_product_usage_id: usage.id,
+        updated_at: params.now,
+      }
+      calls.push(`rpc_link_submission:${params.submissionId}`)
+      submissions.set(params.submissionId, linkedSubmission)
+      return { usage, submission: linkedSubmission }
+    },
+    async cancelProductIntakeUsageForCategory({ category, now }) {
+      calls.push(`cancel_usage:${category}`)
+      const existingUsage = usage
+      const submissionId = existingUsage?.product_submission_id ?? null
+      usage = null
+      if (submissionId) closeOpenSubmission(submissionId, now)
+      return {
+        category,
+        usage_id: existingUsage?.id ?? null,
+        submission_id: submissionId,
+      }
+    },
+    async findProductSubmission(id, userId) {
+      calls.push(`find_submission:${id}`)
+      const submission = submissions.get(id) ?? null
+      return submission?.user_id === userId ? submission : null
+    },
+    async insertProductSubmission(row) {
+      calls.push("insert_submission")
+      const submission = makeSubmission({
+        id: `submission-new-${nextSubmission++}`,
+        ...row,
+      })
+      submissions.set(submission.id, submission)
+      return submission
+    },
+    async updateProductSubmission(id, patch) {
+      calls.push(`update_submission:${id}:${patch.status ?? "link"}`)
+      if (options.failSubmissionLink && patch.user_product_usage_id) {
+        throw new Error("failed submission link")
+      }
+      if (
+        (patch.status === "cancelled_by_user" || patch.status === "rejected") &&
+        usage?.product_submission_id === id
+      ) {
+        throw new Error("trigger violation: close unsuccessful submission after unlinking usage")
+      }
+      const current =
+        submissions.get(id) ??
+        makeSubmission({
+          id,
+          status: "pending_review",
+          user_product_usage_id: usage?.id ?? null,
+        })
+      const updated = { ...current, ...patch }
+      submissions.set(id, updated)
+      return updated
+    },
+    async deleteProductSubmission(id) {
+      calls.push(`delete_submission:${id}`)
+      submissions.delete(id)
+    },
+    async verifyUploadedImage({ sourcePath, userId }) {
+      calls.push(`verify_image:${sourcePath}`)
+      if (!sourcePath.startsWith(`tmp/${userId}/`)) return false
+      return options.uploadedPaths ? options.uploadedPaths.includes(sourcePath) : true
+    },
+    async commitUploadedImage({ sourcePath, userId, submissionId, kind }) {
+      calls.push(`commit_image:${kind}:${sourcePath}`)
+      if (options.failCommitKinds?.includes(kind)) {
+        throw new Error(`failed ${kind} commit`)
+      }
+      if (!sourcePath.includes(userId)) throw new Error("bad source path")
+      if (options.uploadedPaths && !options.uploadedPaths.includes(sourcePath)) {
+        throw new Error("missing source upload")
+      }
+      return `${userId}/${submissionId}/${kind}-${sourcePath.split("/").pop() ?? "image.jpg"}`
+    },
+    async removeCommittedImages(paths) {
+      calls.push(`remove_images:${paths.join(",")}`)
+    },
+    async verifyConversationOwnership(conversationId) {
+      calls.push(`verify_conversation:${conversationId}`)
+      return (options.conversationIds ?? []).includes(conversationId)
+    },
+  }
+
+  return {
+    repository,
+    get usage() {
+      return usage
+    },
+    get submissions() {
+      return Array.from(submissions.values())
+    },
+    calls,
+  }
+}
+
+function manualInput(overrides: Record<string, unknown> = {}) {
+  return {
+    intake_method: "manual",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    brand_text: "Garnier Fructis",
+    product_name_text: "Hair Food Aloe Maske",
+    ...overrides,
+  }
+}
+
+test("product intake feature flag defaults production off and preview/dev on", () => {
+  assert.equal(isProductIntakeEnabled({ NODE_ENV: "production", VERCEL_ENV: "production" }), false)
+  assert.equal(isProductIntakeEnabled({ NODE_ENV: "production", VERCEL_ENV: "preview" }), true)
+  assert.equal(isProductIntakeEnabled({ NODE_ENV: "development" }), true)
+  assert.equal(
+    isProductIntakeEnabled({
+      NODE_ENV: "production",
+      VERCEL_ENV: "production",
+      PRODUCT_INTAKE_ENABLED: "true",
+    }),
+    true,
+  )
+  assert.equal(
+    isProductIntakeEnabled({ NODE_ENV: "development", PRODUCT_INTAKE_ENABLED: "0" }),
+    false,
+  )
+})
+
+test("manual intake schemas require category, frequency, brand identity, and product name", () => {
+  const parsed = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "manual",
+    category: "mask",
+    frequency_range: "1_2x",
+    brand_text: " Garnier Fructis ",
+    product_name_text: " Hair Food Aloe Maske ",
+  })
+
+  assert.equal(parsed.frequency_range as ProductFrequency, "weekly_1x")
+  assert.equal(parsed.brand_text, "Garnier Fructis")
+  assert.equal(parsed.product_name_text, "Hair Food Aloe Maske")
+
+  assert.equal(
+    onboardingProductIntakeSubmissionSchema.safeParse({
+      intake_method: "manual",
+      category: "peeling",
+      frequency_range: "weekly_1x",
+      brand_text: "Brand",
+      product_name_text: "Name",
+    }).success,
+    false,
+  )
+
+  assert.equal(
+    onboardingProductIntakeSubmissionSchema.safeParse({
+      intake_method: "manual",
+      category: "mask",
+      frequency_range: "weekly_1x",
+      product_name_text: "Name",
+    }).success,
+    false,
+  )
+})
+
+test("matched manual intake links user usage to the existing product without creating a submission", async () => {
+  const fake = createFakeRepository()
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse(manualInput()),
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(result.status, "matched")
+  assert.equal(result.matched_product_id, "product-garnier-mask")
+  assert.equal(result.submission, null)
+  assert.equal(fake.usage?.product_id, "product-garnier-mask")
+  assert.equal(fake.usage?.product_submission_id, null)
+  assert.equal(fake.usage?.match_status, "matched")
+  assert.deepEqual(fake.calls, ["replace_usage_matched:product-garnier-mask"])
+})
+
+test("matched photo intake verifies and clears tmp uploads without creating a submission", async () => {
+  const frontPath = `tmp/${USER_ID}/front.jpg`
+  const barcodePath = `tmp/${USER_ID}/barcode.jpg`
+  const fake = createFakeRepository({ uploadedPaths: [frontPath, barcodePath] })
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    brand_text: "Garnier Fructis",
+    product_name_text: "Hair Food Aloe Maske",
+    front_image_path: frontPath,
+    barcode_image_path: barcodePath,
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input,
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(result.status, "matched")
+  assert.equal(result.submission, null)
+  assert.equal(fake.usage?.product_id, "product-garnier-mask")
+  assert.deepEqual(fake.submissions, [])
+  assert.deepEqual(fake.calls, [
+    `verify_image:${frontPath}`,
+    `verify_image:${barcodePath}`,
+    `remove_images:${frontPath},${barcodePath}`,
+    "replace_usage_matched:product-garnier-mask",
+  ])
+})
+
+test("unknown manual intake creates a pending submission and pending usage slot", async () => {
+  const fake = createFakeRepository()
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse(
+      manualInput({
+        brand_text: "Unbekannte Marke",
+        product_name_text: "Mystery Maske",
+      }),
+    ),
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.matched_product_id, null)
+  assert.equal(fake.submissions.length, 1)
+  assert.equal(
+    fake.submissions[0].researched_payload &&
+      Object.keys(fake.submissions[0].researched_payload).length,
+    0,
+  )
+  assert.equal(fake.submissions[0].user_product_usage_id, fake.usage?.id)
+  assert.equal(fake.usage?.product_id, null)
+  assert.equal(fake.usage?.product_submission_id, fake.submissions[0].id)
+  assert.equal(fake.usage?.match_status, "pending_review")
+})
+
+test("photo intake creates a pending submission with image paths and uncertain validation", async () => {
+  const fake = createFakeRepository()
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: `tmp/${USER_ID}/front.jpg`,
+    barcode_image_path: `tmp/${USER_ID}/barcode.jpg`,
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input,
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.intake_method, "photo")
+  assert.equal(fake.submissions[0].intake_method, "photo")
+  assert.equal(
+    fake.submissions[0].front_image_path,
+    `${USER_ID}/${fake.submissions[0].id}/front-front.jpg`,
+  )
+  assert.equal(
+    fake.submissions[0].barcode_image_path,
+    `${USER_ID}/${fake.submissions[0].id}/barcode-barcode.jpg`,
+  )
+  assert.equal(fake.submissions[0].front_image_validation_status, "uncertain")
+  assert.equal(fake.submissions[0].barcode_image_validation_status, "uncertain")
+  assert.equal(fake.usage?.front_image_path, `${USER_ID}/${fake.submissions[0].id}/front-front.jpg`)
+  assert.equal(fake.usage?.match_status, "pending_review")
+})
+
+test("photo intake cleans committed front image and does not create review row if barcode commit fails", async () => {
+  const frontPath = `tmp/${USER_ID}/front.jpg`
+  const barcodePath = `tmp/${USER_ID}/barcode.jpg`
+  const fake = createFakeRepository({
+    uploadedPaths: [frontPath, barcodePath],
+    failCommitKinds: ["barcode"],
+  })
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: frontPath,
+    barcode_image_path: barcodePath,
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input,
+        repository: fake.repository,
+        now: () => "2026-06-13T10:00:00.000Z",
+      }),
+    /failed barcode commit/,
+  )
+
+  const frontCommitCall = fake.calls.find((call) => call.startsWith("commit_image:front:"))
+  assert.ok(frontCommitCall)
+  assert.equal(fake.submissions.length, 0)
+  assert.equal(fake.usage, null)
+  const removedPath = fake.calls.find((call) => call.startsWith("remove_images:"))
+  assert.ok(removedPath)
+  assert.match(removedPath, new RegExp(`^remove_images:${USER_ID}/[0-9a-f-]+/front-front\\.jpg$`))
+  assert.ok(!fake.calls.some((call) => call.startsWith("insert_submission")))
+})
+
+test("photo intake cleans rows/images without mutating usage if pending replacement RPC fails", async () => {
+  const frontPath = `tmp/${USER_ID}/front.jpg`
+  const barcodePath = `tmp/${USER_ID}/barcode.jpg`
+  const fake = createFakeRepository({
+    uploadedPaths: [frontPath, barcodePath],
+    failSubmissionLink: true,
+  })
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: frontPath,
+    barcode_image_path: barcodePath,
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input,
+        repository: fake.repository,
+        now: () => "2026-06-13T10:00:00.000Z",
+      }),
+    /failed submission link/,
+  )
+
+  assert.equal(fake.submissions.length, 0)
+  assert.equal(fake.usage, null)
+  assert.ok(fake.calls.some((call) => call.startsWith("replace_usage_pending:")))
+  assert.ok(fake.calls.some((call) => call.startsWith("delete_submission:")))
+  const removedPath = fake.calls.find((call) => call.startsWith("remove_images:"))
+  assert.ok(removedPath)
+  assert.match(
+    removedPath,
+    new RegExp(
+      `^remove_images:${USER_ID}/[0-9a-f-]+/front-front\\.jpg,${USER_ID}/[0-9a-f-]+/barcode-barcode\\.jpg$`,
+    ),
+  )
+})
+
+test("photo intake persists only server-derived uncertain validation state", async () => {
+  const frontPath = `tmp/${USER_ID}/front.jpg`
+  const barcodePath = `tmp/${USER_ID}/barcode.jpg`
+  const fake = createFakeRepository({ uploadedPaths: [frontPath, barcodePath] })
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: frontPath,
+    front_image_validation_status: "valid_product_front",
+    front_image_validation_metadata: {
+      source: "server_upload_validation",
+      validation: "file_signature_only",
+      mime_type: "image/jpeg",
+    },
+    barcode_image_path: barcodePath,
+    barcode_image_validation_status: "valid_barcode",
+    barcode_image_validation_metadata: {
+      source: "server_upload_validation",
+      validation: "file_signature_only",
+      mime_type: "image/jpeg",
+    },
+  })
+
+  await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input,
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(fake.submissions[0].front_image_validation_status, "uncertain")
+  assert.deepEqual(fake.submissions[0].front_image_validation_metadata, {})
+  assert.equal(fake.submissions[0].barcode_image_validation_status, "uncertain")
+  assert.deepEqual(fake.submissions[0].barcode_image_validation_metadata, {})
+  const historyEntry = fake.submissions[0].intake_history[0] as {
+    at?: string
+    fields?: { front_image_validation_status?: string }
+  }
+  assert.equal(historyEntry.at, "2026-06-13T10:00:00.000Z")
+  assert.equal(historyEntry.fields?.front_image_validation_status, "uncertain")
+})
+
+test("photo intake rejects image paths that do not belong to the user", async () => {
+  const fake = createFakeRepository()
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: "tmp/someone-else/front.jpg",
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input,
+        repository: fake.repository,
+      }),
+    /Bildpfad gehört nicht zu diesem Nutzer/,
+  )
+})
+
+test("photo intake rejects stale committed image paths instead of reusing old submission photos", async () => {
+  const fake = createFakeRepository()
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: `${USER_ID}/old-submission/front.jpg`,
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input,
+        repository: fake.repository,
+      }),
+    /temporären Upload/,
+  )
+
+  assert.equal(fake.submissions.length, 0)
+  assert.equal(fake.usage, null)
+})
+
+test("photo intake verifies tmp uploads exist before creating submission rows", async () => {
+  const fake = createFakeRepository({ uploadedPaths: [] })
+  const input = onboardingProductIntakeSubmissionSchema.parse({
+    intake_method: "photo",
+    category: "mask",
+    frequency_range: "weekly_1x",
+    front_image_path: `tmp/${USER_ID}/guessed.jpg`,
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input,
+        repository: fake.repository,
+      }),
+    /Upload nicht gefunden/,
+  )
+
+  assert.deepEqual(fake.calls, [`verify_image:tmp/${USER_ID}/guessed.jpg`])
+  assert.equal(fake.submissions.length, 0)
+  assert.equal(fake.usage, null)
+})
+
+test("empty onboarding placeholder usage can be claimed without replacement confirmation", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({ id: "placeholder", category: "mask" }),
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse(manualInput()),
+    repository: fake.repository,
+  })
+
+  assert.equal(result.status, "matched")
+  assert.equal(fake.usage?.id, "placeholder")
+  assert.equal(fake.usage?.product_id, "product-garnier-mask")
+})
+
+test("tracked usage requires explicit replacement confirmation", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_name: "Altes Produkt",
+      frequency_range: "weekly_1x",
+    }),
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input: onboardingProductIntakeSubmissionSchema.parse(manualInput()),
+        repository: fake.repository,
+      }),
+    ProductIntakeConflictError,
+  )
+})
+
+test("onboarding same usage id can update a tracked slot without replacement confirmation", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_name: "Altes Produkt",
+      frequency_range: "weekly_1x",
+    }),
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse(
+      manualInput({
+        existing_usage_id: EXISTING_USAGE_ID,
+      }),
+    ),
+    repository: fake.repository,
+  })
+
+  assert.equal(result.status, "matched")
+  assert.equal(fake.usage?.id, EXISTING_USAGE_ID)
+  assert.equal(fake.usage?.product_id, "product-garnier-mask")
+})
+
+test("onboarding same pending photo usage can be saved again without reuploading the front image", async () => {
+  const oldFrontPath = `${USER_ID}/old-submission/front-old.jpg`
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_name: "Mystery Maske",
+      frequency_range: "weekly_1x",
+      product_submission_id: "old-submission",
+      match_status: "pending_review",
+      source: "onboarding",
+      intake_method: "photo",
+      front_image_path: oldFrontPath,
+    }),
+    submissions: [
+      makeSubmission({
+        id: "old-submission",
+        user_product_usage_id: EXISTING_USAGE_ID,
+        intake_method: "photo",
+        brand_text: "Unbekannte Marke",
+        product_name_text: "Mystery Maske",
+        front_image_path: oldFrontPath,
+        status: "pending_review",
+        intake_history: [{ at: "2026-06-13T09:00:00.000Z" }],
+      }),
+    ],
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse({
+      intake_method: "photo",
+      category: "mask",
+      frequency_range: "weekly_3_4x",
+      brand_text: "Unbekannte Marke",
+      product_name_text: "Mystery Maske aktualisiert",
+      existing_usage_id: EXISTING_USAGE_ID,
+    }),
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.usage.id, EXISTING_USAGE_ID)
+  assert.equal(result.usage.front_image_path, oldFrontPath)
+  assert.equal(fake.submissions.length, 1)
+  assert.equal(fake.submissions[0].id, "old-submission")
+  assert.equal(fake.submissions[0].front_image_path, oldFrontPath)
+  assert.equal(fake.submissions[0].frequency_range, "weekly_3_4x")
+  assert.equal(fake.submissions[0].intake_history.length, 2)
+  assert.ok(!fake.calls.includes("insert_submission"))
+  assert.ok(!fake.calls.some((call) => call.startsWith("commit_image:front")))
+})
+
+test("onboarding same pending photo usage updates the current reference when a new front image is uploaded", async () => {
+  const oldFrontPath = `${USER_ID}/old-submission/front-old.jpg`
+  const newFrontUploadPath = `tmp/${USER_ID}/front-new.jpg`
+  const fake = createFakeRepository({
+    uploadedPaths: [newFrontUploadPath],
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_name: "Mystery Maske",
+      frequency_range: "weekly_1x",
+      product_submission_id: "old-submission",
+      match_status: "pending_review",
+      source: "onboarding",
+      intake_method: "photo",
+      front_image_path: oldFrontPath,
+    }),
+    submissions: [
+      makeSubmission({
+        id: "old-submission",
+        user_product_usage_id: EXISTING_USAGE_ID,
+        intake_method: "photo",
+        brand_text: "Unbekannte Marke",
+        product_name_text: "Mystery Maske",
+        front_image_path: oldFrontPath,
+        status: "pending_review",
+      }),
+    ],
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse({
+      intake_method: "photo",
+      category: "mask",
+      frequency_range: "weekly_1x",
+      brand_text: "Unbekannte Marke",
+      product_name_text: "Mystery Maske",
+      front_image_path: newFrontUploadPath,
+      existing_usage_id: EXISTING_USAGE_ID,
+    }),
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  const newFrontPath = `${USER_ID}/old-submission/front-front-new.jpg`
+  assert.equal(result.status, "pending_review")
+  assert.equal(result.usage.front_image_path, newFrontPath)
+  assert.equal(fake.submissions.length, 1)
+  assert.equal(fake.submissions[0].id, "old-submission")
+  assert.equal(fake.submissions[0].front_image_path, newFrontPath)
+  assert.ok(fake.calls.includes(`commit_image:front:${newFrontUploadPath}`))
+  assert.ok(fake.calls.includes(`remove_images:${oldFrontPath}`))
+  assert.ok(!fake.calls.includes("insert_submission"))
+})
+
+test("onboarding mismatched usage id still requires replacement confirmation", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_name: "Altes Produkt",
+      frequency_range: "weekly_1x",
+    }),
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "onboarding",
+        input: onboardingProductIntakeSubmissionSchema.parse(
+          manualInput({
+            existing_usage_id: OTHER_USAGE_ID,
+          }),
+        ),
+        repository: fake.repository,
+      }),
+    ProductIntakeConflictError,
+  )
+})
+
+test("chat still requires replacement confirmation for a tracked slot", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_name: "Altes Produkt",
+      frequency_range: "weekly_1x",
+    }),
+  })
+
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "chat",
+        input: chatProductIntakeSubmissionSchema.parse(manualInput()),
+        repository: fake.repository,
+      }),
+    ProductIntakeConflictError,
+  )
+})
+
+test("confirmed unknown replacement stores previous slot state and cancels old pending submission", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: "existing-usage",
+      product_name: "Altes Produkt",
+      frequency_range: "weekly_1x",
+      product_submission_id: "old-submission",
+      match_status: "pending_review",
+      source: "onboarding",
+      intake_method: "manual",
+    }),
+    submissions: [
+      makeSubmission({
+        id: "old-submission",
+        user_product_usage_id: "existing-usage",
+        status: "pending_review",
+      }),
+    ],
+  })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "onboarding",
+    input: onboardingProductIntakeSubmissionSchema.parse(
+      manualInput({
+        brand_text: "Unbekannte Marke",
+        product_name_text: "Mystery Maske",
+        replace_existing_confirmed: true,
+      }),
+    ),
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.equal(result.status, "pending_review")
+  const newSubmission = fake.submissions.find((submission) => submission.id !== "old-submission")
+  const oldSubmission = fake.submissions.find((submission) => submission.id === "old-submission")
+  assert.ok(newSubmission)
+  assert.equal(newSubmission.previous_product_snapshot.product_name, "Altes Produkt")
+  assert.equal(oldSubmission?.status, "cancelled_by_user")
+  assert.equal(fake.usage?.product_submission_id, newSubmission.id)
+  assert.deepEqual(
+    fake.calls.filter(
+      (call) =>
+        call.startsWith("replace_usage_pending:") ||
+        call === "rpc_cancel_submission:old-submission" ||
+        call.startsWith(`rpc_link_submission:${newSubmission.id}`),
+    ),
+    [
+      `replace_usage_pending:${newSubmission.id}`,
+      "rpc_cancel_submission:old-submission",
+      `rpc_link_submission:${newSubmission.id}`,
+    ],
+  )
+})
+
+test("failed pending replacement leaves old pending usage untouched", async () => {
+  const fake = createFakeRepository({
+    failSubmissionLink: true,
+    usage: makeUsage({
+      id: "existing-usage",
+      product_name: "Altes Produkt",
+      frequency_range: "weekly_1x",
+      product_submission_id: "old-submission",
+      match_status: "pending_review",
+      source: "onboarding",
+      intake_method: "manual",
+    }),
+    submissions: [
+      makeSubmission({
+        id: "old-submission",
+        user_product_usage_id: "existing-usage",
+        status: "pending_review",
+      }),
+    ],
+  })
+
+  await assert.rejects(() =>
+    submitProductIntake({
+      userId: USER_ID,
+      source: "onboarding",
+      input: onboardingProductIntakeSubmissionSchema.parse(
+        manualInput({
+          brand_text: "Unbekannte Marke",
+          product_name_text: "Mystery Maske",
+          replace_existing_confirmed: true,
+        }),
+      ),
+      repository: fake.repository,
+      now: () => "2026-06-13T10:00:00.000Z",
+    }),
+  )
+
+  const oldSubmission = fake.submissions.find((submission) => submission.id === "old-submission")
+  assert.equal(oldSubmission?.status, "pending_review")
+  assert.equal(fake.usage?.product_submission_id, "old-submission")
+  assert.ok(fake.calls.some((call) => call.startsWith("replace_usage_pending:")))
+  assert.ok(!fake.calls.includes("rpc_cancel_submission:old-submission"))
+})
+
+test("cancelling an onboarding usage deletes the slot before closing the linked pending submission", async () => {
+  const fake = createFakeRepository({
+    usage: makeUsage({
+      id: EXISTING_USAGE_ID,
+      product_submission_id: "old-submission",
+      match_status: "pending_review",
+      source: "onboarding",
+      intake_method: "photo",
+    }),
+    submissions: [
+      makeSubmission({
+        id: "old-submission",
+        user_product_usage_id: EXISTING_USAGE_ID,
+        status: "pending_review",
+      }),
+    ],
+  })
+
+  const result = await cancelProductIntakeUsage({
+    userId: USER_ID,
+    category: "mask",
+    repository: fake.repository,
+    now: () => "2026-06-13T10:00:00.000Z",
+  })
+
+  assert.deepEqual(result, {
+    category: "mask",
+    usage_id: EXISTING_USAGE_ID,
+    submission_id: "old-submission",
+  })
+  assert.equal(fake.usage, null)
+  assert.equal(fake.submissions[0].status, "cancelled_by_user")
+  assert.equal(fake.submissions[0].user_product_usage_id, null)
+  assert.deepEqual(fake.calls.slice(-2), [
+    "cancel_usage:mask",
+    "rpc_cancel_submission:old-submission",
+  ])
+})
+
+test("chat intake verifies source conversation ownership and preserves owned conversation id", async () => {
+  const fake = createFakeRepository({ conversationIds: [CONVERSATION_ID] })
+
+  const result = await submitProductIntake({
+    userId: USER_ID,
+    source: "chat",
+    input: chatProductIntakeSubmissionSchema.parse(
+      manualInput({
+        brand_text: "Unbekannte Marke",
+        product_name_text: "Mystery Maske",
+        source_conversation_id: CONVERSATION_ID,
+      }),
+    ),
+    repository: fake.repository,
+  })
+
+  assert.equal(result.status, "pending_review")
+  assert.equal(fake.submissions[0].source, "chat")
+  assert.equal(fake.submissions[0].source_conversation_id, CONVERSATION_ID)
+  assert.deepEqual(
+    fake.calls.filter((call) => call.startsWith("verify_conversation")),
+    [`verify_conversation:${CONVERSATION_ID}`],
+  )
+
+  const denied = createFakeRepository({ conversationIds: [CONVERSATION_ID] })
+  await assert.rejects(
+    () =>
+      submitProductIntake({
+        userId: USER_ID,
+        source: "chat",
+        input: chatProductIntakeSubmissionSchema.parse(
+          manualInput({
+            source_conversation_id: OTHER_CONVERSATION_ID,
+          }),
+        ),
+        repository: denied.repository,
+      }),
+    ProductIntakeOwnershipError,
+  )
+})
+
+test("route handler returns controlled disabled response before auth or persistence", async () => {
+  const handler = createProductIntakePostHandler("onboarding", {
+    isEnabled: () => false,
+    createServerClient: async () => {
+      throw new Error("auth should not be called while disabled")
+    },
+  })
+
+  const response = await handler(
+    new Request("https://example.test/api/product-intake/onboarding", {
+      method: "POST",
+      body: JSON.stringify(manualInput()),
+    }),
+  )
+  const body = await response.json()
+
+  assert.equal(response.status, 503)
+  assert.equal(body.code, "product_intake_disabled")
+})
+
+test("route handler returns controlled client error for wrong-user upload paths", async () => {
+  const fake = createFakeRepository()
+  const handler = createProductIntakePostHandler("onboarding", {
+    isEnabled: () => true,
+    createServerClient: async () =>
+      ({
+        auth: {
+          getUser: async () => ({
+            data: { user: { id: USER_ID } },
+          }),
+        },
+      }) as never,
+    createAdminClient: (() => ({})) as never,
+    createRepository: () => fake.repository,
+  })
+
+  const response = await handler(
+    new Request("https://example.test/api/product-intake/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        intake_method: "photo",
+        category: "mask",
+        frequency_range: "weekly_1x",
+        front_image_path: "tmp/someone-else/front.jpg",
+      }),
+    }),
+  )
+  const body = await response.json()
+
+  assert.equal(response.status, 400)
+  assert.equal(body.code, "product_intake_upload_owner_mismatch")
+  assert.match(body.error, /Bildpfad gehört nicht zu diesem Nutzer/)
+})
+
+test("route handler returns controlled expired response for missing tmp uploads", async () => {
+  const fake = createFakeRepository({ uploadedPaths: [] })
+  const handler = createProductIntakePostHandler("onboarding", {
+    isEnabled: () => true,
+    createServerClient: async () =>
+      ({
+        auth: {
+          getUser: async () => ({
+            data: { user: { id: USER_ID } },
+          }),
+        },
+      }) as never,
+    createAdminClient: (() => ({})) as never,
+    createRepository: () => fake.repository,
+  })
+
+  const response = await handler(
+    new Request("https://example.test/api/product-intake/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        intake_method: "photo",
+        category: "mask",
+        frequency_range: "weekly_1x",
+        front_image_path: `tmp/${USER_ID}/missing.jpg`,
+      }),
+    }),
+  )
+  const body = await response.json()
+
+  assert.equal(response.status, 410)
+  assert.equal(body.code, "product_intake_upload_expired")
+  assert.match(body.error, /Upload nicht gefunden/)
+})
+
+test("route handler keeps storage verification failures as persistence errors", async () => {
+  const fake = createFakeRepository()
+  fake.repository.verifyUploadedImage = async () => {
+    throw new ProductIntakePersistenceError("verify product intake image: Storage unavailable")
+  }
+  const handler = createProductIntakePostHandler("onboarding", {
+    isEnabled: () => true,
+    createServerClient: async () =>
+      ({
+        auth: {
+          getUser: async () => ({
+            data: { user: { id: USER_ID } },
+          }),
+        },
+      }) as never,
+    createAdminClient: (() => ({})) as never,
+    createRepository: () => fake.repository,
+  })
+  const originalConsoleError = console.error
+  console.error = () => {}
+
+  try {
+    const response = await handler(
+      new Request("https://example.test/api/product-intake/onboarding", {
+        method: "POST",
+        body: JSON.stringify({
+          intake_method: "photo",
+          category: "mask",
+          frequency_range: "weekly_1x",
+          front_image_path: `tmp/${USER_ID}/front.jpg`,
+        }),
+      }),
+    )
+    const body = await response.json()
+
+    assert.equal(response.status, 500)
+    assert.equal(body.error, "Produkt konnte nicht gespeichert werden.")
+  } finally {
+    console.error = originalConsoleError
+  }
+})
+
+test("storage upload verification classifies only missing objects as expired user uploads", () => {
+  assert.equal(
+    isMissingProductIntakeUploadError({
+      status: 404,
+      statusCode: "NoSuchKey",
+      message: "Object not found",
+    }),
+    true,
+  )
+
+  assert.equal(
+    isMissingProductIntakeUploadError({
+      status: 404,
+      statusCode: "NoSuchBucket",
+      message: "Bucket not found",
+    }),
+    false,
+  )
+
+  assert.equal(
+    isMissingProductIntakeUploadError({
+      status: 403,
+      statusCode: "AccessDenied",
+      message: "Access denied",
+    }),
+    false,
+  )
+
+  assert.equal(
+    isMissingProductIntakeUploadError({
+      status: 503,
+      statusCode: "ServiceUnavailable",
+      message: "Storage temporarily unavailable",
+    }),
+    false,
+  )
+})
+
+test("image validation accepts image signatures and rejects non-images", async () => {
+  const png = new File(
+    [new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x00])],
+    "front.png",
+    { type: "image/png" },
+  )
+  const validated = await validateProductIntakeImageFile(png, "front")
+
+  assert.equal(validated.mimeType, "image/png")
+  assert.equal(validated.extension, "png")
+  assert.equal(validated.validationStatus, "uncertain")
+  assert.equal(validated.validationMetadata.validation, "file_signature_only")
+
+  const text = new File([new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f])], "front.txt", {
+    type: "text/plain",
+  })
+
+  await assert.rejects(
+    () => validateProductIntakeImageFile(text, "front"),
+    /Bitte lade ein JPG-, PNG-, WebP-, HEIC- oder HEIF-Bild hoch/,
+  )
+})


### PR DESCRIPTION
## Summary
- adds the Phase 3 product-intake lifecycle for chat and onboarding, including the intake card, onboarding drilldown photo/manual paths, replacement confirmation, and feature-flagged product lookup tool events
- adds backend product-intake routes, upload validation, submission persistence, lifecycle RPC migration, readiness/cleanup scripts, and shared client/server helpers
- tightens review findings: precise lookup gating, controlled upload/user-input errors, storage verification classification, German upload controls, dry-run cleanup pagination, and HEIC/HEIF pass-through up to the server limit
- addresses Phase 3 Clawpatch fixups: referenced tmp photos are protected from cleanup, committed onboarding photo reuse follows the existing-usage contract, AgentV2 verifies conversation ownership before admin reads, and parallel `select_products` calls no longer share raw result state

## Verification
- `npx tsx --test tests/product-intake-cleanup-photos.test.ts tests/product-intake-client.test.ts tests/product-intake-client-image-compression.test.ts tests/product-intake-submissions.test.ts tests/product-intake-schema.test.ts tests/product-intake-lookup.test.ts tests/agent-v2-production-chat-pipeline.spec.ts tests/agent-v2-responses-runtime.spec.ts` — passed, 169/169
- `npm run typecheck` — passed
- `npm run lint` — passed with 4 pre-existing warnings in header/avatar/model-client/brush-tools
- `git diff --check` — passed
- `env NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder npm run ci:verify` — passed
- Targeted Clawpatch revalidation returned `fixed` for:
  - `fnd_sig-feat-library-095071f340-4a60_680fbfd852`
  - `fnd_sig-feat-cli-command-8b2aeb085d-_da94465e61`
  - `fnd_sig-feat-library-036dec98b1-855d_672e9e5335`
  - `fnd_sig-feat-library-036dec98b1-eda4_803266fcf0`
- Spec review approved after fixups
- Code-quality review initially found a committed-photo contract blocker; patched and re-review approved
- Claude final code review completed earlier; Medium findings M1/M2 patched before the previous commit
- Simulated-user mobile review found native English file input copy; patched with German custom controls

## Migration / rollout notes
- Adds Supabase migration `20260616120000_product_intake_lifecycle_functions.sql`. It has not been applied to production by this PR.
- `npm run product-intake:check-readiness` was previously run against production and is expected to fail until the Phase 3 migration and `product-intake` storage bucket are applied.
- Product intake remains feature-flagged: production defaults off unless `PRODUCT_INTAKE_ENABLED` is enabled.
- The latest fixup commit adds no new Supabase migration changes.

## Stacking
- Stacked on `codex/product-intake-phase-2`. Do not merge before Phase 1/2 are merged/applied in order.
