### PR TITLE
feat(product-intake): add ops review scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "products:intake:link-existing": "tsx scripts/product-intake/link-existing.ts",
     "products:intake:request-info": "tsx scripts/product-intake/request-info.ts",
     "products:intake:notify-pending": "tsx scripts/product-intake/notify-pending.ts",
+    "products:intake:promote": "tsx scripts/product-intake/promote.ts",
     "products:intake:cleanup-storage": "tsx scripts/product-intake/cleanup-storage.ts",
     "stress:smoke": "k6 run -e K6_PROFILE=smoke scripts/k6/launch-flow.js",
     "stress:average": "k6 run -e K6_PROFILE=average scripts/k6/launch-flow.js",

--- a/scripts/product-intake/approve-ready.ts
+++ b/scripts/product-intake/approve-ready.ts
@@ -1,4 +1,5 @@
 import { createSupabaseClientFromEnv, flag, flagBool, parseArgs, requireFlag } from "./cli"
+import { flushProductIntakeSentry } from "@/lib/observability/product-intake"
 import { approveSubmissionById } from "./approve"
 import { loadSubmissionsByIds, validateSubmissionReady } from "./review-actions"
 
@@ -49,12 +50,17 @@ async function main() {
     }
   }
 
+  if (process.exitCode) {
+    await flushProductIntakeSentry()
+  }
+
   if (!apply) {
     console.log("Batch dry-run only. Re-run with --apply --confirm to approve selected rows.")
   }
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
   console.error(error instanceof Error ? error.message : error)
+  await flushProductIntakeSentry()
   process.exitCode = 1
 })

