### PR TITLE
fix(quiz): clarify dominant hair traits

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1092,8 +1092,8 @@ export default function ProfilePage() {
                         }}
                       >
                         <QuizEditorField
-                          title="Haartextur"
-                          text="Wie dein Haar natürlich fällt, wenn es nass ist."
+                          title="Haarstruktur"
+                          text="Welche Haarstruktur die meisten deiner Haare haben."
                         >
                           <SegmentedControl
                             options={HAIR_TEXTURE_OPTIONS}
@@ -1111,8 +1111,8 @@ export default function ProfilePage() {
                         }}
                       >
                         <QuizEditorField
-                          title="Haar-Dicke"
-                          text="Wie dick ein einzelnes Haar im Vergleich zu einem Nähfaden ist."
+                          title="Haardicke"
+                          text="Wie sich ein einzelnes Haar bei dir meistens im Vergleich zu einem Nähfaden anfühlt."
                         >
                           <SegmentedControl
                             options={HAIR_THICKNESS_OPTIONS}

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -134,14 +134,14 @@ export const PROFILE_SECTION_META: ProfileSectionMeta[] = [
 export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
   {
     key: "hair_texture",
-    label: "Haartextur",
+    label: "Haarstruktur",
     sectionKey: "quiz",
     editTarget: { kind: "quiz" },
     getValue: (profile) => optionLabel(profile?.hair_texture, HAIR_TEXTURE_OPTIONS),
   },
   {
     key: "thickness",
-    label: "Haar-Dicke",
+    label: "Haardicke",
     sectionKey: "quiz",
     editTarget: { kind: "quiz" },
     getValue: (profile) => optionLabel(profile?.thickness, HAIR_THICKNESS_OPTIONS),

--- a/src/lib/quiz/brand-panel-content.ts
+++ b/src/lib/quiz/brand-panel-content.ts
@@ -12,8 +12,8 @@ export interface QuizBrandPanelContent {
 const QUESTION_PANEL_CONTENT: Partial<
   Record<QuizStep, { questionNumber: number; description: string }>
 > = {
-  2: { questionNumber: 1, description: "Deine natürliche Basis." },
-  3: { questionNumber: 2, description: "Wie fein dein Haar ist." },
+  2: { questionNumber: 1, description: "Deine natürliche Haarstruktur." },
+  3: { questionNumber: 2, description: "Dicke einzelner Haare." },
   13: { questionNumber: 3, description: "Wie voll dein Haar insgesamt ist." },
   15: { questionNumber: 4, description: "Wie lang deine Haare aktuell sind." },
   4: { questionNumber: 5, description: "Wie sich die Oberfläche anfühlt." },

--- a/src/lib/quiz/questions.ts
+++ b/src/lib/quiz/questions.ts
@@ -7,9 +7,9 @@ export const quizQuestions: QuizQuestion[] = [
   {
     step: 2,
     questionNumber: 1,
-    title: "Was ist deine natürliche Haartextur?",
+    title: "Welche Haarstruktur haben die meisten deiner Haare?",
     instruction:
-      "Mach eine Strähne tropfnass, drücke sie oben zusammen und lass los \u2013 was passiert?",
+      "Schau dir eine typische nasse Strähne an und wähle unten aus, welche Form sie annimmt.",
     options: [
       {
         value: "straight",
@@ -42,9 +42,8 @@ export const quizQuestions: QuizQuestion[] = [
   {
     step: 3,
     questionNumber: 2,
-    title: "Wie dick sind deine einzelnen Haare?",
-    instruction:
-      "Nimm ein einzelnes Haar und halte es zwischen Daumen und Zeigefinger. Vergleiche es mit einem Nähfaden \u2013 das ist der beste Referenzpunkt.\n\nGemeint ist ein einzelnes Haar, nicht wie viele Haare du insgesamt hast.",
+    title: "Wie dick fühlt sich ein einzelnes Haar bei dir meistens an?",
+    instruction: "Vergleiche ein einzelnes Haar mit einem Nähfaden.",
     options: [
       {
         value: "fine",

--- a/src/lib/quiz/result-card-data.ts
+++ b/src/lib/quiz/result-card-data.ts
@@ -52,7 +52,7 @@ export function buildCardData(rawAnswers: QuizAnswers): CardData {
     },
     {
       icon: "result-clipboard" as const,
-      title: "Haarstärke",
+      title: "Haardicke",
       description: thicknessResults[answers.thickness ?? ""] ?? "",
     },
     {

--- a/src/lib/quiz/results-lookup.ts
+++ b/src/lib/quiz/results-lookup.ts
@@ -20,7 +20,7 @@ export function getHaartypLabel(answers: QuizAnswers): string {
   return `${t}, ${s} Haare`
 }
 
-// --- Card 2: Haarstärke ---
+// --- Card 2: Haardicke ---
 export const thicknessResults: Record<string, string> = {
   fine: "Fein \u2013 braucht leichte, wässrige Produkte. Dicke Cremes drücken feine Haare platt, weil der Haardurchmesser zu gering ist.",
   normal:

--- a/tests/conditioner-flow.spec.ts
+++ b/tests/conditioner-flow.spec.ts
@@ -113,7 +113,7 @@ test.describe("Conditioner Recommendation Flow", () => {
     // Verify we're on the profile page and it has content
     // Look for profile-related German text
     const hasProfileContent =
-      bodyText?.includes("Haartextur") ||
+      bodyText?.includes("Haarstruktur") ||
       bodyText?.includes("Haardicke") ||
       bodyText?.includes("Zugtest") ||
       bodyText?.includes("Profil") ||

--- a/tests/e2e-deployed.spec.ts
+++ b/tests/e2e-deployed.spec.ts
@@ -89,14 +89,14 @@ test.describe("Deployed App E2E Tests", () => {
     await startButton.waitFor({ state: "visible" })
     await startButton.click()
 
-    // Step 1: Hair texture question (question 1/7)
-    await expect(page.getByText(/Haartextur/i)).toBeVisible({ timeout: 15000 })
+    // Step 1: Hair structure question (question 1/7)
+    await expect(page.getByText(/Haarstruktur/i)).toBeVisible({ timeout: 15000 })
 
     // Click "Glatt" option — should auto-advance after 400ms
     await page.getByText("Glatt").first().click()
 
     // Step 2: Hair thickness (question 2/7)
-    await expect(page.getByText(/Wie dick sind deine einzelnen Haare/i)).toBeVisible({
+    await expect(page.getByText(/Wie dick fühlt sich ein einzelnes Haar/i)).toBeVisible({
       timeout: 10000,
     })
     await expect(page.getByText("2/7")).toBeVisible()
@@ -132,7 +132,7 @@ test.describe("Deployed App E2E Tests", () => {
     await startBtn.waitFor({ state: "visible" })
     await startBtn.click()
     // Wait for question title instead of counter (more reliable)
-    await expect(page.getByText(/Haartextur/i)).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(/Haarstruktur/i)).toBeVisible({ timeout: 15000 })
 
     await page.getByText("Glatt").first().click()
     await expect(page.getByText("2/7")).toBeVisible({ timeout: 10000 })
@@ -182,7 +182,7 @@ test.describe("Deployed App E2E Tests", () => {
     await startBtn.click()
 
     // Should be on question 1 — wait for the question title
-    await expect(page.getByText(/Haartextur/i)).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(/Haarstruktur/i)).toBeVisible({ timeout: 15000 })
 
     // Click the back arrow button (the ArrowLeft svg button)
     await page

--- a/tests/quiz-onboarding-e2e.spec.ts
+++ b/tests/quiz-onboarding-e2e.spec.ts
@@ -150,7 +150,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.goto("/quiz", { waitUntil: "networkidle" })
 
       await expect(
-        page.getByRole("heading", { name: /Was ist deine natürliche Haartextur/i }),
+        page.getByRole("heading", { name: /Welche Haarstruktur haben die meisten deiner Haare/i }),
       ).toBeVisible()
 
       await page.getByText("Wellig").first().click()
@@ -487,7 +487,7 @@ test.describe.serial("Quiz to onboarding E2E", () => {
       await page.goto("/quiz", { waitUntil: "networkidle" })
 
       await expect(
-        page.getByRole("heading", { name: /Was ist deine natürliche Haartextur/i }),
+        page.getByRole("heading", { name: /Welche Haarstruktur haben die meisten deiner Haare/i }),
       ).toBeVisible()
       await page.getByText("Glatt").first().click()
       await expect(page.getByText("2/10")).toBeVisible()


### PR DESCRIPTION
## Summary

Clarifies the HAI-111 quiz/profile copy so users choose the dominant or most representative hair trait without introducing mixed-type logic.

## What changed

- Reworded the first quiz questions for `hair_texture` and `thickness` to emphasize the majority/typical trait.
- Standardized visible profile/result terminology from `Haartextur` / `Haar-Dicke` / `Haarstärke` to `Haarstruktur` / `Haardicke`.
- Updated desktop quiz brand-panel summaries and affected text expectations in tests.

## Verification

- `npm run typecheck`
- `npm run lint` (passes with 3 pre-existing warnings in unrelated files: header unused `Menu`, avatar `<img>`, unused `AGENTIC_TOOL_LOOP_PROMPT`)
- Pre-commit hook ran `eslint --fix`, `prettier --write`, and `npm run typecheck`
- Browser smoke earlier in the worktree confirmed Q1/Q2 render with the selected copy in `/quiz`

## Notes / risks

- No recommendation logic, enum values, profile persistence, or mixed-type mapping changed.
- The repo-specific `autoreview` skill/tool was not available in this environment; I performed a focused final diff review against HAI-111 before committing.
