### PR TITLE
Clean conditioner category label

### DIFF
--- a/docs/product-identity-normalization.md
+++ b/docs/product-identity-normalization.md
@@ -15,10 +15,10 @@ Canonical correction passes may update reviewed normalization data and identity 
 
 ## Production Baseline
 
-The verified production baseline has 239 products and these current categories:
+The verified production baseline has 239 products. After `20260625120000_conditioner_category_label_cleanup.sql` is applied, the active category labels are:
 
 - `Bondbuilder`
-- `Conditioner (Drogerie)`
+- `Conditioner`
 - `Leave-in`
 - `Maske`
 - `Öle`
@@ -26,12 +26,12 @@ The verified production baseline has 239 products and these current categories:
 - `Tiefenreinigungsshampoo`
 - `Trockenshampoo`
 
-Canonical category keys are internal stable keys for these existing category labels:
+Canonical category keys are internal stable keys for these active category labels. Legacy raw labels such as `Conditioner (Drogerie)` may still be accepted as input aliases, but the active human-readable category label is `Conditioner`. Inactive or historical product rows may retain the legacy string.
 
-| Current category        | Canonical category key   |
+| Active category         | Canonical category key   |
 | ----------------------- | ------------------------ |
 | Bondbuilder             | `bondbuilder`            |
-| Conditioner (Drogerie)  | `conditioner`            |
+| Conditioner             | `conditioner`            |
 | Leave-in                | `leave_in`               |
 | Maske                   | `mask`                   |
 | Öle                     | `oil`                    |