--- a/scripts/product-intake/approve.ts
+++ b/scripts/product-intake/approve.ts
@@ -7,6 +7,10 @@ import {
   requireFlag,
 } from "./cli"
 import {
+  captureProductIntakeException,
+  flushProductIntakeSentry,
+} from "@/lib/observability/product-intake"
+import {
   appendProductAdditionRecord,
   approveReviewedSubmission,
   loadSubmission,
@@ -91,6 +95,19 @@ export async function approveSubmissionById(params: {
       spec_operations: validation.targetSpecOperations,
     })
   } catch (error) {
+    captureProductIntakeException(error, {
+      stage: "append_addition_record",
+      submissionId: submission.id,
+      approvedProductId: approval.product_id,
+      userId: submission.user_id,
+      source: submission.source,
+      sourceConversationId: submission.source_conversation_id,
+      category: submission.category,
+      intakeMethod: submission.intake_method,
+      status: approval.submission.status,
+      reason: "addition_record_write_failed",
+      committed: true,
+    })
     console.error(
       `Approved in DB, but failed to write addition record. Regenerate for submission ${submission.id}.`,
     )
@@ -132,8 +149,9 @@ async function main() {
 }
 
 if (process.argv[1]?.endsWith("approve.ts")) {
-  main().catch((error) => {
+  main().catch(async (error) => {
     console.error(error instanceof Error ? error.message : error)
+    await flushProductIntakeSentry()
     process.exitCode = 1
   })
 }

--- a/scripts/product-intake/cli.ts
+++ b/scripts/product-intake/cli.ts
@@ -4,6 +4,7 @@ import { join, sep } from "node:path"
 
 import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 import { config as loadEnv } from "dotenv"
+import { initProductIntakeScriptSentry } from "@/lib/observability/product-intake"
 
 export type CliArgs = {
   positional: string[]
@@ -80,6 +81,7 @@ function envCandidatePaths(): string[] {
 
 export function createSupabaseClientFromEnv(): SupabaseClient {
   loadLocalEnv()
+  initProductIntakeScriptSentry()
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY

--- a/scripts/product-intake/link-existing.ts
+++ b/scripts/product-intake/link-existing.ts
@@ -6,6 +6,7 @@ import {
   printJson,
   requireFlag,
 } from "./cli"
+import { flushProductIntakeSentry } from "@/lib/observability/product-intake"
 import { linkExistingProduct, notifyReviewResult } from "./review-actions"
 
 async function main() {
@@ -56,7 +57,8 @@ async function main() {
   })
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
   console.error(error instanceof Error ? error.message : error)
+  await flushProductIntakeSentry()
   process.exitCode = 1
 })

--- a/scripts/product-intake/notify-pending.ts
+++ b/scripts/product-intake/notify-pending.ts
@@ -1,4 +1,5 @@
 import { createSupabaseClientFromEnv, flagInt, parseArgs, printJson } from "./cli"
+import { flushProductIntakeSentry } from "@/lib/observability/product-intake"
 import { notifyReviewResult } from "./review-actions"
 
 async function main() {
@@ -33,10 +34,15 @@ async function main() {
     }
   }
 
+  if (process.exitCode) {
+    await flushProductIntakeSentry()
+  }
+
   printJson({ count: results.length, results })
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
   console.error(error instanceof Error ? error.message : error)
+  await flushProductIntakeSentry()
   process.exitCode = 1
 })

--- a/scripts/product-intake/promote.ts
+++ b/scripts/product-intake/promote.ts
@@ -1,0 +1,338 @@
+import {
+  createSupabaseClientFromEnv,
+  flag,
+  flagBool,
+  parseArgs,
+  printJson,
+  requireFlag,
+} from "./cli"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import {
+  captureProductIntakeException,
+  flushProductIntakeSentry,
+} from "@/lib/observability/product-intake"
+
+type PromotionAction = "promote" | "already_recommended"
+
+type ProductRow = {
+  id: string
+  name?: string | null
+  category?: string | null
+  category_key?: string | null
+  origin?: string | null
+  is_active: boolean | null
+  lifecycle_status?: string | null
+  is_chaarlie_recommended: boolean | null
+  updated_at?: string | null
+}
+
+type ApprovedSubmissionRow = {
+  id: string
+  approved_product_id: string | null
+}
+
+export class PromotionGateError extends Error {
+  override name = "PromotionGateError"
+}
+
+type PromotionPayload = {
+  product_id: string
+  product_name: string | null
+  current_recommendation_state: boolean
+  origin: string | null
+  category: string | null
+  category_key: string | null
+  lifecycle_status: string | null
+  is_active: boolean | null
+  dry_run: boolean
+  proposed_action: PromotionAction
+  reviewer: string | null
+  notes: string | null
+}
+
+type PromotionResult = PromotionPayload & {
+  approved_submission_id?: string
+  missing_spec_tables?: RequiredSpecTable[]
+  next_recommendation_state?: boolean
+  promoted_at?: string
+  required_spec_tables?: RequiredSpecTable[]
+}
+
+const PRODUCT_SELECT =
+  "id,name,category,category_key,origin,is_active,lifecycle_status,is_chaarlie_recommended,updated_at"
+
+export const REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY = {
+  shampoo: ["product_shampoo_specs"],
+  conditioner: ["product_conditioner_specs", "product_conditioner_rerank_specs"],
+  mask: ["product_mask_specs"],
+  leave_in: [
+    "product_leave_in_specs",
+    "product_leave_in_fit_specs",
+    "product_leave_in_eligibility",
+  ],
+  oil: ["product_oil_eligibility"],
+  dry_shampoo: ["product_dry_shampoo_specs"],
+  deep_cleansing_shampoo: ["product_deep_cleansing_shampoo_specs"],
+  bondbuilder: ["product_bondbuilder_specs"],
+} as const
+
+type PromotionCategory = keyof typeof REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY
+type RequiredSpecTable =
+  (typeof REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY)[PromotionCategory][number]
+
+function promotionCategory(product: ProductRow): PromotionCategory | null {
+  const rawCategory = product.category_key ?? product.category
+  if (!rawCategory) return null
+  return rawCategory in REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY
+    ? (rawCategory as PromotionCategory)
+    : null
+}
+
+export function buildPromotionPayload(params: {
+  product: ProductRow
+  dryRun: boolean
+  reviewer: string | null
+  notes: string | null
+}): PromotionPayload {
+  return {
+    product_id: params.product.id,
+    product_name: params.product.name ?? null,
+    current_recommendation_state: params.product.is_chaarlie_recommended === true,
+    origin: params.product.origin ?? null,
+    category: params.product.category ?? params.product.category_key ?? null,
+    category_key: params.product.category_key ?? null,
+    lifecycle_status: params.product.lifecycle_status ?? null,
+    is_active: params.product.is_active,
+    dry_run: params.dryRun,
+    proposed_action:
+      params.product.is_chaarlie_recommended === true ? "already_recommended" : "promote",
+    reviewer: params.reviewer,
+    notes: params.notes,
+  }
+}
+
+export function validatePromotableProduct(product: ProductRow): RequiredSpecTable[] {
+  if (product.origin !== "user_submitted") {
+    throw new PromotionGateError(
+      `Product ${product.id} origin is ${product.origin ?? "missing"}; promotion requires user_submitted`,
+    )
+  }
+
+  if (product.is_active !== true) {
+    throw new PromotionGateError(
+      `Product ${product.id} is not active; promotion requires is_active=true`,
+    )
+  }
+
+  if (product.lifecycle_status !== "active") {
+    throw new PromotionGateError(
+      `Product ${product.id} lifecycle_status is ${
+        product.lifecycle_status ?? "missing"
+      }; promotion requires active`,
+    )
+  }
+
+  const category = promotionCategory(product)
+  if (!category) {
+    throw new PromotionGateError(
+      `Product ${product.id} has unsupported or missing category for promotion: ${
+        product.category_key ?? product.category ?? "missing"
+      }`,
+    )
+  }
+
+  return [...REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY[category]]
+}
+
+async function loadProduct(supabase: SupabaseClient, productId: string): Promise<ProductRow> {
+  const { data, error } = await supabase
+    .from("products")
+    .select(PRODUCT_SELECT)
+    .eq("id", productId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to load product ${productId}: ${error.message ?? "unknown error"}`)
+  }
+  if (!data) {
+    throw new PromotionGateError(`Product ${productId} not found`)
+  }
+
+  return data as ProductRow
+}
+
+async function missingSpecTables(
+  supabase: SupabaseClient,
+  productId: string,
+  tables: RequiredSpecTable[],
+): Promise<RequiredSpecTable[]> {
+  const results = await Promise.all(
+    tables.map(async (table) => {
+      const { data, error } = await supabase
+        .from(table)
+        .select("product_id")
+        .eq("product_id", productId)
+        .limit(1)
+
+      if (error) {
+        throw new Error(
+          `Failed to check ${table} for product ${productId}: ${error.message ?? "unknown error"}`,
+        )
+      }
+
+      return Array.isArray(data) && data.length > 0 ? null : table
+    }),
+  )
+
+  return results.filter((table): table is RequiredSpecTable => table !== null)
+}
+
+async function loadApprovedSubmissionForProduct(
+  supabase: SupabaseClient,
+  productId: string,
+): Promise<ApprovedSubmissionRow> {
+  const { data, error } = await supabase
+    .from("product_submissions")
+    .select("id,approved_product_id")
+    .eq("approved_product_id", productId)
+    .eq("status", "approved")
+    .limit(1)
+
+  if (error) {
+    throw new Error(
+      `Failed to load approved intake submission for product ${productId}: ${
+        error.message ?? "unknown error"
+      }`,
+    )
+  }
+
+  const row = Array.isArray(data) ? data[0] : null
+  if (!row) {
+    throw new PromotionGateError(
+      `Product ${productId} cannot be promoted without an approved intake submission`,
+    )
+  }
+
+  return row as ApprovedSubmissionRow
+}
+
+export async function promoteProductById(params: {
+  supabase?: SupabaseClient
+  productId: string
+  confirm: boolean
+  reviewer: string | null
+  notes: string | null
+}): Promise<PromotionResult> {
+  const supabase = params.supabase ?? createSupabaseClientFromEnv()
+  const product = await loadProduct(supabase, params.productId)
+  const dryRun = !params.confirm
+  const payload = buildPromotionPayload({
+    product,
+    dryRun,
+    reviewer: params.reviewer,
+    notes: params.notes,
+  })
+
+  if (product.is_chaarlie_recommended === true) {
+    printJson(payload)
+    return payload
+  }
+
+  const requiredSpecTables = validatePromotableProduct(product)
+  if (!product.updated_at) {
+    throw new PromotionGateError(
+      `Product ${product.id} cannot be promoted without updated_at concurrency guard`,
+    )
+  }
+
+  const approvedSubmission = await loadApprovedSubmissionForProduct(supabase, product.id)
+  const missingTables = await missingSpecTables(supabase, product.id, requiredSpecTables)
+  if (missingTables.length > 0) {
+    printJson({
+      ...payload,
+      approved_submission_id: approvedSubmission.id,
+      required_spec_tables: requiredSpecTables,
+      missing_spec_tables: missingTables,
+    })
+    throw new PromotionGateError(
+      `Product ${product.id} is missing required category specs: ${missingTables.join(", ")}`,
+    )
+  }
+
+  if (dryRun) {
+    const result = {
+      ...payload,
+      approved_submission_id: approvedSubmission.id,
+      required_spec_tables: requiredSpecTables,
+    }
+    printJson(result)
+
+    return result
+  }
+
+  const updatedAt = new Date().toISOString()
+  const { data, error } = await supabase
+    .from("products")
+    .update({
+      is_chaarlie_recommended: true,
+      updated_at: updatedAt,
+    })
+    .eq("id", product.id)
+    .eq("is_active", true)
+    .eq("lifecycle_status", "active")
+    .eq("is_chaarlie_recommended", false)
+    .eq("updated_at", product.updated_at)
+    .select("id, updated_at")
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to promote product ${product.id}: ${error.message ?? "unknown error"}`)
+  }
+  if (!data) {
+    throw new PromotionGateError(
+      `Product ${product.id} changed after validation; re-run promotion review`,
+    )
+  }
+
+  const result = {
+    ...payload,
+    dry_run: false,
+    promoted_at: (data as { updated_at?: string | null }).updated_at ?? updatedAt,
+    next_recommendation_state: true,
+    approved_submission_id: approvedSubmission.id,
+    required_spec_tables: requiredSpecTables,
+  }
+  printJson(result)
+
+  return result
+}
+
+export function shouldCapturePromotionError(error: unknown): boolean {
+  return !(error instanceof PromotionGateError)
+}
+
+async function main(args = parseArgs()) {
+  await promoteProductById({
+    productId: requireFlag(args, "product-id"),
+    confirm: flagBool(args, "confirm"),
+    reviewer: flag(args, "reviewer"),
+    notes: flag(args, "notes"),
+  })
+}
+
+if (process.argv[1]?.endsWith("promote.ts")) {
+  const args = parseArgs()
+  main(args).catch(async (error) => {
+    if (shouldCapturePromotionError(error)) {
+      captureProductIntakeException(error, {
+        stage: "promote_product",
+        productId: flag(args, "product-id"),
+        reason: "failed",
+        committed: false,
+      })
+      await flushProductIntakeSentry()
+    }
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/product-intake/queue-reporting.ts
+++ b/scripts/product-intake/queue-reporting.ts
@@ -1,0 +1,255 @@
+type QueueSubmissionStatus =
+  | "pending_review"
+  | "researching"
+  | "ready_for_review"
+  | "needs_more_info"
+  | "matched_existing"
+  | "approved"
+  | "rejected"
+  | "cancelled_by_user"
+  | string
+
+export type ProductIntakeQueueRow = {
+  id: string
+  created_at: string
+  updated_at?: string | null
+  user_id: string
+  source: string
+  category: string
+  brand_text: string | null
+  product_name_text: string | null
+  front_image_path: string | null
+  barcode_image_path: string | null
+  status: QueueSubmissionStatus
+  reviewed_at?: string | null
+  approved_product_id?: string | null
+  notification_sent_at?: string | null
+  cleanup_after?: string | null
+  photos_deleted_at?: string | null
+  researched_payload?: Record<string, unknown> | null
+}
+
+export type QueueFilters = {
+  minAgeDays?: number | null
+  maxAgeDays?: number | null
+}
+
+export type QueueProjectedRow = {
+  id: string
+  age_days: number
+  created_at: string
+  updated_at: string
+  user: string
+  source: string
+  category: string
+  brand: string
+  name: string
+  front_image: string
+  barcode_image: string
+  status: string
+  research_state: string
+  notification_status: string
+  approval_outcome: string
+  photo_retention: string
+}
+
+export function queueResultLimit(params: {
+  report: boolean
+  format: string
+  limit: number
+  limitExplicit: boolean
+}): number | null {
+  if (params.report) {
+    return null
+  }
+  if ((params.format === "json" || params.format === "csv") && !params.limitExplicit) return null
+  return params.limit
+}
+
+const CLOSED_NOTIFICATION_STATUSES = new Set([
+  "approved",
+  "matched_existing",
+  "needs_more_info",
+  "rejected",
+])
+const CLOSED_OUTCOME_STATUSES = new Set([
+  "approved",
+  "matched_existing",
+  "needs_more_info",
+  "rejected",
+  "cancelled_by_user",
+])
+
+export function ageDays(createdAt: string, now: Date): number {
+  const created = new Date(createdAt)
+  const ageMs = now.getTime() - created.getTime()
+  if (!Number.isFinite(ageMs) || ageMs <= 0) return 0
+  return Math.floor(ageMs / (24 * 60 * 60 * 1000))
+}
+
+export function notificationStatus(row: ProductIntakeQueueRow): "" | "pending" | "sent" {
+  if (!CLOSED_NOTIFICATION_STATUSES.has(row.status)) return ""
+  return row.notification_sent_at ? "sent" : "pending"
+}
+
+export function approvalOutcome(row: ProductIntakeQueueRow): string {
+  return CLOSED_OUTCOME_STATUSES.has(row.status) ? row.status : ""
+}
+
+export function researchState(payload: Record<string, unknown> | null | undefined): string {
+  if (!payload || Object.keys(payload).length === 0) return "none"
+  const hasDraft = Boolean(payload.draft)
+  const hasFinal = Boolean(payload.final)
+  if (hasDraft && hasFinal) return "draft_and_final"
+  if (hasDraft) return "draft_only"
+  if (hasFinal) return "final_only"
+  return "payload_other"
+}
+
+export function photoRetention(row: ProductIntakeQueueRow, now: Date): string {
+  if (row.photos_deleted_at) return "photos_deleted"
+  if (!row.cleanup_after) return "no_cleanup_date"
+  return new Date(row.cleanup_after).getTime() <= now.getTime() ? "cleanup_due" : "pending_cleanup"
+}
+
+export function matchesQueueFilters(row: ProductIntakeQueueRow, filters: QueueFilters, now: Date) {
+  const age = ageDays(row.created_at, now)
+  if (filters.minAgeDays !== null && filters.minAgeDays !== undefined && age < filters.minAgeDays) {
+    return false
+  }
+  if (filters.maxAgeDays !== null && filters.maxAgeDays !== undefined && age > filters.maxAgeDays) {
+    return false
+  }
+
+  return true
+}
+
+export function projectQueueRow(
+  row: ProductIntakeQueueRow,
+  now: Date,
+  hashUserId: (userId: string) => string,
+): QueueProjectedRow {
+  return {
+    id: row.id,
+    age_days: ageDays(row.created_at, now),
+    created_at: row.created_at,
+    updated_at: row.updated_at ?? "",
+    user: hashUserId(row.user_id),
+    source: row.source,
+    category: row.category,
+    brand: row.brand_text ?? "",
+    name: row.product_name_text ?? "",
+    front_image: row.front_image_path ? "yes" : "",
+    barcode_image: row.barcode_image_path ? "yes" : "",
+    status: row.status,
+    research_state: researchState(row.researched_payload),
+    notification_status: notificationStatus(row),
+    approval_outcome: approvalOutcome(row),
+    photo_retention: photoRetention(row, now),
+  }
+}
+
+export function compactQueueRow(row: QueueProjectedRow) {
+  return {
+    id: row.id,
+    age_days: row.age_days,
+    source: row.source,
+    category: row.category,
+    brand: row.brand,
+    name: row.name,
+    status: row.status,
+    research_state: row.research_state,
+    notification_status: row.notification_status,
+  }
+}
+
+export function buildQueueReport(rows: ProductIntakeQueueRow[], now: Date) {
+  return {
+    total: rows.length,
+    by_status: countBy(rows, (row) => row.status),
+    by_age_bucket: countBy(rows, (row) => ageBucket(ageDays(row.created_at, now))),
+    by_category: countBy(rows, (row) => row.category),
+    by_source: countBy(rows, (row) => row.source),
+    by_notification_status: countBy(rows, notificationStatus),
+    by_approval_outcome: countBy(rows, approvalOutcome),
+    by_research_state: countBy(rows, (row) => researchState(row.researched_payload)),
+    by_photo_retention: countBy(rows, (row) => photoRetention(row, now)),
+  }
+}
+
+export function formatQueueCsv(rows: QueueProjectedRow[]): string {
+  const columns: Array<keyof QueueProjectedRow> = [
+    "id",
+    "age_days",
+    "created_at",
+    "updated_at",
+    "user",
+    "source",
+    "category",
+    "brand",
+    "name",
+    "front_image",
+    "barcode_image",
+    "status",
+    "research_state",
+    "notification_status",
+    "approval_outcome",
+    "photo_retention",
+  ]
+  return [
+    columns.join(","),
+    ...rows.map((row) => columns.map((column) => csvCell(row[column])).join(",")),
+  ].join("\n")
+}
+
+export function renderQueueOutput(params: {
+  rows: ProductIntakeQueueRow[]
+  now: Date
+  hashUserId: (userId: string) => string
+  report: boolean
+  format: string
+  compact: boolean
+}):
+  | { kind: "json"; value: unknown }
+  | { kind: "csv"; value: string }
+  | { kind: "table"; value: unknown[] }
+  | { kind: "empty_text"; value: string } {
+  if (params.report) {
+    return { kind: "json", value: buildQueueReport(params.rows, params.now) }
+  }
+
+  const projected = params.rows.map((row) => projectQueueRow(row, params.now, params.hashUserId))
+  if (params.format === "json") {
+    return { kind: "json", value: projected }
+  }
+  if (params.format === "csv") {
+    return { kind: "csv", value: formatQueueCsv(projected) }
+  }
+  if (params.rows.length === 0) {
+    return { kind: "empty_text", value: "No product intake submissions found." }
+  }
+
+  return { kind: "table", value: params.compact ? projected.map(compactQueueRow) : projected }
+}
+
+function ageBucket(age: number): string {
+  if (age <= 1) return "0-1d"
+  if (age <= 3) return "2-3d"
+  if (age <= 7) return "4-7d"
+  return "8+d"
+}
+
+function countBy<T>(rows: T[], getKey: (row: T) => string): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const row of rows) {
+    const key = getKey(row) || "none"
+    counts[key] = (counts[key] ?? 0) + 1
+  }
+  return counts
+}
+
+function csvCell(value: unknown): string {
+  const raw = value === null || value === undefined ? "" : String(value)
+  if (!/[",\n]/.test(raw)) return raw
+  return `"${raw.replaceAll('"', '""')}"`
+}

--- a/scripts/product-intake/queue.ts
+++ b/scripts/product-intake/queue.ts
@@ -1,4 +1,11 @@
 import { createSupabaseClientFromEnv, flag, flagBool, flagInt, hashUserId, parseArgs } from "./cli"
+import type { SupabaseClient } from "@supabase/supabase-js"
+import {
+  matchesQueueFilters,
+  queueResultLimit,
+  renderQueueOutput,
+  type ProductIntakeQueueRow,
+} from "./queue-reporting"
 
 const ACTIONABLE_STATUSES = [
   "pending_review",
@@ -6,80 +13,175 @@ const ACTIONABLE_STATUSES = [
   "ready_for_review",
   "needs_more_info",
 ] as const
-
-type QueueRow = {
-  id: string
-  created_at: string
-  user_id: string
-  source: string
-  category: string
-  brand_text: string | null
-  product_name_text: string | null
-  front_image_path: string | null
-  barcode_image_path: string | null
-  status: string
-}
+const QUEUE_SELECT = [
+  "id",
+  "created_at",
+  "updated_at",
+  "user_id",
+  "source",
+  "category",
+  "brand_text",
+  "product_name_text",
+  "front_image_path",
+  "barcode_image_path",
+  "status",
+  "reviewed_at",
+  "approved_product_id",
+  "notification_sent_at",
+  "cleanup_after",
+  "photos_deleted_at",
+  "researched_payload",
+].join(", ")
+const QUEUE_EXPORT_PAGE_SIZE = 1000
 
 async function main() {
   const args = parseArgs()
   const supabase = createSupabaseClientFromEnv()
   const limit = flagInt(args, "limit", 50)
+  const limitExplicit = args.flags.has("limit")
   const statusFilter = flag(args, "status")
+  const categoryFilter = flag(args, "category")
+  const sourceFilter = flag(args, "source")
+  const format = flag(args, "format") ?? "table"
+  const compact = flagBool(args, "compact")
+  const report = flagBool(args, "report")
   const includeClosed = flagBool(args, "include-closed")
+  const minAgeDays = optionalPositiveInt(args, "min-age-days")
+  const maxAgeDays = optionalPositiveInt(args, "max-age-days")
+  const now = new Date()
 
-  let query = supabase
-    .from("product_submissions")
-    .select(
-      [
-        "id",
-        "created_at",
-        "user_id",
-        "source",
-        "category",
-        "brand_text",
-        "product_name_text",
-        "front_image_path",
-        "barcode_image_path",
-        "status",
-      ].join(", "),
+  if (report && limitExplicit) {
+    throw new Error(
+      "--report cannot be combined with --limit because report counts must be complete",
     )
-    .order("created_at", { ascending: true })
-    .limit(limit)
+  }
 
-  if (statusFilter) {
-    query = query.eq("status", statusFilter)
-  } else if (!includeClosed) {
+  const resultLimit = queueResultLimit({ report, format, limit, limitExplicit })
+  const rows = await loadQueueRows({
+    supabase,
+    statusFilter,
+    categoryFilter,
+    sourceFilter,
+    includeClosed,
+    minAgeDays,
+    maxAgeDays,
+    resultLimit,
+    now,
+  })
+  const output = renderQueueOutput({ rows, now, hashUserId, report, format, compact })
+  if (output.kind === "json") {
+    console.log(JSON.stringify(output.value, null, 2))
+  } else if (output.kind === "csv" || output.kind === "empty_text") {
+    console.log(output.value)
+  } else {
+    console.table(output.value)
+  }
+}
+
+if (process.argv[1]?.endsWith("queue.ts")) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+}
+
+export async function loadQueueRows(params: {
+  supabase: SupabaseClient
+  statusFilter: string | null
+  categoryFilter: string | null
+  sourceFilter: string | null
+  includeClosed: boolean
+  minAgeDays: number | null
+  maxAgeDays: number | null
+  resultLimit: number | null
+  now: Date
+}): Promise<ProductIntakeQueueRow[]> {
+  const rows: ProductIntakeQueueRow[] = []
+  for (let offset = 0; ; ) {
+    const remaining =
+      params.resultLimit === null ? QUEUE_EXPORT_PAGE_SIZE : params.resultLimit - rows.length
+    if (remaining <= 0) break
+
+    const pageSize = Math.min(QUEUE_EXPORT_PAGE_SIZE, remaining)
+    const { data, error } = await buildQueueQuery(params).range(offset, offset + pageSize - 1)
+    if (error) throw new Error(`load product intake queue: ${error.message}`)
+
+    const page = (data ?? []) as unknown as ProductIntakeQueueRow[]
+    rows.push(...page)
+    offset += pageSize
+    if (page.length < pageSize) break
+  }
+
+  return filterLoadedRows(rows, params)
+}
+
+function buildQueueQuery(params: {
+  supabase: SupabaseClient
+  statusFilter: string | null
+  categoryFilter: string | null
+  sourceFilter: string | null
+  includeClosed: boolean
+  minAgeDays: number | null
+  maxAgeDays: number | null
+  now: Date
+}) {
+  let query = params.supabase
+    .from("product_submissions")
+    .select(QUEUE_SELECT)
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true })
+
+  if (params.statusFilter) {
+    query = query.eq("status", params.statusFilter)
+  } else if (!params.includeClosed) {
     query = query.in("status", [...ACTIONABLE_STATUSES])
   }
-
-  const { data, error } = await query
-  if (error) {
-    throw new Error(`load product intake queue: ${error.message}`)
+  if (params.categoryFilter) {
+    query = query.eq("category", params.categoryFilter)
+  }
+  if (params.sourceFilter) {
+    query = query.eq("source", params.sourceFilter)
+  }
+  if (params.minAgeDays !== null) {
+    query = query.lte("created_at", ageCutoffIso(params.now, params.minAgeDays))
+  }
+  if (params.maxAgeDays !== null) {
+    query = query.gte("created_at", ageCutoffIso(params.now, params.maxAgeDays + 1))
   }
 
-  const rows = (data ?? []) as QueueRow[]
-  if (rows.length === 0) {
-    console.log("No product intake submissions found.")
-    return
-  }
+  return query
+}
 
-  console.table(
-    rows.map((row) => ({
-      id: row.id,
-      created_at: row.created_at,
-      user: hashUserId(row.user_id),
-      source: row.source,
-      category: row.category,
-      brand: row.brand_text ?? "",
-      name: row.product_name_text ?? "",
-      front_image: row.front_image_path ? "yes" : "",
-      barcode_image: row.barcode_image_path ? "yes" : "",
-      status: row.status,
-    })),
+function filterLoadedRows(
+  data: ProductIntakeQueueRow[] | null,
+  filters: {
+    minAgeDays: number | null
+    maxAgeDays: number | null
+    now: Date
+  },
+): ProductIntakeQueueRow[] {
+  return ((data ?? []) as ProductIntakeQueueRow[]).filter((row) =>
+    matchesQueueFilters(
+      row,
+      {
+        minAgeDays: filters.minAgeDays,
+        maxAgeDays: filters.maxAgeDays,
+      },
+      filters.now,
+    ),
   )
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error)
-  process.exitCode = 1
-})
+function optionalPositiveInt(args: ReturnType<typeof parseArgs>, name: string): number | null {
+  const raw = flag(args, name)
+  if (!raw) return null
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0 || String(parsed) !== raw.trim()) {
+    throw new Error(`--${name} must be a non-negative integer`)
+  }
+  return parsed
+}
+
+function ageCutoffIso(now: Date, days: number): string {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+}

--- a/scripts/product-intake/request-info.ts
+++ b/scripts/product-intake/request-info.ts
@@ -8,6 +8,7 @@ import {
   printJson,
   requireFlag,
 } from "./cli"
+import { flushProductIntakeSentry } from "@/lib/observability/product-intake"
 import { notifyReviewResult, rejectSubmission, requestMoreInfo } from "./review-actions"
 
 async function readMissingFields(path: string | null): Promise<unknown[]> {
@@ -126,7 +127,8 @@ async function main() {
   })
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
   console.error(error instanceof Error ? error.message : error)
+  await flushProductIntakeSentry()
   process.exitCode = 1
 })

--- a/scripts/product-intake/review-actions.ts
+++ b/scripts/product-intake/review-actions.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { sendProductIntakeReviewNotification } from "@/lib/product-intake/notifications"
+import { captureProductIntakeException } from "@/lib/observability/product-intake"
 import type {
   ProductIntakeFinalReviewedPayload,
   ProductIntakeTargetSpecOperation,
@@ -87,6 +88,18 @@ export async function approveReviewedSubmission(params: {
   })
 
   if (error) {
+    captureProductIntakeException(error, {
+      stage: "approve_reviewed_product",
+      submissionId: params.submission.id,
+      userId: params.submission.user_id,
+      source: params.submission.source,
+      sourceConversationId: params.submission.source_conversation_id,
+      category: params.submission.category,
+      intakeMethod: params.submission.intake_method,
+      status: params.submission.status,
+      reason: error.code ?? "rpc_error",
+      committed: false,
+    })
     throw new Error(`approve product submission ${params.submission.id}: ${error.message}`)
   }
 
@@ -110,6 +123,13 @@ export async function linkExistingProduct(params: {
   })
 
   if (error) {
+    captureProductIntakeException(error, {
+      stage: "link_existing_product",
+      submissionId: params.submissionId,
+      productId: params.productId,
+      reason: error.code ?? "rpc_error",
+      committed: false,
+    })
     throw new Error(`link product submission ${params.submissionId}: ${error.message}`)
   }
 
@@ -137,6 +157,12 @@ export async function requestMoreInfo(params: {
   })
 
   if (error) {
+    captureProductIntakeException(error, {
+      stage: "request_more_info",
+      submissionId: params.submissionId,
+      reason: error.code ?? "rpc_error",
+      committed: false,
+    })
     throw new Error(`request info for product submission ${params.submissionId}: ${error.message}`)
   }
 
@@ -162,6 +188,12 @@ export async function rejectSubmission(params: {
   })
 
   if (error) {
+    captureProductIntakeException(error, {
+      stage: "reject_submission",
+      submissionId: params.submissionId,
+      reason: error.code ?? "rpc_error",
+      committed: false,
+    })
     throw new Error(`reject product submission ${params.submissionId}: ${error.message}`)
   }
 
@@ -211,5 +243,21 @@ export async function appendProductAdditionRecord(record: AdditionRecord): Promi
 }
 
 export async function notifyReviewResult(supabase: SupabaseClient, submission: ProductSubmission) {
-  return sendProductIntakeReviewNotification(supabase, submission)
+  try {
+    return await sendProductIntakeReviewNotification(supabase, submission)
+  } catch (error) {
+    captureProductIntakeException(error, {
+      stage: "send_review_notification",
+      submissionId: submission.id,
+      approvedProductId: submission.approved_product_id,
+      userId: submission.user_id,
+      source: submission.source,
+      sourceConversationId: submission.source_conversation_id,
+      category: submission.category,
+      intakeMethod: submission.intake_method,
+      status: submission.status,
+      notificationResult: "failed",
+    })
+    throw error
+  }
 }

--- a/src/lib/observability/product-intake.ts
+++ b/src/lib/observability/product-intake.ts
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto"
+
+import * as Sentry from "@sentry/nextjs"
+import { scrubSentryBreadcrumb, scrubSentryEvent } from "@/lib/observability/checkout"
+
+type ProductIntakeStage =
+  | "approve_reviewed_product"
+  | "link_existing_product"
+  | "request_more_info"
+  | "reject_submission"
+  | "append_addition_record"
+  | "send_review_notification"
+  | "promote_product"
+
+type BreadcrumbLevel = "debug" | "info" | "warning" | "error"
+
+export interface ProductIntakeSentryDetails {
+  stage: ProductIntakeStage
+  submissionId?: string | null
+  approvedProductId?: string | null
+  productId?: string | null
+  userId?: string | null
+  source?: string | null
+  sourceConversationId?: string | null
+  category?: string | null
+  intakeMethod?: string | null
+  status?: string | null
+  reason?: string | null
+  notificationResult?: "sent" | "already_sent" | "no_message_needed" | "failed" | null
+  committed?: boolean | null
+}
+
+export interface ProductIntakeSentryPayload {
+  tags: Record<string, string>
+  context: Record<string, unknown>
+}
+
+interface ProductIntakeScopeLike {
+  setContext(name: string, context: Record<string, unknown>): void
+  setLevel?(level: BreadcrumbLevel): void
+  setTag(key: string, value: string): void
+}
+
+interface ProductIntakeSentrySink {
+  captureException(error: unknown): void
+  flush?(timeout?: number): Promise<boolean>
+  init?(options: Record<string, unknown>): void
+  withScope(callback: (scope: ProductIntakeScopeLike) => void): void
+}
+
+let scriptSentryInitialized = false
+
+export function initProductIntakeScriptSentry(sink: ProductIntakeSentrySink = Sentry) {
+  if (scriptSentryInitialized || !process.env.NEXT_PUBLIC_SENTRY_DSN || !sink.init) {
+    return
+  }
+
+  sink.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment:
+      process.env.VERCEL_ENV ?? process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV,
+    sendDefaultPii: false,
+    tracesSampleRate: 0,
+    beforeSend: scrubSentryEvent,
+    beforeSendTransaction: scrubSentryEvent,
+    beforeBreadcrumb: scrubSentryBreadcrumb,
+  })
+  scriptSentryInitialized = true
+}
+
+export function buildProductIntakeSentryPayload(
+  details: ProductIntakeSentryDetails,
+): ProductIntakeSentryPayload {
+  const context: Record<string, unknown> = {
+    stage: details.stage,
+  }
+  const tags: Record<string, string> = {
+    "product_intake.stage": details.stage,
+  }
+
+  addOptional(context, "submission_id", details.submissionId)
+  addOptional(context, "approved_product_id", details.approvedProductId)
+  addOptional(context, "product_id", details.productId)
+  addOptional(context, "user_hash", details.userId ? hashProductIntakeUserId(details.userId) : null)
+  addOptional(context, "source", details.source)
+  addOptional(
+    context,
+    "source_conversation_hash",
+    details.sourceConversationId ? hashProductIntakeIdentifier(details.sourceConversationId) : null,
+  )
+  addOptional(context, "source_conversation_present", Boolean(details.sourceConversationId) || null)
+  addOptional(context, "category", details.category)
+  addOptional(context, "intake_method", details.intakeMethod)
+  addOptional(context, "status", details.status)
+  addOptional(context, "reason", details.reason)
+  addOptional(context, "notification_result", details.notificationResult)
+  addOptional(context, "committed", details.committed)
+
+  addTag(tags, "product_intake.source", details.source)
+  addTag(tags, "product_intake.category", details.category)
+  addTag(tags, "product_intake.intake_method", details.intakeMethod)
+  addTag(tags, "product_intake.status", details.status)
+  addTag(tags, "product_intake.reason", details.reason)
+  addTag(tags, "product_intake.notification_result", details.notificationResult)
+
+  return { tags, context }
+}
+
+export function hashProductIntakeUserId(userId: string): string {
+  return hashProductIntakeIdentifier(userId)
+}
+
+function hashProductIntakeIdentifier(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 10)
+}
+
+export function captureProductIntakeException(
+  error: unknown,
+  details: ProductIntakeSentryDetails,
+  sink: ProductIntakeSentrySink = Sentry,
+) {
+  const payload = buildProductIntakeSentryPayload(details)
+  sink.withScope((scope) => {
+    for (const [key, value] of Object.entries(payload.tags)) {
+      scope.setTag(key, value)
+    }
+    scope.setContext("product_intake", payload.context)
+    scope.setLevel?.("error")
+    sink.captureException(error)
+  })
+}
+
+export async function flushProductIntakeSentry(
+  timeoutMs = 2000,
+  sink: ProductIntakeSentrySink = Sentry,
+): Promise<boolean> {
+  if (!sink.flush) return false
+  try {
+    return await sink.flush(timeoutMs)
+  } catch {
+    return false
+  }
+}
+
+function addOptional(target: Record<string, unknown>, key: string, value: unknown) {
+  if (value === undefined || value === null || value === "") return
+  target[key] = value
+}
+
+function addTag(target: Record<string, string>, key: string, value: unknown) {
+  if (value === undefined || value === null || value === "") return
+  target[key] = String(value)
+}

