### PR TITLE
Add hair length to quiz and profile

### DIFF
--- a/data/agent-v2/guidance/base/general-advice.json
+++ b/data/agent-v2/guidance/base/general-advice.json
@@ -54,6 +54,12 @@
       "message": "For dosage, order, cadence, placement, or application questions, give practical profile-scaled steps before shopping or product alternatives; shampoo application can focus on scalp/roots, but deep-cleansing shampoo is not conceptually scalp-only."
     },
     {
+      "rubric_id": "advice.hair_length_application_signal",
+      "priority": "high",
+      "source": "base/general-advice.md",
+      "message": "Use hair length as an application and relevance signal, not a damage diagnosis: very short hair has no real lengths-and-ends zone, short hair needs smaller amounts, and long/very long hair mainly needs sectioning, distribution, detangling, and protection copy."
+    },
+    {
       "rubric_id": "advice.troubleshoot_before_products",
       "priority": "high",
       "source": "base/general-advice.md",

--- a/data/agent-v2/guidance/base/general-advice.md
+++ b/data/agent-v2/guidance/base/general-advice.md
@@ -66,6 +66,8 @@ For application, dosage, order, cadence, routine placement, sectioning, or "wie 
 
 Scale amount and placement with profile signals such as fine hair, oily scalp, dry lengths, curls, density, length, heat use, and routine complexity. Start small for fine hair, oily roots, or buildup risk; allow more only when thickness, dryness, density, or curl pattern supports it.
 
+Use hair length as an application and relevance signal, not as a damage diagnosis. Very short hair has no real lengths-and-ends zone, so length-focused products, detangling steps, CWC/OWC, oils, masks, and night-protection advice should be optional or skipped unless another signal or direct user request justifies them. Short hair usually needs smaller amounts; medium hair can use normal lengths-and-ends placement; long and very long hair mainly need better sectioning, distribution, detangling, and protection copy, not automatic repair escalation.
+
 Separate scalp/roots from lengths/ends when that prevents dryness, oiliness, residue, or irritation. For shampoo, place the product mainly on the scalp; the lengths usually get enough from rinse-down. An optional second wash is only for when the scalp still does not feel clean after the first wash.
 
 For reset comparisons, do not turn the shampoo placement rule into a category rule. Shampoo application can focus on scalp/roots, but deep-cleansing shampoo is not conceptually scalp-only: product/mineral film through lengths or hard-water feel points toward reset/clarifying/chelating shampoo, while scalp-local residue or oily-root buildup on tolerant skin may point toward gentle occasional scalp peeling. Persistent itch, redness, burning, pain, repeated flakes, or shedding belongs to the safety boundary, not stronger peeling.
@@ -82,6 +84,8 @@ For tangles, knots, brush resistance, curl/coily handling, or friction-heavy bre
 
 Use conditioner or leave-in slip when relevant, work in sections, start at the ends, and move upward. Do not suggest pushing through painful resistance. For curly or coily hair, avoid dry brushing as a default and favor low-tension handling with enough slip.
 
+For very short hair, do not force detangling or ends-up sectioning language unless the user explicitly asks or has enough length for it. For long and very long hair, sectioning and gentle detangling become more important because the same product amount is harder to distribute evenly.
+
 If a conditioner or leave-in is already present, consider amount, timing, saturation, placement, and tool choice before adding another product.
 
 ## CWC And OWC
@@ -90,6 +94,8 @@ CWC and OWC are wash techniques, not product categories or repair treatments. CW
 OWC is the heavier oil-wash-conditioner route for drier, curlier, coarser, more porous, or more damaged lengths when scalp and buildup risk allow. Keep OWC less default for fine, flat-prone, oily-root, low-density, or weight-sensitive hair.
 
 Both still include a real shampoo step on the scalp. Do not collapse them into co-washing, cleansing conditioners, standalone hair oiling, structural repair, regrowth, or fixed-cadence protocols. Avoid intensifying CWC/OWC when active scalp symptoms, persistent flaking/itching, inflammation, or repeated greasy/coated results are the foreground issue.
+
+Do not auto-suggest CWC or OWC for very short hair from mechanical-stress signals alone. If the user directly asks about CWC/OWC with very short hair, answer educationally and make clear that it may be unnecessary when there are no real lengths to protect.
 
 ## German Copy Fit
 Use natural German or German-friendly wording for common review-sensitive phrases. Prefer `starkes Brechen`, `brüchige Längen`, or `gummiartig` depending on context; do not write `starkes Schnappen`. Prefer `Routine beim Lufttrocknen`; do not write `Air-Dry-Routine`. For scalp-actives wording, say `nicht zu viele starke Kopfhaut-Wirkstoffe kombinieren`; do not write `Actives stapeln`.

--- a/data/agent-v2/guidance/base/product-recommendation.json
+++ b/data/agent-v2/guidance/base/product-recommendation.json
@@ -58,6 +58,12 @@
       "message": "Frame ranked products as suitable options with tradeoffs, connect every fit to profile/tool facts, and avoid winner-takes-all phrasing."
     },
     {
+      "rubric_id": "product.hair_length_usage_only",
+      "priority": "high",
+      "source": "base/product-recommendation.md",
+      "message": "When hair length is surfaced in profile basis or category caveats, use it for amount, application zone, sectioning, frequency, and protection guidance only; do not turn length into an unsupported product claim or deterministic damage score."
+    },
+    {
       "rubric_id": "product.one_natural_fit_sentence_per_product",
       "priority": "high",
       "source": "base/product-recommendation.md",

--- a/data/agent-v2/guidance/base/product-recommendation.md
+++ b/data/agent-v2/guidance/base/product-recommendation.md
@@ -60,6 +60,8 @@ Present ranked products as options with tradeoffs, not as a winner-takes-all ver
 
 Connect every product fit to profile/tool facts: use the profile basis, supported claims, comparison facts, category guidance, or explicit caveats from select_products. Keep usage caveats practical and brief.
 
+When hair length is surfaced in profile basis or category caveats, use it for amount, application zone, sectioning, frequency, and protection guidance only. Do not turn hair length into an unsupported product claim or a deterministic damage score. Very short hair should make length-only products feel optional unless another grounded signal supports them; long and very long hair should mainly influence coverage and distribution copy.
+
 When profile context is the basis, connect product fit to relevant profile facts such as wash rhythm, styling habits, drying method, goals, scalp state, or weight risk. Anchor usage cadence to wash rhythm when that is the clearest reason for how often to use the product.
 
 When tied product metadata axes matter, phrase them as practical implications instead of catalog classification language. Do not say a product is `eingestuft`, `klassifiziert`, `im Katalog`, or has a `Claim hinterlegt`; say what the grounded fact means for the user's hair, routine, or tradeoff.

--- a/data/agent-v2/guidance/base/routine-building.json
+++ b/data/agent-v2/guidance/base/routine-building.json
@@ -62,6 +62,12 @@
       "message": "Explain routines through scalp wash needs, fibre conditioning needs, texture/thickness weight limits, and real-life repeatability; add the fewest steps and change one product at a time."
     },
     {
+      "rubric_id": "routine.hair_length_tunes_application",
+      "priority": "high",
+      "source": "base/routine-building.md",
+      "message": "Use hair length to tune amounts, placement, step relevance, frequency, and protection guidance: avoid automatic lengths-and-ends extras for very short hair, keep short hair light, and use sectioning/coverage copy for long or very long hair without treating length as damage."
+    },
+    {
       "rubric_id": "routine.threshold_change_vs_explain",
       "priority": "high",
       "source": "base/routine-building.md",

--- a/data/agent-v2/guidance/base/routine-building.md
+++ b/data/agent-v2/guidance/base/routine-building.md
@@ -41,6 +41,8 @@ For broad routine answers, use a basics-first explanation: shampoo + conditioner
 
 Use two to three relevant profile facts when they materially affect the routine, such as hair pattern, thickness, scalp state, goals, damage, wash rhythm, or drying method. Include drying method when it changes order, frequency, heat protection, styling, or weight risk.
 
+Use hair length to tune amounts, placement, step relevance, frequency, and protection guidance. Very short hair should not receive automatic lengths-and-ends extras when no other signal supports them; short hair should stay light and small-dose; medium hair can use normal length-care placement; long and very long hair should get sectioning, coverage, detangling, and protective-copy emphasis without treating length itself as damage.
+
 Always make these basics understandable, not just named:
 - shampoo role: what it is doing in this routine.
 - shampoo type: which type fits the profile and why.
@@ -57,6 +59,7 @@ Use the routine tool output, then explain the routine with these old assembly pr
 - scalp state drives the wash step.
 - fibre state drives conditioner, mask, and leave-in direction.
 - texture and thickness drives product count and product weight.
+- hair length drives amount, distribution, and whether length/ends extras are relevant.
 - life fit decides how much routine the user can repeat.
 
 Prefer the fewest steps needed to solve the visible problem. Keep a working routine unchanged unless the user's state changed or buildup is likely. Change one product at a time and judge after several wash cycles.

--- a/data/agent-v2/guidance/categories/bondbuilder.json
+++ b/data/agent-v2/guidance/categories/bondbuilder.json
@@ -83,6 +83,12 @@
       "message": "For bond-repair relevance questions, keep primary_intent general_advice and answer as a category-fit assessment tied to structural damage signals such as bleach, color, chemical services, heat stress, breakage, snapping, mushy or over-elastic wet feel, or service preparation."
     },
     {
+      "rubric_id": "category.bondbuilder.hair_length_not_damage_signal",
+      "priority": "high",
+      "source": "categories/bondbuilder.md",
+      "message": "Hair length alone is not a Bondbuilder signal: do not recommend bondbuilder, increase repair severity, or infer structural damage from length unless chemical, heat, breakage, or wet-feel signals support it."
+    },
+    {
       "rubric_id": "category.bondbuilder.lane_decision_clarity",
       "priority": "high",
       "source": "categories/bondbuilder.md",

--- a/data/agent-v2/guidance/categories/bondbuilder.md
+++ b/data/agent-v2/guidance/categories/bondbuilder.md
@@ -29,6 +29,8 @@ Bondbuilders can improve strength, elasticity, and resilience of damaged strands
 
 The realistic ceiling is partial and incremental: `better` and `more stable` are realistic; `like new`, permanent split-end repair, regrowth, or full restoration to virgin hair are not.
 
+Hair length alone is not a Bondbuilder signal. Long or very long hair may need better distribution and protection guidance because the ends are older, but do not recommend bondbuilder, increase repair severity, or infer structural damage from length unless chemical, heat, breakage, or wet-feel signals support it.
+
 ## Category Boundaries
 Belongs here:
 - targeted structural repair for chemically or heat-stressed lengths

--- a/data/agent-v2/guidance/categories/conditioner.json
+++ b/data/agent-v2/guidance/categories/conditioner.json
@@ -84,6 +84,12 @@
       "message": "For fine or low-density hair, adjust conditioner amount, weight, and placement before removing conditioning support entirely."
     },
     {
+      "rubric_id": "category.conditioner.hair_length_amount_relevance",
+      "priority": "high",
+      "source": "categories/conditioner.md",
+      "message": "Use hair length to tune conditioner amount and relevance: very short hair may need only a tiny targeted amount, short hair stays light, and medium/long/very long hair uses lengths-and-ends placement with better distribution rather than stronger repair claims by length alone."
+    },
+    {
       "rubric_id": "category.conditioner.cwc_owc_length_protection",
       "priority": "medium",
       "source": "categories/conditioner.md",

--- a/data/agent-v2/guidance/categories/conditioner.md
+++ b/data/agent-v2/guidance/categories/conditioner.md
@@ -41,6 +41,8 @@ Balanced category comparisons should not force one central category in `request_
 ## Fit And Placement Logic
 Conditioner fit is shaped mainly by hair thickness, weight sensitivity, length dryness, texture needs, and protein/moisture balance.
 
+Hair length changes conditioner amount and relevance. Very short hair may need only a tiny amount where hair actually feels dry or chemically stressed; do not force full lengths-and-ends copy when there is no real lengths zone. Short hair usually needs small, light placement away from roots. Medium, long, and very long hair can use normal lengths-and-ends placement, with long and very long hair needing more careful distribution rather than stronger repair claims by length alone.
+
 For fine hair or low density, use light-to-medium support, smaller amounts, and cautious placement away from the roots. Do not skip conditioner automatically: fine or low-density hair can still need length care; the adjustment is amount, weight, and placement.
 
 For curly, coily, coarse, chemically treated, rough, or hard-to-detangle hair, the category can lean toward more slip and conditioning intensity when the profile and tool facts support it. Keep scalp and buildup risk in view.

--- a/data/agent-v2/guidance/categories/deep-cleansing-shampoo.json
+++ b/data/agent-v2/guidance/categories/deep-cleansing-shampoo.json
@@ -89,6 +89,12 @@
       "message": "For dry, fine, curly, color-treated, chemically stressed, fragile, or sensitive profiles, keep the reset gentler, less frequent, and explicitly need-based."
     },
     {
+      "rubric_id": "category.deep_cleansing.hair_length_indirect_only",
+      "priority": "medium",
+      "source": "categories/deep-cleansing-shampoo.md",
+      "message": "Hair length is only an indirect reset signal: long or very long hair can affect distribution and full-length residue when coated lengths are already reported, but do not recommend deep cleansing because hair is long."
+    },
+    {
       "rubric_id": "category.deep_cleansing.buildup_before_richness",
       "priority": "high",
       "source": "categories/deep-cleansing-shampoo.md",

--- a/data/agent-v2/guidance/categories/deep-cleansing-shampoo.md
+++ b/data/agent-v2/guidance/categories/deep-cleansing-shampoo.md
@@ -70,6 +70,8 @@ Name the likely reset job before recommending action:
 
 If the signal is only ordinary oiliness, sweat, or light residue, compare normal shampoo before escalating to deep cleansing. If the signal is mainly scalp-local residue or oily-root buildup on tolerant skin, compare gentle occasional scalp peeling. If the signal is product/mineral film through lengths or hard-water feel, compare reset/clarifying/chelating shampoo. If the signal is dry lengths without coating, route toward conditioner, leave-in, mask, oil, bondbuilder, or technique rather than reset-first advice.
 
+Hair length is only an indirect reset signal. Long or very long hair can make distribution and full-length residue harder to manage when coated lengths are already reported, but do not recommend deep cleansing because hair is long. Very short hair usually has little length-residue surface, so keep reset reasoning scalp/root or product-residue based.
+
 For dry, fine, curly, bleached, color-treated, fragile, or sensitive profiles, keep reset language gentler, less frequent, and explicitly need-based. Follow reset washes with conditioner or suitable length care, but do not invent exact product order or timing.
 
 Mention `care_balance_context.shampoo_cadence` only when reset or buildup signals moved the target upward or wash rhythm is directly relevant to the reset decision. Keep reset answers focused on the reset job; do not turn every reset answer into a wash-frequency lecture.

--- a/data/agent-v2/guidance/categories/dry-shampoo.json
+++ b/data/agent-v2/guidance/categories/dry-shampoo.json
@@ -89,6 +89,12 @@
       "message": "Tie fit to oily roots or a short wash gap, explain that dry shampoo absorbs oil between washes, then explain root placement, distribution as product directions support, and washing it out later."
     },
     {
+      "rubric_id": "category.dry_shampoo.hair_length_application_only",
+      "priority": "medium",
+      "source": "categories/dry-shampoo.md",
+      "message": "Hair length is not a major dry-shampoo signal; use it only for application practicality such as root sectioning on long hair, and never for length dryness, frizz, split ends, or protection."
+    },
+    {
       "rubric_id": "category.dry_shampoo.scalp_comfort_gate",
       "priority": "high",
       "source": "categories/dry-shampoo.md",

--- a/data/agent-v2/guidance/categories/dry-shampoo.md
+++ b/data/agent-v2/guidance/categories/dry-shampoo.md
@@ -58,6 +58,8 @@ Internal Frische-Bridge logic can remain, but customer-facing German should use 
 
 Keep the category narrow: dry shampoo is for visible root oil and short-term freshness. It belongs mainly at the roots, should be distributed or brushed/comb-through only as product directions support, and should be washed out later with normal shampoo and water.
 
+Hair length is not a major dry-shampoo signal. Use it only for application practicality, such as sectioning at the roots on long or very long hair. Do not recommend dry shampoo because hair is long, and do not use dry shampoo for length dryness, frizz, split ends, or protection.
+
 For oily roots, dry shampoo can be an occasional bridge, but wash frequency should still match scalp oiliness, activity, styling-product use, comfort, and lifestyle. If the user needs it frequently, frame that as a bridge or sign to adjust wash rhythm/root routine, not as proof they should simply wash normally. Do not tell every oily-root user to wash less. If the user reports heaviness, itch, flakes, burning, soreness, or congestion after dry shampoo, stop escalating dry shampoo and move toward actual cleansing, simplification, or safety wording.
 
 If `care_balance_context.shampoo_cadence` shows frequent dry-shampoo use while the target wet-shampoo cadence is above current real shampoo use, say dry shampoo can bridge visible freshness, but it does not replace wet scalp cleansing with shampoo and water.

--- a/data/agent-v2/guidance/categories/leave-in.json
+++ b/data/agent-v2/guidance/categories/leave-in.json
@@ -60,6 +60,12 @@
       "message": "Match leave-in weight, dose, and placement to thickness, texture, frizz, dryness, tangling, styling prep, and flat-prone or fine hair."
     },
     {
+      "rubric_id": "category.leave_in.hair_length_relevance",
+      "priority": "high",
+      "source": "categories/leave-in.md",
+      "message": "Use hair length to tune leave-in relevance and dose: very short hair should not get leave-in only for lengths-and-ends care unless another signal or direct request supports it; long and very long hair mainly need sectioning and coverage guidance, not repair escalation."
+    },
+    {
       "rubric_id": "category.leave_in.simplification_clarity",
       "priority": "medium",
       "source": "categories/leave-in.md",

--- a/data/agent-v2/guidance/categories/leave-in.md
+++ b/data/agent-v2/guidance/categories/leave-in.md
@@ -54,6 +54,8 @@ Common look-alikes:
 ## Fit And Usage Logic
 Match leave-in weight, dose, and placement to thickness, density, texture, frizz, dryness, tangling, styling prep, heat use, and buildup risk.
 
+Hair length changes leave-in relevance and dose. Very short hair usually should not get a leave-in only for lengths-and-ends care unless heat use, curl styling, dryness, chemical stress, or a direct user request creates a clear reason. Short hair needs very small amounts. Long and very long hair can justify stronger sectioning and coverage guidance, but length alone should not become a repair or damage signal.
+
 Fine, low-density, oily-root, flat-prone, or buildup-prone profiles need small amounts, careful distribution, and placement away from roots. Wavy, curly, coarse, chemically treated, dry, or rough-feeling lengths may benefit from more leave-on support.
 
 Replacing conditioner only when selected product data and routine context support it can be discussed as a possible simplification candidate. It is a special case, not the default.

--- a/data/agent-v2/guidance/categories/mask.json
+++ b/data/agent-v2/guidance/categories/mask.json
@@ -66,6 +66,12 @@
       "message": "Keep usage practical and flexible: usually after shampoo, lengths and ends, rinse well, gelegentlich/alle paar Wäschen/bei Bedarf, and stretch use if hair feels heavy, too soft, or flat."
     },
     {
+      "rubric_id": "category.mask.hair_length_coverage_relevance",
+      "priority": "high",
+      "source": "categories/mask.md",
+      "message": "Use hair length to tune mask coverage and relevance: very short hair should not receive an automatic mask unless another signal supports it, short hair needs less product and lower frequency, and long or very long hair needs sectioning/coverage without inferring structural damage from length alone."
+    },
+    {
       "rubric_id": "category.mask.lightweight_dry_frizzy_addon",
       "priority": "high",
       "source": "categories/mask.md",

--- a/data/agent-v2/guidance/categories/mask.md
+++ b/data/agent-v2/guidance/categories/mask.md
@@ -56,6 +56,8 @@ Protein/moisture balance matters for mask fit because masks can shift the feel o
 
 Fine or low-density hair usually needs lighter, shorter, or less frequent mask use. Curly, coarse, chemically treated, bleached, colored, porous, rough, or high-friction lengths may justify more intensive periodic care.
 
+Hair length changes mask coverage and relevance. Very short hair usually should not receive a mask as an automatic extra unless dryness, chemical stress, roughness, curls/coils, or a direct user request makes it useful. Short hair needs less product and lower frequency. Long and very long hair can need sectioning and enough coverage for older ends, but do not infer structural damage from length alone.
+
 If hair feels heavy, too soft, flat, coated, or slow to dry, stretch cadence, use less, or reset/simplify before adding richer care.
 
 Do not ask about protein/moisture direction by default. Ask only when the user raises protein/moisture, the profile already signals it, or rough, limp, brittle, coated, or recently chemically stressed hair makes that distinction materially useful.

--- a/data/agent-v2/guidance/categories/oil.json
+++ b/data/agent-v2/guidance/categories/oil.json
@@ -102,6 +102,12 @@
       "message": "For fine, oily, flat, low-density, coated, or buildup-prone hair, keep dose tiny, end-focused, pre-wash-only, or skip oil if another layer is likely to weigh hair down."
     },
     {
+      "rubric_id": "category.oil.hair_length_relevance",
+      "priority": "high",
+      "source": "categories/oil.md",
+      "message": "Use hair length to tune oil relevance and amount: very short hair usually should not get oil for lengths or ends unless another signal or direct request supports it; long and very long hair may need sectioning or end-focused distribution, but oil stays optional and non-repair."
+    },
+    {
       "rubric_id": "category.oil.washout_technique",
       "priority": "medium",
       "source": "categories/oil.md",

--- a/data/agent-v2/guidance/categories/oil.md
+++ b/data/agent-v2/guidance/categories/oil.md
@@ -72,6 +72,8 @@ For broad oil use, assume finishing oil by default unless the user says scalp, p
 
 For fine, oily, flat, low-density, coated, or buildup-prone hair, keep dose tiny, end-focused, or skip oil if another layer is likely to weigh hair down. If oil use is contributing to coated/heavy residue, compare deep cleansing instead of adding more oil.
 
+Hair length changes oil relevance and amount. Very short hair usually should not get oil for lengths or ends unless the user asks, the hair is chemically stressed/dry, or a product-specific styling finish is clearly relevant. Short hair needs a tiny amount at most. Long and very long hair can need more careful sectioning or end-focused distribution, but oil should still stay optional and should not be treated as repair.
+
 ## Wash-Out Technique
 For pre-wash oiling, give practical technique before product shopping:
 

--- a/data/agent-v2/guidance/categories/shampoo.json
+++ b/data/agent-v2/guidance/categories/shampoo.json
@@ -60,6 +60,12 @@
       "message": "When useful, mention shampoo mainly at the scalp and rinse thoroughly."
     },
     {
+      "rubric_id": "category.shampoo.hair_length_weak_signal",
+      "priority": "medium",
+      "source": "categories/shampoo.md",
+      "message": "Hair length should only weakly affect normal shampoo advice: do not scale shampoo like a length-care product, and use length mainly for placement, rinse-down, and length-protection caveats."
+    },
+    {
       "rubric_id": "category.shampoo.length_goal_steering",
       "priority": "high",
       "source": "categories/shampoo.md",

--- a/data/agent-v2/guidance/categories/shampoo.md
+++ b/data/agent-v2/guidance/categories/shampoo.md
@@ -52,6 +52,8 @@ Common look-alikes:
 ## Scalp/Length Split Logic
 Keep shampoo mainly on the scalp and roots. Rinse-down is normally enough for lengths unless there is heavy product residue.
 
+Hair length should only weakly affect normal shampoo advice. Even for long or very long hair, do not scale shampoo like a length-care product; scale placement, rinse-down, and length-protection caveats instead. Very short hair usually needs no lengths-and-ends shampoo caveat because there is no real lengths zone.
+
 When the user says a shampoo works for the scalp but dries out the lengths, do not discard the scalp logic automatically. Explain that the scalp may still need the shampoo while the lengths need protection: lighter application, less direct shampoo on lengths, conditioner after washing, and sometimes conditioner before shampoo as CWC/OWC length protection.
 
 "Wash less" is not a universal goal. Wash rhythm should fit scalp oiliness, activity, styling-product use, dry-shampoo use, texture, and comfort.

--- a/docs/customerio-data-contract.md
+++ b/docs/customerio-data-contract.md
@@ -45,6 +45,8 @@ thickness
 thickness_label
 density
 density_label
+hair_length
+hair_length_label
 cuticle_condition
 cuticle_condition_label
 protein_moisture_balance

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -41,6 +41,7 @@ import {
 import {
   PRODUCT_FREQUENCY_LABELS,
   fehler,
+  HAIR_LENGTH_OPTIONS,
   normalizeProductFrequency,
   type ProductFrequencyInput,
 } from "@/lib/vocabulary"
@@ -82,6 +83,7 @@ type QuizDraft = {
   hair_texture: string
   thickness: string
   density: string
+  hair_length: string
   cuticle_condition: string
   protein_moisture_balance: string
   chemical_treatment: ChemicalTreatment[]
@@ -179,6 +181,7 @@ function createQuizDraft(profile: HairProfile | null): QuizDraft {
     hair_texture: profile?.hair_texture ?? "",
     thickness: profile?.thickness ?? "",
     density: profile?.density ?? "",
+    hair_length: profile?.hair_length ?? "",
     cuticle_condition: profile?.cuticle_condition ?? "",
     protein_moisture_balance: profile?.protein_moisture_balance ?? "",
     chemical_treatment: profile?.chemical_treatment ?? [],
@@ -194,6 +197,7 @@ function createLocalHairProfile(
   fields: Partial<HairProfile>,
 ): HairProfile {
   const now = fields.updated_at ?? new Date().toISOString()
+  const hasHairLengthOverride = Object.prototype.hasOwnProperty.call(fields, "hair_length")
 
   return {
     id: currentProfile?.id ?? `local-${userId}`,
@@ -203,7 +207,7 @@ function createLocalHairProfile(
     density: currentProfile?.density ?? null,
     concerns: currentProfile?.concerns ?? [],
     products_used: currentProfile?.products_used ?? null,
-    shampoo_frequency: null,
+    shampoo_frequency: currentProfile?.shampoo_frequency ?? null,
     heat_styling: currentProfile?.heat_styling ?? null,
     styling_tools: currentProfile?.styling_tools ?? null,
     goals: currentProfile?.goals ?? [],
@@ -226,6 +230,9 @@ function createLocalHairProfile(
     created_at: currentProfile?.created_at ?? now,
     updated_at: now,
     ...fields,
+    hair_length: hasHairLengthOverride
+      ? (fields.hair_length ?? null)
+      : (currentProfile?.hair_length ?? null),
   }
 }
 
@@ -244,6 +251,10 @@ function toggleChemicalTreatment(
   }
 
   return [...withoutNatural, treatment]
+}
+
+function hasProfileFieldValue(value: ProfileFieldValue): boolean {
+  return value !== null && (!Array.isArray(value) || value.length > 0)
 }
 
 function toggleConcern(currentValues: ProfileConcern[], concern: ProfileConcern): ProfileConcern[] {
@@ -726,10 +737,10 @@ export default function ProfilePage() {
   const goalsField = goalsFields[0] ?? null
   const productRows = useMemo(() => createProductRows(productUsage), [productUsage])
 
-  const quizFilled = quizFields.filter((field) => field.value !== null)
-  const stylingFilled = stylingFields.filter((field) => field.value !== null)
-  const routineFilled = routineFields.filter((field) => field.value !== null)
-  const goalsFilled = goalsFields.filter((field) => field.value !== null)
+  const quizFilled = quizFields.filter((field) => hasProfileFieldValue(field.value))
+  const stylingFilled = stylingFields.filter((field) => hasProfileFieldValue(field.value))
+  const routineFilled = routineFields.filter((field) => hasProfileFieldValue(field.value))
+  const goalsFilled = goalsFields.filter((field) => hasProfileFieldValue(field.value))
   const selectedProductCategories = productRows.map((row) => row.categoryLabel)
   const incompleteProductRows = productRows.filter((row) => !row.isComplete)
 
@@ -848,6 +859,7 @@ export default function ProfilePage() {
       | "hair_texture"
       | "thickness"
       | "density"
+      | "hair_length"
       | "cuticle_condition"
       | "protein_moisture_balance"
       | "concerns"
@@ -858,6 +870,7 @@ export default function ProfilePage() {
       hair_texture: (quizDraft.hair_texture || null) as HairProfile["hair_texture"],
       thickness: (quizDraft.thickness || null) as HairProfile["thickness"],
       density: (quizDraft.density || null) as HairProfile["density"],
+      hair_length: (quizDraft.hair_length || null) as HairProfile["hair_length"],
       cuticle_condition: (quizDraft.cuticle_condition || null) as HairProfile["cuticle_condition"],
       protein_moisture_balance: (quizDraft.protein_moisture_balance ||
         null) as HairProfile["protein_moisture_balance"],
@@ -1132,6 +1145,25 @@ export default function ProfilePage() {
 
                       <div
                         ref={(node) => {
+                          quizFieldRefs.current.hair_length = node
+                        }}
+                      >
+                        <QuizEditorField
+                          title="Haarlänge"
+                          text="Wie lang deine Haare aktuell sind; bei Locken zählt die sanft gestreckte Länge."
+                        >
+                          <SegmentedControl
+                            options={HAIR_LENGTH_OPTIONS}
+                            value={quizDraft.hair_length}
+                            onChange={(value) =>
+                              setQuizDraft((current) => ({ ...current, hair_length: value }))
+                            }
+                          />
+                        </QuizEditorField>
+                      </div>
+
+                      <div
+                        ref={(node) => {
                           quizFieldRefs.current.cuticle_condition = node
                         }}
                       >
@@ -1367,26 +1399,45 @@ export default function ProfilePage() {
                     </div>
                   </div>
                 ) : (
-                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                    {quizFields.map((field) => {
-                      const isMissing = field.value == null
-                      return (
-                        <ProfileFieldCard
-                          key={field.key}
-                          field={field}
-                          onClick={() => openTarget("quiz", field.editTarget, field.key)}
-                          tone={isMissing ? "attention" : "default"}
-                          className={isMissing ? "md:col-span-2 xl:col-span-3" : undefined}
-                        >
-                          {isMissing ? (
-                            <ProfileFieldValue
-                              value={null}
-                              emptyLabel="Noch offen — tippen zum Ergänzen"
-                            />
-                          ) : undefined}
-                        </ProfileFieldCard>
-                      )
-                    })}
+                  <div className="space-y-4">
+                    {hairProfile?.hair_length == null ? (
+                      <InlinePromptCard
+                        title="Haarlänge ergänzen"
+                        text="Ergänze deine Haarlänge, damit Mengen und Anwendungshinweise genauer werden."
+                        action={
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className="w-auto"
+                            onClick={() => startQuizEditing("hair_length")}
+                          >
+                            Haarlänge ergänzen
+                          </Button>
+                        }
+                      />
+                    ) : null}
+
+                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                      {quizFields.map((field) => {
+                        const isMissing = field.value == null
+                        return (
+                          <ProfileFieldCard
+                            key={field.key}
+                            field={field}
+                            onClick={() => openTarget("quiz", field.editTarget, field.key)}
+                            tone={isMissing ? "attention" : "default"}
+                            className={isMissing ? "md:col-span-2 xl:col-span-3" : undefined}
+                          >
+                            {isMissing ? (
+                              <ProfileFieldValue
+                                value={null}
+                                emptyLabel="Noch offen — tippen zum Ergänzen"
+                              />
+                            ) : undefined}
+                          </ProfileFieldCard>
+                        )
+                      })}
+                    </div>
                   </div>
                 )}
               </CardContent>

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -19,6 +19,7 @@ const STEP_NAMES: Record<number, string> = {
   2: "hair_texture",
   3: "hair_thickness",
   13: "hair_density",
+  15: "hair_length",
   4: "surface_test",
   5: "pull_test",
   6: "scalp",

--- a/src/app/result/[leadId]/page.tsx
+++ b/src/app/result/[leadId]/page.tsx
@@ -7,7 +7,7 @@ import { ResultPageClient } from "./result-client"
 import { hasCurrentAppAccess } from "@/lib/billing/subscriptions"
 import { normalizeStoredQuizAnswers } from "@/lib/quiz/normalization"
 import type { QuizAnswers } from "@/lib/quiz/types"
-import { quizAnswersSchema } from "@/lib/quiz/validators"
+import { storedQuizAnswersSchema } from "@/lib/quiz/validators"
 import { createAdminClient } from "@/lib/supabase/admin"
 
 export const dynamic = "force-dynamic"
@@ -48,7 +48,7 @@ async function getLeadResult(leadId: string): Promise<LeadResultRow | null> {
 
 function parseQuizAnswers(raw: unknown): QuizAnswers | null {
   const normalized = normalizeStoredQuizAnswers((raw as Record<string, unknown> | null) ?? null)
-  const parsed = quizAnswersSchema.safeParse(normalized)
+  const parsed = storedQuizAnswersSchema.safeParse(normalized)
 
   return parsed.success ? parsed.data : null
 }

--- a/src/components/landing/how-it-works.tsx
+++ b/src/components/landing/how-it-works.tsx
@@ -10,7 +10,7 @@ const steps: Step[] = [
   {
     number: "1",
     title: "Quiz machen",
-    body: "2 Minuten, neun Fragen. Zugtest, Oberfläche, Kopfhaut, deine Ziele.",
+    body: "2 Minuten, zehn Fragen. Zugtest, Oberfläche, Kopfhaut, deine Ziele.",
   },
   {
     number: "2",

--- a/src/components/landing/what-is.tsx
+++ b/src/components/landing/what-is.tsx
@@ -78,7 +78,7 @@ export function WhatIs() {
           <div className="relative flex min-h-[380px] items-center justify-center overflow-hidden rounded-3xl bg-[var(--brand-plum-ice)] p-12">
             <div className="max-w-[280px] rounded-[18px] bg-white p-6 shadow-[0_20px_60px_-10px_rgba(42,24,69,0.2)]">
               <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em] text-[var(--brand-plum)]/60">
-                Frage 4 / 9
+                Frage 6 / 10
               </p>
               <p className="mb-5 font-header text-xl text-[var(--brand-plum-darkest)]">
                 Wie elastisch ist dein Haar?

--- a/src/components/quiz/quiz-info-strip.tsx
+++ b/src/components/quiz/quiz-info-strip.tsx
@@ -20,7 +20,7 @@ export function QuizInfoStrip({ onDismiss }: Props) {
         <strong className="font-semibold">
           Lass uns deine Haare verstehen — Schritt für Schritt.
         </strong>{" "}
-        9 schnelle Fragen zur Basis, dann gehts an deine Routine und Produkte.
+        10 schnelle Fragen zur Basis, dann gehts an deine Routine und Produkte.
       </p>
       <button
         type="button"

--- a/src/components/quiz/quiz-question.tsx
+++ b/src/components/quiz/quiz-question.tsx
@@ -14,6 +14,7 @@ const ANSWER_KEY_MAP: Record<number, keyof import("@/lib/quiz/types").QuizAnswer
   2: "structure",
   3: "thickness",
   13: "density",
+  15: "hair_length",
   4: "fingertest",
   5: "pulltest",
   7: "treatment",

--- a/src/components/quiz/quiz-results.tsx
+++ b/src/components/quiz/quiz-results.tsx
@@ -79,12 +79,20 @@ export function QuizResults() {
 
     trackAppEvent("quiz_completed", {
       thickness: answers.thickness,
+      hairLength: answers.hair_length,
       hairTexture: answers.structure,
       leadId: leadId ?? undefined,
       scalpCondition: answers.scalp_condition,
       scalpType: answers.scalp_type,
     })
-  }, [answers.scalp_condition, answers.scalp_type, answers.structure, answers.thickness, leadId])
+  }, [
+    answers.hair_length,
+    answers.scalp_condition,
+    answers.scalp_type,
+    answers.structure,
+    answers.thickness,
+    leadId,
+  ])
 
   useEffect(() => {
     captureQuizCompleted()

--- a/src/components/quiz/quiz-scalp-question.tsx
+++ b/src/components/quiz/quiz-scalp-question.tsx
@@ -178,10 +178,10 @@ export function QuizScalpQuestion() {
           <ArrowLeft className="h-5 w-5" />
         </button>
         <div className="flex-1">
-          <QuizProgressBar current={7} total={QUIZ_TOTAL_QUESTIONS} />
+          <QuizProgressBar current={8} total={QUIZ_TOTAL_QUESTIONS} />
         </div>
         <span className="text-sm text-[var(--text-caption)] tabular-nums">
-          7/{QUIZ_TOTAL_QUESTIONS}
+          8/{QUIZ_TOTAL_QUESTIONS}
         </span>
       </div>
 

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, type ComponentPropsWithoutRef } from "react"
 import {
   type LucideIcon,
   Waves,
@@ -70,6 +71,73 @@ import {
   Eraser,
 } from "lucide-react"
 
+type HairLengthIconProps = ComponentPropsWithoutRef<LucideIcon>
+
+// Hair length encoded as a vertical bar: a fixed serif crossbar marks the start
+// at the top, and a flat-topped bar grows downward by `ext` viewBox units (very
+// short → very long). The motif is optically centered on y=12.
+function createHairLengthIcon(ext: number, displayName: string): LucideIcon {
+  const round = (value: number) => Math.round(value * 1000) / 1000
+  const top = round(12 - ext / 2 + 0.5)
+  const bottom = round(12 + ext / 2 + 0.5)
+  const halfWidth = 1.6
+  const left = 12 - halfWidth
+  const right = 12 + halfWidth
+  const arcTop = round(bottom - halfWidth)
+  const barPath = `M${left} ${top} L${right} ${top} L${right} ${arcTop} A${halfWidth} ${halfWidth} 0 0 1 ${left} ${arcTop} Z`
+
+  const HairLengthIcon = forwardRef<SVGSVGElement, HairLengthIconProps>(
+    (
+      {
+        color = "currentColor",
+        size = 24,
+        strokeWidth = 2,
+        absoluteStrokeWidth,
+        className,
+        children,
+        ...props
+      },
+      ref,
+    ) => {
+      const width = Number(size)
+      const numericStrokeWidth = Number(strokeWidth)
+      const resolvedStrokeWidth =
+        absoluteStrokeWidth && Number.isFinite(width) && Number.isFinite(numericStrokeWidth)
+          ? (numericStrokeWidth * 24) / width
+          : strokeWidth
+
+      return (
+        <svg
+          ref={ref}
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={color}
+          strokeWidth={resolvedStrokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={className}
+          {...props}
+        >
+          <path d={barPath} fill={color} stroke="none" />
+          <line x1={8.5} y1={top} x2={15.5} y2={top} />
+          {children}
+        </svg>
+      )
+    },
+  )
+  HairLengthIcon.displayName = displayName
+  return HairLengthIcon as LucideIcon
+}
+
+const HairLengthVeryShort = createHairLengthIcon(6, "HairLengthVeryShort")
+const HairLengthShort = createHairLengthIcon(9.4, "HairLengthShort")
+const HairLengthMedium = createHairLengthIcon(12.8, "HairLengthMedium")
+const HairLengthLong = createHairLengthIcon(16.2, "HairLengthLong")
+const HairLengthVeryLong = createHairLengthIcon(19.6, "HairLengthVeryLong")
+
 // Each key is a semantic icon name. Values are Lucide icons today,
 // swappable to custom SVG components later in this single file.
 const iconMap = {
@@ -82,6 +150,12 @@ const iconMap = {
   "hair-fine": Feather,
   "hair-normal": Equal,
   "hair-coarse": Cylinder,
+  // Hair length
+  "hair-length-very-short": HairLengthVeryShort,
+  "hair-length-short": HairLengthShort,
+  "hair-length-medium": HairLengthMedium,
+  "hair-length-long": HairLengthLong,
+  "hair-length-very-long": HairLengthVeryLong,
   // Surface feel
   "surface-smooth": Sparkles,
   "surface-uneven": Activity,

--- a/src/lib/agent-v2/compare/run-agent-v2.ts
+++ b/src/lib/agent-v2/compare/run-agent-v2.ts
@@ -527,6 +527,7 @@ function createEmptyAgentV2HairProfile(): HairProfile {
     user_id: "",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,
@@ -565,6 +566,7 @@ function buildAgentV2EffectiveHairProfile(
   return {
     ...(fallback ?? createEmptyAgentV2HairProfile()),
     hair_texture: profile.hairTexture,
+    hair_length: profile.hairLength,
     thickness: profile.thickness,
     density: profile.density,
     concerns: [...profile.concerns],

--- a/src/lib/agent-v2/production/chat-pipeline.ts
+++ b/src/lib/agent-v2/production/chat-pipeline.ts
@@ -122,10 +122,10 @@ export interface PipelineResult {
 
 interface ProductionAgentV2PipelineDeps {
   client?: AgentV2ResponsesClient
-  loadConversationHistory?: (conversationId: string) => Promise<Message[]>
+  loadConversationHistory?: (conversationId: string, userId: string) => Promise<Message[]>
   getUserContext?: (userId: string) => Promise<UserContextProjection>
   loadUserMemoryContext?: (userId: string) => Promise<UserMemoryContext>
-  loadConversationState?: (conversationId: string) => Promise<unknown>
+  loadConversationState?: (conversationId: string, userId: string) => Promise<unknown>
   createSelectProductsTool?: typeof createSelectProductsTool
   createBuildOrFixRoutineTool?: typeof createBuildOrFixRoutineTool
   runAgentV2ResponsesTurn?: typeof runAgentV2ResponsesTurn
@@ -264,6 +264,7 @@ function createEmptyAgentV2HairProfile(): HairProfile {
     user_id: "",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,
@@ -302,6 +303,7 @@ function buildAgentV2EffectiveHairProfile(
   return {
     ...(fallback ?? createEmptyAgentV2HairProfile()),
     hair_texture: profile.hairTexture,
+    hair_length: profile.hairLength,
     thickness: profile.thickness,
     density: profile.density,
     concerns: [...profile.concerns],
@@ -449,14 +451,17 @@ export async function runAgentV2ProductionPipeline(
     { result: rawConversationState },
   ] = await Promise.all([
     measureAsync(() =>
-      (deps.loadConversationHistory ?? loadAgentV2ProductionConversationHistory)(conversationId),
+      (deps.loadConversationHistory ?? loadAgentV2ProductionConversationHistory)(
+        conversationId,
+        userId,
+      ),
     ),
     measureAsync(() => (deps.getUserContext ?? getUserContext)(userId)),
     measureAsync(() => (deps.loadUserMemoryContext ?? loadUserMemoryContext)(userId)),
     measureAsync(() =>
       deps.loadConversationState
-        ? deps.loadConversationState(conversationId)
-        : loadPersistedConversationState(createAdminClient(), conversationId),
+        ? deps.loadConversationState(conversationId, userId)
+        : loadPersistedConversationState(createAdminClient(), conversationId, userId),
     ),
   ])
 

--- a/src/lib/agent-v2/production/conversation-history.ts
+++ b/src/lib/agent-v2/production/conversation-history.ts
@@ -6,7 +6,27 @@ type ConversationHistoryQueryResult = {
   error: unknown
 }
 
+type ConversationOwnershipQueryResult = {
+  data: { id: string } | null
+  error: unknown
+}
+
 type ConversationHistoryClient = {
+  from(table: "conversations"): {
+    select(columns: string): {
+      eq(
+        column: "id",
+        value: string,
+      ): {
+        eq(
+          column: "user_id",
+          value: string,
+        ): {
+          maybeSingle(): Promise<ConversationOwnershipQueryResult>
+        }
+      }
+    }
+  }
   from(table: "messages"): {
     select(columns: string): {
       eq(
@@ -26,9 +46,27 @@ type ConversationHistoryClient = {
 
 export async function loadAgentV2ProductionConversationHistory(
   conversationId: string,
-  client: unknown = createAdminClient(),
+  userIdOrClient?: string | unknown,
+  maybeClient?: unknown,
 ): Promise<Message[]> {
+  const userId = typeof userIdOrClient === "string" ? userIdOrClient : undefined
+  const client =
+    (typeof userIdOrClient === "string" ? maybeClient : userIdOrClient) ?? createAdminClient()
   const admin = client as ConversationHistoryClient
+
+  if (userId) {
+    const { data: conversation, error: ownershipError } = await admin
+      .from("conversations")
+      .select("id")
+      .eq("id", conversationId)
+      .eq("user_id", userId)
+      .maybeSingle()
+
+    if (ownershipError || !conversation) {
+      throw new Error("AgentV2 production conversation is not available for this user.")
+    }
+  }
+
   const { data, error } = await admin
     .from("messages")
     .select("*")
@@ -38,7 +76,7 @@ export async function loadAgentV2ProductionConversationHistory(
 
   if (error) {
     console.error("Failed to load AgentV2 production conversation history:", error)
-    return []
+    throw new Error("Failed to load AgentV2 production conversation history.")
   }
 
   return ((data as Message[]) ?? []).slice().reverse()

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -30,6 +30,7 @@ export type AppEventMap = {
     value: number
   }
   quiz_completed: {
+    hairLength?: string
     hairTexture?: string
     leadId?: string | null
     scalpCondition?: string | null

--- a/src/lib/chat-runtime/conversation-state-store.ts
+++ b/src/lib/chat-runtime/conversation-state-store.ts
@@ -56,14 +56,20 @@ export async function loadConversationState(
 export async function loadAgentV2ConversationState(
   supabase: SupabaseClient,
   conversationId: string | null | undefined,
+  userId?: string,
 ): Promise<AgentV2ConversationStateV2> {
   if (!conversationId) return normalizeAgentV2ConversationState(null)
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("conversation_states")
     .select("state")
     .eq("conversation_id", conversationId)
-    .maybeSingle()
+
+  if (userId) {
+    query = query.eq("user_id", userId)
+  }
+
+  const { data, error } = await query.maybeSingle()
 
   if (error) {
     console.error("Failed to load AgentV2 conversation state:", error)

--- a/src/lib/customerio/quiz-traits.ts
+++ b/src/lib/customerio/quiz-traits.ts
@@ -1,6 +1,7 @@
 import type { CustomerIoServerProperties } from "@/lib/customerio/server"
 import { canonicalizeQuizAnswers } from "@/lib/quiz/normalization"
 import type { QuizAnswers } from "@/lib/quiz/types"
+import { HAIR_LENGTH_LABELS } from "@/lib/vocabulary"
 import { GOAL_LABELS, PROFILE_CONCERN_LABELS } from "@/lib/vocabulary/concerns-goals"
 
 const HAIR_TEXTURE_LABELS: Record<string, string> = {
@@ -98,6 +99,8 @@ export function buildCustomerIoQuizLeadSync({
     thickness_label: labelFor(answers.thickness, THICKNESS_LABELS),
     density: answers.density,
     density_label: labelFor(answers.density, DENSITY_LABELS),
+    hair_length: answers.hair_length,
+    hair_length_label: labelFor(answers.hair_length, HAIR_LENGTH_LABELS),
     cuticle_condition: answers.fingertest,
     cuticle_condition_label: labelFor(answers.fingertest, CUTICLE_CONDITION_LABELS),
     protein_moisture_balance: answers.pulltest,

--- a/src/lib/customerio/result-artifact-service.ts
+++ b/src/lib/customerio/result-artifact-service.ts
@@ -1,5 +1,5 @@
 import { normalizeStoredQuizAnswers } from "@/lib/quiz/normalization"
-import { quizAnswersSchema } from "@/lib/quiz/validators"
+import { storedQuizAnswersSchema } from "@/lib/quiz/validators"
 
 import { buildQuizResultArtifactEmailPayload } from "./quiz-result-artifact"
 import type { CustomerIoTransactionalEmailPayload } from "./transactional"
@@ -81,7 +81,7 @@ export async function handleResultArtifactEmail({
   const name = lead.name?.trim() ?? ""
   const email = lead.email?.trim() ?? ""
   const normalizedAnswers = normalizeStoredQuizAnswers(lead.quiz_answers)
-  const parsedAnswers = quizAnswersSchema.safeParse(normalizedAnswers)
+  const parsedAnswers = storedQuizAnswersSchema.safeParse(normalizedAnswers)
 
   if (!parsedAnswers.success) {
     await store.markFailed(leadId, "Result artifact email has incomplete quiz answers")

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -18,6 +18,7 @@ import type { OnboardingStep } from "@/lib/onboarding/store"
 import {
   BRUSH_TYPE_LABELS,
   DRYING_METHOD_LABELS,
+  HAIR_LENGTH_OPTIONS,
   NIGHT_PROTECTION_LABELS,
   TOWEL_MATERIAL_LABELS,
   TOWEL_TECHNIQUE_LABELS,
@@ -151,6 +152,13 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
     sectionKey: "quiz",
     editTarget: { kind: "quiz" },
     getValue: (profile) => optionLabel(profile?.density, HAIR_DENSITY_OPTIONS),
+  },
+  {
+    key: "hair_length",
+    label: "Haarlänge",
+    sectionKey: "quiz",
+    editTarget: { kind: "quiz" },
+    getValue: (profile) => optionLabel(profile?.hair_length, HAIR_LENGTH_OPTIONS),
   },
   {
     key: "cuticle_condition",

--- a/src/lib/quiz/brand-panel-content.ts
+++ b/src/lib/quiz/brand-panel-content.ts
@@ -15,12 +15,13 @@ const QUESTION_PANEL_CONTENT: Partial<
   2: { questionNumber: 1, description: "Deine natürliche Basis." },
   3: { questionNumber: 2, description: "Wie fein dein Haar ist." },
   13: { questionNumber: 3, description: "Wie voll dein Haar insgesamt ist." },
-  4: { questionNumber: 4, description: "Wie sich die Oberfläche anfühlt." },
-  5: { questionNumber: 5, description: "Wie belastbar die Längen sind." },
-  7: { questionNumber: 6, description: "Wie stark dein Haar behandelt ist." },
-  6: { questionNumber: 7, description: "Was an der Kopfhaut mitspielt." },
-  8: { questionNumber: 8, description: "Was dich gerade ausbremst." },
-  12: { questionNumber: 9, description: "Worauf wir hinarbeiten." },
+  15: { questionNumber: 4, description: "Wie lang deine Haare aktuell sind." },
+  4: { questionNumber: 5, description: "Wie sich die Oberfläche anfühlt." },
+  5: { questionNumber: 6, description: "Wie belastbar die Längen sind." },
+  7: { questionNumber: 7, description: "Wie stark dein Haar behandelt ist." },
+  6: { questionNumber: 8, description: "Was an der Kopfhaut mitspielt." },
+  8: { questionNumber: 9, description: "Was dich gerade ausbremst." },
+  12: { questionNumber: 10, description: "Worauf wir hinarbeiten." },
 }
 
 export function getQuizBrandPanelContent(

--- a/src/lib/quiz/draft.ts
+++ b/src/lib/quiz/draft.ts
@@ -5,8 +5,10 @@ export const QUIZ_DRAFT_STORAGE_KEY = "chaarlie:quiz-draft:v1"
 export const QUIZ_DRAFT_TTL_MS = 1000 * 60 * 60 * 24 * 14
 
 const QUIZ_DRAFT_VERSION = 1
+const HAIR_LENGTH_STEP: QuizStep = 15
 const LEAD_CAPTURE_STEP: QuizStep = 9
-const VALID_DRAFT_STEPS = new Set<QuizStep>([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+const VALID_DRAFT_STEPS = new Set<QuizStep>([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+const STEPS_AFTER_HAIR_LENGTH = new Set<QuizStep>([4, 5, 6, 7, 8, 9, 10, 11, 12, 14])
 
 export interface QuizDraft {
   version: typeof QUIZ_DRAFT_VERSION
@@ -36,7 +38,11 @@ function getBrowserStorage(): Storage | null {
   }
 }
 
-function getRestorableStep(step: QuizStep): QuizStep {
+function getRestorableStep(step: QuizStep, answers?: QuizAnswers): QuizStep {
+  if (answers && !answers.hair_length && STEPS_AFTER_HAIR_LENGTH.has(step)) {
+    return HAIR_LENGTH_STEP
+  }
+
   return step === 10 || step === 11 || step === 14 ? LEAD_CAPTURE_STEP : step
 }
 
@@ -74,7 +80,7 @@ export function saveQuizDraft(input: QuizDraftInput, storage = getBrowserStorage
   const draft: QuizDraft = {
     version: QUIZ_DRAFT_VERSION,
     savedAt: Date.now(),
-    step: getRestorableStep(input.step),
+    step: getRestorableStep(input.step, input.answers),
     answers: input.answers,
   }
 
@@ -109,10 +115,12 @@ export function loadQuizDraft(storage = getBrowserStorage()): QuizDraft | null {
       return null
     }
 
+    const answers = normalizeDraftAnswers(parsed.answers)
+
     return {
       ...parsed,
-      step: getRestorableStep(parsed.step),
-      answers: normalizeDraftAnswers(parsed.answers),
+      step: getRestorableStep(parsed.step, answers),
+      answers,
     }
   } catch {
     clearQuizDraft(storage)

--- a/src/lib/quiz/link-to-profile.ts
+++ b/src/lib/quiz/link-to-profile.ts
@@ -20,6 +20,61 @@ export function resolveProfileDensityFromQuizAnswers(answers: QuizAnswers): stri
   return hasCompleteLegacyDiagnostics ? "medium" : undefined
 }
 
+export function buildProfileDataFromQuizAnswers(answers: QuizAnswers): Record<string, unknown> {
+  const profileData: Record<string, unknown> = {}
+
+  if (answers.structure) profileData.hair_texture = answers.structure
+  if (answers.thickness) profileData.thickness = answers.thickness
+  if (answers.hair_length) profileData.hair_length = answers.hair_length
+  const density = resolveProfileDensityFromQuizAnswers(answers)
+  if (density) profileData.density = density
+
+  // Map quiz cuticle condition keys to English
+  const CUTICLE_MAP: Record<string, string> = {
+    glatt: "smooth",
+    leicht_uneben: "slightly_rough",
+    rau: "rough",
+  }
+  if (answers.fingertest)
+    profileData.cuticle_condition = CUTICLE_MAP[answers.fingertest] ?? answers.fingertest
+  if (answers.pulltest) profileData.protein_moisture_balance = answers.pulltest
+
+  // Map quiz scalp keys to English
+  const SCALP_TYPE_MAP: Record<string, string> = {
+    fettig: "oily",
+    ausgeglichen: "balanced",
+    trocken: "dry",
+  }
+  const SCALP_CONDITION_MAP: Record<string, string> = {
+    schuppen: "dandruff",
+    trockene_schuppen: "dry_flakes",
+    gereizt: "irritated",
+  }
+
+  if (answers.scalp_type) {
+    profileData.scalp_type = SCALP_TYPE_MAP[answers.scalp_type] ?? answers.scalp_type
+  }
+  if (answers.scalp_condition) {
+    profileData.scalp_condition =
+      SCALP_CONDITION_MAP[answers.scalp_condition] ?? answers.scalp_condition
+  } else if (answers.has_scalp_issue === false) {
+    profileData.scalp_condition = null
+  }
+  if (answers.concerns !== undefined) profileData.concerns = answers.concerns
+
+  // Map quiz chemical treatment keys to English
+  const TREATMENT_MAP: Record<string, string> = {
+    natur: "natural",
+    gefaerbt: "colored",
+    blondiert: "bleached",
+  }
+  if (answers.treatment) {
+    profileData.chemical_treatment = answers.treatment.map((t: string) => TREATMENT_MAP[t] ?? t)
+  }
+
+  return profileData
+}
+
 /**
  * After a user authenticates, link their quiz lead data to their profile.
  *
@@ -97,53 +152,7 @@ export async function linkQuizToProfile(
   // --- Map quiz answers to hair_profiles columns ---
   const profileData: Record<string, unknown> = {
     user_id: userId,
-  }
-
-  if (answers.structure) profileData.hair_texture = answers.structure
-  if (answers.thickness) profileData.thickness = answers.thickness
-  const density = resolveProfileDensityFromQuizAnswers(answers)
-  if (density) profileData.density = density
-  // Map quiz cuticle condition keys to English
-  const CUTICLE_MAP: Record<string, string> = {
-    glatt: "smooth",
-    leicht_uneben: "slightly_rough",
-    rau: "rough",
-  }
-  if (answers.fingertest)
-    profileData.cuticle_condition = CUTICLE_MAP[answers.fingertest] ?? answers.fingertest
-  if (answers.pulltest) profileData.protein_moisture_balance = answers.pulltest
-
-  // Map quiz scalp keys to English
-  const SCALP_TYPE_MAP: Record<string, string> = {
-    fettig: "oily",
-    ausgeglichen: "balanced",
-    trocken: "dry",
-  }
-  const SCALP_CONDITION_MAP: Record<string, string> = {
-    schuppen: "dandruff",
-    trockene_schuppen: "dry_flakes",
-    gereizt: "irritated",
-  }
-
-  if (answers.scalp_type) {
-    profileData.scalp_type = SCALP_TYPE_MAP[answers.scalp_type] ?? answers.scalp_type
-  }
-  if (answers.scalp_condition) {
-    profileData.scalp_condition =
-      SCALP_CONDITION_MAP[answers.scalp_condition] ?? answers.scalp_condition
-  } else if (answers.has_scalp_issue === false) {
-    profileData.scalp_condition = null
-  }
-  if (answers.concerns !== undefined) profileData.concerns = answers.concerns
-
-  // Map quiz chemical treatment keys to English
-  const TREATMENT_MAP: Record<string, string> = {
-    natur: "natural",
-    gefaerbt: "colored",
-    blondiert: "bleached",
-  }
-  if (answers.treatment) {
-    profileData.chemical_treatment = answers.treatment.map((t: string) => TREATMENT_MAP[t] ?? t)
+    ...buildProfileDataFromQuizAnswers(answers),
   }
 
   const incomingGoals =

--- a/src/lib/quiz/normalization.ts
+++ b/src/lib/quiz/normalization.ts
@@ -1,4 +1,5 @@
 import type { QuizAnswers } from "./types"
+import { HAIR_LENGTHS } from "@/lib/vocabulary"
 import { GOALS } from "@/lib/vocabulary/concerns-goals"
 
 const MAX_GOALS = 5
@@ -6,6 +7,7 @@ const MAX_GOALS = 5
 export const QUIZ_STRUCTURE_VALUES = ["straight", "wavy", "curly", "coily"] as const
 export const QUIZ_THICKNESS_VALUES = ["fine", "normal", "coarse"] as const
 export const QUIZ_DENSITY_VALUES = ["low", "medium", "high"] as const
+export const QUIZ_HAIR_LENGTH_VALUES = HAIR_LENGTHS
 export const QUIZ_FINGERTEST_VALUES = ["glatt", "leicht_uneben", "rau"] as const
 export const QUIZ_PULLTEST_VALUES = ["stretches_bounces", "stretches_stays", "snaps"] as const
 export const QUIZ_SCALP_TYPE_VALUES = ["fettig", "ausgeglichen", "trocken"] as const
@@ -204,6 +206,9 @@ export function normalizeStoredQuizAnswers(
       ? source.thickness
       : undefined,
     density: isAllowedValue(source.density, QUIZ_DENSITY_VALUES) ? source.density : undefined,
+    hair_length: isAllowedValue(source.hair_length, QUIZ_HAIR_LENGTH_VALUES)
+      ? source.hair_length
+      : undefined,
     fingertest: isAllowedValue(source.fingertest, QUIZ_FINGERTEST_VALUES)
       ? source.fingertest
       : undefined,

--- a/src/lib/quiz/questions.ts
+++ b/src/lib/quiz/questions.ts
@@ -1,6 +1,7 @@
 import type { QuizQuestion } from "./types"
+import { HAIR_LENGTH_OPTIONS } from "@/lib/vocabulary"
 
-export const QUIZ_TOTAL_QUESTIONS = 9
+export const QUIZ_TOTAL_QUESTIONS = 10
 
 export const quizQuestions: QuizQuestion[] = [
   {
@@ -36,7 +37,7 @@ export const quizQuestions: QuizQuestion[] = [
       },
     ],
     selectionMode: "single",
-    motivation: "Super — noch 8 kurze Fragen.",
+    motivation: "Super — noch 9 kurze Fragen.",
   },
   {
     step: 3,
@@ -97,8 +98,24 @@ export const quizQuestions: QuizQuestion[] = [
     motivation: "Genau — jetzt kennen wir die wichtigsten Grunddaten.",
   },
   {
-    step: 4,
+    step: 15,
     questionNumber: 4,
+    title: "Wie lang sind deine Haare aktuell?",
+    instruction:
+      "Bei Locken oder Coils zählt die sanft gestreckte Länge einer Strähne.\n\nWenn du zwischen zwei Längen liegst, wähle die längere Option.",
+    options: [
+      { ...HAIR_LENGTH_OPTIONS[0], icon: "hair-length-very-short" },
+      { ...HAIR_LENGTH_OPTIONS[1], icon: "hair-length-short" },
+      { ...HAIR_LENGTH_OPTIONS[2], icon: "hair-length-medium" },
+      { ...HAIR_LENGTH_OPTIONS[3], icon: "hair-length-long" },
+      { ...HAIR_LENGTH_OPTIONS[4], icon: "hair-length-very-long" },
+    ],
+    selectionMode: "single",
+    motivation: "Danke — damit werden Mengen und Anwendung genauer.",
+  },
+  {
+    step: 4,
+    questionNumber: 5,
     title: "Wie fühlt sich dein Haar an?",
     instruction:
       "Nimm ein gewaschenes, trockenes Haar aus deiner Bürste \u2013 es darf kein Produkt mehr drauf sein. Schließ die Augen und fahre ganz langsam mit zwei Fingern von der Wurzel zur Spitze. Konzentrier dich darauf, was du fühlst:",
@@ -127,7 +144,7 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 5,
-    questionNumber: 5,
+    questionNumber: 6,
     title: "Wie elastisch ist dein Haar?",
     instruction:
       "Nimm dasselbe Haar. Klemm es zwischen Ringfinger und Zeigefinger auf der einen Seite und zwischen Ringfinger und Mittelfinger auf der anderen. Zieh jetzt vorsichtig \u2013 wirklich mit Gefühl, nicht reißen. Beobachte genau, was passiert:\n\nZiehe nur leicht. Uns geht es um die Tendenz, nicht um Perfektion.",
@@ -156,7 +173,7 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 7,
-    questionNumber: 6,
+    questionNumber: 7,
     title: "Sind deine Haare chemisch behandelt?",
     instruction:
       "Chemische Prozesse wie Blondieren oder Färben verändern die innere Struktur deiner Haare grundlegend. Blondieren bricht Brückenverbindungen auf und entzieht Protein \u2013 das muss in der Pflege ausgeglichen werden.",
@@ -185,7 +202,7 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 8,
-    questionNumber: 8,
+    questionNumber: 9,
     title: "Welche Haarprobleme beschäftigen dich gerade am meisten?",
     instruction:
       "Wähle bis zu 3 Punkte aus, die aktuell am besten zu deinen Längen und Spitzen passen.",

--- a/src/lib/quiz/store.ts
+++ b/src/lib/quiz/store.ts
@@ -21,7 +21,7 @@ interface QuizState {
   reset: () => void
 }
 
-const STEP_ORDER: QuizStep[] = [2, 3, 13, 4, 5, 7, 6, 8, 12, 9, 10, 11, 14]
+const STEP_ORDER: QuizStep[] = [2, 3, 13, 15, 4, 5, 7, 6, 8, 12, 9, 10, 11, 14]
 
 function nextStep(current: QuizStep): QuizStep {
   const idx = STEP_ORDER.indexOf(current)

--- a/src/lib/quiz/types.ts
+++ b/src/lib/quiz/types.ts
@@ -4,6 +4,7 @@ export type QuizStep =
   | 2 // haartextur
   | 3 // haarstaerke
   | 13 // haardichte
+  | 15 // haarlaenge
   | 4 // oberflaeche
   | 5 // zugtest
   | 6 // kopfhaut
@@ -20,7 +21,7 @@ export type LeadCaptureSubStep = "name" | "email" | "consent"
 export type SelectionMode = "single" | "multi"
 
 import type { IconName } from "@/components/ui/icon"
-import type { ProfileConcern } from "@/lib/vocabulary"
+import type { HairLength, ProfileConcern } from "@/lib/vocabulary"
 
 export interface QuizOption {
   value: string
@@ -44,6 +45,7 @@ export interface QuizAnswers {
   structure?: string
   thickness?: string
   density?: string
+  hair_length?: HairLength
   fingertest?: string
   pulltest?: string
   scalp_type?: string

--- a/src/lib/quiz/validators.ts
+++ b/src/lib/quiz/validators.ts
@@ -3,6 +3,7 @@ import {
   QUIZ_STRUCTURE_VALUES,
   QUIZ_THICKNESS_VALUES,
   QUIZ_DENSITY_VALUES,
+  QUIZ_HAIR_LENGTH_VALUES,
   QUIZ_FINGERTEST_VALUES,
   QUIZ_PULLTEST_VALUES,
   QUIZ_CONCERN_VALUES,
@@ -12,29 +13,37 @@ import {
 } from "./normalization"
 import { GOALS } from "@/lib/vocabulary/concerns-goals"
 
-export const quizAnswersSchema = z
-  .object({
-    structure: z.enum(QUIZ_STRUCTURE_VALUES),
-    thickness: z.enum(QUIZ_THICKNESS_VALUES),
-    density: z.enum(QUIZ_DENSITY_VALUES),
-    fingertest: z.enum(QUIZ_FINGERTEST_VALUES),
-    pulltest: z.enum(QUIZ_PULLTEST_VALUES),
-    scalp_type: z.enum(QUIZ_SCALP_TYPE_VALUES),
-    has_scalp_issue: z.boolean(),
-    scalp_condition: z.enum(QUIZ_SCALP_CONDITION_VALUES).optional(),
-    concerns: z.array(z.enum(QUIZ_CONCERN_VALUES)).max(3, "Bitte waehle hoechstens drei Bedenken"),
-    concerns_other_text: z.string().trim().max(50, "Bitte bleib bei maximal 50 Zeichen").optional(),
-    treatment: z
-      .array(z.enum(QUIZ_TREATMENT_VALUES))
-      .min(1, "Bitte waehle mindestens eine Behandlung"),
-    goals: z
-      .array(z.enum(GOALS))
-      .min(1, "Bitte waehle mindestens ein Ziel")
-      .max(5, "Bitte waehle hoechstens fuenf Ziele")
-      .optional(),
-  })
-  .strict()
-  .superRefine((answers, ctx) => {
+const baseQuizAnswersShape = {
+  structure: z.enum(QUIZ_STRUCTURE_VALUES),
+  thickness: z.enum(QUIZ_THICKNESS_VALUES),
+  density: z.enum(QUIZ_DENSITY_VALUES),
+  fingertest: z.enum(QUIZ_FINGERTEST_VALUES),
+  pulltest: z.enum(QUIZ_PULLTEST_VALUES),
+  scalp_type: z.enum(QUIZ_SCALP_TYPE_VALUES),
+  has_scalp_issue: z.boolean(),
+  scalp_condition: z.enum(QUIZ_SCALP_CONDITION_VALUES).optional(),
+  concerns: z.array(z.enum(QUIZ_CONCERN_VALUES)).max(3, "Bitte waehle hoechstens drei Bedenken"),
+  concerns_other_text: z.string().trim().max(50, "Bitte bleib bei maximal 50 Zeichen").optional(),
+  treatment: z
+    .array(z.enum(QUIZ_TREATMENT_VALUES))
+    .min(1, "Bitte waehle mindestens eine Behandlung"),
+  goals: z
+    .array(z.enum(GOALS))
+    .min(1, "Bitte waehle mindestens ein Ziel")
+    .max(5, "Bitte waehle hoechstens fuenf Ziele")
+    .optional(),
+} satisfies z.ZodRawShape
+
+function applyQuizAnswerRules<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+  return schema.strict().superRefine((rawAnswers, ctx) => {
+    const answers = rawAnswers as {
+      treatment: string[]
+      concerns: string[]
+      has_scalp_issue: boolean
+      scalp_condition?: string
+      goals?: string[]
+    }
+
     if (new Set(answers.treatment).size !== answers.treatment.length) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -93,6 +102,21 @@ export const quizAnswersSchema = z
       }
     }
   })
+}
+
+export const quizAnswersSchema = applyQuizAnswerRules(
+  z.object({
+    ...baseQuizAnswersShape,
+    hair_length: z.enum(QUIZ_HAIR_LENGTH_VALUES),
+  }),
+)
+
+export const storedQuizAnswersSchema = applyQuizAnswerRules(
+  z.object({
+    ...baseQuizAnswersShape,
+    hair_length: z.enum(QUIZ_HAIR_LENGTH_VALUES).optional(),
+  }),
+)
 
 export const leadSchema = z.object({
   name: z.string().min(1, "Name ist erforderlich"),

--- a/src/lib/recommendation-engine/adapters/from-persistence.ts
+++ b/src/lib/recommendation-engine/adapters/from-persistence.ts
@@ -62,6 +62,7 @@ function emptyRawHairProfileInput(): RawHairProfileInput {
   return {
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     goals: [],
@@ -97,6 +98,7 @@ function buildRawHairProfileInput(
   return {
     hair_texture: profile.hair_texture,
     thickness: profile.thickness,
+    hair_length: profile.hair_length ?? null,
     density: profile.density,
     concerns: profile.concerns ?? [],
     goals: profile.goals ?? [],

--- a/src/lib/recommendation-engine/hair-length.ts
+++ b/src/lib/recommendation-engine/hair-length.ts
@@ -1,0 +1,36 @@
+import type { HairLength } from "@/lib/vocabulary"
+
+export type LengthCareIntensity =
+  | "unknown"
+  | "minimal"
+  | "light"
+  | "standard"
+  | "elevated"
+  | "maximum"
+
+export function hasLengthEndsZone(hairLength: HairLength | null | undefined): boolean {
+  return hairLength !== "very_short" && hairLength != null
+}
+
+export function getLengthCareIntensity(
+  hairLength: HairLength | null | undefined,
+): LengthCareIntensity {
+  switch (hairLength) {
+    case "very_short":
+      return "minimal"
+    case "short":
+      return "light"
+    case "medium":
+      return "standard"
+    case "long":
+      return "elevated"
+    case "very_long":
+      return "maximum"
+    default:
+      return "unknown"
+  }
+}
+
+export function suppressLengthOnlyCare(hairLength: HairLength | null | undefined): boolean {
+  return hairLength === "very_short"
+}

--- a/src/lib/recommendation-engine/normalize.ts
+++ b/src/lib/recommendation-engine/normalize.ts
@@ -40,6 +40,7 @@ export function normalizeRecommendationInput(input: RawRecommendationInput): Nor
 
   return {
     hairTexture: profile.hair_texture,
+    hairLength: profile.hair_length,
     thickness: profile.thickness,
     density: profile.density,
     concerns: profile.concerns ?? [],

--- a/src/lib/recommendation-engine/runtime.ts
+++ b/src/lib/recommendation-engine/runtime.ts
@@ -189,6 +189,7 @@ function buildRawInputFromEffectiveContext(context: EffectiveCareContext): RawRe
   return {
     profile: {
       hair_texture: profile.hairTexture,
+      hair_length: profile.hairLength,
       thickness: profile.thickness,
       density: profile.density,
       concerns: [...profile.concerns],

--- a/src/lib/recommendation-engine/types.ts
+++ b/src/lib/recommendation-engine/types.ts
@@ -6,6 +6,7 @@ import type {
   DryingMethod,
   Goal,
   HairDensity,
+  HairLength,
   HairTexture,
   HairThickness,
   HeatStyling,
@@ -123,6 +124,7 @@ export interface RawRoutineInventoryItem {
 export interface RawHairProfileInput {
   hair_texture: HairTexture | null
   thickness: HairThickness | null
+  hair_length: HairLength | null
   density: HairDensity | null
   concerns: ProfileConcern[]
   goals: Goal[]
@@ -158,6 +160,7 @@ export type RoutineInventory = Record<InventoryCategory, NormalizedRoutineInvent
 
 export interface NormalizedProfile {
   hairTexture: HairTexture | null
+  hairLength: HairLength | null
   thickness: HairThickness | null
   density: HairDensity | null
   concerns: ProfileConcern[]

--- a/src/lib/routines/brush-tools.ts
+++ b/src/lib/routines/brush-tools.ts
@@ -92,15 +92,14 @@ function includesAny(text: string, terms: string[]): boolean {
 
 /** Accepts an already-normalized message string (via normalizeText). */
 export function hasExplicitBrushToolsRequest(normalizedMessage: string): boolean {
-  return includesAny(normalizedMessage, BRUSH_TOOLS_TERMS)
+  return (
+    includesAny(normalizedMessage, BRUSH_TOOLS_TERMS) ||
+    includesAny(normalizedMessage, DETANGLING_TERMS)
+  )
 }
 
 /** Accepts an already-normalized message string (via normalizeText). */
-export function hasBrushToolsNeed(
-  profile: HairProfile | null,
-  normalizedMessage: string,
-  context: RoutineContext,
-): boolean {
+export function hasBrushToolsNeed(profile: HairProfile | null, normalizedMessage: string): boolean {
   return (
     hasDirectMechanicalStressSignals(
       profile?.towel_technique,

--- a/src/lib/routines/brush-tools.ts
+++ b/src/lib/routines/brush-tools.ts
@@ -90,11 +90,19 @@ function includesAny(text: string, terms: string[]): boolean {
   return terms.some((term) => text.includes(normalizeText(term)))
 }
 
+function hasDirectDetanglingRequest(normalizedMessage: string): boolean {
+  return (
+    /\bentwirr\w*\b/.test(normalizedMessage) ||
+    /\bdetangl\w*\b/.test(normalizedMessage) ||
+    /\bknoten\b.{0,40}\b(?:loes\w*|los\w*|raus\w*|entfern\w*)\b/.test(normalizedMessage)
+  )
+}
+
 /** Accepts an already-normalized message string (via normalizeText). */
 export function hasExplicitBrushToolsRequest(normalizedMessage: string): boolean {
   return (
     includesAny(normalizedMessage, BRUSH_TOOLS_TERMS) ||
-    includesAny(normalizedMessage, DETANGLING_TERMS)
+    hasDirectDetanglingRequest(normalizedMessage)
   )
 }
 

--- a/src/lib/routines/hair-length-policy.ts
+++ b/src/lib/routines/hair-length-policy.ts
@@ -1,0 +1,126 @@
+import type {
+  HairProfile,
+  RoutineContext,
+  RoutineProductCategory,
+  RoutineSlotAdvice,
+  RoutineTopicId,
+} from "@/lib/types"
+import {
+  getLengthCareIntensity,
+  suppressLengthOnlyCare,
+} from "@/lib/recommendation-engine/hair-length"
+
+export function hasHeatExposureNeed(context: RoutineContext): boolean {
+  return (
+    context.heat_styling === "daily" ||
+    context.heat_styling === "several_weekly" ||
+    context.drying_method === "blow_dry" ||
+    context.drying_method === "blow_dry_diffuser" ||
+    (context.styling_tools ?? []).some(
+      (tool) =>
+        tool === "flat_iron" ||
+        tool === "curling_iron" ||
+        tool === "blow_dryer" ||
+        tool === "diffuser" ||
+        tool === "thermal_rollers",
+    )
+  )
+}
+
+function isNeedDrivenCareSlot(
+  slot: RoutineSlotAdvice,
+  context: RoutineContext,
+  activeTopicIds: Set<RoutineTopicId>,
+): boolean {
+  const concerns = new Set(context.concerns)
+  const goals = new Set(context.goals)
+  const treatments = new Set(context.chemical_treatment)
+  const explicitTopicIds = new Set(context.explicit_topic_ids)
+
+  if (slot.topic_ids.some((topicId) => explicitTopicIds.has(topicId))) return true
+  if (slot.topic_ids.includes("lockenrefresh") && activeTopicIds.has("lockenrefresh")) return true
+  if (context.has_dryness_damage_signals || context.has_damage_signals) return true
+  if (hasHeatExposureNeed(context)) return true
+  if (concerns.has("dryness") || concerns.has("frizz") || concerns.has("tangling")) return true
+  if (goals.has("moisture") || goals.has("less_frizz") || goals.has("curl_definition")) return true
+  if (treatments.has("colored") || treatments.has("bleached")) return true
+
+  return slot.action === "avoid"
+}
+
+export function applyHairLengthRoutineCopy(
+  slot: RoutineSlotAdvice,
+  hairLength: HairProfile["hair_length"],
+): RoutineSlotAdvice {
+  const intensity = getLengthCareIntensity(hairLength)
+  if (intensity === "minimal") {
+    return {
+      ...slot,
+      caveats: [
+        ...slot.caveats,
+        "Bei sehr kurzem Haar nur eine sehr kleine Menge dort verwenden, wo wirklich Pflege gebraucht wird; wenn nichts trocken wirkt, bleibt der Schritt sehr schlank.",
+      ],
+    }
+  }
+
+  if (intensity === "light") {
+    return {
+      ...slot,
+      caveats: [
+        ...slot.caveats,
+        "Bei kurzem Haar reicht eine kleine Menge; lieber leicht und sparsam starten.",
+      ],
+    }
+  }
+
+  if (intensity === "elevated" || intensity === "maximum") {
+    return {
+      ...slot,
+      rationale: [
+        ...slot.rationale,
+        intensity === "maximum"
+          ? "Bei sehr langem Haar partienweise arbeiten, damit Längen und Spitzen gleichmäßig erreicht werden."
+          : "Bei langem Haar auf gleichmäßige Verteilung in Längen und Spitzen achten.",
+      ],
+      caveats: [
+        ...slot.caveats,
+        "Schutz und Entwirren eher über saubere Sektionen und gute Abdeckung steuern, nicht über mehr Repair-Produkte.",
+      ],
+    }
+  }
+
+  return slot
+}
+
+export function applyHairLengthRoutinePolicy(
+  slot: RoutineSlotAdvice,
+  params: {
+    hairLength: HairProfile["hair_length"]
+    context: RoutineContext
+    activeTopicIds: Set<RoutineTopicId>
+  },
+): RoutineSlotAdvice | null {
+  const lengthSensitiveCategories = new Set<RoutineProductCategory>(["leave_in", "mask", "oil"])
+  if (
+    suppressLengthOnlyCare(params.hairLength) &&
+    slot.category !== null &&
+    lengthSensitiveCategories.has(slot.category) &&
+    !isNeedDrivenCareSlot(slot, params.context, params.activeTopicIds)
+  ) {
+    return null
+  }
+
+  if (
+    slot.category === "conditioner" ||
+    slot.category === "leave_in" ||
+    slot.category === "mask" ||
+    slot.category === "oil" ||
+    slot.topic_ids.includes("brush_tools") ||
+    slot.topic_ids.includes("cwc") ||
+    slot.topic_ids.includes("owc")
+  ) {
+    return applyHairLengthRoutineCopy(slot, params.hairLength)
+  }
+
+  return slot
+}

--- a/src/lib/routines/planner.ts
+++ b/src/lib/routines/planner.ts
@@ -18,12 +18,18 @@ import {
   hasExplicitBrushToolsRequest,
 } from "@/lib/routines/brush-tools"
 import { CURLY_TEXTURES } from "@/lib/routines/constants"
+import {
+  applyHairLengthRoutineCopy,
+  applyHairLengthRoutinePolicy,
+  hasHeatExposureNeed,
+} from "@/lib/routines/hair-length-policy"
 import { hasDirectMechanicalStressSignals } from "@/lib/profile/signal-derivations"
 import {
   buildRecommendationEngineRuntimeFromPersistence,
   buildRecommendationRequestContext,
 } from "@/lib/recommendation-engine"
 import { buildRoutineItemsFromInventoryCategories } from "@/lib/recommendation-engine/adapters/from-persistence"
+import { suppressLengthOnlyCare } from "@/lib/recommendation-engine/hair-length"
 import type {
   HairProfile,
   RoutineContext,
@@ -552,6 +558,7 @@ function selectWashProtectionTopic(
   const compareMode = isCwcOwcComparisonRequest(message)
   const explicitCwc = context.explicit_topic_ids.includes("cwc")
   const explicitOwc = context.explicit_topic_ids.includes("owc")
+  const lacksLengthEndsZone = suppressLengthOnlyCare(profile?.hair_length ?? null)
 
   if (compareMode) {
     const topicId = hasOwcFit(profile, context)
@@ -569,6 +576,10 @@ function selectWashProtectionTopic(
 
   if (explicitCwc) {
     return { topicId: "cwc", compareMode }
+  }
+
+  if (lacksLengthEndsZone && !context.has_dryness_damage_signals && !context.has_damage_signals) {
+    return { topicId: null, compareMode }
   }
 
   if (!context.has_wash_protection_need) {
@@ -835,7 +846,11 @@ export function activateRoutineTopics(
     }
   }
 
-  if (explicit.has("brush_tools") || hasBrushToolsNeed(profile, normalizedMessage, context)) {
+  const lacksLengthEndsZone = suppressLengthOnlyCare(profile?.hair_length ?? null)
+  if (
+    explicit.has("brush_tools") ||
+    (!lacksLengthEndsZone && hasBrushToolsNeed(profile, normalizedMessage))
+  ) {
     push(
       "brush_tools",
       explicit.has("brush_tools")
@@ -1439,8 +1454,16 @@ function buildRoutineSlots(
     leave_in: leaveInDecision,
     mask: maskDecision,
   } = decisionContext
+  const pushRoutineSlot = (slot: RoutineSlotAdvice) => {
+    const guardedSlot = applyHairLengthRoutinePolicy(slot, {
+      hairLength: profile?.hair_length ?? null,
+      context,
+      activeTopicIds,
+    })
+    if (guardedSlot) pushSlot(sections, guardedSlot)
+  }
 
-  pushSlot(sections, {
+  pushRoutineSlot({
     id: "base-shampoo",
     kind: "product_slot",
     phase: "base_wash",
@@ -1493,7 +1516,7 @@ function buildRoutineSlots(
         : "keep"
     : "add"
 
-  pushSlot(sections, {
+  pushRoutineSlot({
     id: "base-conditioner",
     kind: "product_slot",
     phase: "base_wash",
@@ -1518,7 +1541,7 @@ function buildRoutineSlots(
 
   if (activeWashProtectionTopic === "cwc") {
     if (explicitWashProtectionWithoutNeed) {
-      pushSlot(sections, {
+      pushRoutineSlot({
         id: "base-cwc-technique",
         kind: "instruction",
         phase: "base_wash",
@@ -1538,13 +1561,13 @@ function buildRoutineSlots(
         attachment_priority: 92,
       })
     } else {
-      pushSlot(sections, buildCwcTechniqueSlot())
+      pushRoutineSlot(buildCwcTechniqueSlot())
     }
   }
 
   if (activeWashProtectionTopic === "owc") {
     if (explicitWashProtectionWithoutNeed) {
-      pushSlot(sections, {
+      pushRoutineSlot({
         id: "base-owc-technique",
         kind: "instruction",
         phase: "base_wash",
@@ -1564,8 +1587,8 @@ function buildRoutineSlots(
         attachment_priority: 92,
       })
     } else {
-      pushSlot(sections, buildOwcOilSlot(context, explicitOwcRequest, oilPresent))
-      pushSlot(sections, buildOwcTechniqueSlot(profile, context))
+      pushRoutineSlot(buildOwcOilSlot(context, explicitOwcRequest, oilPresent))
+      pushRoutineSlot(buildOwcTechniqueSlot(profile, context))
     }
   }
 
@@ -1577,7 +1600,8 @@ function buildRoutineSlots(
     context.goals.includes("curl_definition") ||
     context.concerns.includes("frizz") ||
     context.concerns.includes("dryness") ||
-    context.concerns.includes("tangling")
+    context.concerns.includes("tangling") ||
+    (hasHeatExposureNeed(context) && !context.uses_heat_protection)
 
   if (shouldUseLeaveIn || leaveInPresent) {
     const leaveInAction: RoutineSlotAction =
@@ -1596,8 +1620,13 @@ function buildRoutineSlots(
         `Der Finish-Schritt soll vor allem für ${LEAVE_IN_STYLING_CONTEXT_LABELS[leaveInDecision.targetProfile.stylingContext]} passen.`,
       )
     }
+    if (hasHeatExposureNeed(context) && !context.uses_heat_protection) {
+      leaveInReasons.push(
+        "Bei Hitze durch Föhn, Diffusor oder Styling-Tools sollte der Schritt Hitzeschutz abdecken.",
+      )
+    }
 
-    pushSlot(sections, {
+    pushRoutineSlot({
       id: "maintenance-leave-in",
       kind: "product_slot",
       phase: "maintenance",
@@ -1645,7 +1674,7 @@ function buildRoutineSlots(
       }
     }
 
-    pushSlot(sections, {
+    pushRoutineSlot({
       id: "maintenance-refresh",
       kind: "instruction",
       phase: "maintenance",
@@ -1663,11 +1692,11 @@ function buildRoutineSlots(
   }
 
   if (activeTopicIds.has("brush_tools")) {
-    pushSlot(sections, buildBrushToolsSlot(profile, context, normalizeText(message)))
+    pushRoutineSlot(buildBrushToolsSlot(profile, context, normalizeText(message)))
   }
 
   if (maskDecision.relevant || maskPresent) {
-    pushSlot(sections, {
+    pushRoutineSlot({
       id: "occasional-mask",
       kind: "product_slot",
       phase: "occasional",
@@ -1703,12 +1732,11 @@ function buildRoutineSlots(
       !bondBuilderDriven
 
     if (context.has_scalp_clarify_signals) {
-      pushSlot(sections, buildScalpClarifySlot(context, shampooPresent))
+      pushRoutineSlot(buildScalpClarifySlot(context, shampooPresent))
     }
 
     if (context.has_hair_reset_signals || bondBuilderDriven || educationalClarify) {
-      pushSlot(
-        sections,
+      pushRoutineSlot(
         buildHairResetSlot({
           context,
           shampooPresent,
@@ -1719,7 +1747,7 @@ function buildRoutineSlots(
     }
 
     if (context.has_hard_reset_signals) {
-      pushSlot(sections, buildHardResetSlot(context))
+      pushRoutineSlot(buildHardResetSlot(context))
     }
   }
 
@@ -1755,7 +1783,7 @@ function buildRoutineSlots(
       )
     }
 
-    pushSlot(sections, {
+    pushRoutineSlot({
       id: "occasional-oil",
       kind: "product_slot",
       phase: "occasional",
@@ -1777,7 +1805,7 @@ function buildRoutineSlots(
       context.explicit_topic_ids.includes("bond_builder") && !context.has_bond_builder_signals
 
     if (explicitWithoutSignals) {
-      pushSlot(sections, {
+      pushRoutineSlot({
         id: "occasional-bond-builder",
         kind: "instruction",
         phase: "occasional",
@@ -1834,7 +1862,7 @@ function buildRoutineSlots(
         )
       }
 
-      pushSlot(sections, {
+      pushRoutineSlot({
         id: "occasional-bond-builder",
         kind: "instruction",
         phase: "occasional",
@@ -1856,7 +1884,7 @@ function buildRoutineSlots(
   if (forcedCategory && !hasRoutineCategorySlot(sections, forcedCategory)) {
     const forcedSlot = buildForcedRequestedCategorySlot(forcedCategory, profile)
     if (forcedSlot) {
-      pushSlot(sections, forcedSlot)
+      pushSlot(sections, applyHairLengthRoutineCopy(forcedSlot, profile?.hair_length ?? null))
     }
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@
 import type {
   HairTexture,
   HairThickness,
+  HairLength,
   HairDensity,
   ProductFrequency,
   HeatStyling,
@@ -88,6 +89,7 @@ import type { ShampooBucket, ShampooBucketPair } from "@/lib/shampoo/constants"
 export type {
   HairTexture,
   HairThickness,
+  HairLength,
   HairDensity,
   ProductFrequency,
   HeatStyling,
@@ -157,6 +159,7 @@ export interface HairProfile {
   user_id: string
   hair_texture: HairTexture | null
   thickness: HairThickness | null
+  hair_length: HairLength | null
   density: HairDensity | null
   concerns: ProfileConcern[]
   products_used: string | null

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -4,6 +4,7 @@ import { isConditionerCategory } from "@/lib/conditioner/constants"
 import {
   HAIR_TEXTURES,
   HAIR_THICKNESSES,
+  HAIR_LENGTHS,
   HAIR_DENSITIES,
   PROFILE_CONCERNS,
   GOALS,
@@ -55,6 +56,7 @@ export const hairProfileFullSchema = z.object({
   hair_texture: z.enum(HAIR_TEXTURES).nullable(),
   thickness: z.enum(HAIR_THICKNESSES).nullable(),
   density: z.enum(HAIR_DENSITIES).nullable().default(null),
+  hair_length: z.enum(HAIR_LENGTHS).nullable().default(null),
   concerns: z.array(z.enum(PROFILE_CONCERNS)).default([]),
   products_used: z.string().nullable().default(null),
   heat_styling: z.enum(HEAT_STYLING_LEVELS).nullable().default(null),

--- a/src/lib/vocabulary/hair-length.ts
+++ b/src/lib/vocabulary/hair-length.ts
@@ -1,0 +1,24 @@
+export const HAIR_LENGTHS = ["very_short", "short", "medium", "long", "very_long"] as const
+export type HairLength = (typeof HAIR_LENGTHS)[number]
+
+export const HAIR_LENGTH_LABELS = {
+  very_short: "Sehr kurz",
+  short: "Kurz",
+  medium: "Mittellang",
+  long: "Lang",
+  very_long: "Sehr lang",
+} as const satisfies Record<HairLength, string>
+
+export const HAIR_LENGTH_DESCRIPTIONS = {
+  very_short: "Maschinenschnitt bis Pixie, etwa bis zu den Ohren.",
+  short: "Bob-Länge, unter den Ohren bis knapp über die Schultern.",
+  medium: "Schulterlänge bis Brusthöhe oder untere Schulterblätter.",
+  long: "Unter Brust oder Schulterblättern bis ungefähr zur Taille.",
+  very_long: "Taille oder länger.",
+} as const satisfies Record<HairLength, string>
+
+export const HAIR_LENGTH_OPTIONS = HAIR_LENGTHS.map((value) => ({
+  value,
+  label: HAIR_LENGTH_LABELS[value],
+  description: HAIR_LENGTH_DESCRIPTIONS[value],
+}))

--- a/src/lib/vocabulary/index.ts
+++ b/src/lib/vocabulary/index.ts
@@ -11,6 +11,14 @@ export {
 export type { HairTexture, HairThickness } from "./hair-types"
 
 export {
+  HAIR_LENGTHS,
+  HAIR_LENGTH_LABELS,
+  HAIR_LENGTH_DESCRIPTIONS,
+  HAIR_LENGTH_OPTIONS,
+} from "./hair-length"
+export type { HairLength } from "./hair-length"
+
+export {
   PROFILE_CONCERNS,
   PROFILE_CONCERN_LABELS,
   PROFILE_CONCERN_OPTIONS,

--- a/supabase/migrations/20260618120000_add_hair_length_to_profiles.sql
+++ b/supabase/migrations/20260618120000_add_hair_length_to_profiles.sql
@@ -1,0 +1,12 @@
+alter table public.hair_profiles
+  add column if not exists hair_length text;
+
+alter table public.hair_profiles
+  drop constraint if exists hair_profiles_hair_length_check;
+
+alter table public.hair_profiles
+  add constraint hair_profiles_hair_length_check
+  check (
+    hair_length is null
+    or hair_length in ('very_short', 'short', 'medium', 'long', 'very_long')
+  );

--- a/tests/agent-get-user-context.spec.ts
+++ b/tests/agent-get-user-context.spec.ts
@@ -14,6 +14,7 @@ function makeProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user_test",
     hair_texture: "wavy",
     thickness: "normal",
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,

--- a/tests/agent-guidance.spec.ts
+++ b/tests/agent-guidance.spec.ts
@@ -52,6 +52,7 @@ function createHairProfile(overrides: Partial<HairProfile>): HairProfile {
     user_id: "user-1",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,

--- a/tests/agent-routine-tool.spec.ts
+++ b/tests/agent-routine-tool.spec.ts
@@ -17,6 +17,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user-1",
     hair_texture: "curly",
     thickness: "normal",
+    hair_length: null,
     density: "medium",
     concerns: ["dryness"],
     products_used: null,

--- a/tests/agent-v2-production-chat-pipeline.spec.ts
+++ b/tests/agent-v2-production-chat-pipeline.spec.ts
@@ -62,6 +62,7 @@ function createCompleteHairProfile(overrides: Partial<HairProfile> = {}): HairPr
     user_id: "user-1",
     hair_texture: "wavy",
     thickness: "fine",
+    hair_length: null,
     density: "medium",
     concerns: ["frizz"],
     products_used: null,
@@ -358,6 +359,102 @@ test("AgentV2 production conversation history loads the latest ten messages chro
       "Message 11",
       "Message 12",
     ],
+  )
+})
+
+test("AgentV2 production conversation history checks ownership before loading admin-scoped messages", async () => {
+  const returnedMessages = [createMessage(1)]
+  const calls: Array<{ table: string; column: string; value: string }> = []
+  const fakeClient = {
+    from(table: string) {
+      return {
+        select() {
+          return {
+            eq(column: string, value: string) {
+              calls.push({ table, column, value })
+              if (table === "conversations") {
+                return {
+                  eq(nextColumn: string, nextValue: string) {
+                    calls.push({ table, column: nextColumn, value: nextValue })
+                    return {
+                      async maybeSingle() {
+                        return { data: { id: "conversation-1" }, error: null }
+                      },
+                    }
+                  },
+                }
+              }
+
+              return {
+                order() {
+                  return {
+                    async limit() {
+                      return { data: returnedMessages, error: null }
+                    },
+                  }
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+
+  const messages = await loadAgentV2ProductionConversationHistory(
+    "conversation-1",
+    "user-1",
+    fakeClient,
+  )
+
+  assert.deepEqual(
+    calls.filter((call) => call.table === "conversations"),
+    [
+      { table: "conversations", column: "id", value: "conversation-1" },
+      { table: "conversations", column: "user_id", value: "user-1" },
+    ],
+  )
+  assert.deepEqual(messages, returnedMessages)
+})
+
+test("AgentV2 production conversation history fails loudly when messages cannot be loaded", async () => {
+  const fakeClient = {
+    from(table: string) {
+      return {
+        select() {
+          return {
+            eq() {
+              if (table === "conversations") {
+                return {
+                  eq() {
+                    return {
+                      async maybeSingle() {
+                        return { data: { id: "conversation-1" }, error: null }
+                      },
+                    }
+                  },
+                }
+              }
+
+              return {
+                order() {
+                  return {
+                    async limit() {
+                      return { data: null, error: { message: "database unavailable" } }
+                    },
+                  }
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+
+  await assert.rejects(
+    () => loadAgentV2ProductionConversationHistory("conversation-1", "user-1", fakeClient),
+    /Failed to load AgentV2 production conversation history/,
   )
 })
 

--- a/tests/agentic-tool-loop.spec.ts
+++ b/tests/agentic-tool-loop.spec.ts
@@ -2080,6 +2080,7 @@ test("tool-loop current frizz and tangling signals steer routine priority away f
         user_id: "user-1",
         hair_texture: "straight",
         thickness: "normal",
+        hair_length: null,
         density: "medium",
         concerns: [],
         products_used: "Shampoo, Conditioner, Maske, Oel",

--- a/tests/analytics-tracking.test.ts
+++ b/tests/analytics-tracking.test.ts
@@ -183,6 +183,49 @@ test("facade strips undefined payload values once before destination dispatch", 
   })
 })
 
+test("quiz completed analytics payload includes hair length when present", () => {
+  withDestinationSpies((calls) => {
+    trackAppEvent("quiz_completed", {
+      hairLength: "medium",
+      hairTexture: "wavy",
+      leadId: "lead-123",
+      scalpCondition: "gereizt",
+      scalpType: "trocken",
+      thickness: "fine",
+    })
+
+    assert.deepEqual(
+      calls.map((call) => call.payload),
+      [
+        {
+          hairLength: "medium",
+          hairTexture: "wavy",
+          leadId: "lead-123",
+          scalpCondition: "gereizt",
+          scalpType: "trocken",
+          thickness: "fine",
+        },
+        {
+          hairLength: "medium",
+          hairTexture: "wavy",
+          leadId: "lead-123",
+          scalpCondition: "gereizt",
+          scalpType: "trocken",
+          thickness: "fine",
+        },
+        {
+          hairLength: "medium",
+          hairTexture: "wavy",
+          leadId: "lead-123",
+          scalpCondition: "gereizt",
+          scalpType: "trocken",
+          thickness: "fine",
+        },
+      ],
+    )
+  })
+})
+
 test("destination failures are isolated and do not throw from the facade", () => {
   const originalPostHog = postHogDestination.track
   const originalCustomerIo = customerIoDestination.track

--- a/tests/auth-intake-routing.e2e.spec.ts
+++ b/tests/auth-intake-routing.e2e.spec.ts
@@ -131,6 +131,7 @@ test.describe.serial("Authenticated intake routing", () => {
     await page.getByText("Wellig").first().click()
     await page.getByText("Mittel").first().click()
     await page.getByText("Mittlere Dichte").click()
+    await page.getByText("Mittellang").click()
     await page.getByText("Leicht uneben").click()
     await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
 
@@ -211,7 +212,7 @@ test.describe.serial("Authenticated intake routing", () => {
       .toBe("linked")
 
     const latestLead = await fetchLatestLead()
-    expect(latestLead?.quiz_answers).toMatchObject({ density: "medium" })
+    expect(latestLead?.quiz_answers).toMatchObject({ density: "medium", hair_length: "medium" })
     await expect.poll(fetchHairProfileDensity, { timeout: 30_000 }).toBe("medium")
   })
 })

--- a/tests/chat-debug-trace.spec.ts
+++ b/tests/chat-debug-trace.spec.ts
@@ -51,6 +51,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user-1",
     hair_texture: "wavy",
     thickness: "fine",
+    hair_length: null,
     density: "medium",
     concerns: ["frizz"],
     products_used: null,

--- a/tests/conversation-state.spec.ts
+++ b/tests/conversation-state.spec.ts
@@ -42,6 +42,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user-1",
     hair_texture: "wavy",
     thickness: "fine",
+    hair_length: null,
     density: "medium",
     concerns: [],
     products_used: null,

--- a/tests/customerio-quiz-sync.test.ts
+++ b/tests/customerio-quiz-sync.test.ts
@@ -28,6 +28,7 @@ test("quiz lead sync returns failed results without throwing when Customer.io is
           structure: "wavy",
           thickness: "fine",
           density: "low",
+          hair_length: "medium",
           fingertest: "leicht_uneben",
           pulltest: "stretches_stays",
           scalp_type: "trocken",
@@ -71,6 +72,7 @@ test("quiz lead sync sends Customer.io profile and event when marketing consent 
           structure: "wavy",
           thickness: "fine",
           density: "low",
+          hair_length: "medium",
           fingertest: "leicht_uneben",
           pulltest: "stretches_stays",
           scalp_type: "trocken",
@@ -95,6 +97,8 @@ test("quiz lead sync sends Customer.io profile and event when marketing consent 
       assert.equal(identifyTraits.marketing_consent, false)
       assert.equal(identifyTraits.consent_timestamp, undefined)
       assert.equal(identifyTraits.quiz_completed_at, "2026-05-28T10:00:00.000Z")
+      assert.equal(identifyTraits.hair_length, "medium")
+      assert.equal(identifyTraits.hair_length_label, "Mittellang")
 
       assert.equal(calls[1].body.event, "quiz_profile_submitted")
       const eventProperties = calls[1].body.properties as Record<string, unknown>

--- a/tests/customerio-quiz-traits.test.ts
+++ b/tests/customerio-quiz-traits.test.ts
@@ -14,6 +14,7 @@ test("builds rich Customer.io quiz traits with labels when consent is true", () 
       structure: "wavy",
       thickness: "fine",
       density: "low",
+      hair_length: "medium",
       fingertest: "leicht_uneben",
       pulltest: "stretches_stays",
       scalp_type: "trocken",
@@ -37,6 +38,8 @@ test("builds rich Customer.io quiz traits with labels when consent is true", () 
   assert.equal(sync.identifyTraits.thickness_label, "Fein")
   assert.equal(sync.identifyTraits.density, "low")
   assert.equal(sync.identifyTraits.density_label, "Wenig Haare")
+  assert.equal(sync.identifyTraits.hair_length, "medium")
+  assert.equal(sync.identifyTraits.hair_length_label, "Mittellang")
   assert.equal(sync.identifyTraits.cuticle_condition, "leicht_uneben")
   assert.equal(sync.identifyTraits.cuticle_condition_label, "Leicht uneben")
   assert.equal(sync.identifyTraits.protein_moisture_balance, "stretches_stays")
@@ -69,6 +72,7 @@ test("builds rich Customer.io quiz traits when marketing consent is false", () =
       structure: "curly",
       thickness: "coarse",
       density: "high",
+      hair_length: "long",
       fingertest: "rau",
       pulltest: "snaps",
       scalp_type: "fettig",
@@ -93,6 +97,8 @@ test("builds rich Customer.io quiz traits when marketing consent is false", () =
   assert.equal(sync.identifyTraits.thickness_label, "Dick")
   assert.equal(sync.identifyTraits.density, "high")
   assert.equal(sync.identifyTraits.density_label, "Viele Haare")
+  assert.equal(sync.identifyTraits.hair_length, "long")
+  assert.equal(sync.identifyTraits.hair_length_label, "Lang")
   assert.equal(sync.identifyTraits.cuticle_condition, "rau")
   assert.equal(sync.identifyTraits.cuticle_condition_label, "Rau")
   assert.equal(sync.identifyTraits.protein_moisture_balance, "snaps")

--- a/tests/hair-profile-derived.test.ts
+++ b/tests/hair-profile-derived.test.ts
@@ -11,6 +11,7 @@ function makeProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user_test",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,

--- a/tests/heat-tools-vocabulary.test.tsx
+++ b/tests/heat-tools-vocabulary.test.tsx
@@ -29,6 +29,19 @@ test("hair profile validator accepts thermal rollers as a styling tool", () => {
   assert.deepEqual(parsed.styling_tools, ["thermal_rollers"])
 })
 
+test("hair profile validator preserves hair length for full profile saves", () => {
+  const parsed = hairProfileFullSchema.parse({
+    hair_texture: "wavy",
+    thickness: "normal",
+    density: "medium",
+    hair_length: "long",
+    concerns: [],
+    goals: [],
+  })
+
+  assert.equal(parsed.hair_length, "long")
+})
+
 test("heat tools onboarding screen renders thermal rollers as a selectable option", () => {
   const html = renderToStaticMarkup(
     <HeatToolsScreen

--- a/tests/product-display-model.test.ts
+++ b/tests/product-display-model.test.ts
@@ -116,6 +116,7 @@ function createFineHairProfile(): HairProfile {
     user_id: "user-1",
     hair_texture: "wavy",
     thickness: "fine",
+    hair_length: null,
     density: "medium",
     concerns: [],
     products_used: null,

--- a/tests/profile-page-smoke.spec.ts
+++ b/tests/profile-page-smoke.spec.ts
@@ -95,6 +95,7 @@ test.describe.serial("@ci Profile page smoke", () => {
       hair_texture: "wavy",
       thickness: "fine",
       density: "medium",
+      hair_length: "long",
       concerns: [],
       heat_styling: "once_weekly",
       styling_tools: ["flat_iron"],
@@ -210,7 +211,10 @@ test.describe.serial("@ci Profile page smoke", () => {
     await expect(page.getByText("Weitere Produkte")).toHaveCount(0)
     await expect(page.getByText("Aus Haar-Check")).toHaveCount(0)
     await expect(page.getByText("Aus Onboarding")).toHaveCount(0)
-    await expect(page.locator("#profile-section-quiz").getByText("9/9 vollständig")).toBeVisible()
+    await expect(page.locator("#profile-section-quiz").getByText("10/10 vollständig")).toBeVisible()
+    await expect(
+      page.getByRole("button").filter({ hasText: "Haarlänge" }).filter({ hasText: "Lang" }),
+    ).toBeVisible()
     await expect(
       page
         .getByRole("button")

--- a/tests/profile-section-config.test.ts
+++ b/tests/profile-section-config.test.ts
@@ -10,6 +10,7 @@ function makeProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user_test",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,
@@ -56,4 +57,16 @@ test("profile shows no towel technique as an answered editable value", () => {
     ),
     "Keine Trocknungstechnik",
   )
+})
+
+test("profile quiz section includes editable hair length after density", () => {
+  const quizFields = PROFILE_FIELD_CONFIG.filter((field) => field.sectionKey === "quiz")
+  const densityIndex = quizFields.findIndex((field) => field.key === "density")
+  const hairLengthField = quizFields[densityIndex + 1]
+
+  assert.notEqual(densityIndex, -1)
+  assert.equal(hairLengthField?.key, "hair_length")
+  assert.equal(hairLengthField.label, "Haarlänge")
+  assert.deepEqual(hairLengthField.editTarget, { kind: "quiz" })
+  assert.equal(hairLengthField.getValue(makeProfile({ hair_length: "long" })), "Lang")
 })

--- a/tests/quiz-brand-panel-content.test.ts
+++ b/tests/quiz-brand-panel-content.test.ts
@@ -3,21 +3,21 @@ import test from "node:test"
 
 import { getQuizBrandPanelContent } from "../src/lib/quiz/brand-panel-content"
 
-test("question eight keeps the desktop rail with concise concerns copy", () => {
+test("question nine keeps the desktop rail with concise concerns copy", () => {
   const content = getQuizBrandPanelContent(8, "name")
 
-  assert.equal(content.eyebrow, "FRAGE 8 VON 9")
+  assert.equal(content.eyebrow, "FRAGE 9 VON 10")
   assert.equal(content.description, "Was dich gerade ausbremst.")
-  assert.equal(content.progressCurrent, 8)
+  assert.equal(content.progressCurrent, 9)
   assert.equal(content.progressComplete, false)
 })
 
-test("goals step becomes question nine in the desktop rail", () => {
+test("goals step becomes question ten in the desktop rail", () => {
   const content = getQuizBrandPanelContent(12, "name")
 
-  assert.equal(content.eyebrow, "FRAGE 9 VON 9")
+  assert.equal(content.eyebrow, "FRAGE 10 VON 10")
   assert.equal(content.description, "Worauf wir hinarbeiten.")
-  assert.equal(content.progressCurrent, 9)
+  assert.equal(content.progressCurrent, 10)
   assert.equal(content.progressComplete, false)
 })
 
@@ -26,7 +26,7 @@ test("lead capture uses a short finalization message with completed progress", (
 
   assert.equal(content.eyebrow, "FAST GESCHAFFT")
   assert.equal(content.description, "Gleich zeigen wir dir dein Profil.")
-  assert.equal(content.progressCurrent, 9)
+  assert.equal(content.progressCurrent, 10)
   assert.equal(content.progressComplete, true)
 })
 
@@ -35,6 +35,6 @@ test("analysis keeps the same desktop rail shell with concise processing copy", 
 
   assert.equal(content.eyebrow, "ANALYSE")
   assert.equal(content.description, "Wir setzen alles zusammen.")
-  assert.equal(content.progressCurrent, 9)
+  assert.equal(content.progressCurrent, 10)
   assert.equal(content.progressComplete, true)
 })

--- a/tests/quiz-draft.test.ts
+++ b/tests/quiz-draft.test.ts
@@ -43,6 +43,7 @@ test("quiz draft stores only restorable quiz answers and progress", () => {
     step: 12 as const,
     answers: {
       structure: "wavy",
+      hair_length: "medium" as const,
       goals: ["shine"],
     },
     lead: {
@@ -63,6 +64,7 @@ test("quiz draft stores only restorable quiz answers and progress", () => {
   assert.equal(stored.step, 12)
   assert.deepEqual(stored.answers, {
     structure: "wavy",
+    hair_length: "medium",
     goals: ["shine"],
   })
   assert.equal(JSON.stringify(stored).includes("lea@example.com"), false)
@@ -74,7 +76,7 @@ test("quiz draft resumes post-lead quiz states from lead capture instead of stor
   const storage = new MemoryStorage()
   const quizStateWithLeadFields = {
     step: 10 as const,
-    answers: { structure: "curly" },
+    answers: { structure: "curly", hair_length: "medium" as const },
     lead: { name: "Mia", email: "mia@example.com", marketingConsent: false },
     leadId: "550e8400-e29b-41d4-a716-446655440000",
   }
@@ -84,7 +86,7 @@ test("quiz draft resumes post-lead quiz states from lead capture instead of stor
   const draft = loadQuizDraft(storage)
 
   assert.equal(draft?.step, 9)
-  assert.deepEqual(draft?.answers, { structure: "curly" })
+  assert.deepEqual(draft?.answers, { structure: "curly", hair_length: "medium" })
 })
 
 test("stored post-lead quiz draft steps resume from lead capture", () => {
@@ -97,15 +99,90 @@ test("stored post-lead quiz draft steps resume from lead capture", () => {
         version: 1,
         savedAt: Date.now(),
         step,
-        answers: { structure: "wavy" },
+        answers: { structure: "wavy", hair_length: "medium" },
       }),
     )
 
     const draft = loadQuizDraft(storage)
 
     assert.equal(draft?.step, 9)
-    assert.deepEqual(draft?.answers, { structure: "wavy" })
+    assert.deepEqual(draft?.answers, { structure: "wavy", hair_length: "medium" })
   }
+})
+
+test("stored quiz drafts can resume at the hair length question", () => {
+  const storage = new MemoryStorage()
+
+  storage.setItem(
+    QUIZ_DRAFT_STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      savedAt: Date.now(),
+      step: 15,
+      answers: {
+        structure: "wavy",
+        thickness: "normal",
+        density: "medium",
+      },
+    }),
+  )
+
+  const draft = loadQuizDraft(storage)
+
+  assert.equal(draft?.step, 15)
+  assert.deepEqual(draft?.answers, {
+    structure: "wavy",
+    thickness: "normal",
+    density: "medium",
+  })
+})
+
+test("legacy quiz drafts after density resume at hair length when hair length is missing", () => {
+  for (const step of [4, 5, 6, 7, 8, 9, 10, 11, 12, 14]) {
+    const storage = new MemoryStorage()
+
+    storage.setItem(
+      QUIZ_DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        savedAt: Date.now(),
+        step,
+        answers: {
+          structure: "wavy",
+          thickness: "normal",
+          density: "medium",
+        },
+      }),
+    )
+
+    const draft = loadQuizDraft(storage)
+
+    assert.equal(draft?.step, 15)
+  }
+})
+
+test("quiz drafts after hair length keep their original step when hair length is present", () => {
+  const storage = new MemoryStorage()
+
+  storage.setItem(
+    QUIZ_DRAFT_STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      savedAt: Date.now(),
+      step: 4,
+      answers: {
+        structure: "wavy",
+        thickness: "normal",
+        density: "medium",
+        hair_length: "medium",
+      },
+    }),
+  )
+
+  const draft = loadQuizDraft(storage)
+
+  assert.equal(draft?.step, 4)
+  assert.equal(draft?.answers.hair_length, "medium")
 })
 
 test("stored quiz draft answers are normalized before restore", () => {
@@ -119,6 +196,7 @@ test("stored quiz draft answers are normalized before restore", () => {
       step: 12,
       answers: {
         structure: "wavy",
+        hair_length: "medium",
         goals: "volume",
         concerns: ["frizz", "unknown"],
         treatment: ["natur", "gefaerbt"],
@@ -132,6 +210,7 @@ test("stored quiz draft answers are normalized before restore", () => {
   assert.equal(draft?.step, 12)
   assert.deepEqual(draft?.answers, {
     structure: "wavy",
+    hair_length: "medium",
     concerns: ["frizz"],
     treatment: ["gefaerbt"],
   })

--- a/tests/quiz-lead-lifecycle.test.ts
+++ b/tests/quiz-lead-lifecycle.test.ts
@@ -11,6 +11,7 @@ test("dedupe reuses a recent lead when normalized answers match", () => {
         quiz_answers: {
           structure: "curly",
           thickness: "normal",
+          hair_length: "medium",
           fingertest: "rau",
           pulltest: "ueberdehnt",
           scalp_condition: "keine",
@@ -23,6 +24,7 @@ test("dedupe reuses a recent lead when normalized answers match", () => {
     {
       structure: "curly",
       thickness: "normal",
+      hair_length: "medium",
       fingertest: "rau",
       pulltest: "stretches_stays",
       scalp_type: "fettig",
@@ -43,6 +45,7 @@ test("dedupe still reuses a legacy lead missing the new scalp gate and concern f
         quiz_answers: {
           structure: "curly",
           thickness: "normal",
+          hair_length: "medium",
           fingertest: "rau",
           pulltest: "ueberdehnt",
           scalp_type: "fettig",
@@ -53,6 +56,7 @@ test("dedupe still reuses a legacy lead missing the new scalp gate and concern f
     {
       structure: "curly",
       thickness: "normal",
+      hair_length: "medium",
       fingertest: "rau",
       pulltest: "stretches_stays",
       scalp_type: "fettig",
@@ -73,6 +77,7 @@ test("dedupe distinguishes concern notes with different text", () => {
         quiz_answers: {
           structure: "curly",
           thickness: "normal",
+          hair_length: "medium",
           fingertest: "rau",
           pulltest: "ueberdehnt",
           scalp_type: "fettig",
@@ -85,6 +90,7 @@ test("dedupe distinguishes concern notes with different text", () => {
     {
       structure: "curly",
       thickness: "normal",
+      hair_length: "medium",
       fingertest: "rau",
       pulltest: "stretches_stays",
       scalp_type: "fettig",

--- a/tests/quiz-link-to-profile.test.ts
+++ b/tests/quiz-link-to-profile.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import { resolveProfileDensityFromQuizAnswers } from "../src/lib/quiz/link-to-profile"
+import * as linkToProfile from "../src/lib/quiz/link-to-profile"
+
+const { resolveProfileDensityFromQuizAnswers } = linkToProfile
 
 test("linking uses the explicit quiz density when present", () => {
   assert.equal(resolveProfileDensityFromQuizAnswers({ density: "high" }), "high")
@@ -30,5 +32,17 @@ test("linking does not invent density for sparse or partial answers", () => {
       thickness: "normal",
     }),
     undefined,
+  )
+})
+
+test("profile update data includes quiz hair length when present", () => {
+  assert.equal(
+    linkToProfile.buildProfileDataFromQuizAnswers({
+      structure: "wavy",
+      thickness: "normal",
+      density: "medium",
+      hair_length: "long",
+    }).hair_length,
+    "long",
   )
 })

--- a/tests/quiz-motivation-copy.test.ts
+++ b/tests/quiz-motivation-copy.test.ts
@@ -4,10 +4,13 @@ import { quizQuestions, QUIZ_TOTAL_QUESTIONS } from "../src/lib/quiz/questions"
 
 test("quiz motivation copy matches the visible question count", () => {
   const firstQuestion = quizQuestions.find((question) => question.questionNumber === 1)
-  const fifthQuestion = quizQuestions.find((question) => question.questionNumber === 5)
-  const problemsQuestion = quizQuestions.find((question) => question.questionNumber === 8)
+  const elasticityQuestion = quizQuestions.find((question) => question.questionNumber === 6)
+  const problemsQuestion = quizQuestions.find((question) => question.questionNumber === 9)
 
   assert.equal(firstQuestion?.motivation, `Super — noch ${QUIZ_TOTAL_QUESTIONS - 1} kurze Fragen.`)
-  assert.equal(fifthQuestion?.motivation, `Gut gemacht — noch ${QUIZ_TOTAL_QUESTIONS - 5} Fragen.`)
+  assert.equal(
+    elasticityQuestion?.motivation,
+    `Gut gemacht — noch ${QUIZ_TOTAL_QUESTIONS - 6} Fragen.`,
+  )
   assert.equal(problemsQuestion?.motivation, "Fast geschafft — eine Frage noch.")
 })

--- a/tests/quiz-normalization.test.ts
+++ b/tests/quiz-normalization.test.ts
@@ -43,6 +43,11 @@ test("density values are normalized and invalid values are removed", () => {
   assert.equal(normalizeStoredQuizAnswers({ density: "unknown" }).density, undefined)
 })
 
+test("hair length values are normalized and invalid values are removed", () => {
+  assert.equal(normalizeStoredQuizAnswers({ hair_length: "very_long" }).hair_length, "very_long")
+  assert.equal(normalizeStoredQuizAnswers({ hair_length: "unknown" }).hair_length, undefined)
+})
+
 test("legacy scalp values still map to type and condition", () => {
   const normalized = normalizeStoredQuizAnswers({
     structure: "wavy",

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -50,7 +50,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
     const { data, error } = await admin
       .from("hair_profiles")
       .select(
-        "hair_texture, thickness, density, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment, concerns, desired_volume, goals, drying_method, routine_preference",
+        "hair_texture, thickness, density, hair_length, cuticle_condition, protein_moisture_balance, scalp_type, scalp_condition, chemical_treatment, concerns, desired_volume, goals, drying_method, routine_preference",
       )
       .eq("user_id", userId)
       .maybeSingle()
@@ -154,19 +154,22 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       ).toBeVisible()
 
       await page.getByText("Wellig").first().click()
-      await expect(page.getByText("2/9")).toBeVisible()
+      await expect(page.getByText("2/10")).toBeVisible()
 
       await page.getByText("Mittel").first().click()
-      await expect(page.getByText("3/9")).toBeVisible()
+      await expect(page.getByText("3/10")).toBeVisible()
 
       await page.getByText("Mittlere Dichte").click()
-      await expect(page.getByText("4/9")).toBeVisible()
+      await expect(page.getByText("4/10")).toBeVisible()
+
+      await page.getByText("Mittellang").click()
+      await expect(page.getByText("5/10")).toBeVisible()
 
       await page.getByText("Leicht uneben").click()
-      await expect(page.getByText("5/9")).toBeVisible()
+      await expect(page.getByText("6/10")).toBeVisible()
 
       await page.getByText("Dehnt sich, bleibt ausgeleiert").click()
-      await expect(page.getByText("6/9")).toBeVisible()
+      await expect(page.getByText("7/10")).toBeVisible()
 
       await expect(
         page.getByRole("heading", { name: /Sind deine Haare chemisch behandelt/i }),
@@ -186,8 +189,8 @@ test.describe.serial("Quiz to onboarding E2E", () => {
 
       await page.getByRole("button", { name: /^Weiter$/i }).click()
 
-      // Scalp question (7/9)
-      await expect(page.getByText("7/9")).toBeVisible()
+      // Scalp question (8/10)
+      await expect(page.getByText("8/10")).toBeVisible()
       await expect(
         page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
       ).toBeVisible()
@@ -203,7 +206,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.getByRole("button", { name: "JA" }).click()
       await page.getByText("Trockene Schuppen").click()
 
-      await expect(page.getByText("8/9")).toBeVisible()
+      await expect(page.getByText("9/10")).toBeVisible()
       await expect(page.getByText(/Welche Haarprobleme/i)).toBeVisible()
       await page.getByText("Trockenheit").click()
       await page.getByText("Frizz").click()
@@ -416,6 +419,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       const latestLead = await fetchLatestLead()
       expect(latestLead?.quiz_answers).toMatchObject({
         density: "medium",
+        hair_length: "medium",
       })
 
       await expect
@@ -434,6 +438,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         hair_texture: "wavy",
         thickness: "normal",
         density: "medium",
+        hair_length: "medium",
         cuticle_condition: "slightly_rough",
         protein_moisture_balance: "stretches_stays",
         scalp_type: "dry",
@@ -463,6 +468,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         hair_texture: "wavy",
         thickness: "normal",
         density: "medium",
+        hair_length: "medium",
         cuticle_condition: "slightly_rough",
         protein_moisture_balance: "stretches_stays",
         scalp_type: "dry",
@@ -484,13 +490,15 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         page.getByRole("heading", { name: /Was ist deine natürliche Haartextur/i }),
       ).toBeVisible()
       await page.getByText("Glatt").first().click()
-      await expect(page.getByText("2/9")).toBeVisible()
+      await expect(page.getByText("2/10")).toBeVisible()
       await page.getByRole("button", { name: /Fein Kaum spürbar/i }).click()
-      await expect(page.getByText("3/9")).toBeVisible()
+      await expect(page.getByText("3/10")).toBeVisible()
       await page.getByText("Wenig Haare").click()
-      await expect(page.getByText("4/9")).toBeVisible()
+      await expect(page.getByText("4/10")).toBeVisible()
+      await page.getByText("Sehr kurz").click()
+      await expect(page.getByText("5/10")).toBeVisible()
       await page.getByText("Glatt wie Glas").click()
-      await expect(page.getByText("5/9")).toBeVisible()
+      await expect(page.getByText("6/10")).toBeVisible()
       await page.getByText("Reißt sofort").click()
 
       await expect(
@@ -506,7 +514,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await naturCard.click()
 
       await page.getByRole("button", { name: /^Weiter$/i }).click()
-      await expect(page.getByText("7/9")).toBeVisible()
+      await expect(page.getByText("8/10")).toBeVisible()
       await expect(
         page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
       ).toBeVisible()
@@ -515,7 +523,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         .filter({ has: page.getByText(/^Fettig$/) })
         .click()
       await page.getByRole("button", { name: "NEIN" }).click()
-      await expect(page.getByText("8/9")).toBeVisible()
+      await expect(page.getByText("9/10")).toBeVisible()
       await page.getByRole("button", { name: /Etwas anderes/i }).click()
       await page.getByLabel("Eigene Notiz").fill("verklebt schnell")
       await page.getByRole("button", { name: /^Weiter$/i }).click()
@@ -619,6 +627,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       const latestLead = await fetchLatestLead()
       expect(latestLead?.quiz_answers).toMatchObject({
         density: "low",
+        hair_length: "very_short",
         concerns: [],
         concerns_other_text: "verklebt schnell",
       })
@@ -640,6 +649,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
         hair_texture: "straight",
         thickness: "fine",
         density: "low",
+        hair_length: "very_short",
         cuticle_condition: "smooth",
         protein_moisture_balance: "snaps",
         scalp_type: "oily",

--- a/tests/quiz-validators.test.ts
+++ b/tests/quiz-validators.test.ts
@@ -8,6 +8,7 @@ function createBaseAnswers() {
     structure: "wavy",
     thickness: "normal",
     density: "medium",
+    hair_length: "medium",
     fingertest: "leicht_uneben",
     pulltest: "stretches_stays",
     scalp_type: "trocken",
@@ -28,6 +29,13 @@ test("quiz schema accepts an empty concern array with a negative scalp gate", ()
 test("quiz schema requires density as the third physical hair attribute", () => {
   const answers = createBaseAnswers()
   delete (answers as Partial<typeof answers>).density
+
+  assert.throws(() => quizAnswersSchema.parse(answers))
+})
+
+test("quiz schema requires hair length as the fourth physical hair attribute", () => {
+  const answers = createBaseAnswers()
+  delete (answers as Partial<typeof answers>).hair_length
 
   assert.throws(() => quizAnswersSchema.parse(answers))
 })

--- a/tests/recommendation-engine-chat.test.ts
+++ b/tests/recommendation-engine-chat.test.ts
@@ -13,6 +13,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user-1",
     hair_texture: "straight",
     thickness: "fine",
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,

--- a/tests/recommendation-engine-foundation.fixtures.ts
+++ b/tests/recommendation-engine-foundation.fixtures.ts
@@ -7,6 +7,7 @@ function buildProfile(overrides: Partial<HairProfile>): HairProfile {
     user_id: "user_1",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,

--- a/tests/recommendation-engine-shampoo-cadence.test.ts
+++ b/tests/recommendation-engine-shampoo-cadence.test.ts
@@ -28,6 +28,7 @@ function inventoryItem(
 function profile(overrides: Partial<NormalizedProfile> = {}): NormalizedProfile {
   return {
     hairTexture: null,
+    hairLength: null,
     thickness: null,
     density: null,
     concerns: [],

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -8,6 +8,11 @@ import {
   getRoutineAutofillSlots,
   projectRoutinePlanForLayer,
 } from "../src/lib/routines/planner"
+import {
+  getLengthCareIntensity,
+  hasLengthEndsZone,
+  suppressLengthOnlyCare,
+} from "../src/lib/recommendation-engine/hair-length"
 import type { HairProfile } from "../src/lib/types"
 
 function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
@@ -16,6 +21,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user-1",
     hair_texture: "wavy",
     thickness: "fine",
+    hair_length: null,
     density: "medium",
     concerns: [],
     products_used: null,
@@ -46,6 +52,202 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
 }
 
 test.describe("Routine planner", () => {
+  test("hair length helper maps length zones and care intensity conservatively", () => {
+    expect(hasLengthEndsZone("very_short")).toBe(false)
+    expect(hasLengthEndsZone(null)).toBe(false)
+    expect(hasLengthEndsZone("short")).toBe(true)
+    expect(hasLengthEndsZone("medium")).toBe(true)
+    expect(hasLengthEndsZone("long")).toBe(true)
+    expect(hasLengthEndsZone("very_long")).toBe(true)
+
+    expect(getLengthCareIntensity("very_short")).toBe("minimal")
+    expect(getLengthCareIntensity("short")).toBe("light")
+    expect(getLengthCareIntensity("medium")).toBe("standard")
+    expect(getLengthCareIntensity("long")).toBe("elevated")
+    expect(getLengthCareIntensity("very_long")).toBe("maximum")
+    expect(getLengthCareIntensity(null)).toBe("unknown")
+
+    expect(suppressLengthOnlyCare("very_short")).toBe(true)
+    expect(suppressLengthOnlyCare("short")).toBe(false)
+    expect(suppressLengthOnlyCare("medium")).toBe(false)
+    expect(suppressLengthOnlyCare("long")).toBe(false)
+    expect(suppressLengthOnlyCare("very_long")).toBe(false)
+    expect(suppressLengthOnlyCare(null)).toBe(false)
+  })
+
+  test("very short healthy profile does not add length-only care extras", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_short",
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu mir?",
+    )
+
+    const slots = plan.sections.flatMap((section) => section.slots)
+
+    expect(
+      slots
+        .find((slot) => slot.id === "base-conditioner")
+        ?.caveats.some((line) => /sehr kurzem Haar|sehr kleine Menge/i.test(line)),
+    ).toBe(true)
+    expect(slots.find((slot) => slot.id === "maintenance-leave-in")).toBeUndefined()
+    expect(slots.find((slot) => slot.id === "occasional-oil")).toBeUndefined()
+    expect(slots.find((slot) => slot.id === "occasional-mask")).toBeUndefined()
+    expect(slots.find((slot) => slot.id === "maintenance-brush-tools")).toBeUndefined()
+  })
+
+  test("very short profile does not auto-add detangling or wash-protection guidance from mechanical stress alone", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_short",
+        night_protection: ["tight_hairstyles"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu mir?",
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("brush_tools")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("cwc")
+
+    const slotIds = plan.sections.flatMap((section) => section.slots.map((slot) => slot.id))
+    expect(slotIds).not.toContain("maintenance-brush-tools")
+    expect(slotIds).not.toContain("base-cwc-technique")
+  })
+
+  test("very short profile keeps direct detangling questions explicit", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_short",
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Wie entwirre ich Knoten bei meinen Haaren?",
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("brush_tools")
+    expect(plan.sections.flatMap((section) => section.slots.map((slot) => slot.id))).toContain(
+      "maintenance-brush-tools",
+    )
+  })
+
+  test("very short profile can still receive need-driven CWC guidance", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_short",
+        concerns: ["dryness"],
+        chemical_treatment: ["colored"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine hilft gegen trockene Haare?",
+    )
+
+    expect(plan.active_topics.map((topic) => topic.id)).toContain("cwc")
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("owc")
+
+    const cwcSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "base-cwc-technique")
+
+    expect(cwcSlot).toBeDefined()
+    expect([...(cwcSlot?.rationale ?? []), ...(cwcSlot?.caveats ?? [])].join(" ")).toMatch(
+      /sehr kurzem Haar|sehr kleine Menge/i,
+    )
+  })
+
+  test("very short profile still keeps heat-protection guidance when heat use exists", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_short",
+        heat_styling: "daily",
+        uses_heat_protection: false,
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu mir, wenn ich taeglich glaette?",
+    )
+
+    const slots = plan.sections.flatMap((section) => section.slots)
+    const heatGuidance = slots.find(
+      (slot) =>
+        slot.id === "maintenance-leave-in" &&
+        [...slot.rationale, ...slot.caveats].some((line) => /Hitze|Hitzeschutz/i.test(line)),
+    )
+
+    expect(heatGuidance).toBeDefined()
+  })
+
+  test("very short profile still keeps heat-protection guidance for diffuser drying", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_short",
+        drying_method: "blow_dry_diffuser",
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt zu mir?",
+    )
+
+    const heatGuidance = plan.sections
+      .flatMap((section) => section.slots)
+      .find(
+        (slot) =>
+          slot.id === "maintenance-leave-in" &&
+          [...slot.rationale, ...slot.caveats].some((line) => /Hitze|Hitzeschutz/i.test(line)),
+      )
+
+    expect(heatGuidance).toBeDefined()
+  })
+
+  test("short hair allows need-driven ends care but keeps the copy light", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "short",
+        concerns: ["dryness"],
+        goals: ["moisture"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine hilft gegen trockene Laengen?",
+    )
+
+    const leaveInSlot = plan.sections
+      .flatMap((section) => section.slots)
+      .find((slot) => slot.id === "maintenance-leave-in")
+
+    expect(leaveInSlot?.action).toBe("add")
+    const leaveInCopy = [...(leaveInSlot?.rationale ?? []), ...(leaveInSlot?.caveats ?? [])].join(
+      " ",
+    )
+    expect(leaveInCopy).toMatch(/kleine Menge|leicht|sparsam/i)
+  })
+
+  test("very long hair strengthens coverage copy without triggering bond builder by length alone", () => {
+    const plan = buildRoutinePlan(
+      createProfile({
+        hair_texture: "straight",
+        hair_length: "very_long",
+        concerns: ["frizz"],
+        goals: ["less_frizz"],
+        current_routine_products: ["shampoo", "conditioner"],
+      }),
+      "Welche Routine passt gegen Frizz?",
+    )
+
+    const slots = plan.sections.flatMap((section) => section.slots)
+    const leaveInSlot = slots.find((slot) => slot.id === "maintenance-leave-in")
+
+    expect(leaveInSlot).toBeDefined()
+    expect([...leaveInSlot!.rationale, ...leaveInSlot!.caveats].join(" ")).toMatch(
+      /partienweise|Sektion|Längen|Spitzen|Schutz/i,
+    )
+    expect(slots.find((slot) => slot.id === "occasional-bond-builder")).toBeUndefined()
+    expect(plan.active_topics.map((topic) => topic.id)).not.toContain("bond_builder")
+  })
+
   test("wavy frizz routine stays structure-first and adds one lightweight finish slot", () => {
     const profile = createProfile({
       concerns: ["frizz"],
@@ -113,6 +315,7 @@ test.describe("Routine planner", () => {
       createProfile({
         hair_texture: "straight",
         thickness: "fine",
+        hair_length: "very_short",
         concerns: ["oily_scalp"],
         goals: ["shine"],
         current_routine_products: ["shampoo", "conditioner"],

--- a/tests/routine-signal-consumers.test.ts
+++ b/tests/routine-signal-consumers.test.ts
@@ -10,6 +10,7 @@ function createProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user-1",
     hair_texture: "wavy",
     thickness: "fine",
+    hair_length: null,
     density: "medium",
     concerns: [],
     products_used: null,

--- a/tests/suggested-prompts.test.ts
+++ b/tests/suggested-prompts.test.ts
@@ -10,6 +10,7 @@ function makeProfile(overrides: Partial<HairProfile> = {}): HairProfile {
     user_id: "user_test",
     hair_texture: null,
     thickness: null,
+    hair_length: null,
     density: null,
     concerns: [],
     products_used: null,


### PR DESCRIPTION
## Why
Beta feedback showed that hair length was not visibly captured, which made dosage, lengths/ends guidance, and very-short-hair recommendations less precise.

## What changed
- Adds `hair_length` as a structured five-value profile field and mandatory quiz step after density.
- Persists hair length through quiz leads, profile linking, profile editing, result analytics, and Customer.io traits.
- Adds conservative recommendation/routine handling: hair length tunes amount/application/protection guidance, suppresses unnecessary length-only extras for very short hair, and does not treat length alone as damage.
- Updates AgentV2 guidance and runtime profile context so chat/routine copy can reference hair length safely.
- Adds a Supabase migration for the nullable `hair_profiles.hair_length` column and enum check constraint.

## Verification
- `npm run typecheck`
- `npm run lint` (passes with 3 pre-existing warnings: unused `Menu`, `avatar` `<img>`, unused `AGENTIC_TOOL_LOOP_PROMPT`)
- `npm run build`
- `git diff --check`
- `npx tsx --test tests/quiz-draft.test.ts tests/quiz-validators.test.ts tests/quiz-normalization.test.ts tests/quiz-link-to-profile.test.ts tests/customerio-quiz-traits.test.ts tests/analytics-tracking.test.ts tests/agent-v2-production-chat-pipeline.spec.ts`
- `npx playwright test tests/routine-planner.spec.ts --project=chromium`
- `PLAYWRIGHT_BASE_URL=http://localhost:3326 npx playwright test tests/profile-page-smoke.spec.ts tests/quiz-onboarding-e2e.spec.ts --project=chromium`

## Migration state
- Changed migration: `20260618120000_add_hair_length_to_profiles.sql`
- Supabase project `pqdkhefxsxkyeqelqegq`: migration is already applied remotely (`Local 20260618120000 | Remote 20260618120000`).
- Existing unrelated migration-history divergence remains in the project, but this branch's migration is applied.