--- a/plans/2026-06-25-conditioner-category-canonicalization-cleanup.claude-review.md
+++ b/plans/2026-06-25-conditioner-category-canonicalization-cleanup.claude-review.md
@@ -1,0 +1,62 @@
+I have enough grounding. Here is the verdict report.
+
+---
+
+**Verdict:** Re-shape first (lean hard). The plan is ~3–4× larger than its own goal, it re-introduces an abstraction CLAUDE.md forbids, and at least one task as written will **regress existing passing tests**. The committed one-line patch already achieves most of the user-visible goal; the migration + docs are the only other load-bearing pieces.
+
+---
+
+**Lean shape**
+
+- **Irreducible goal:** Users never see `Conditioner (Drogerie)`; the canonical key stays `conditioner`; the old string remains an accepted alias at boundaries.
+- **The goal is already ~80% met by the uncommitted patch.** The *only* place that actually leaked the legacy string to users was `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner` rendered at `src/components/chat/product-intake-card.tsx:242`. The committed change `src/lib/product-identity/index.ts:41` (`"Conditioner (Drogerie)"` → `"Conditioner"`) fixes that path. Every other display path I checked *already* emitted "Conditioner":
+  - `src/components/chat/product-display-model.ts:48-71` maps both `conditioner` and `conditioner-drogerie` → `"Conditioner"` (proven by passing test `tests/product-display-model.test.ts:357`).
+  - `src/lib/onboarding/product-options.ts:5` maps `conditioner` → `"Conditioner"`.
+  - `src/components/chat/product-card.tsx:27` maps `conditioner-drogerie` → `product-conditioner` icon.
+- **Cut or defer:**
+  - **Task 1 (central registry)** — speculative abstraction. The plan itself says "export derived constants so existing callers do not need broad rewrites," i.e. *no external behavior change*. That is exactly the "no over-engineering / no speculative abstractions" CLAUDE.md prohibits. Cut.
+  - **Task 2 — `product-display-model.ts` + `product-card.tsx` rewrites** — pure dedup of maps that already satisfy the goal, and one variant is a test-breaking regression (see Blockers). Defer.
+  - **Task 2 — `from-persistence.ts` alias normalization** — guards against input the DB makes impossible (see below). Cut.
+  - **Task 3 — hand-edits to `data/product-catalog-snapshot.json` and `data/product-catalog-normalization.json`** — both are *generated* artifacts (`snapshot.json:3` `"exported_at"`, produced by `scripts/product-identity/export-catalog.ts:25`; `normalization.json:5` "Generated from … snapshot after production re-baseline"). Editing them by hand pre-migration makes `current_category` lie about present DB state and diverge from regeneration. Defer to a post-migration re-export. The validator does **not** require it: `scripts/product-identity/validate-normalization.ts:160,279` accept any value where `normalizeCategoryKey(x) !== null`, so both old and new strings already pass.
+  - **Task 3 — `schema.json` enum edit** (`data/product-catalog-normalization.schema.json:44,94`) — documentation only; nothing loads the JSON-Schema enum at runtime or in tests. Optional, cosmetic.
+- **Minimal surviving shape:** (1) the committed `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner` line; (2) a forward-only data migration for `product_categories.display_name_de` and `products.category`; (3) `docs/product-identity-normalization.md`; (4) keep the existing alias in `normalizeCategoryKey` + `CONDITIONER_DB_CATEGORIES`. Optionally keep the committed `derived.ts`/`product-usage-rows.ts` normalization as belt-and-suspenders for `products.category` free-text, but recognize it as defensive, not goal-driving.
+- **Hard tradeoff the plan avoids:** Until the migration is actually *applied*, `products.category` (~43 rows, `data/product-catalog-snapshot.json:91…721`) and `product_categories.display_name_de` (`supabase/migrations/20260612120000_…sql:84`) still hold `Conditioner (Drogerie)`. The plan defers application behind approval — so "Done when active data no longer treats it as preferred" is **not** achieved by this PR alone. The plan should say so explicitly.
+
+---
+
+**Prior art**
+
+- **Schema/label migration + alias compatibility** → canonical shape is expand → backfill → contract, with the alias retained at the boundary. The chosen direction (keep `Conditioner (Drogerie)` in `normalizeCategoryKey`, change the display label, forward-only data UPDATE) **matches** the canonical shape well. ✅
+- **Reverse key→display-text map** (`CONDITIONER_DB_CATEGORIES`, `constants.ts:21-25`) → this is a sibling of `OIL_DB_CATEGORIES`, `BONDBUILDER_DB_CATEGORIES`, etc., all consumed by `matcher.ts:23-32` to build a `products.category IN (...)` filter. The plan's alternative "replace live callers with `normalizeCategoryKey`" **deviates wrongly**: `normalizeCategoryKey` goes text→key; the matcher needs key→[possible texts]. Renaming just this one constant also breaks symmetry with its siblings for zero behavior gain.
+
+---
+
+**Blockers** (will fail/regress as written)
+
+1. **Task 2 "replace local category display map with shared helper" breaks existing passing tests.** `tests/product-display-model.test.ts:358-359` assert `getProductCategoryLabel("Öle") === "Öl"` and `getProductCategoryLabel("deep_cleansing_shampoo") === "Tiefenreinigung"`. The shared `getProductCategoryDisplayLabel` (`src/lib/product-identity/index.ts:102-109`) returns `"Öle"` and `"Tiefenreinigungsshampoo"` for those — *different strings*. Swapping `product-display-model.ts:291-294` to the shared helper makes these tests fail. — *Fix: don't replace this map; if dedup is truly wanted, preserve label parity first.*
+2. **`getProductCategoryDisplayLabel` returns `""` for `peeling`/`serum`/`scrub`** (unsupported keys, not in `PRODUCT_CATEGORY_DISPLAY_LABELS`), whereas `product-display-model.ts:70` returns `"Peeling"`. Routing the drawer/compact-fact label through the shared helper drops the category label for peeling products. — *Fix: keep the local map for unsupported categories, or add a fallback.*
+
+---
+
+**High-confidence issues** (correctness, not preference)
+
+- **Legacy-text normalization in the profile/recommendation paths defends against impossible input.** `user_product_usage.category` is FK-constrained to canonical keys: `supabase/migrations/20260612130000_product_intake_submissions.sql:164-165` (`FOREIGN KEY (category) REFERENCES public.product_categories(key)`, validated at `:173`), and `product_categories.key` holds keys, not display text (`20260612120000_…sql:84`). The earlier CHECK constraint already restricted it to keys (`20260409_onboarding_v2_extras.sql:4-9`). So `derived.ts`/`product-usage-rows.ts`/`from-persistence.ts` never receive `"Conditioner (Drogerie)"`. The committed tests (`tests/hair-profile-derived.test.ts` +`tests/profile-product-usage-rows.test.ts`) feed that string directly to the function, bypassing the DB — they prove handling of a value the schema forbids. Not harmful, but not load-bearing; Task 2's `from-persistence.ts` addition (`canonicalizeInventoryCategory`, `from-persistence.ts:132-138`) is pure future-proofing.
+- **The matcher caller is unnamed.** Plan's Target File Map says modify `constants.ts` but never lists `src/lib/product-matching/matcher.ts:25`, the actual consumer. After the migration sets `products.category = 'Conditioner'`, the matcher still works because `"Conditioner"` is already in `CONDITIONER_DB_CATEGORIES` (`constants.ts:22`) — so *no change is needed here at all.*
+- **`isConditionerCategory` (`constants.ts:36`) has 8 live callers** (admin pages, `api/admin/products/*`, `validators/index.ts:174`, `concern-taxonomy.ts:137`) the plan never mentions. It uses `startsWith("conditioner")`, so it tolerates both strings — fine to leave, but it contradicts the Source-Context claim that `product-identity/index.ts` "owns category keys." Category identity is spread across several `is*Category` helpers.
+
+---
+
+**Smaller / nice-to-haves**
+
+- **Verification references a non-existent test.** `npx tsx --test tests/recommendation-engine-adapters.test.ts` (plan line 213) — no such file exists; it's only created in Task 5. Running the focused block before Task 5 errors.
+- **Migration test won't cover the new migration.** `tests/product-identity-schema.test.ts:7-8` hard-targets the file ending `_product_identity_normalization.sql`; the new `_conditioner_category_label_cleanup.sql` is invisible to it. Task 5's "Add or update migration/schema tests" is too vague to guarantee coverage.
+- **`tests/product-catalog-normalization.test.ts:455` loads the real `data/product-catalog-normalization.json`** — low risk (validator accepts both strings) but confirms that JSON is test-coupled, another reason to leave the generated file alone rather than hand-edit.
+- **Fuzzy either/or verbs invite the regressive branch.** "Move … to one category registry **or** registry-derived constants" and "Rename … **or** replace live callers with `normalizeCategoryKey`" leave the choice to the implementing subagent; a reasoning model may pick the test-breaking option.
+
+---
+
+**Bottom line**
+
+Don't ship this plan to a subagent as written: Task 2 will red existing tests, Task 1 adds a forbidden abstraction, and Tasks 2–4 mostly defend against data the DB FK already makes impossible or hand-edit generated artifacts. The leanest correct version is small: keep the committed `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner = "Conditioner"` line (it fixes the one real leak at `product-intake-card.tsx:242`), add the forward-only data migration for `product_categories.display_name_de` + `products.category`, update the doc, and keep the alias in `normalizeCategoryKey`/`CONDITIONER_DB_CATEGORIES`. State plainly that the legacy string only disappears from the DB once the migration is *applied*. Drop the registry, the `product-display-model`/`product-card` rewrites, the `from-persistence` change, and the snapshot/normalization JSON hand-edits.
+
+Want me to spec the leaner counter-proposal as a side-by-side so you can compare before re-issuing to a subagent?