--- a/tests/product-intake-observability.test.ts
+++ b/tests/product-intake-observability.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  buildProductIntakeSentryPayload,
+  captureProductIntakeException,
+  flushProductIntakeSentry,
+  initProductIntakeScriptSentry,
+} from "../src/lib/observability/product-intake"
+
+test("product intake Sentry payload keeps searchable tags without product prose", () => {
+  const payload = buildProductIntakeSentryPayload({
+    stage: "send_review_notification",
+    submissionId: "submission-1",
+    approvedProductId: "product-1",
+    userId: "user-1",
+    source: "chat",
+    sourceConversationId: "conversation-1",
+    category: "shampoo",
+    intakeMethod: "photo",
+    status: "approved",
+    reason: "message_insert_failed",
+    notificationResult: "failed",
+    committed: true,
+  })
+
+  assert.deepEqual(payload.tags, {
+    "product_intake.stage": "send_review_notification",
+    "product_intake.source": "chat",
+    "product_intake.category": "shampoo",
+    "product_intake.intake_method": "photo",
+    "product_intake.status": "approved",
+    "product_intake.reason": "message_insert_failed",
+    "product_intake.notification_result": "failed",
+  })
+  assert.equal(payload.context.submission_id, "submission-1")
+  assert.equal(payload.context.approved_product_id, "product-1")
+  assert.equal(payload.context.user_hash, "c6c289e49e")
+  assert.equal("user_id" in payload.context, false)
+  assert.equal(payload.context.source_conversation_hash, "413055e0cb")
+  assert.equal(payload.context.source_conversation_present, true)
+  assert.equal("source_conversation_id" in payload.context, false)
+  assert.equal("brand_text" in payload.context, false)
+  assert.equal("product_name_text" in payload.context, false)
+  assert.equal("review_notes" in payload.context, false)
+})
+
+test("captureProductIntakeException scopes tags and context", () => {
+  const tags: Record<string, string> = {}
+  const contexts: Record<string, Record<string, unknown>> = {}
+  const captured: unknown[] = []
+  const sink = {
+    captureException: (error: unknown) => captured.push(error),
+    withScope: (callback: {
+      (scope: {
+        setContext: (name: string, context: Record<string, unknown>) => void
+        setLevel: (level: string) => void
+        setTag: (key: string, value: string) => void
+      }): void
+    }) =>
+      callback({
+        setContext: (name, context) => {
+          contexts[name] = context
+        },
+        setLevel: (level) => {
+          tags.level = level
+        },
+        setTag: (key, value) => {
+          tags[key] = value
+        },
+      }),
+  }
+  const error = new Error("notification failed")
+
+  captureProductIntakeException(
+    error,
+    {
+      stage: "send_review_notification",
+      submissionId: "submission-1",
+      status: "approved",
+      notificationResult: "failed",
+    },
+    sink,
+  )
+
+  assert.equal(captured[0], error)
+  assert.equal(tags["product_intake.stage"], "send_review_notification")
+  assert.equal(tags["product_intake.status"], "approved")
+  assert.equal(tags["product_intake.notification_result"], "failed")
+  assert.equal(tags.level, "error")
+  assert.equal(contexts.product_intake.submission_id, "submission-1")
+})
+
+test("product intake script Sentry init is skipped without a DSN", () => {
+  const previousDsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+  delete process.env.NEXT_PUBLIC_SENTRY_DSN
+  let initCalls = 0
+
+  initProductIntakeScriptSentry({
+    captureException: () => {},
+    init: () => {
+      initCalls += 1
+    },
+    withScope: () => {},
+  })
+
+  assert.equal(initCalls, 0)
+  if (previousDsn) {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = previousDsn
+  }
+})
+
+test("flushProductIntakeSentry flushes short-lived script captures", async () => {
+  const timeouts: number[] = []
+  const flushed = await flushProductIntakeSentry(2000, {
+    captureException: () => {},
+    flush: async (timeout) => {
+      timeouts.push(timeout ?? 0)
+      return true
+    },
+    withScope: () => {},
+  })
+
+  assert.equal(flushed, true)
+  assert.deepEqual(timeouts, [2000])
+})

