### PR TITLE
HAI-122: Clarify selections and support brush multiselect

### DIFF
--- a/scripts/eval-chat/fixtures.ts
+++ b/scripts/eval-chat/fixtures.ts
@@ -17,7 +17,7 @@ const FULL_PROFILE: HairProfileOverrides = {
   heat_styling: "rarely",
   drying_method: "air_dry",
   towel_technique: "rough_rubbing",
-  brush_type: "paddle",
+  brush_type: ["paddle"],
   night_protection: [],
   goals: ["shine"],
   onboarding_completed: true,

--- a/scripts/eval-chat/types.ts
+++ b/scripts/eval-chat/types.ts
@@ -17,7 +17,7 @@ export interface HairProfileOverrides {
   styling_tools?: string[] | null
   drying_method?: string | null
   towel_technique?: string | null
-  brush_type?: string | null
+  brush_type?: string[] | null
   night_protection?: string[] | null
   goals?: string[]
   uses_heat_protection?: boolean

--- a/scripts/ux-audit-seed.mjs
+++ b/scripts/ux-audit-seed.mjs
@@ -44,7 +44,7 @@ const { error: hpErr } = await admin.from("hair_profiles").upsert({
   towel_material: "frottee",
   towel_technique: "gentle_press",
   drying_method: "air_dry",
-  brush_type: "wide_tooth_comb",
+  brush_type: ["wide_tooth_comb"],
   night_protection: null,
 }, { onConflict: "user_id" })
 if (hpErr) console.log("hair_profiles upsert error:", hpErr.message)

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -729,7 +729,7 @@ export function OnboardingFlow({
         return (
           <ProductChecklistScreen
             title="Deine Basis-Produkte"
-            subtitle="Welche Produkte nutzt du regelmäßig?"
+            subtitle="Was kommt aktuell in deiner Basis-Routine vor?"
             options={BASIC_PRODUCT_OPTIONS}
             selected={store.selectedBasicProducts}
             onToggle={toggleBasicProduct}
@@ -743,7 +743,7 @@ export function OnboardingFlow({
         return (
           <ProductChecklistScreen
             title="Weitere Produkte"
-            subtitle="Nutzt du auch etwas davon?"
+            subtitle="Was nutzt du außerdem regelmäßig?"
             options={EXTRA_PRODUCT_OPTIONS}
             selected={store.selectedExtraProducts}
             onToggle={toggleExtraProduct}
@@ -871,7 +871,7 @@ export function OnboardingFlow({
       case "towel_technique":
         return (
           <SingleSelectScreen
-            title="Wie trocknest du?"
+            title="Wie gehst du mit dem Handtuch meistens vor?"
             subtitle="Rubbeln oder sanft ausdrücken?"
             options={towelTechniqueWithIcon}
             selected={store.towelTechnique}

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -8,6 +8,7 @@ import { useOnboardingStore } from "@/lib/onboarding/store"
 import type { OnboardingEditScope, OnboardingStep } from "@/lib/onboarding/store"
 import { shouldHydrateStoredHeatProtection } from "@/lib/onboarding/heat-protection-hydration"
 import { buildProductUsagePayloads } from "@/lib/onboarding/product-usage-save"
+import { normalizeBrushTypeValues } from "@/lib/profile/brush-type"
 import {
   isUnselectedShampooFallbackItem,
   SHAMPOO_CATEGORY,
@@ -83,7 +84,6 @@ const BRUSH_TYPE_ICONS: Record<string, IconName> = {
   round: "brush-round",
   boar_bristle: "brush-boar-bristle",
   fingers: "brush-fingers",
-  none_regular: "brush-none",
 }
 
 const NIGHT_PROTECTION_ICONS: Record<string, IconName> = {
@@ -169,6 +169,7 @@ function getFinalContinueLabel(
     (currentStep === "product_drilldown" ||
       currentStep === "heat_tools" ||
       currentStep === "drying_method" ||
+      currentStep === "brush_type" ||
       currentStep === "night_protection")
   ) {
     return "Speichern und zurück zum Profil"
@@ -250,8 +251,9 @@ export function OnboardingFlow({
       } else if (Array.isArray(hairProfile.drying_method) && hairProfile.drying_method.length > 0) {
         store.setDryingMethod(hairProfile.drying_method[0] as DryingMethod)
       }
-      if (hairProfile.brush_type) {
-        store.setBrushType(hairProfile.brush_type as BrushType)
+      const storedBrushTypes = normalizeBrushTypeValues(hairProfile.brush_type)
+      if (storedBrushTypes) {
+        store.setBrushType(storedBrushTypes)
       }
       if (Array.isArray(hairProfile.night_protection)) {
         store.setNightProtection(normalizeNightProtectionValues(hairProfile.night_protection) ?? [])
@@ -666,6 +668,16 @@ export function OnboardingFlow({
     }
   }, [])
 
+  const toggleBrushType = useCallback((value: string) => {
+    const { brushType, setBrushType } = useOnboardingStore.getState()
+    const selectedBrushTypes = brushType ?? []
+    if (selectedBrushTypes.includes(value as BrushType)) {
+      setBrushType(selectedBrushTypes.filter((v) => v !== value))
+    } else {
+      setBrushType([...selectedBrushTypes, value as BrushType])
+    }
+  }, [])
+
   // ── Don't render until hydrated ──
 
   if (!hydrated) {
@@ -900,16 +912,31 @@ export function OnboardingFlow({
 
       case "brush_type":
         return (
-          <SingleSelectScreen
-            title="Welche Bürste oder welchen Kamm nutzt du?"
-            subtitle="Das falsche Tool kann Haarbruch verursachen. Zeig uns, was du nutzt."
+          <MultiSelectScreen
+            title="Welche Bürsten oder Kämme nutzt du?"
+            subtitle="Mehrfachauswahl möglich. Wähle alles aus, was du regelmäßig nutzt."
             options={brushTypeWithIcon}
-            selected={store.brushType}
-            onSelect={(val) => {
-              store.setBrushType(val as BrushType)
+            selected={store.brushType ?? []}
+            onToggle={toggleBrushType}
+            onContinue={() => handleStepComplete("brush_type")}
+            onBack={handleBack}
+            continueLabel={getFinalContinueLabel(
+              "brush_type",
+              store,
+              editScope,
+              singleStepEdit,
+              returnTo,
+            )}
+            noneLabel={
+              editScope === "routine" || singleStepEdit
+                ? "Keine regelmäßige Bürste speichern"
+                : "Nichts davon"
+            }
+            onNone={() => {
+              store.setBrushType([])
               handleStepComplete("brush_type")
             }}
-            onBack={handleBack}
+            isSaving={savingStep === "brush_type"}
           />
         )
 

--- a/src/lib/agent-v2/tools/tool-definitions.ts
+++ b/src/lib/agent-v2/tools/tool-definitions.ts
@@ -28,6 +28,7 @@ import {
   AgentV2GuidanceCategorySchema,
   LoadAgentV2AdvisorGuidanceInputSchema,
 } from "@/lib/agent-v2/tools/guidance-tool"
+import { normalizeBrushTypeValues } from "@/lib/profile/brush-type"
 import { INVENTORY_CATEGORIES } from "@/lib/recommendation-engine/contracts"
 import {
   BRUSH_TYPES,
@@ -225,7 +226,7 @@ export const CurrentCareFactToolParametersSchema = z.strictObject({
     "context_signal",
   ]),
   field: z.union([ProfileFactFieldSchema, ProfileArrayFactFieldSchema]).nullable(),
-  value: z.union([z.string(), z.boolean()]).nullable(),
+  value: z.union([z.string(), z.array(z.string()), z.boolean()]).nullable(),
   category: InventoryCategorySchema.nullable(),
   present: z.boolean().nullable(),
   frequency: ProductFrequencySchema.nullable(),
@@ -238,6 +239,8 @@ export type ProfileFactField = z.infer<typeof ProfileFactFieldSchema>
 export type ProfileArrayFactField = z.infer<typeof ProfileArrayFactFieldSchema>
 
 type CurrentCareFactToolParameters = z.infer<typeof CurrentCareFactToolParametersSchema>
+type CurrentCareFactToolValue = NonNullable<CurrentCareFactToolParameters["value"]>
+const BRUSH_TYPE_SET = new Set<string>(BRUSH_TYPES)
 
 export const ClassifyTurnGateToolParametersSchema = z.strictObject({
   gate_status: AgentV2TurnGateResultSchema.shape.gate_status.describe(
@@ -381,7 +384,7 @@ function toCurrentCareFactToolParameters(
       input.kind === "profile_override" || input.kind === "profile_augment" ? input.field : null,
     value:
       input.kind === "profile_override" || input.kind === "profile_augment"
-        ? (input.value as string | boolean)
+        ? (input.value as CurrentCareFactToolValue)
         : null,
     category:
       input.kind === "routine_presence" || input.kind === "routine_frequency"
@@ -394,12 +397,27 @@ function toCurrentCareFactToolParameters(
   }
 }
 
-function normalizeProfileOverrideValue(field: ProfileFactField, value: string | boolean): unknown {
+function normalizeProfileOverrideValue(field: ProfileFactField, value: CurrentCareFactToolValue): unknown {
   if (field === "usesHeatProtection") {
     if (typeof value !== "boolean") {
       throw new Error("Invalid current care fact tool input")
     }
     return value
+  }
+  if (field === "brushType") {
+    if (Array.isArray(value)) {
+      const uniqueValues = [...new Set(value)]
+      const hasInvalidValue = value.some((item) => item !== "none_regular" && !BRUSH_TYPE_SET.has(item))
+      const mixesNoneWithBrushes = uniqueValues.includes("none_regular") && uniqueValues.length > 1
+      if (hasInvalidValue || mixesNoneWithBrushes) {
+        throw new Error("Invalid current care fact tool input")
+      }
+    }
+    const normalized = normalizeBrushTypeValues(value)
+    if (normalized === null) {
+      throw new Error("Invalid current care fact tool input")
+    }
+    return normalized
   }
   if (typeof value !== "string") {
     throw new Error("Invalid current care fact tool input")
@@ -418,8 +436,10 @@ function normalizeProfileOverrideValue(field: ProfileFactField, value: string | 
     towelMaterial: TOWEL_MATERIALS,
     towelTechnique: TOWEL_TECHNIQUES,
     dryingMethod: DRYING_METHODS,
-    brushType: BRUSH_TYPES,
-  } satisfies Record<Exclude<ProfileFactField, "usesHeatProtection">, readonly string[]>
+  } satisfies Record<
+    Exclude<ProfileFactField, "usesHeatProtection" | "brushType">,
+    readonly string[]
+  >
 
   return normalizeEnumLikeValue(allowedValuesByField[field], value)
 }

--- a/src/lib/agent/tools/get-user-context.ts
+++ b/src/lib/agent/tools/get-user-context.ts
@@ -210,7 +210,7 @@ function deriveSuggestedOverlays(
   if (
     (hairProfile?.heat_styling && hairProfile.heat_styling !== "never") ||
     Boolean(hairProfile?.styling_tools?.length) ||
-    Boolean(hairProfile?.brush_type) ||
+    Boolean(hairProfile?.brush_type?.length) ||
     Boolean(hairProfile?.drying_method && hairProfile.drying_method !== "air_dry")
   ) {
     addOverlay("overlay:mechanical_stress")

--- a/src/lib/agent/tools/load-advisor-guidance.ts
+++ b/src/lib/agent/tools/load-advisor-guidance.ts
@@ -461,7 +461,7 @@ function hasMechanicalStress(userContext: UserContextProjection): boolean {
   return (
     hasActiveHeatStyling(profile) ||
     Boolean(profile?.styling_tools?.length) ||
-    Boolean(profile?.brush_type) ||
+    Boolean(profile?.brush_type?.length) ||
     Boolean(profile?.drying_method && profile.drying_method !== "air_dry") ||
     hasDerivedSignal(userContext, "mechanical") ||
     hasDerivedSignal(userContext, "friction") ||

--- a/src/lib/dev/local-login.ts
+++ b/src/lib/dev/local-login.ts
@@ -164,7 +164,7 @@ async function seedLocalDevProfile(
       towel_material: "mikrofaser",
       towel_technique: "gentle_press",
       drying_method: "air_dry",
-      brush_type: "wide_tooth_comb",
+      brush_type: ["wide_tooth_comb"],
       night_protection: [],
       uses_heat_protection: false,
     },

--- a/src/lib/onboarding/store.ts
+++ b/src/lib/onboarding/store.ts
@@ -82,7 +82,7 @@ interface OnboardingState {
   towelMaterial: TowelMaterial | null
   towelTechnique: TowelTechnique | null
   dryingMethod: DryingMethod | null
-  brushType: BrushType | null
+  brushType: BrushType[] | null
   nightProtection: NightProtection[]
 
   // Navigation
@@ -104,7 +104,7 @@ interface OnboardingState {
   setTowelMaterial: (val: TowelMaterial | null) => void
   setTowelTechnique: (val: TowelTechnique | null) => void
   setDryingMethod: (val: DryingMethod | null) => void
-  setBrushType: (val: BrushType | null) => void
+  setBrushType: (val: BrushType[] | null) => void
   setNightProtection: (val: NightProtection[]) => void
 
   // Computed helpers
@@ -150,7 +150,7 @@ const initialData = {
   towelMaterial: null as TowelMaterial | null,
   towelTechnique: null as TowelTechnique | null,
   dryingMethod: null as DryingMethod | null,
-  brushType: null as BrushType | null,
+  brushType: null as BrushType[] | null,
   nightProtection: [] as NightProtection[],
 }
 

--- a/src/lib/profile/brush-type.ts
+++ b/src/lib/profile/brush-type.ts
@@ -1,0 +1,65 @@
+import { BRUSH_TYPES, type BrushType } from "@/lib/vocabulary"
+
+const MECHANICAL_STRESS_DRIVER_BY_BRUSH: Partial<Record<BrushType, string>> = {
+  paddle: "high_stress_brush",
+  round: "high_stress_brush",
+}
+
+const FRICTION_SIGNAL_BRUSHES = new Set<BrushType>(["paddle", "round", "boar_bristle"])
+
+const MECHANICAL_STRESS_SCORE_BY_BRUSH: Partial<Record<BrushType, number>> = {
+  paddle: 1,
+  round: 1,
+}
+
+const VALID_BRUSH_TYPES = new Set<string>(BRUSH_TYPES)
+
+function uniqueBrushTypes(brushTypes: readonly BrushType[]): BrushType[] {
+  return [...new Set(brushTypes)]
+}
+
+export function normalizeBrushTypeValues(value: unknown): BrushType[] | null {
+  if (value === null || value === undefined) return null
+  if (value === "none_regular") return []
+  if (Array.isArray(value)) {
+    return uniqueBrushTypes(
+      value.filter((item): item is BrushType => VALID_BRUSH_TYPES.has(String(item))),
+    )
+  }
+  if (typeof value === "string" && VALID_BRUSH_TYPES.has(value)) return [value as BrushType]
+  return null
+}
+
+export function hasMechanicalStressBrush(
+  brushTypes: readonly BrushType[] | null | undefined,
+): boolean {
+  return Boolean(brushTypes?.some((brushType) => brushType in MECHANICAL_STRESS_SCORE_BY_BRUSH))
+}
+
+export function hasBrushFrictionSignal(
+  brushTypes: readonly BrushType[] | null | undefined,
+): boolean {
+  return Boolean(brushTypes?.some((brushType) => FRICTION_SIGNAL_BRUSHES.has(brushType)))
+}
+
+export function getBrushMechanicalStressContribution(
+  brushTypes: readonly BrushType[] | null | undefined,
+): { score: number; drivers: string[] } {
+  const uniqueBrushes = uniqueBrushTypes(brushTypes ?? [])
+  const drivers = [
+    ...new Set(
+      uniqueBrushes
+        .map((brushType) => MECHANICAL_STRESS_DRIVER_BY_BRUSH[brushType])
+        .filter((driver): driver is string => Boolean(driver)),
+    ),
+  ]
+  const score = uniqueBrushes.reduce(
+    (total, brushType) => total + (MECHANICAL_STRESS_SCORE_BY_BRUSH[brushType] ?? 0),
+    0,
+  )
+
+  return {
+    score: Math.min(score, 2),
+    drivers,
+  }
+}

--- a/src/lib/profile/section-config.ts
+++ b/src/lib/profile/section-config.ts
@@ -297,8 +297,17 @@ export const PROFILE_FIELD_CONFIG: ProfileFieldConfig[] = [
     label: "Bürste / Kamm",
     sectionKey: "routine",
     editTarget: { kind: "onboarding", step: "brush_type" },
-    getValue: (profile) =>
-      profile?.brush_type ? (BRUSH_TYPE_LABELS[profile.brush_type] ?? profile.brush_type) : null,
+    getValue: (profile) => {
+      if (profile?.brush_type?.length) {
+        return optionLabels(profile.brush_type, BRUSH_TYPE_LABELS)
+      }
+
+      if (profile?.brush_type && profile.brush_type.length === 0) {
+        return "Keine regelmäßige Bürste"
+      }
+
+      return null
+    },
   },
   {
     key: "night_protection",

--- a/src/lib/profile/signal-derivations.ts
+++ b/src/lib/profile/signal-derivations.ts
@@ -6,6 +6,7 @@ import type {
   StylingTool,
   TowelTechnique,
 } from "@/lib/vocabulary"
+import { hasMechanicalStressBrush } from "@/lib/profile/brush-type"
 
 export function hasAnsweredArrayValues<T>(value: readonly T[] | null | undefined): boolean {
   return Array.isArray(value) && value.length > 0
@@ -17,9 +18,9 @@ export function isExplicitNoneArray<T>(value: readonly T[] | null | undefined): 
 
 export function hasDirectMechanicalStressSignals(
   towelTechnique: TowelTechnique | null | undefined,
-  brushType: BrushType | null | undefined,
+  brushTypes: readonly BrushType[] | null | undefined,
 ): boolean {
-  return towelTechnique === "rough_rubbing" || brushType === "paddle" || brushType === "round"
+  return towelTechnique === "rough_rubbing" || hasMechanicalStressBrush(brushTypes)
 }
 
 export function deriveLeaveInStylingContextFromStages(

--- a/src/lib/recommendation-engine/assessments/damage.ts
+++ b/src/lib/recommendation-engine/assessments/damage.ts
@@ -6,6 +6,7 @@ import type {
   NormalizedProfile,
   RepairPriority,
 } from "@/lib/recommendation-engine/types"
+import { getBrushMechanicalStressContribution } from "@/lib/profile/brush-type"
 import { isExplicitNoneArray } from "@/lib/profile/signal-derivations"
 import {
   getChemicalTreatmentDamageDrivers,
@@ -207,10 +208,9 @@ export function buildDamageAssessment(profile: NormalizedProfile): DamageAssessm
     activeProtectiveFactors.push("gentle_towel_technique")
   }
 
-  if (profile.brushType === "paddle" || profile.brushType === "round") {
-    mechanicalScore += 1
-    activeDamageDrivers.push("high_stress_brush")
-  }
+  const brushMechanicalStress = getBrushMechanicalStressContribution(profile.brushType)
+  mechanicalScore += brushMechanicalStress.score
+  activeDamageDrivers.push(...brushMechanicalStress.drivers)
 
   if (isExplicitNoneArray(profile.nightProtection)) {
     mechanicalScore += 1

--- a/src/lib/recommendation-engine/effective-care-context.ts
+++ b/src/lib/recommendation-engine/effective-care-context.ts
@@ -26,6 +26,7 @@ function cloneNormalizedProfile(profile: NormalizedProfile): NormalizedProfile {
     goals: [...profile.goals],
     stylingTools: profile.stylingTools === null ? null : [...profile.stylingTools],
     chemicalTreatment: [...profile.chemicalTreatment],
+    brushType: profile.brushType === null ? null : [...profile.brushType],
     nightProtection: profile.nightProtection === null ? null : [...profile.nightProtection],
     routineInventory: {
       shampoo: cloneRoutineItem(profile.routineInventory.shampoo),

--- a/src/lib/recommendation-engine/normalize.ts
+++ b/src/lib/recommendation-engine/normalize.ts
@@ -1,4 +1,5 @@
 import { INVENTORY_CATEGORIES } from "@/lib/recommendation-engine/contracts"
+import { normalizeBrushTypeValues } from "@/lib/profile/brush-type"
 import { getVisibleProductUsageItems } from "@/lib/product-usage/shampoo-fallback"
 import { normalizeNightProtectionValues, normalizeProductFrequency } from "@/lib/vocabulary"
 import type {
@@ -56,7 +57,7 @@ export function normalizeRecommendationInput(input: RawRecommendationInput): Nor
     towelMaterial: profile.towel_material,
     towelTechnique: profile.towel_technique,
     dryingMethod: profile.drying_method,
-    brushType: profile.brush_type,
+    brushType: normalizeBrushTypeValues(profile.brush_type),
     nightProtection: normalizeNightProtectionValues(profile.night_protection),
     usesHeatProtection: profile.uses_heat_protection ?? false,
     routineInventory: normalizeRoutineInventory(input.routineInventory),

--- a/src/lib/recommendation-engine/planner/intervention.ts
+++ b/src/lib/recommendation-engine/planner/intervention.ts
@@ -480,7 +480,7 @@ export function buildInterventionPlan(
   if (profile.towelTechnique === "rough_rubbing") {
     behaviorReasons.push("rough_towel_handling")
   }
-  if (profile.brushType === "paddle" || profile.brushType === "round") {
+  if (profile.brushType?.some((brushType) => brushType === "paddle" || brushType === "round")) {
     behaviorReasons.push("rough_brushing")
   }
   if (isExplicitNoneArray(profile.nightProtection)) {

--- a/src/lib/recommendation-engine/types.ts
+++ b/src/lib/recommendation-engine/types.ts
@@ -139,7 +139,7 @@ export interface RawHairProfileInput {
   towel_material: TowelMaterial | null
   towel_technique: TowelTechnique | null
   drying_method: DryingMethod | null
-  brush_type: BrushType | null
+  brush_type: BrushType[] | null
   night_protection: NightProtection[] | null
   uses_heat_protection: boolean
 }
@@ -176,7 +176,7 @@ export interface NormalizedProfile {
   towelMaterial: TowelMaterial | null
   towelTechnique: TowelTechnique | null
   dryingMethod: DryingMethod | null
-  brushType: BrushType | null
+  brushType: BrushType[] | null
   nightProtection: NightProtection[] | null
   usesHeatProtection: boolean
   routineInventory: RoutineInventory

--- a/src/lib/routines/brush-tools.ts
+++ b/src/lib/routines/brush-tools.ts
@@ -4,6 +4,7 @@ import {
   deriveLeaveInStylingContextFromStages,
   hasDirectMechanicalStressSignals,
 } from "@/lib/profile/signal-derivations"
+import { hasBrushFrictionSignal } from "@/lib/profile/brush-type"
 
 const BRUSH_TOOLS_TERMS = [
   "buerste",
@@ -110,9 +111,7 @@ export function hasExplicitBrushToolsRequest(normalizedMessage: string): boolean
 export function hasBrushToolsNeed(profile: HairProfile | null, normalizedMessage: string): boolean {
   return (
     hasDirectMechanicalStressSignals(profile?.towel_technique, profile?.brush_type) ||
-    profile?.brush_type === "paddle" ||
-    profile?.brush_type === "round" ||
-    profile?.brush_type === "boar_bristle" ||
+    hasBrushFrictionSignal(profile?.brush_type) ||
     includesAny(normalizedMessage, DETANGLING_TERMS)
   )
 }
@@ -146,8 +145,7 @@ export function buildBrushToolsSlot(
       CURLY_TEXTURES.has(context.hair_texture))
   const sectioningRelevant = includesAny(normalizedMessage, SECTIONING_TERMS)
   const dryStylingBrushRelevant =
-    profile?.brush_type === "paddle" ||
-    profile?.brush_type === "round" ||
+    profile?.brush_type?.some((brushType) => brushType === "paddle" || brushType === "round") ||
     includesAny(normalizedMessage, DRY_STYLING_BRUSH_TERMS)
 
   const rationale: string[] = []
@@ -229,11 +227,7 @@ export function buildBrushToolsSlot(
     )
   }
 
-  const needsAdjustment =
-    profile?.brush_type === "paddle" ||
-    profile?.brush_type === "round" ||
-    profile?.brush_type === "boar_bristle" ||
-    hasMechanicalStressSignals
+  const needsAdjustment = hasBrushFrictionSignal(profile?.brush_type) || hasMechanicalStressSignals
   const action: RoutineSlotAction = needsAdjustment ? "adjust" : "add"
 
   return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -178,7 +178,7 @@ export interface HairProfile {
   towel_material: TowelMaterial | null
   towel_technique: TowelTechnique | null
   drying_method: DryingMethod | null
-  brush_type: BrushType | null
+  brush_type: BrushType[] | null
   night_protection: NightProtection[] | null
   uses_heat_protection: boolean
   additional_notes: string | null

--- a/src/lib/validators/index.ts
+++ b/src/lib/validators/index.ts
@@ -52,6 +52,15 @@ import {
   RESET_INTENSITIES,
 } from "@/lib/recommendation-engine/contracts"
 
+const brushTypeSchema = z
+  .union([
+    z.array(z.enum(BRUSH_TYPES)).transform((values) => [...new Set(values)]),
+    z.enum(BRUSH_TYPES).transform((value) => [value]),
+    z.literal("none_regular").transform(() => []),
+  ])
+  .nullable()
+  .default(null)
+
 export const hairProfileFullSchema = z.object({
   hair_texture: z.enum(HAIR_TEXTURES).nullable(),
   thickness: z.enum(HAIR_THICKNESSES).nullable(),
@@ -67,7 +76,7 @@ export const hairProfileFullSchema = z.object({
   towel_material: z.enum(TOWEL_MATERIALS).nullable().default(null),
   towel_technique: z.enum(TOWEL_TECHNIQUES).nullable().default(null),
   drying_method: z.enum(DRYING_METHODS).nullable().default(null),
-  brush_type: z.enum(BRUSH_TYPES).nullable().default(null),
+  brush_type: brushTypeSchema,
   night_protection: z.array(z.enum(NIGHT_PROTECTIONS)).nullable().default(null),
   uses_heat_protection: z.boolean().default(false),
   additional_notes: z.string().nullable().default(null),

--- a/src/lib/vocabulary/onboarding-care.ts
+++ b/src/lib/vocabulary/onboarding-care.ts
@@ -70,7 +70,6 @@ export const BRUSH_TYPES = [
   "round",
   "boar_bristle",
   "fingers",
-  "none_regular",
 ] as const
 export type BrushType = (typeof BRUSH_TYPES)[number]
 
@@ -81,7 +80,6 @@ export const BRUSH_TYPE_LABELS = {
   round: "Rundbürste",
   boar_bristle: "Wildschweinborsten-Bürste",
   fingers: "Nur Finger",
-  none_regular: "Keine regelmäßige Bürste",
 } as const satisfies Record<BrushType, string>
 
 export const BRUSH_TYPE_OPTIONS = BRUSH_TYPES.map((value) => ({

--- a/supabase/migrations/20260626143000_brush_type_multiselect.sql
+++ b/supabase/migrations/20260626143000_brush_type_multiselect.sql
@@ -1,0 +1,37 @@
+DO $$
+DECLARE
+  constraint_record record;
+BEGIN
+  FOR constraint_record IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.hair_profiles'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%brush_type%'
+  LOOP
+    EXECUTE format('ALTER TABLE public.hair_profiles DROP CONSTRAINT IF EXISTS %I', constraint_record.conname);
+  END LOOP;
+END $$;
+
+ALTER TABLE public.hair_profiles
+  ALTER COLUMN brush_type DROP DEFAULT,
+  ALTER COLUMN brush_type TYPE text[]
+  USING CASE
+    WHEN brush_type IS NULL THEN NULL
+    WHEN brush_type = 'none_regular' THEN ARRAY[]::text[]
+    ELSE ARRAY[brush_type]::text[]
+  END;
+
+ALTER TABLE public.hair_profiles
+  ADD CONSTRAINT hair_profiles_brush_type_check
+  CHECK (
+    brush_type IS NULL
+    OR brush_type <@ ARRAY[
+      'wide_tooth_comb',
+      'detangling',
+      'paddle',
+      'round',
+      'boar_bristle',
+      'fingers'
+    ]::text[]
+  );

--- a/tests/agent-v2-current-care-context.spec.ts
+++ b/tests/agent-v2-current-care-context.spec.ts
@@ -46,13 +46,19 @@ test("AgentV2 exposes set_current_care_context with current-turn fact schema", (
       evidenceQuote: "I use a flat iron twice a week",
     }),
     CurrentCareFactInputSchema.parse({
+      kind: "profile_override",
+      field: "brushType",
+      value: ["fingers"],
+      evidenceQuote: "Actually I only finger-detangle",
+    }),
+    CurrentCareFactInputSchema.parse({
       kind: "context_signal",
       code: "flat_fast",
       evidenceQuote: "my hair gets flat fast",
     }),
   ]
 
-  assert.equal(accepted.length, 6)
+  assert.equal(accepted.length, 7)
 })
 
 test("AgentV2 model-facing current-care tool schema uses direct root fields", () => {
@@ -147,6 +153,112 @@ test("AgentV2 accepts shape-changing chemical treatment profile augments", () =>
       },
     )
   }
+})
+
+test("AgentV2 parses brush type as a current-turn profile override array", () => {
+  assert.deepEqual(
+    parseCurrentCareFactToolInput({
+      kind: "profile_override",
+      field: "brushType",
+      value: "fingers",
+      evidenceQuote: "Actually I only finger-detangle",
+    }),
+    {
+      kind: "profile_override",
+      field: "brushType",
+      value: ["fingers"],
+      evidenceQuote: "Actually I only finger-detangle",
+    },
+  )
+
+  assert.deepEqual(
+    parseCurrentCareFactToolInput({
+      kind: "profile_override",
+      field: "brushType",
+      value: ["paddle", "round", "paddle"],
+      evidenceQuote: "I use a paddle brush and a round brush",
+    }),
+    {
+      kind: "profile_override",
+      field: "brushType",
+      value: ["paddle", "round"],
+      evidenceQuote: "I use a paddle brush and a round brush",
+    },
+  )
+
+  assert.deepEqual(
+    parseCurrentCareFactToolInput({
+      kind: "profile_override",
+      field: "brushType",
+      value: "none_regular",
+      evidenceQuote: "I do not use a brush regularly",
+    }),
+    {
+      kind: "profile_override",
+      field: "brushType",
+      value: [],
+      evidenceQuote: "I do not use a brush regularly",
+    },
+  )
+
+  assert.deepEqual(
+    parseCurrentCareFactToolInput({
+      kind: "profile_override",
+      field: "brushType",
+      value: ["none_regular", "none_regular"],
+      evidenceQuote: "I do not use a brush regularly",
+    }),
+    {
+      kind: "profile_override",
+      field: "brushType",
+      value: [],
+      evidenceQuote: "I do not use a brush regularly",
+    },
+  )
+
+  assert.throws(
+    () =>
+      parseCurrentCareFactToolInput({
+        kind: "profile_override",
+        field: "brushType",
+        value: true,
+        evidenceQuote: "I brush my hair",
+      }),
+    /Invalid current care fact tool input/,
+  )
+
+  assert.throws(
+    () =>
+      parseCurrentCareFactToolInput({
+        kind: "profile_override",
+        field: "brushType",
+        value: "unknown",
+        evidenceQuote: "I use a mystery brush",
+      }),
+    /Invalid current care fact tool input/,
+  )
+
+  assert.throws(
+    () =>
+      parseCurrentCareFactToolInput({
+        kind: "profile_override",
+        field: "brushType",
+        value: ["unknown"],
+        evidenceQuote: "I use a mystery brush",
+      }),
+    /Invalid current care fact tool input/,
+  )
+
+  assert.throws(
+    () =>
+      parseCurrentCareFactToolInput({
+        kind: "profile_override",
+        field: "brushType",
+        value: ["none_regular", "paddle"],
+        evidenceQuote: "I do not use a brush but also a paddle brush",
+      }),
+    /Invalid current care fact tool input/,
+  )
 })
 
 test("AgentV2 rejects invalid current-care profile values", () => {

--- a/tests/brush-type-multiselect.test.ts
+++ b/tests/brush-type-multiselect.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  getBrushMechanicalStressContribution,
+  normalizeBrushTypeValues,
+} from "../src/lib/profile/brush-type"
+import { buildDamageAssessment } from "../src/lib/recommendation-engine/assessments/damage"
+import { normalizeRecommendationInput } from "../src/lib/recommendation-engine/normalize"
+import { hairProfileFullSchema } from "../src/lib/validators"
+
+const baseProfileInput = {
+  hair_texture: null,
+  thickness: null,
+}
+
+test("hair profile schema treats brush type as nullable selected-value array", () => {
+  assert.equal(
+    hairProfileFullSchema.parse({ ...baseProfileInput, brush_type: null }).brush_type,
+    null,
+  )
+  assert.deepEqual(
+    hairProfileFullSchema.parse({ ...baseProfileInput, brush_type: [] }).brush_type,
+    [],
+  )
+  assert.deepEqual(
+    hairProfileFullSchema.parse({ ...baseProfileInput, brush_type: ["paddle", "round"] })
+      .brush_type,
+    ["paddle", "round"],
+  )
+  assert.deepEqual(
+    hairProfileFullSchema.parse({ ...baseProfileInput, brush_type: ["paddle", "paddle"] })
+      .brush_type,
+    ["paddle"],
+  )
+  assert.throws(
+    () => hairProfileFullSchema.parse({ ...baseProfileInput, brush_type: ["none_regular"] }),
+    /Invalid input/,
+  )
+  assert.throws(
+    () => hairProfileFullSchema.parse({ ...baseProfileInput, brush_type: ["paddle", "unknown"] }),
+    /Invalid input/,
+  )
+})
+
+test("brush mechanical stress keeps scored drivers and caps score", () => {
+  const contribution = getBrushMechanicalStressContribution(["paddle", "round", "boar_bristle"])
+
+  assert.equal(contribution.score, 2)
+  assert.deepEqual(contribution.drivers, ["high_stress_brush"])
+})
+
+test("low-tension detangling tools do not add mechanical stress", () => {
+  assert.deepEqual(
+    getBrushMechanicalStressContribution(["wide_tooth_comb", "detangling", "fingers"]),
+    {
+      score: 0,
+      drivers: [],
+    },
+  )
+  assert.deepEqual(getBrushMechanicalStressContribution([]), {
+    score: 0,
+    drivers: [],
+  })
+})
+
+test("boar bristle does not add mechanical damage score or damage drivers", () => {
+  assert.deepEqual(getBrushMechanicalStressContribution(["boar_bristle"]), {
+    score: 0,
+    drivers: [],
+  })
+})
+
+test("damage assessment keeps boar bristle out of active damage drivers", () => {
+  const profile = normalizeRecommendationInput({
+    profile: {
+      ...baseProfileInput,
+      brush_type: ["paddle", "round", "boar_bristle"],
+      chemical_treatment: [],
+      concerns: [],
+      cuticle_condition: "smooth",
+      density: null,
+      drying_method: null,
+      goals: [],
+      hair_length: null,
+      heat_styling: "never",
+      night_protection: null,
+      protein_moisture_balance: "stretches_bounces",
+      scalp_condition: null,
+      scalp_type: null,
+      shampoo_frequency: null,
+      styling_tools: null,
+      towel_material: null,
+      towel_technique: "gentle_press",
+      uses_heat_protection: false,
+    },
+    routineInventory: [],
+  })
+  const damage = buildDamageAssessment(profile)
+
+  assert.equal(damage.mechanicalLevel, "moderate")
+  assert.deepEqual(
+    damage.activeDamageDrivers.filter((driver) => driver.includes("brush")),
+    ["high_stress_brush"],
+  )
+})
+
+test("duplicate brush values are ignored during normalization and scoring", () => {
+  assert.deepEqual(normalizeBrushTypeValues(["paddle", "paddle", "round"]), ["paddle", "round"])
+  assert.deepEqual(getBrushMechanicalStressContribution(["paddle", "paddle"]), {
+    score: 1,
+    drivers: ["high_stress_brush"],
+  })
+})
+
+test("brush type normalization maps legacy none and drops unknown values", () => {
+  assert.deepEqual(normalizeBrushTypeValues("none_regular"), [])
+  assert.deepEqual(normalizeBrushTypeValues(["paddle", "unknown"]), ["paddle"])
+  assert.equal(normalizeBrushTypeValues("unknown"), null)
+})

--- a/tests/profile-page-smoke.spec.ts
+++ b/tests/profile-page-smoke.spec.ts
@@ -108,7 +108,7 @@ test.describe.serial("@ci Profile page smoke", () => {
       towel_material: "frottee",
       towel_technique: "gentle_press",
       drying_method: "air_dry",
-      brush_type: "wide_tooth_comb",
+      brush_type: ["wide_tooth_comb"],
       night_protection: [],
       goals: ["shine", "volume"],
       desired_volume: "more",

--- a/tests/profile-section-config.test.ts
+++ b/tests/profile-section-config.test.ts
@@ -84,6 +84,18 @@ test("profile routine section shows length tip accessory night protection label"
   )
 })
 
+test("profile routine section distinguishes unanswered brush type from explicit none", () => {
+  const brushTypeField = PROFILE_FIELD_CONFIG.find((field) => field.key === "brush_type")
+
+  assert.ok(brushTypeField)
+  assert.equal(brushTypeField.getValue(makeProfile({ brush_type: null })), null)
+  assert.equal(brushTypeField.getValue(makeProfile({ brush_type: [] })), "Keine regelmäßige Bürste")
+  assert.deepEqual(brushTypeField.getValue(makeProfile({ brush_type: ["paddle", "round"] })), [
+    "Paddle-Bürste",
+    "Rundbürste",
+  ])
+})
+
 test("goals edit derives persisted desired volume from selected goals", () => {
   assert.equal(deriveDesiredVolumeFromGoals(["volume"], null), "more")
   assert.equal(deriveDesiredVolumeFromGoals(["less_volume"], null), "less")

--- a/tests/recommendation-engine-care-balance.test.ts
+++ b/tests/recommendation-engine-care-balance.test.ts
@@ -241,6 +241,68 @@ test("current-turn profile override replaces a scalar normalized field", () => {
   ])
 })
 
+test("current-turn brush type override replaces saved brush tools for this turn", () => {
+  const rawInput = adaptRecommendationInputFromPersistence(
+    {
+      ...LOW_DAMAGE_PROFILE,
+      brush_type: ["paddle"],
+    },
+    [],
+  ).input
+
+  const context = buildEffectiveCareContext(rawInput, [
+    {
+      kind: "profile_override",
+      field: "brushType",
+      value: ["fingers"],
+      evidenceQuote: "Ich entwirre eigentlich nur mit den Fingern",
+      source: "current_turn",
+    },
+  ])
+
+  assert.deepEqual(context.normalized.brushType, ["fingers"])
+  assert.deepEqual(context.conflicts, [
+    {
+      fieldPath: "profile.brushType",
+      savedValue: ["paddle"],
+      currentTurnValue: ["fingers"],
+      source: "current_turn",
+      evidenceQuote: "Ich entwirre eigentlich nur mit den Fingern",
+    },
+  ])
+})
+
+test("current-turn brush type override can clear saved brush tools for this turn", () => {
+  const rawInput = adaptRecommendationInputFromPersistence(
+    {
+      ...LOW_DAMAGE_PROFILE,
+      brush_type: ["paddle"],
+    },
+    [],
+  ).input
+
+  const context = buildEffectiveCareContext(rawInput, [
+    {
+      kind: "profile_override",
+      field: "brushType",
+      value: [],
+      evidenceQuote: "Ich nutze gerade keine Bürste regelmäßig",
+      source: "current_turn",
+    },
+  ])
+
+  assert.deepEqual(context.normalized.brushType, [])
+  assert.deepEqual(context.conflicts, [
+    {
+      fieldPath: "profile.brushType",
+      savedValue: ["paddle"],
+      currentTurnValue: [],
+      source: "current_turn",
+      evidenceQuote: "Ich nutze gerade keine Bürste regelmäßig",
+    },
+  ])
+})
+
 test("context signals are retained without changing the effective profile", () => {
   const rawInput = adaptRecommendationInputFromPersistence(LOW_DAMAGE_PROFILE, []).input
   const facts: CurrentTurnCareFact[] = [

--- a/tests/recommendation-engine-foundation.fixtures.ts
+++ b/tests/recommendation-engine-foundation.fixtures.ts
@@ -53,7 +53,7 @@ export const LOW_DAMAGE_PROFILE = buildProfile({
   styling_tools: [],
   towel_technique: "gentle_press",
   drying_method: "air_dry",
-  brush_type: "wide_tooth_comb",
+  brush_type: ["wide_tooth_comb"],
   night_protection: ["silk_satin_pillow"],
   uses_heat_protection: false,
 })
@@ -75,7 +75,7 @@ export const SEVERE_DAMAGE_PROFILE = buildProfile({
   towel_material: "frottee",
   towel_technique: "rough_rubbing",
   drying_method: "blow_dry",
-  brush_type: "paddle",
+  brush_type: ["paddle"],
   night_protection: [],
   uses_heat_protection: false,
 })

--- a/tests/routine-planner.spec.ts
+++ b/tests/routine-planner.spec.ts
@@ -838,7 +838,7 @@ test.describe("Routine planner", () => {
         density: "medium",
         concerns: [],
         cuticle_condition: "smooth",
-        brush_type: "paddle",
+        brush_type: ["paddle"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
       "Welche Routine passt zu meinen Locken, wenn sie sich an Waschtagen schnell verhaken?",
@@ -987,7 +987,7 @@ test.describe("Routine planner", () => {
         concerns: ["dryness"],
         cuticle_condition: "rough",
         scalp_condition: "dry_flakes",
-        brush_type: "paddle",
+        brush_type: ["paddle"],
         current_routine_products: ["shampoo", "conditioner"],
       }),
       "Welche Routine passt zu meinen Locken?",
@@ -1503,7 +1503,7 @@ test.describe("Routine planner", () => {
     test("rough brushing proactively adds a brush tools slot", () => {
       const plan = buildRoutinePlan(
         createProfile({
-          brush_type: "paddle",
+          brush_type: ["paddle"],
         }),
         "Welche Routine passt zu mir?",
       )


### PR DESCRIPTION
## Summary
- Clarifies onboarding selection copy for HAI-122 and makes brush type a true multiselect.
- Migrates hair_profiles.brush_type from scalar text to text[] while preserving null vs explicit empty selection.
- Centralizes brush normalization/scoring, keeps boar bristle as friction guidance only, and preserves the existing high_stress_brush damage-driver contract.
- Updates Agent V2 current-turn brush overrides, profile display, routine/recommendation consumers, and tests for array semantics.

## Verification
- npx tsx --test tests/brush-type-multiselect.test.ts tests/agent-v2-current-care-context.spec.ts tests/recommendation-engine-care-balance.test.ts tests/recommendation-engine-foundation.test.ts tests/profile-section-config.test.ts tests/routine-signal-consumers.test.ts
- npm run typecheck
- npm run lint (passes with 3 pre-existing warnings)
- npx playwright test tests/routine-planner.spec.ts --project=chromium
- git diff --check
- Claude bounded code review on final diff; actionable findings addressed.

## Notes / risks
- Brush scoring intentionally counts paddle + round as +2 mechanical stress, capped at 2; this was confirmed as acceptable.
- Supabase CLI is not available in this shell, so migration 20260626143000_brush_type_multiselect.sql is not confirmed against production migration state yet. Before merge/deploy, confirm target project pqdkhefxsxkyeqelqegq has not applied it and run the usual migration-state check.
- The generated claude-code-review*.md files are local-only review artifacts and are not included.