--- a/plans/2026-06-25-conditioner-category-canonicalization-cleanup.code-review.claude.md
+++ b/plans/2026-06-25-conditioner-category-canonicalization-cleanup.code-review.claude.md
@@ -1,0 +1,35 @@
+All in-scope tests pass (9/9), and production data confirms **0** pre-existing bare `Conditioner` rows, so the unique-constraint collision I was probing is latent, not active. I have everything needed for the review.
+
+---
+
+# Code Review — Conditioner Category Label Cleanup
+
+**Verdict:** The change correctly meets all three stated requirements (display label → `Conditioner`, legacy alias preserved, data-only migration). No blocking bugs found. Findings below are low-severity / residual-risk, plus one verified-safe latent migration risk worth recording.
+
+I verified against production (`pqdkhefxsxkyeqelqegq`): **42** active rows currently carry `Conditioner (Drogerie)` (will be renamed), **1** inactive row carries it (left by design), and **0** rows currently carry the bare `Conditioner` label.
+
+## Findings (by severity)
+
+### 1. LOW (latent, currently safe) — Bulk `category` rename has no guard against the `products_name_category_unique` constraint
+`supabase/migrations/20260625120000_conditioner_category_label_cleanup.sql:11-17` updates `products.category` from `Conditioner (Drogerie)` → `Conditioner`. There is a `UNIQUE (name, category)` constraint on `products` (`supabase/migrations/20260316102000_allow_duplicate_product_names_across_categories.sql:16`). If a product ever already exists with category exactly `Conditioner` and a `name` matching one of the active rows being renamed, the `UPDATE` aborts the whole migration with a unique violation.
+
+I checked the live DB: there are **0** rows with category `Conditioner` today, and the 42 active rows are mutually unique under the existing `(name, 'Conditioner (Drogerie)')` constraint, so they rename cleanly. **The migration is safe to apply against current data.** This is only a note that the migration silently depends on that precondition holding at apply time; it is not asserted or defended in the SQL.
+
+### 2. LOW — Doc states the post-migration label as the *verified, current* production baseline
+`docs/product-identity-normalization.md:17-18` now reads: *"The verified production baseline has 239 products and these active categories: … `Conditioner`"*. The migration is deferred (per the plan, not applied without approval), so production still stores `Conditioner (Drogerie)` on those 42 active rows right now. The plan itself called for making clear that "active DB state is clean only after the migration is applied" (`plans/...-cleanup.md:57`), but the "Production Baseline" section presents the target label as already verified. A future agent verifying prod against this doc would see a mismatch. Consider noting the baseline reflects the intended post-migration state.
+
+### 3. LOW (nit) — Redundant `updated_at = now()` in both UPDATEs
+Both UPDATE statements set `updated_at = now()` (`...cleanup.sql:7` and `:16`). Both tables already have `BEFORE UPDATE` triggers that set it: `set_updated_at_product_categories` (`20260612120000_product_identity_normalization.sql:312-316`) and `set_updated_at_products` (`00001_initial_schema.sql:430`). Harmless and arguably explicit-by-intent, but redundant.
+
+### 4. LOW (test gap) — Migration test is textual only; behavior/idempotency/scoping untested
+`tests/conditioner-category-label-cleanup-migration.test.ts` asserts regex patterns against the SQL *file text*. It does not execute the migration, so it cannot catch a semantic error that still matches the regexes, and it does not cover the two behaviors that actually carry risk: the active-only scoping (inactive rows intentionally retained) and re-run idempotency (the `IS DISTINCT FROM` / `WHERE category = 'Conditioner (Drogerie)'` guards). This matches what the plan asked for (file-shape assertions), so it's acceptable — but the highest-value behaviors remain unverified by any executable test. The regexes themselves are correctly precise (e.g. `/category = 'Conditioner'/i` matches the SET clause but not `'Conditioner (Drogerie)'` in the WHERE).
+
+## Observations (not defects)
+
+- **Active-only scoping is intentional and consistent.** The migration filters `is_active = true AND lifecycle_status = 'active'` (`...cleanup.sql:16-17`). This diverges from the plan's *suggested* SQL snippet (which had no such filter, `plans/...-cleanup.md:173-177`) but matches the plan's documented expected post-migration shape (`:251-253`) and the review requirement ("clean active production labels"). The 1 inactive row keeps the legacy label by design.
+- **No user-facing leak and no lookup regression.** Every conditioner read/display path tolerates both the old and new raw labels: `CONDITIONER_DB_CATEGORIES` lists all three (`src/lib/conditioner/constants.ts:21-25`), `isConditionerCategory` prefix-matches (`:36-40`), the `match_conditioner_products` default filter already includes `'Conditioner'` (`20260314223500_fix_conditioner_category_mapping.sql`), the spec-sync trigger uses `LIKE 'conditioner%'`, and `getProductCategoryLabel` maps both `Conditioner (Drogerie)` and `Conditioner` → `"Conditioner"` (`src/components/chat/product-display-model.ts:48-71, 528-538`). So code can ship before or after the migration with no functional gap (rollout-safe, as the plan claims).
+- **Requirements satisfied:** display label `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner = "Conditioner"` (`src/lib/product-identity/index.ts:40`); alias retained `["conditioner", "Conditioner (Drogerie)"]` (`:52`) with test coverage `normalizeCategoryKey("Conditioner (Drogerie)") === "conditioner"` (`tests/product-identity-normalize.test.ts:36`); migration is data-only with no schema changes (asserted `:34-38`).
+
+## Residual risk (out of declared scope)
+
+- `scripts/export-missing-affiliate-links.ts:54-56` hardcodes `category: "Conditioner (Drogerie)"`. If that one-off affiliate-backfill utility is re-run after the migration, it would no longer match the renamed active conditioners. Not a runtime path; flagging only because the literal will go stale.