--- a/tests/product-intake-review-scripts.test.ts
+++ b/tests/product-intake-review-scripts.test.ts
@@ -3,11 +3,28 @@ import { readFileSync } from "node:fs"
 import test from "node:test"
 
 import {
+  PromotionGateError,
+  REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY,
+  buildPromotionPayload,
+  promoteProductById,
+  shouldCapturePromotionError,
+  validatePromotableProduct,
+} from "../scripts/product-intake/promote"
+import {
+  buildQueueReport,
+  matchesQueueFilters,
+  projectQueueRow,
+  queueResultLimit,
+  renderQueueOutput,
+  type ProductIntakeQueueRow,
+} from "../scripts/product-intake/queue-reporting"
+import {
   buildProductIntakeReviewMessage,
   buildProductIntakeReviewRagContext,
 } from "../src/lib/product-intake/notifications"
 import type { ProductSubmission } from "../src/lib/types"
 import { parseArgs } from "../scripts/product-intake/cli"
+import { loadQueueRows } from "../scripts/product-intake/queue"
 
 const reviewMigration = readFileSync(
   "supabase/migrations/20260617120000_product_intake_review_workflow_functions.sql",
@@ -16,9 +33,13 @@ const reviewMigration = readFileSync(
 const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
   scripts: Record<string, string>
 }
+const approveScript = readFileSync("scripts/product-intake/approve.ts", "utf8")
 const linkExistingScript = readFileSync("scripts/product-intake/link-existing.ts", "utf8")
+const queueScript = readFileSync("scripts/product-intake/queue.ts", "utf8")
 const requestInfoScript = readFileSync("scripts/product-intake/request-info.ts", "utf8")
 const researchScript = readFileSync("scripts/product-intake/research.ts", "utf8")
+const promoteScript = readFileSync("scripts/product-intake/promote.ts", "utf8")
+const notifyPendingScript = readFileSync("scripts/product-intake/notify-pending.ts", "utf8")
 const cleanupPhotosScript = readFileSync("scripts/product-intake/cleanup-photos.ts", "utf8")
 const cleanupStorageScript = readFileSync("scripts/product-intake/cleanup-storage.ts", "utf8")
 const notificationsSource = readFileSync("src/lib/product-intake/notifications.ts", "utf8")
@@ -54,6 +75,10 @@ test("Phase 4A package scripts expose the script-first review workflow", () => {
   assert.equal(
     packageJson.scripts["products:intake:notify-pending"],
     "tsx scripts/product-intake/notify-pending.ts",
+  )
+  assert.equal(
+    packageJson.scripts["products:intake:promote"],
+    "tsx scripts/product-intake/promote.ts",
   )
   assert.equal(
     packageJson.scripts["products:intake:cleanup-storage"],
@@ -137,6 +162,41 @@ test("destructive review scripts default to dry-run and require explicit confirm
   assert.match(researchScript, /\.eq\("updated_at", submission\.updated_at\)/)
   assert.match(researchScript, /submission\.researched_payload \?\? {}/)
   assert.match(researchScript, /error\?\.message \?\? "no row updated"/)
+  assert.match(queueScript, /--report|flagBool\(args, "report"\)/)
+  assert.match(queueScript, /flag\(args, "category"\)/)
+  assert.match(queueScript, /flag\(args, "source"\)/)
+  assert.doesNotMatch(queueScript, /flag\(args, "notification"\)/)
+  assert.match(queueScript, /renderQueueOutput/)
+
+  assert.doesNotMatch(promoteScript, /Dry-run only/)
+  assert.match(promoteScript, /confirm:\s*flagBool\(args, "confirm"\)/)
+  assert.match(promoteScript, /Product \${productId} not found/)
+  assert.match(promoteScript, /is_active=true/)
+  assert.match(promoteScript, /lifecycle_status/)
+  assert.match(promoteScript, /missing required category specs/)
+  assert.match(promoteScript, /proposed_action:[\s\S]{0,160}"already_recommended"/)
+  assert.match(promoteScript, /is_chaarlie_recommended:\s*true/)
+  assert.match(promoteScript, /updated_at:\s*updatedAt/)
+  assert.match(promoteScript, /origin !== "user_submitted"/)
+  assert.match(promoteScript, /\.from\("product_submissions"\)/)
+  assert.match(promoteScript, /\.eq\("status", "approved"\)/)
+  assert.match(promoteScript, /stage:\s*"promote_product"/)
+  assert.match(promoteScript, /flushProductIntakeSentry/)
+  assert.match(promoteScript, /shouldCapturePromotionError/)
+  assert.match(promoteScript, /\.eq\("is_active", true\)/)
+  assert.match(promoteScript, /\.eq\("lifecycle_status", "active"\)/)
+  assert.match(promoteScript, /\.eq\("is_chaarlie_recommended", false\)/)
+  assert.match(promoteScript, /\.eq\("updated_at", product\.updated_at\)/)
+  assert.doesNotMatch(promoteScript, /origin:\s*"curated"/)
+  assert.match(approveScript, /stage:\s*"append_addition_record"/)
+  assert.match(approveScript, /committed:\s*true/)
+  assert.match(queueScript, /\.lte\("created_at"/)
+  assert.match(queueScript, /\.gte\("created_at"/)
+  assert.match(approveScript, /flushProductIntakeSentry/)
+  assert.match(linkExistingScript, /flushProductIntakeSentry/)
+  assert.match(requestInfoScript, /flushProductIntakeSentry/)
+  assert.doesNotMatch(notifyPendingScript, /stage:\s*"notify_pending"/)
+  assert.match(notifyPendingScript, /flushProductIntakeSentry/)
 })
 
 test("product intake CLI preserves inline flag values containing equals signs", () => {
@@ -146,6 +206,589 @@ test("product intake CLI preserves inline flag values containing equals signs", 
   assert.equal(args.flags.get("apply"), true)
   assert.deepEqual(args.positional, ["extra"])
 })
+
+test("queue reporting derives ops status, filters, report counts, and csv output", () => {
+  const now = new Date("2026-06-17T12:00:00.000Z")
+  const rows: ProductIntakeQueueRow[] = [
+    {
+      id: "submission-1",
+      created_at: "2026-06-16T12:00:00.000Z",
+      updated_at: "2026-06-17T10:00:00.000Z",
+      user_id: "user-1",
+      source: "chat",
+      category: "mask",
+      brand_text: "Garnier",
+      product_name_text: "Hair Food, Aloe",
+      front_image_path: "front.jpg",
+      barcode_image_path: null,
+      status: "approved",
+      reviewed_at: "2026-06-17T09:00:00.000Z",
+      approved_product_id: "product-1",
+      notification_sent_at: null,
+      cleanup_after: "2026-06-17T11:00:00.000Z",
+      photos_deleted_at: null,
+      researched_payload: { draft: {}, final: {} },
+    },
+    {
+      id: "submission-2",
+      created_at: "2026-06-09T12:00:00.000Z",
+      updated_at: "2026-06-10T10:00:00.000Z",
+      user_id: "user-2",
+      source: "onboarding",
+      category: "conditioner",
+      brand_text: null,
+      product_name_text: "Repair",
+      front_image_path: null,
+      barcode_image_path: null,
+      status: "pending_review",
+      notification_sent_at: null,
+      cleanup_after: null,
+      photos_deleted_at: null,
+      researched_payload: {},
+    },
+    {
+      id: "submission-3",
+      created_at: "2026-06-14T12:00:00.000Z",
+      updated_at: "2026-06-15T10:00:00.000Z",
+      user_id: "user-3",
+      source: "chat",
+      category: "shampoo",
+      brand_text: "dm",
+      product_name_text: "Shampoo",
+      front_image_path: null,
+      barcode_image_path: null,
+      status: "rejected",
+      notification_sent_at: "2026-06-15T11:00:00.000Z",
+      cleanup_after: "2026-06-20T11:00:00.000Z",
+      photos_deleted_at: "2026-06-16T11:00:00.000Z",
+      researched_payload: { final: {} },
+    },
+  ]
+
+  const projected = projectQueueRow(rows[0], now, (userId) => `hash-${userId}`)
+  assert.equal(projected.age_days, 1)
+  assert.equal(projected.notification_status, "pending")
+  assert.equal(projected.approval_outcome, "approved")
+  assert.equal(projected.research_state, "draft_and_final")
+  assert.equal(projected.photo_retention, "cleanup_due")
+
+  assert.equal(matchesQueueFilters(rows[0], {}, now), true)
+  assert.equal(matchesQueueFilters(rows[2], { minAgeDays: 4 }, now), false)
+  assert.equal(
+    queueResultLimit({ report: false, format: "table", limit: 50, limitExplicit: false }),
+    50,
+  )
+  assert.equal(
+    queueResultLimit({ report: true, format: "table", limit: 50, limitExplicit: false }),
+    null,
+  )
+  assert.equal(
+    queueResultLimit({ report: false, format: "json", limit: 50, limitExplicit: false }),
+    null,
+  )
+  assert.equal(
+    queueResultLimit({ report: false, format: "csv", limit: 50, limitExplicit: false }),
+    null,
+  )
+  assert.equal(
+    queueResultLimit({ report: false, format: "json", limit: 5, limitExplicit: true }),
+    5,
+  )
+  assert.equal(queueResultLimit({ report: false, format: "csv", limit: 5, limitExplicit: true }), 5)
+
+  const report = buildQueueReport(rows, now)
+  assert.deepEqual(report.by_status, { approved: 1, pending_review: 1, rejected: 1 })
+  assert.deepEqual(report.by_age_bucket, { "0-1d": 1, "8+d": 1, "2-3d": 1 })
+  assert.deepEqual(report.by_notification_status, { pending: 1, none: 1, sent: 1 })
+  assert.deepEqual(report.by_research_state, {
+    draft_and_final: 1,
+    none: 1,
+    final_only: 1,
+  })
+
+  const emptyReport = renderQueueOutput({
+    rows: [],
+    now,
+    hashUserId: (userId) => `hash-${userId}`,
+    report: true,
+    format: "table",
+    compact: false,
+  })
+  const emptyJson = renderQueueOutput({
+    rows: [],
+    now,
+    hashUserId: (userId) => `hash-${userId}`,
+    report: false,
+    format: "json",
+    compact: false,
+  })
+  const emptyCsv = renderQueueOutput({
+    rows: [],
+    now,
+    hashUserId: (userId) => `hash-${userId}`,
+    report: false,
+    format: "csv",
+    compact: false,
+  })
+  const emptyTable = renderQueueOutput({
+    rows: [],
+    now,
+    hashUserId: (userId) => `hash-${userId}`,
+    report: false,
+    format: "table",
+    compact: false,
+  })
+
+  assert.deepEqual(emptyReport, {
+    kind: "json",
+    value: {
+      total: 0,
+      by_status: {},
+      by_age_bucket: {},
+      by_category: {},
+      by_source: {},
+      by_notification_status: {},
+      by_approval_outcome: {},
+      by_research_state: {},
+      by_photo_retention: {},
+    },
+  })
+  assert.deepEqual(emptyJson, { kind: "json", value: [] })
+  assert.equal(emptyCsv.kind, "csv")
+  assert.match(emptyCsv.value, /^id,age_days,created_at/)
+  assert.equal(emptyTable.kind, "empty_text")
+
+  const csv = renderQueueOutput({
+    rows: [rows[0]],
+    now,
+    hashUserId: (userId) => `hash-${userId}`,
+    report: false,
+    format: "csv",
+    compact: false,
+  })
+  assert.equal(csv.kind, "csv")
+  assert.match(csv.value, /"Hair Food, Aloe"/)
+})
+
+test("queue loader pages complete exports while preserving explicit sample limits", async () => {
+  const now = new Date("2026-06-17T12:00:00.000Z")
+  const rows = Array.from(
+    { length: 1001 },
+    (_, index): ProductIntakeQueueRow => ({
+      id: `submission-${index + 1}`,
+      created_at: "2026-06-17T10:00:00.000Z",
+      updated_at: "2026-06-17T11:00:00.000Z",
+      user_id: `user-${index + 1}`,
+      source: "chat",
+      category: "mask",
+      brand_text: "Garnier",
+      product_name_text: `Hair Food ${index + 1}`,
+      front_image_path: null,
+      barcode_image_path: null,
+      status: "pending_review",
+      notification_sent_at: null,
+      cleanup_after: null,
+      photos_deleted_at: null,
+      researched_payload: {},
+    }),
+  )
+
+  const exportSupabase = fakeQueueSupabase(rows)
+  const exportRows = await loadQueueRows({
+    supabase: exportSupabase,
+    statusFilter: null,
+    categoryFilter: null,
+    sourceFilter: null,
+    includeClosed: false,
+    minAgeDays: null,
+    maxAgeDays: null,
+    resultLimit: null,
+    now,
+  })
+
+  assert.equal(exportRows.length, 1001)
+  assert.deepEqual(exportSupabase.rangeCalls, [
+    { from: 0, to: 999 },
+    { from: 1000, to: 1999 },
+  ])
+  assert.deepEqual(exportSupabase.orderCalls, ["created_at", "id", "created_at", "id"])
+
+  const largeSampleRows = Array.from(
+    { length: 1501 },
+    (_, index): ProductIntakeQueueRow => ({
+      ...rows[0],
+      id: `large-submission-${index + 1}`,
+      user_id: `large-user-${index + 1}`,
+      product_name_text: `Large Hair Food ${index + 1}`,
+    }),
+  )
+  const sampleSupabase = fakeQueueSupabase(largeSampleRows)
+  const sampleRows = await loadQueueRows({
+    supabase: sampleSupabase,
+    statusFilter: null,
+    categoryFilter: null,
+    sourceFilter: null,
+    includeClosed: false,
+    minAgeDays: null,
+    maxAgeDays: null,
+    resultLimit: 1500,
+    now,
+  })
+
+  assert.equal(sampleRows.length, 1500)
+  assert.deepEqual(sampleSupabase.rangeCalls, [
+    { from: 0, to: 999 },
+    { from: 1000, to: 1499 },
+  ])
+  assert.deepEqual(sampleSupabase.orderCalls, ["created_at", "id", "created_at", "id"])
+})
+
+test("promotion command reports state and preserves category-specific readiness gates", () => {
+  assert.deepEqual(REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY.conditioner, [
+    "product_conditioner_specs",
+    "product_conditioner_rerank_specs",
+  ])
+  assert.deepEqual(REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY.leave_in, [
+    "product_leave_in_specs",
+    "product_leave_in_fit_specs",
+    "product_leave_in_eligibility",
+  ])
+  assert.deepEqual(REQUIRED_PROMOTION_SPEC_TABLES_BY_CATEGORY.oil, ["product_oil_eligibility"])
+
+  const payload = buildPromotionPayload({
+    product: {
+      id: "product-1",
+      name: "Garnier Hair Food Aloe",
+      category: "Maske",
+      category_key: "mask",
+      origin: "user_submitted",
+      is_active: true,
+      lifecycle_status: "active",
+      is_chaarlie_recommended: false,
+    },
+    dryRun: true,
+    reviewer: "Nick",
+    notes: "Approved in Phase 4B",
+  })
+
+  assert.equal(payload.current_recommendation_state, false)
+  assert.equal(payload.origin, "user_submitted")
+  assert.equal(payload.category, "Maske")
+  assert.equal(payload.category_key, "mask")
+  assert.equal(payload.lifecycle_status, "active")
+  assert.equal(payload.is_active, true)
+  assert.equal(payload.dry_run, true)
+  assert.equal(payload.proposed_action, "promote")
+  assert.equal(payload.reviewer, "Nick")
+  assert.equal(payload.notes, "Approved in Phase 4B")
+
+  assert.deepEqual(
+    validatePromotableProduct({
+      id: "product-1",
+      category: null,
+      category_key: "mask",
+      origin: "user_submitted",
+      is_active: true,
+      lifecycle_status: "active",
+      is_chaarlie_recommended: false,
+    }),
+    ["product_mask_specs"],
+  )
+
+  assert.throws(
+    () =>
+      validatePromotableProduct({
+        id: "product-2",
+        category: null,
+        category_key: "mask",
+        origin: "user_submitted",
+        is_active: false,
+        lifecycle_status: "active",
+        is_chaarlie_recommended: false,
+      }),
+    /is_active=true/,
+  )
+  assert.throws(
+    () =>
+      validatePromotableProduct({
+        id: "product-3",
+        category: null,
+        category_key: "mask",
+        origin: "user_submitted",
+        is_active: true,
+        lifecycle_status: "discontinued",
+        is_chaarlie_recommended: false,
+      }),
+    /promotion requires active/,
+  )
+  assert.throws(
+    () =>
+      validatePromotableProduct({
+        id: "product-4",
+        category: null,
+        category_key: "mask",
+        origin: "user_submitted",
+        is_active: true,
+        lifecycle_status: null,
+        is_chaarlie_recommended: false,
+      }),
+    /lifecycle_status is missing/,
+  )
+
+  assert.equal(shouldCapturePromotionError(new PromotionGateError("missing specs")), false)
+  assert.equal(shouldCapturePromotionError(new Error("database unavailable")), true)
+})
+
+test("promotion command blocks missing specs and stale guarded updates", async () => {
+  const product = {
+    id: "product-1",
+    name: "Garnier Hair Food Aloe",
+    category: "Maske",
+    category_key: "mask",
+    origin: "user_submitted",
+    is_active: true,
+    lifecycle_status: "active",
+    is_chaarlie_recommended: false,
+    updated_at: "2026-06-17T10:00:00.000Z",
+  }
+
+  await withSilencedConsole(async () => {
+    const missingSpecSupabase = fakePromotionSupabase({
+      product,
+      approvedSubmissionRows: [{ id: "submission-1", approved_product_id: "product-1" }],
+      specRowsByTable: { product_mask_specs: [] },
+      updateResult: { id: "product-1", updated_at: "2026-06-17T11:00:00.000Z" },
+    })
+
+    await assert.rejects(
+      () =>
+        promoteProductById({
+          supabase: missingSpecSupabase,
+          productId: "product-1",
+          confirm: true,
+          reviewer: "Nick",
+          notes: null,
+        }),
+      /missing required category specs/,
+    )
+    assert.equal(missingSpecSupabase.updateCalls.length, 0)
+
+    const staleSupabase = fakePromotionSupabase({
+      product,
+      approvedSubmissionRows: [{ id: "submission-1", approved_product_id: "product-1" }],
+      specRowsByTable: { product_mask_specs: [{ product_id: "product-1" }] },
+      updateResult: null,
+    })
+
+    await assert.rejects(
+      () =>
+        promoteProductById({
+          supabase: staleSupabase,
+          productId: "product-1",
+          confirm: true,
+          reviewer: "Nick",
+          notes: null,
+        }),
+      /changed after validation/,
+    )
+    assert.deepEqual(staleSupabase.updateCalls[0]?.filters, {
+      id: "product-1",
+      is_active: true,
+      lifecycle_status: "active",
+      is_chaarlie_recommended: false,
+      updated_at: "2026-06-17T10:00:00.000Z",
+    })
+  })
+})
+
+test("promotion command requires an approved intake submission and updates only after readiness checks pass", async () => {
+  const product = {
+    id: "product-1",
+    name: "Garnier Hair Food Aloe",
+    category: "Maske",
+    category_key: "mask",
+    origin: "user_submitted",
+    is_active: true,
+    lifecycle_status: "active",
+    is_chaarlie_recommended: false,
+    updated_at: "2026-06-17T10:00:00.000Z",
+  }
+
+  await withSilencedConsole(async () => {
+    const noApprovedSubmissionSupabase = fakePromotionSupabase({
+      product,
+      approvedSubmissionRows: [],
+      specRowsByTable: { product_mask_specs: [{ product_id: "product-1" }] },
+      updateResult: { id: "product-1", updated_at: "2026-06-17T11:00:00.000Z" },
+    })
+
+    await assert.rejects(
+      () =>
+        promoteProductById({
+          supabase: noApprovedSubmissionSupabase,
+          productId: "product-1",
+          confirm: true,
+          reviewer: "Nick",
+          notes: null,
+        }),
+      /approved intake submission/,
+    )
+    assert.equal(noApprovedSubmissionSupabase.updateCalls.length, 0)
+
+    const successSupabase = fakePromotionSupabase({
+      product,
+      approvedSubmissionRows: [{ id: "submission-1", approved_product_id: "product-1" }],
+      specRowsByTable: { product_mask_specs: [{ product_id: "product-1" }] },
+      updateResult: { id: "product-1", updated_at: "2026-06-17T11:00:00.000Z" },
+    })
+
+    const result = await promoteProductById({
+      supabase: successSupabase,
+      productId: "product-1",
+      confirm: true,
+      reviewer: "Nick",
+      notes: "Ready",
+    })
+
+    assert.equal(result.next_recommendation_state, true)
+    assert.equal(result.promoted_at, "2026-06-17T11:00:00.000Z")
+    assert.deepEqual(successSupabase.updateCalls[0]?.patch, {
+      is_chaarlie_recommended: true,
+      updated_at: successSupabase.updateCalls[0]?.patch.updated_at,
+    })
+  })
+})
+
+function fakePromotionSupabase(params: {
+  product: Record<string, unknown>
+  approvedSubmissionRows?: Record<string, unknown>[]
+  specRowsByTable: Record<string, unknown[]>
+  updateResult: Record<string, unknown> | null
+}) {
+  const updateCalls: Array<{ patch: Record<string, unknown>; filters: Record<string, unknown> }> =
+    []
+  const client = {
+    updateCalls,
+    from(table: string) {
+      const filters: Record<string, unknown> = {}
+      let patch: Record<string, unknown> | null = null
+      const query = {
+        select: () => query,
+        update: (nextPatch: Record<string, unknown>) => {
+          patch = nextPatch
+          return query
+        },
+        eq: (key: string, value: unknown) => {
+          filters[key] = value
+          return query
+        },
+        limit: () => query,
+        maybeSingle: async () => {
+          if (table !== "products") {
+            return { data: null, error: new Error(`unexpected maybeSingle table ${table}`) }
+          }
+          if (patch) {
+            updateCalls.push({ patch, filters })
+            return { data: params.updateResult, error: null }
+          }
+          return { data: params.product, error: null }
+        },
+        then: (resolve: (value: { data: unknown[]; error: null }) => unknown) =>
+          Promise.resolve({
+            data:
+              table === "product_submissions"
+                ? (params.approvedSubmissionRows ?? [])
+                : (params.specRowsByTable[table] ?? []),
+            error: null,
+          }).then(resolve),
+      }
+      return query
+    },
+  }
+
+  return client as typeof client & Parameters<typeof promoteProductById>[0]["supabase"]
+}
+
+function fakeQueueSupabase(rows: ProductIntakeQueueRow[]) {
+  const orderCalls: string[] = []
+  const rangeCalls: Array<{ from: number; to: number }> = []
+  const client = {
+    orderCalls,
+    rangeCalls,
+    from(table: string) {
+      assert.equal(table, "product_submissions")
+      const eqFilters: Record<string, unknown> = {}
+      const inFilters: Record<string, unknown[]> = {}
+      const lteFilters: Record<string, string> = {}
+      const gteFilters: Record<string, string> = {}
+      let rangeValue: { from: number; to: number } | null = null
+      const query = {
+        select: () => query,
+        order: (column: string) => {
+          orderCalls.push(column)
+          return query
+        },
+        eq: (key: string, value: unknown) => {
+          eqFilters[key] = value
+          return query
+        },
+        in: (key: string, value: unknown[]) => {
+          inFilters[key] = value
+          return query
+        },
+        lte: (key: string, value: string) => {
+          lteFilters[key] = value
+          return query
+        },
+        gte: (key: string, value: string) => {
+          gteFilters[key] = value
+          return query
+        },
+        range: (from: number, to: number) => {
+          rangeCalls.push({ from, to })
+          rangeValue = { from, to }
+          return query
+        },
+        then: (resolve: (value: { data: ProductIntakeQueueRow[]; error: null }) => unknown) => {
+          let data = [...rows]
+          for (const [key, value] of Object.entries(eqFilters)) {
+            data = data.filter((row) => (row as unknown as Record<string, unknown>)[key] === value)
+          }
+          for (const [key, values] of Object.entries(inFilters)) {
+            data = data.filter((row) =>
+              values.includes((row as unknown as Record<string, unknown>)[key]),
+            )
+          }
+          for (const [key, value] of Object.entries(lteFilters)) {
+            data = data.filter(
+              (row) => String((row as unknown as Record<string, unknown>)[key]) <= value,
+            )
+          }
+          for (const [key, value] of Object.entries(gteFilters)) {
+            data = data.filter(
+              (row) => String((row as unknown as Record<string, unknown>)[key]) >= value,
+            )
+          }
+          if (rangeValue) data = data.slice(rangeValue.from, rangeValue.to + 1)
+          return Promise.resolve({ data, error: null }).then(resolve)
+        },
+      }
+      return query
+    },
+  }
+
+  return client as typeof client & Parameters<typeof loadQueueRows>[0]["supabase"]
+}
+
+async function withSilencedConsole(run: () => Promise<void>) {
+  const originalLog = console.log
+  try {
+    console.log = () => {}
+    await run()
+  } finally {
+    console.log = originalLog
+  }
+}
 
 function notificationSubmission(
   patch: Partial<ProductSubmission>,


### PR DESCRIPTION
## Summary

Adds the Phase 4B script-first product-intake ops layer on top of Phase 4A review core.

## What changed

- Adds queue reporting/export helpers for product submissions, including actionable defaults, JSON/CSV/report output, deterministic paging, and complete report/export pagination.
- Adds a dry-run-first `products:intake:promote` command for promoting fully approved user-submitted products to Chaarlie-recommended catalog products.
- Adds product-intake Sentry helpers that avoid raw user/conversation identifiers and product prose while still capturing useful ops failure metadata.
- Flushes Sentry from short-lived review scripts and avoids duplicate notification failure captures.
- Covers queue, promotion, observability, and notification behavior with focused tests.

## Verification

- `npx tsx --test tests/product-intake-observability.test.ts tests/product-intake-review-scripts.test.ts`
- `npm run typecheck` via pre-commit hook
- `git diff --check HEAD~1..HEAD`
- Queue CLI smoke for empty JSON, explicit limited JSON, CSV, full report, invalid age rejection, and report-plus-limit rejection.
- Final `equesting-code-review` found no critical, important, or minor issues.

## Notes

- Stacked on `codex/product-intake-phase-4a-review-core`.
- No Supabase migration files are changed in this PR.
- Follow-up ideas from review: add explicit tests for already-recommended no-op promotion semantics and unknown queue format validation if needed later.