--- a/plans/2026-06-25-conditioner-category-canonicalization-cleanup.md
+++ b/plans/2026-06-25-conditioner-category-canonicalization-cleanup.md
@@ -1,0 +1,275 @@
+# Conditioner Category Canonicalization Cleanup Plan
+
+> **For agentic workers:** This is a narrow product-category cleanup plan. Implement from a repo-local worktree and stop before staging, committing, pushing, PR creation, or applying migrations unless the user explicitly approves those actions.
+
+## Implementation Goal Contract
+
+Goal: Clean up the legacy `Conditioner (Drogerie)` category so active internal state uses canonical category key `conditioner`, active display text uses `Conditioner`, and the old string exists only as a compatibility alias at input/source boundaries.
+
+Constraints:
+
+- Keep existing product-intake UX, chat behavior, onboarding flow, recommendation behavior, and product status behavior unchanged except for category identity/label cleanup.
+- Do not remove compatibility for old data, old snapshots, stale user/session payloads, or source imports that still say `Conditioner (Drogerie)`.
+- Prefer `products.category_key`, `product_categories.key`, `product_submissions.category`, and `user_product_usage.category` for runtime behavior.
+- Keep `products.category` as a legacy human-readable compatibility field during this PR; update its active conditioner value to `Conditioner`.
+- Do not apply Supabase migrations without explicit approval.
+
+Non-goals:
+
+- Do not drop `products.category` or `products.brand`.
+- Do not introduce a broad category registry refactor.
+- Do not rewrite historical docs, old audit reports, old generated snapshots, or already-applied migrations purely to erase historical references.
+- Do not introduce a new market/channel taxonomy for Drogerie in this PR.
+- Do not change recommendation rules, product ranking, intake matching policy, or approval status semantics.
+
+Done when:
+
+- Current user-facing helpers do not emit `Conditioner (Drogerie)`.
+- Active DB display/data migrations will move `conditioner` category display and active `products.category` rows to `Conditioner` once applied.
+- `Conditioner (Drogerie)` still normalizes to `conditioner`.
+- Current docs state that `Conditioner (Drogerie)` is a legacy/source alias only.
+- Focused tests and typecheck pass.
+
+## Chosen Direction
+
+Fully migrate the active model while retaining the old label as a compatibility alias.
+
+| Concept | Target |
+| --- | --- |
+| Internal key | `conditioner` |
+| User-facing label | `Conditioner` |
+| Active DB category display | `Conditioner` |
+| Active `products.category` compatibility text | `Conditioner` |
+| Legacy accepted alias | `Conditioner (Drogerie)` |
+
+Why: `Conditioner (Drogerie)` mixes product category with market/channel. Category should describe product use; channel should be separate metadata if needed later. Keeping the old string as an alias is defensive input handling, not keeping the old model alive.
+
+## Review Status
+
+Claude plan review completed: `plans/2026-06-25-conditioner-category-canonicalization-cleanup.claude-review.md`.
+
+Accepted findings folded into this revision:
+
+- Cut the broad category registry refactor. It was larger than the goal and risked changing unrelated category display behavior.
+- Do not replace the local `product-display-model.ts` display map in this PR. It intentionally renders some compact labels such as `Öl` and `Tiefenreinigung`; swapping to shared display labels would regress existing tests.
+- Do not hand-edit generated catalog snapshot/normalization data before the DB migration is applied and a re-export is run.
+- Keep `CONDITIONER_DB_CATEGORIES` compatibility behavior unless an implementation-time caller audit proves a smaller change is needed.
+- Make clear that active DB state is clean only after the migration is applied.
+
+Deferred findings:
+
+- A future category-display consolidation may still be worthwhile, but only if it preserves current per-surface labels and has its own tests.
+
+Rejected findings:
+
+- Claude framed the defensive profile/hair-profile legacy-input tests as non-load-bearing because the DB currently constrains `user_product_usage.category` to keys. That is true for live DB writes, but the code may still receive stale local/test/session data. Defensive normalization is acceptable if already touched, but it is not required for this cleanup plan.
+
+## Source Context
+
+Relevant current state:
+
+- `src/lib/product-identity/index.ts` owns category keys and aliases. `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner` must be `Conditioner`, while `normalizeCategoryKey("Conditioner (Drogerie)")` must keep returning `conditioner`.
+- `src/components/chat/product-intake-card.tsx` renders `PRODUCT_CATEGORY_DISPLAY_LABELS`, so the shared display label is the key user-facing leak.
+- `src/components/chat/product-display-model.ts` already maps legacy conditioner category text to `Conditioner` and has existing tests for that behavior.
+- `src/lib/onboarding/product-options.ts` already displays `conditioner` as `Conditioner`.
+- `src/components/chat/product-card.tsx` already maps `conditioner-drogerie` to the conditioner icon.
+- `supabase/migrations/20260612120000_product_identity_normalization.sql` historically seeded `product_categories.display_name_de` for `conditioner` as `Conditioner (Drogerie)`.
+- Production/current active `products.category` rows may still contain `Conditioner (Drogerie)` even though `products.category_key` is the canonical runtime key.
+
+## Target File Map
+
+### Product Identity And User-Facing Label
+
+- Modify: `src/lib/product-identity/index.ts`
+  - Ensure `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner` is `Conditioner`.
+  - Keep `Conditioner (Drogerie)` and `Conditioner Profi` as aliases for `conditioner`.
+  - Keep `Conditioner` as both display label and accepted alias.
+  - Do not introduce a broad registry refactor in this PR.
+
+### Database
+
+- Create: `supabase/migrations/<timestamp>_conditioner_category_label_cleanup.sql`
+  - Update `product_categories.display_name_de` where `key = 'conditioner'` to `Conditioner`.
+  - Update active legacy `products.category = 'Conditioner (Drogerie)'` rows to `Conditioner`.
+  - Do not drop `products.category`.
+  - Do not remove `Conditioner (Drogerie)` alias support from app code.
+
+### Current Documentation
+
+- Modify: `docs/product-identity-normalization.md`
+  - State the current contract:
+    - canonical key is `conditioner`;
+    - display label is `Conditioner`;
+    - `Conditioner (Drogerie)` is a legacy/source alias only.
+  - If the doc includes a current category mapping table, update the preferred active label to `Conditioner`.
+
+### Tests
+
+- Modify: `tests/product-identity-normalize.test.ts`
+  - Assert `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner === "Conditioner"`.
+  - Assert `normalizeCategoryKey("Conditioner (Drogerie)") === "conditioner"`.
+- Modify or create a migration-focused test.
+  - Do not rely on `tests/product-identity-schema.test.ts` unless it is updated to inspect the new migration file; that test currently targets the original identity migration.
+  - Assert the new migration updates `product_categories.display_name_de`.
+  - Assert the new migration updates `products.category`.
+  - Assert the new migration does not drop legacy columns.
+- Keep existing `tests/product-display-model.test.ts` assertions intact.
+
+### Optional Defensive Runtime Cleanup
+
+These are acceptable only if they stay small and tests remain focused:
+
+- `src/lib/profile/product-usage-rows.ts`
+  - Normalize legacy category text before display/sort if the file is already touched.
+- `src/lib/hair-profile/derived.ts`
+  - Normalize legacy category text before derived routine context if the file is already touched.
+
+Do not expand the PR into `product-display-model.ts`, `product-card.tsx`, `from-persistence.ts`, or script rewrites unless a failing test or direct caller audit proves they are needed for this conditioner cleanup.
+
+## Generated Data Policy
+
+Do not hand-edit generated files before migration application:
+
+- `data/product-catalog-normalization.json`
+- `data/product-catalog-snapshot.json`
+
+Reason: those files represent exported/current DB state. Changing them before the DB migration is applied makes them describe a state that does not exist yet and risks divergence on the next export.
+
+After the migration is approved and applied, re-export/regenerate these files through the existing product identity scripts if the repo process requires updated snapshots.
+
+The JSON schema may be updated only if it is clearly documenting the post-migration active baseline. If doing so, make the legacy alias behavior explicit in docs/tests.
+
+## Implementation Tasks
+
+### 1. Lock Display Label And Alias Contract
+
+- [x] Ensure `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner` is `Conditioner`.
+- [x] Keep `Conditioner (Drogerie)` in category aliases.
+- [x] Add/keep focused tests for both display and alias behavior.
+
+Acceptance:
+
+- `normalizeCategoryKey("Conditioner (Drogerie)") === "conditioner"`.
+- `PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner === "Conditioner"`.
+- Chat/product-intake category select renders `Conditioner`.
+
+### 2. Add Forward Data Migration
+
+- [x] Create the new Supabase migration.
+- [x] Update `product_categories.display_name_de` for key `conditioner`.
+- [x] Update active `products.category` values from `Conditioner (Drogerie)` to `Conditioner`.
+- [x] Keep all legacy columns and compatibility fields.
+- [x] Do not apply the migration without explicit approval.
+
+Suggested migration shape:
+
+```sql
+UPDATE public.product_categories
+SET display_name_de = 'Conditioner',
+    updated_at = now()
+WHERE key = 'conditioner'
+  AND display_name_de IS DISTINCT FROM 'Conditioner';
+
+UPDATE public.products
+SET category = 'Conditioner',
+    updated_at = now()
+WHERE category = 'Conditioner (Drogerie)';
+```
+
+Acceptance:
+
+- The migration is forward-only and data-only.
+- Re-running the migration is safe.
+- Code still accepts `Conditioner (Drogerie)` as an alias after the migration.
+
+### 3. Update Current Product Identity Documentation
+
+- [x] Update `docs/product-identity-normalization.md`.
+- [x] Distinguish active category label from legacy alias.
+- [x] Avoid rewriting historical audit docs.
+
+Acceptance:
+
+- Future agents can tell that `Conditioner (Drogerie)` is not the preferred active value.
+- The doc does not imply that Drogerie is still part of the category taxonomy.
+
+### 4. Add Migration Coverage
+
+- [x] Add a focused test file or extend an existing migration test so the new migration is actually inspected.
+- [x] Assert `product_categories` display update exists.
+- [x] Assert active `products.category` update exists.
+- [x] Assert no schema/table/legacy-column drops or `ALTER TABLE` changes appear.
+
+Acceptance:
+
+- The migration behavior is covered by a test that would fail if the new migration were omitted.
+
+### 5. Optional Defensive Normalization
+
+- [x] Skipped for this lean PR after Claude/code review; live DB category paths are canonical-key constrained.
+- [x] Do not broaden this into recommendation-engine or script rewrites without evidence.
+
+Acceptance:
+
+- Existing tests stay green.
+- Defensive tests are clearly framed as compatibility, not proof of expected DB shape.
+
+## Verification Plan
+
+Focused commands:
+
+```bash
+npx tsx --test tests/product-identity-normalize.test.ts
+npx tsx --test tests/product-display-model.test.ts
+npx tsx --test tests/product-identity-schema.test.ts
+```
+
+If optional defensive normalization is included:
+
+```bash
+npx tsx --test tests/profile-product-usage-rows.test.ts
+npx tsx --test tests/hair-profile-derived.test.ts
+```
+
+Broader checks after focused tests pass:
+
+```bash
+npm run typecheck
+npm run test:node
+```
+
+Database verification before applying migrations:
+
+```sql
+select key, display_name_de from public.product_categories where key = 'conditioner';
+select category, category_key, count(*) from public.products group by category, category_key order by category, category_key;
+```
+
+Expected post-migration production shape:
+
+- `product_categories.key = 'conditioner'` has `display_name_de = 'Conditioner'`.
+- Active products that previously had `category = 'Conditioner (Drogerie)'` have `category = 'Conditioner'`.
+- `category_key = 'conditioner'` remains the internal runtime key.
+- Inactive or historical product rows may still retain the legacy display string by design.
+
+## Rollout And Safety
+
+- Code can ship before or after the data migration because alias compatibility remains.
+- The DB is only fully clean after the migration is applied.
+- Rollback is simple: update `products.category` and `product_categories.display_name_de` back to `Conditioner (Drogerie)` if absolutely needed. App code will still accept both values.
+- Do not remove the alias in this PR.
+
+## Review Gates
+
+- [x] Run Claude plan review and classify findings.
+- [x] Patch accepted plan findings before implementation.
+- [x] Before implementation, restate this implementation goal contract and branch-gate state.
+- [x] After implementation, run focused tests plus typecheck.
+- [x] Run Claude and Superpowers code review after implementation.
+- [x] Stop before staging, committing, pushing, PR creation, or migration application for explicit approval.
+
+## Open Risks
+
+- Production may have undocumented analytics or exports reading `products.category`. The migration remains compatible because the field is retained and still human-readable.
+- Generated product catalog files may temporarily show the old string until a post-migration export runs.
+- If the old value appears in long-lived chat/session metadata, code compatibility handles it, but historical messages may still contain the old visible text.

--- a/src/lib/product-identity/index.ts
+++ b/src/lib/product-identity/index.ts
@@ -37,7 +37,7 @@ export type KnownProductCategoryKey = (typeof KNOWN_PRODUCT_CATEGORY_KEYS)[numbe
 
 export const PRODUCT_CATEGORY_DISPLAY_LABELS: Record<SupportedProductCategoryKey, string> = {
   shampoo: "Shampoo",
-  conditioner: "Conditioner (Drogerie)",
+  conditioner: "Conditioner",
   leave_in: "Leave-in",
   mask: "Maske",
   oil: "Öle",

--- a/supabase/migrations/20260625120000_conditioner_category_label_cleanup.sql
+++ b/supabase/migrations/20260625120000_conditioner_category_label_cleanup.sql
@@ -1,0 +1,34 @@
+-- Data-only cleanup: keep the internal key `conditioner`, but use the active
+-- user-facing German category label `Conditioner`.
+
+UPDATE public.product_categories
+SET
+  display_name_de = 'Conditioner',
+  updated_at = now()
+WHERE key = 'conditioner'
+  AND display_name_de IS DISTINCT FROM 'Conditioner';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.products legacy
+    JOIN public.products existing
+      ON existing.name = legacy.name
+      AND existing.category = 'Conditioner'
+      AND existing.id <> legacy.id
+    WHERE legacy.category = 'Conditioner (Drogerie)'
+      AND legacy.is_active = true
+      AND legacy.lifecycle_status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'Cannot rename active conditioner products because the target category would violate products_name_category_unique';
+  END IF;
+END $$;
+
+UPDATE public.products
+SET
+  category = 'Conditioner',
+  updated_at = now()
+WHERE category = 'Conditioner (Drogerie)'
+  AND is_active = true
+  AND lifecycle_status = 'active';

--- a/tests/conditioner-category-label-cleanup-migration.test.ts
+++ b/tests/conditioner-category-label-cleanup-migration.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { existsSync, readFileSync } from "node:fs"
+import test from "node:test"
+
+const migrationPath = "supabase/migrations/20260625120000_conditioner_category_label_cleanup.sql"
+
+function readMigration() {
+  assert.equal(existsSync(migrationPath), true, "conditioner label cleanup migration is missing")
+  return readFileSync(migrationPath, "utf8")
+}
+
+function normalizeSql(sql: string) {
+  return sql.replace(/\s+/g, " ").trim()
+}
+
+function extractStatement(sql: string, tableName: string) {
+  const pattern = new RegExp(`UPDATE\\s+public\\.${tableName}\\b[\\s\\S]*?;`, "i")
+  const match = sql.match(pattern)
+
+  assert.ok(match, `migration is missing the public.${tableName} update`)
+  return normalizeSql(match[0])
+}
+
+test("conditioner label cleanup migration updates active display and product categories only", () => {
+  const migration = readMigration()
+  const normalizedSql = normalizeSql(migration)
+  const categoryUpdate = extractStatement(migration, "product_categories")
+  const productUpdate = extractStatement(migration, "products")
+
+  assert.match(categoryUpdate, /UPDATE public\.product_categories/i)
+  assert.match(categoryUpdate, /display_name_de = 'Conditioner'/i)
+  assert.match(categoryUpdate, /updated_at = now\(\)/i)
+  assert.match(categoryUpdate, /WHERE key = 'conditioner'/i)
+  assert.match(categoryUpdate, /display_name_de IS DISTINCT FROM 'Conditioner'/i)
+
+  assert.match(productUpdate, /UPDATE public\.products/i)
+  assert.match(productUpdate, /category = 'Conditioner'/i)
+  assert.match(productUpdate, /WHERE category = 'Conditioner \(Drogerie\)'/i)
+  assert.match(productUpdate, /is_active = true/i)
+  assert.match(productUpdate, /lifecycle_status = 'active'/i)
+  assert.match(productUpdate, /updated_at = now\(\)/i)
+
+  assert.match(normalizedSql, /RAISE EXCEPTION/i)
+  assert.match(normalizedSql, /products_name_category_unique/i)
+  assert.match(normalizedSql, /existing\.name = legacy\.name/i)
+  assert.match(normalizedSql, /existing\.category = 'Conditioner'/i)
+  assert.match(normalizedSql, /existing\.id <> legacy\.id/i)
+
+  assert.doesNotMatch(normalizedSql, /DROP\s+COLUMN\s+(IF\s+EXISTS\s+)?brand\b/i)
+  assert.doesNotMatch(normalizedSql, /DROP\s+COLUMN\s+(IF\s+EXISTS\s+)?category\b/i)
+  assert.doesNotMatch(normalizedSql, /DROP\s+TABLE/i)
+  assert.doesNotMatch(normalizedSql, /ALTER\s+TABLE/i)
+  assert.doesNotMatch(normalizedSql, /ALTER\s+TABLE\s+public\.products\s+DROP/i)
+})

--- a/tests/product-identity-normalize.test.ts
+++ b/tests/product-identity-normalize.test.ts
@@ -27,6 +27,7 @@ test("canonical category constants include supported and known unsupported keys"
 
   assert.equal(KNOWN_PRODUCT_CATEGORY_KEYS.includes("heat_protectant"), true)
   assert.equal(KNOWN_PRODUCT_CATEGORY_KEYS.includes("hairspray"), true)
+  assert.equal(PRODUCT_CATEGORY_DISPLAY_LABELS.conditioner, "Conditioner")
   assert.equal(PRODUCT_CATEGORY_DISPLAY_LABELS.leave_in, "Leave-in")
 })
 


### PR DESCRIPTION
## Summary

- Changes the canonical user-facing conditioner category display label from `Conditioner (Drogerie)` to `Conditioner`.
- Keeps legacy aliases so existing/raw `Conditioner (Drogerie)` category text still normalizes to `conditioner`.
- Adds a data-only Supabase migration to clean active conditioner category labels, plus a preflight guard for target `(name, category)` uniqueness collisions.
- Records the implementation plan plus Claude plan/code review notes.

## Verification

- `npx tsx --test tests/product-identity-normalize.test.ts tests/conditioner-category-label-cleanup-migration.test.ts`
- `npx tsx --test tests/product-display-model.test.ts tests/product-identity-schema.test.ts`
- `npm run typecheck`
- `git diff --check --cached` before commit
- Claude code review: no blocking findings after follow-up fixes
- Superpowers code review: no remaining Critical/Important findings after re-check

## Migration State

- Added migration: `20260625120000_conditioner_category_label_cleanup.sql`.
- Checked linked Supabase project `pqdkhefxsxkyeqelqegq` with `npx supabase migration list --linked`.
- `20260625120000` is local-only/unapplied; it was not applied during this PR.
- The linked project also reports remote-only migration `20260623143000`, so do not run a blind `supabase db push`; reconcile the migration stack before applying or merging toward production.

## Base Note

This is a stacked draft PR targeting `codex/product-identity-canonical-correction`, because fresh `main` does not yet contain the product-identity files this cleanup builds on. Targeting `main` directly would include unrelated product-intake/product-identity stack changes.
