### PR TITLE
HAI-116: Add optional info tips

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,19 +1,22 @@
-import { redirect } from "next/navigation"
+import { permanentRedirect, redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { OnboardingFlow } from "@/components/onboarding/onboarding-flow"
 import { linkQuizToProfile } from "@/lib/quiz/link-to-profile"
 import { getOnboardingEditScope, type OnboardingStep } from "@/lib/onboarding/store"
 import { resolveIntakeState } from "@/lib/auth/intake-state"
+import { PRODUCT_CATEGORY_ORDER } from "@/lib/onboarding/product-options"
+
+type OnboardingSearchParams = {
+  lead?: string | string[]
+  step?: string | string[]
+  returnTo?: string | string[]
+  category?: string | string[]
+  editMode?: string | string[]
+}
 
 interface OnboardingPageProps {
-  searchParams: Promise<{
-    lead?: string | string[]
-    step?: string | string[]
-    returnTo?: string | string[]
-    category?: string | string[]
-    editMode?: string | string[]
-  }>
+  searchParams: Promise<OnboardingSearchParams>
 }
 
 const VALID_ONBOARDING_STEPS = new Set<OnboardingStep>([
@@ -32,6 +35,53 @@ const VALID_ONBOARDING_STEPS = new Set<OnboardingStep>([
   "night_protection",
   "celebration",
 ])
+const VALID_PRODUCT_CATEGORIES = new Set(PRODUCT_CATEGORY_ORDER)
+const PRODUCT_CATEGORY_ALIASES: Record<string, string> = {
+  bond_builder: "bondbuilder",
+  hair_oil: "oil",
+  scalp_peeling: "peeling",
+}
+
+function firstSearchParamValue(value: string | string[] | undefined): string | null {
+  return (Array.isArray(value) ? value[0] : value) ?? null
+}
+
+function canonicalizeProductCategory(value: string | string[] | undefined): string | null {
+  const candidate = firstSearchParamValue(value)?.trim()
+  if (!candidate) {
+    return null
+  }
+  return PRODUCT_CATEGORY_ALIASES[candidate] ?? candidate
+}
+
+function appendSearchParam(
+  params: URLSearchParams,
+  key: keyof OnboardingSearchParams,
+  value: string | string[] | undefined,
+) {
+  if (Array.isArray(value)) {
+    value.forEach((item) => params.append(key, item))
+    return
+  }
+
+  if (value) {
+    params.set(key, value)
+  }
+}
+
+function buildCanonicalOnboardingPath(
+  searchParams: OnboardingSearchParams,
+  canonicalCategory: string,
+) {
+  const params = new URLSearchParams()
+  appendSearchParam(params, "lead", searchParams.lead)
+  appendSearchParam(params, "step", searchParams.step)
+  appendSearchParam(params, "returnTo", searchParams.returnTo)
+  params.set("category", canonicalCategory)
+  appendSearchParam(params, "editMode", searchParams.editMode)
+
+  return `/onboarding?${params.toString()}`
+}
 
 function resolveOnboardingStep(value: string | string[] | undefined): OnboardingStep | null {
   const candidate = Array.isArray(value) ? value[0] : value
@@ -50,11 +100,11 @@ function resolveReturnTo(value: string | string[] | undefined): string | null {
 }
 
 function resolveDrilldownCategory(value: string | string[] | undefined): string | null {
-  const candidate = Array.isArray(value) ? value[0] : value
-  if (!candidate?.trim()) {
+  const normalizedCandidate = canonicalizeProductCategory(value)
+  if (!normalizedCandidate) {
     return null
   }
-  return candidate.trim()
+  return VALID_PRODUCT_CATEGORIES.has(normalizedCandidate) ? normalizedCandidate : null
 }
 
 function resolveSingleStepEdit(value: string | string[] | undefined) {
@@ -75,6 +125,15 @@ export default async function OnboardingPage({ searchParams }: OnboardingPagePro
   const singleStepEdit = resolveSingleStepEdit(resolvedSearchParams.editMode)
   const editScope =
     returnTo && forcedStep && !singleStepEdit ? getOnboardingEditScope(forcedStep) : null
+  const rawDrilldownCategory = firstSearchParamValue(resolvedSearchParams.category)?.trim()
+
+  if (
+    rawDrilldownCategory &&
+    initialDrilldownCategory &&
+    rawDrilldownCategory !== initialDrilldownCategory
+  ) {
+    permanentRedirect(buildCanonicalOnboardingPath(resolvedSearchParams, initialDrilldownCategory))
+  }
 
   const {
     data: { user },

--- a/src/components/onboarding/onboarding-flow.tsx
+++ b/src/components/onboarding/onboarding-flow.tsx
@@ -17,6 +17,7 @@ import { OnboardingProgressBar } from "@/components/onboarding/onboarding-progre
 import {
   BASIC_PRODUCT_OPTIONS,
   EXTRA_PRODUCT_OPTIONS,
+  PRODUCT_CATEGORY_DRILLDOWN_TITLES,
   PRODUCT_CATEGORY_LABELS,
 } from "@/lib/onboarding/product-options"
 import { normalizeProductFrequency } from "@/lib/vocabulary"
@@ -275,12 +276,12 @@ export function OnboardingFlow({
     }
 
     // Resume scenario: populate product selections from user_product_usage rows
-    if (productUsage.length > 0) {
-      const basicValues = BASIC_PRODUCT_OPTIONS.map((o) => o.value)
-      const extraValues = EXTRA_PRODUCT_OPTIONS.map((o) => o.value)
-      const basics: string[] = []
-      const extras: string[] = []
+    const basicValues = BASIC_PRODUCT_OPTIONS.map((o) => o.value)
+    const extraValues = EXTRA_PRODUCT_OPTIONS.map((o) => o.value)
+    const basics: string[] = []
+    const extras: string[] = []
 
+    if (productUsage.length > 0) {
       for (const row of productUsage) {
         const cat = row.category as string
         const productName = typeof row.product_name === "string" ? row.product_name : null
@@ -306,16 +307,30 @@ export function OnboardingFlow({
           })
         }
       }
+    }
 
-      if (basics.length > 0) store.setSelectedBasicProducts(basics)
-      if (extras.length > 0) store.setSelectedExtraProducts(extras)
+    if (step === "product_drilldown" && initialDrilldownCategory) {
+      if (
+        basicValues.includes(initialDrilldownCategory) &&
+        !basics.includes(initialDrilldownCategory)
+      ) {
+        basics.push(initialDrilldownCategory)
+      } else if (
+        extraValues.includes(initialDrilldownCategory) &&
+        !extras.includes(initialDrilldownCategory)
+      ) {
+        extras.push(initialDrilldownCategory)
+      }
+    }
 
-      if (step === "product_drilldown" && initialDrilldownCategory) {
-        const orderedCategories = [...basics, ...extras]
-        const targetIndex = orderedCategories.indexOf(initialDrilldownCategory)
-        if (targetIndex >= 0) {
-          store.setCurrentDrilldownIndex(targetIndex)
-        }
+    if (basics.length > 0) store.setSelectedBasicProducts(basics)
+    if (extras.length > 0) store.setSelectedExtraProducts(extras)
+
+    if (step === "product_drilldown" && initialDrilldownCategory) {
+      const orderedCategories = [...basics, ...extras]
+      const targetIndex = orderedCategories.indexOf(initialDrilldownCategory)
+      if (targetIndex >= 0) {
+        store.setCurrentDrilldownIndex(targetIndex)
       }
     }
 
@@ -711,6 +726,12 @@ export function OnboardingFlow({
   const nightProtectionWithIcon = NIGHT_PROTECTION_OPTIONS.map((o) => ({
     ...o,
     icon: NIGHT_PROTECTION_ICONS[o.value] ?? fallbackIcon,
+    infoTipId:
+      o.value === "silk_satin_bonnet"
+        ? ("routine.bonnet" as const)
+        : o.value === "pineapple"
+          ? ("routine.pineapple" as const)
+          : undefined,
   }))
 
   // ── Drilldown helpers ──
@@ -775,6 +796,12 @@ export function OnboardingFlow({
           <ProductDrilldownScreen
             category={currentCategory}
             categoryLabel={PRODUCT_CATEGORY_LABELS[currentCategory] ?? currentCategory}
+            categoryTitle={PRODUCT_CATEGORY_DRILLDOWN_TITLES[currentCategory]}
+            infoTipId={
+              [...BASIC_PRODUCT_OPTIONS, ...EXTRA_PRODUCT_OPTIONS].find(
+                (option) => option.value === currentCategory,
+              )?.infoTipId
+            }
             subtitle={CATEGORY_SUBTITLES[currentCategory]}
             productName={currentDrilldown.productName}
             frequency={currentDrilldown.frequency}
@@ -885,6 +912,8 @@ export function OnboardingFlow({
           <SingleSelectScreen
             title="Wie gehst du mit dem Handtuch meistens vor?"
             subtitle="Rubbeln oder sanft ausdrücken?"
+            titleInfoTipId="routine.towel_technique"
+            titleInfoLabel="Info zu sanftem Trocknen"
             options={towelTechniqueWithIcon}
             selected={store.towelTechnique}
             onSelect={(val) => {
@@ -900,6 +929,8 @@ export function OnboardingFlow({
           <SingleSelectScreen
             title="Wie trocknest du dein Haar hauptsächlich?"
             subtitle="Hitze ist der größte Stressfaktor — wir passen deinen Plan daran an."
+            titleInfoTipId="routine.diffuser"
+            titleInfoLabel="Info zu Diffusor"
             options={dryingMethodWithIcon}
             selected={store.dryingMethod}
             onSelect={(val) => {

--- a/src/components/onboarding/screens/heat-protection-screen.tsx
+++ b/src/components/onboarding/screens/heat-protection-screen.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react"
 import { ArrowLeft } from "lucide-react"
 import { QuizOptionCard } from "@/components/quiz/quiz-option-card"
+import { InfoTip } from "@/components/ui/info-tip"
+import { INFO_TIPS } from "@/lib/help/info-tips"
 
 interface HeatProtectionScreenProps {
   selected: boolean | null
@@ -13,6 +15,7 @@ interface HeatProtectionScreenProps {
 export function HeatProtectionScreen({ selected, onSelect, onBack }: HeatProtectionScreenProps) {
   const advancingRef = useRef(false)
   const [localSelected, setLocalSelected] = useState(selected)
+  const tip = INFO_TIPS["routine.heat_protection"]
 
   useEffect(() => {
     setLocalSelected(selected)
@@ -38,9 +41,19 @@ export function HeatProtectionScreen({ selected, onSelect, onBack }: HeatProtect
         <ArrowLeft className="h-5 w-5" />
       </button>
 
-      <h1 className="animate-fade-in-up font-header text-3xl leading-tight text-foreground mb-6">
-        Benutzt du Hitzeschutz?
-      </h1>
+      <div className="animate-fade-in-up mb-6 flex items-start justify-between gap-3">
+        <h1 className="min-w-0 flex-1 font-header text-3xl leading-tight text-foreground">
+          Benutzt du Hitzeschutz?
+        </h1>
+        <div className="mt-1 flex shrink-0 justify-end">
+          <InfoTip
+            title={tip.title}
+            body={tip.body}
+            label="Info zu Hitzeschutz"
+            buttonClassName="h-7 w-7"
+          />
+        </div>
+      </div>
 
       <div className="space-y-3">
         <QuizOptionCard

--- a/src/components/onboarding/screens/multi-select-screen.tsx
+++ b/src/components/onboarding/screens/multi-select-screen.tsx
@@ -3,11 +3,15 @@
 import { ArrowLeft } from "lucide-react"
 import { QuizOptionCard } from "@/components/quiz/quiz-option-card"
 import type { IconName } from "@/components/ui/icon"
+import { InfoTip } from "@/components/ui/info-tip"
+import { INFO_TIPS, type InfoTipId } from "@/lib/help/info-tips"
 
 interface MultiSelectScreenProps {
   title: string
   subtitle?: string
-  options: { value: string; label: string; icon: IconName }[]
+  titleInfoTipId?: InfoTipId
+  titleInfoLabel?: string
+  options: { value: string; label: string; icon: IconName; infoTipId?: InfoTipId }[]
   selected: string[]
   onToggle: (value: string) => void
   onContinue: () => void
@@ -21,6 +25,8 @@ interface MultiSelectScreenProps {
 export function MultiSelectScreen({
   title,
   subtitle,
+  titleInfoTipId,
+  titleInfoLabel,
   options,
   selected,
   onToggle,
@@ -32,6 +38,7 @@ export function MultiSelectScreen({
   continueLabel = "Weiter",
 }: MultiSelectScreenProps) {
   const hasSelection = selected.length > 0
+  const titleTip = titleInfoTipId ? INFO_TIPS[titleInfoTipId] : null
 
   return (
     <div>
@@ -44,9 +51,21 @@ export function MultiSelectScreen({
         <ArrowLeft className="h-5 w-5" />
       </button>
 
-      <h1 className="animate-fade-in-up font-header text-3xl leading-tight text-foreground mb-2">
-        {title}
-      </h1>
+      <div className="animate-fade-in-up mb-2 flex items-start justify-between gap-3">
+        <h1 className="min-w-0 flex-1 font-header text-3xl leading-tight text-foreground">
+          {title}
+        </h1>
+        {titleTip && (
+          <div className="mt-1 flex shrink-0 justify-end">
+            <InfoTip
+              title={titleTip.title}
+              body={titleTip.body}
+              label={titleInfoLabel ?? `Info zu ${title}`}
+              buttonClassName="h-7 w-7"
+            />
+          </div>
+        )}
+      </div>
 
       {subtitle && (
         <p
@@ -58,17 +77,31 @@ export function MultiSelectScreen({
       )}
 
       <div className="space-y-3 mb-6 mt-4">
-        {options.map((option, i) => (
-          <QuizOptionCard
-            key={option.value}
-            icon={option.icon}
-            label={option.label}
-            active={selected.includes(option.value)}
-            disabled={isSaving}
-            onClick={() => onToggle(option.value)}
-            animationDelay={100 + i * 60}
-          />
-        ))}
+        {options.map((option, i) => {
+          const tip = option.infoTipId ? INFO_TIPS[option.infoTipId] : null
+
+          return (
+            <QuizOptionCard
+              key={option.value}
+              icon={option.icon}
+              label={option.label}
+              active={selected.includes(option.value)}
+              disabled={isSaving}
+              onClick={() => onToggle(option.value)}
+              animationDelay={100 + i * 60}
+              trailing={
+                tip ? (
+                  <InfoTip
+                    title={tip.title}
+                    body={tip.body}
+                    label={`Info zu ${option.label}`}
+                    buttonClassName="h-7 w-7"
+                  />
+                ) : undefined
+              }
+            />
+          )
+        })}
       </div>
 
       {noneLabel && onNone && (

--- a/src/components/onboarding/screens/product-checklist-screen.tsx
+++ b/src/components/onboarding/screens/product-checklist-screen.tsx
@@ -3,11 +3,13 @@
 import { ArrowLeft } from "lucide-react"
 import { QuizOptionCard } from "@/components/quiz/quiz-option-card"
 import type { IconName } from "@/components/ui/icon"
+import { InfoTip } from "@/components/ui/info-tip"
+import { INFO_TIPS, type InfoTipId } from "@/lib/help/info-tips"
 
 interface ProductChecklistScreenProps {
   title: string
   subtitle: string
-  options: { value: string; label: string; icon: IconName }[]
+  options: { value: string; label: string; icon: IconName; infoTipId?: InfoTipId }[]
   selected: string[]
   onToggle: (value: string) => void
   onContinue: () => void
@@ -56,17 +58,31 @@ export function ProductChecklistScreen({
       </p>
 
       <div className="space-y-3 mb-6">
-        {options.map((option, i) => (
-          <QuizOptionCard
-            key={option.value}
-            icon={option.icon}
-            label={option.label}
-            active={selected.includes(option.value)}
-            disabled={isSaving}
-            onClick={() => onToggle(option.value)}
-            animationDelay={100 + i * 60}
-          />
-        ))}
+        {options.map((option, i) => {
+          const tip = option.infoTipId ? INFO_TIPS[option.infoTipId] : null
+
+          return (
+            <QuizOptionCard
+              key={option.value}
+              icon={option.icon}
+              label={option.label}
+              active={selected.includes(option.value)}
+              disabled={isSaving}
+              onClick={() => onToggle(option.value)}
+              animationDelay={100 + i * 60}
+              trailing={
+                tip ? (
+                  <InfoTip
+                    title={tip.title}
+                    body={tip.body}
+                    label={`Info zu ${option.label}`}
+                    buttonClassName="h-7 w-7"
+                  />
+                ) : undefined
+              }
+            />
+          )
+        })}
       </div>
 
       {noneLabel && onNone && (

--- a/src/components/onboarding/screens/product-drilldown-screen.tsx
+++ b/src/components/onboarding/screens/product-drilldown-screen.tsx
@@ -3,10 +3,14 @@
 import { ArrowLeft } from "lucide-react"
 import { PRODUCT_FREQUENCY_OPTIONS } from "@/lib/vocabulary"
 import type { ProductFrequency } from "@/lib/vocabulary"
+import { InfoTip } from "@/components/ui/info-tip"
+import { INFO_TIPS, type InfoTipId } from "@/lib/help/info-tips"
 
 interface ProductDrilldownScreenProps {
   category: string
   categoryLabel: string
+  categoryTitle?: string
+  infoTipId?: InfoTipId
   subtitle?: string
   productName: string
   frequency: ProductFrequency | null
@@ -19,6 +23,8 @@ interface ProductDrilldownScreenProps {
 
 export function ProductDrilldownScreen({
   categoryLabel,
+  categoryTitle,
+  infoTipId,
   subtitle,
   productName,
   frequency,
@@ -28,6 +34,8 @@ export function ProductDrilldownScreen({
   onBack,
   continueLabel = "Weiter",
 }: ProductDrilldownScreenProps) {
+  const tip = infoTipId ? INFO_TIPS[infoTipId] : null
+
   return (
     <div>
       <button
@@ -38,9 +46,21 @@ export function ProductDrilldownScreen({
         <ArrowLeft className="h-5 w-5" />
       </button>
 
-      <h1 className="animate-fade-in-up font-header text-3xl leading-tight text-foreground mb-2">
-        Dein {categoryLabel}
-      </h1>
+      <div className="animate-fade-in-up mb-2 flex items-start justify-between gap-3">
+        <h1 className="min-w-0 flex-1 font-header text-3xl leading-tight text-foreground">
+          {categoryTitle ?? `Dein ${categoryLabel}`}
+        </h1>
+        {tip && (
+          <div className="mt-1 flex shrink-0 justify-end">
+            <InfoTip
+              title={tip.title}
+              body={tip.body}
+              label={`Info zu ${categoryLabel}`}
+              buttonClassName="h-7 w-7"
+            />
+          </div>
+        )}
+      </div>
 
       <p
         className="animate-fade-in-up text-sm text-[var(--text-sub)] mb-6"

--- a/src/components/onboarding/screens/single-select-screen.tsx
+++ b/src/components/onboarding/screens/single-select-screen.tsx
@@ -4,11 +4,15 @@ import { useEffect, useRef, useState } from "react"
 import { ArrowLeft } from "lucide-react"
 import { QuizOptionCard } from "@/components/quiz/quiz-option-card"
 import type { IconName } from "@/components/ui/icon"
+import { InfoTip } from "@/components/ui/info-tip"
+import { INFO_TIPS, type InfoTipId } from "@/lib/help/info-tips"
 
 interface SingleSelectScreenProps {
   title: string
   subtitle?: string
-  options: { value: string; label: string; icon: IconName }[]
+  titleInfoTipId?: InfoTipId
+  titleInfoLabel?: string
+  options: { value: string; label: string; icon: IconName; infoTipId?: InfoTipId }[]
   selected: string | null
   onSelect: (value: string) => void
   onBack: () => void
@@ -17,6 +21,8 @@ interface SingleSelectScreenProps {
 export function SingleSelectScreen({
   title,
   subtitle,
+  titleInfoTipId,
+  titleInfoLabel,
   options,
   selected,
   onSelect,
@@ -35,6 +41,8 @@ export function SingleSelectScreen({
       if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
     }
   }, [])
+
+  const titleTip = titleInfoTipId ? INFO_TIPS[titleInfoTipId] : null
 
   function cancelPendingAdvance() {
     if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
@@ -68,9 +76,21 @@ export function SingleSelectScreen({
         <ArrowLeft className="h-5 w-5" />
       </button>
 
-      <h1 className="animate-fade-in-up font-header text-3xl leading-tight text-foreground mb-2">
-        {title}
-      </h1>
+      <div className="animate-fade-in-up mb-2 flex items-start justify-between gap-3">
+        <h1 className="min-w-0 flex-1 font-header text-3xl leading-tight text-foreground">
+          {title}
+        </h1>
+        {titleTip && (
+          <div className="mt-1 flex shrink-0 justify-end">
+            <InfoTip
+              title={titleTip.title}
+              body={titleTip.body}
+              label={titleInfoLabel ?? `Info zu ${title}`}
+              buttonClassName="h-7 w-7"
+            />
+          </div>
+        )}
+      </div>
 
       {subtitle && (
         <p
@@ -82,16 +102,30 @@ export function SingleSelectScreen({
       )}
 
       <div className="space-y-3 mt-4">
-        {options.map((option, i) => (
-          <QuizOptionCard
-            key={option.value}
-            icon={option.icon}
-            label={option.label}
-            active={localSelected === option.value}
-            onClick={() => handleSelect(option.value)}
-            animationDelay={100 + i * 60}
-          />
-        ))}
+        {options.map((option, i) => {
+          const tip = option.infoTipId ? INFO_TIPS[option.infoTipId] : null
+
+          return (
+            <QuizOptionCard
+              key={option.value}
+              icon={option.icon}
+              label={option.label}
+              active={localSelected === option.value}
+              onClick={() => handleSelect(option.value)}
+              animationDelay={100 + i * 60}
+              trailing={
+                tip ? (
+                  <InfoTip
+                    title={tip.title}
+                    body={tip.body}
+                    label={`Info zu ${option.label}`}
+                    buttonClassName="h-7 w-7"
+                  />
+                ) : undefined
+              }
+            />
+          )
+        })}
       </div>
     </div>
   )

--- a/src/components/quiz/quiz-goals.tsx
+++ b/src/components/quiz/quiz-goals.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from "react"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { QuizProgressBar } from "./quiz-progress-bar"
-import { QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
+import { getQuizQuestionNumber, QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
 import { useQuizStore } from "@/lib/quiz/store"
 import { trackAppEvent } from "@/lib/analytics/track-app-event"
 import { cn } from "@/lib/utils"
@@ -53,6 +53,7 @@ export function QuizGoals() {
   }, [selectedGoals, goNext])
 
   const canContinue = selectedGoals.length > 0
+  const questionNumber = getQuizQuestionNumber(12) ?? QUIZ_TOTAL_QUESTIONS
 
   return (
     <div className="flex flex-col" key="quiz-goals">
@@ -65,10 +66,10 @@ export function QuizGoals() {
           <ArrowLeft className="h-5 w-5" />
         </button>
         <div className="flex-1">
-          <QuizProgressBar current={QUIZ_TOTAL_QUESTIONS} total={QUIZ_TOTAL_QUESTIONS} />
+          <QuizProgressBar current={questionNumber} total={QUIZ_TOTAL_QUESTIONS} />
         </div>
         <span className="text-sm text-[var(--text-caption)] tabular-nums">
-          {QUIZ_TOTAL_QUESTIONS}/{QUIZ_TOTAL_QUESTIONS}
+          {questionNumber}/{QUIZ_TOTAL_QUESTIONS}
         </span>
       </div>
 
@@ -95,8 +96,9 @@ export function QuizGoals() {
               type="button"
               onClick={() => handleToggle(goal)}
               disabled={isDisabled}
+              aria-pressed={isSelected}
               className={cn(
-                "animate-fade-in-up flex h-full min-h-[104px] flex-col rounded-2xl border px-4 py-4 text-left transition-all duration-200",
+                "relative animate-fade-in-up flex h-full min-h-[104px] items-center rounded-2xl border px-4 py-5 pr-12 text-left transition-all duration-200",
                 isSelected
                   ? "border-[var(--brand-plum)] bg-[rgba(var(--brand-plum-rgb),0.08)] shadow-[0_14px_36px_-28px_rgba(var(--brand-plum-rgb),0.45)]"
                   : "border-border bg-card hover:border-primary/30 hover:bg-muted/40",
@@ -104,38 +106,27 @@ export function QuizGoals() {
               )}
               style={{ animationDelay: `${i * 40}ms` }}
             >
-              <div className="mb-4 flex items-center justify-between gap-3">
-                <span
-                  className={cn(
-                    "rounded-full px-2.5 py-1 text-[11px] font-semibold transition-colors",
-                    isSelected
-                      ? "bg-white/85 text-[var(--brand-plum)]"
-                      : "bg-muted text-[var(--text-caption)]",
-                  )}
-                >
-                  {isSelected ? "Ausgewählt" : "Ziel"}
-                </span>
-                <div
-                  className={cn(
-                    "flex h-6 w-6 items-center justify-center rounded-full border transition-colors",
-                    isSelected
-                      ? "border-[var(--brand-plum)] bg-[var(--brand-plum)] text-primary-foreground"
-                      : "border-border bg-white text-transparent",
-                  )}
-                >
-                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                    <path
-                      d="M2.5 6L5 8.5L9.5 4"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-              </div>
               <span className="text-[15px] font-semibold leading-snug text-foreground sm:text-base">
                 {getAvailableGoalLabel(goal, hairTexture)}
+              </span>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "absolute right-4 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full border transition-colors",
+                  isSelected
+                    ? "border-[var(--brand-plum)] bg-[var(--brand-plum)] text-primary-foreground"
+                    : "border-border bg-white text-transparent",
+                )}
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path
+                    d="M2.5 6L5 8.5L9.5 4"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
               </span>
             </button>
           )

--- a/src/components/quiz/quiz-option-card.tsx
+++ b/src/components/quiz/quiz-option-card.tsx
@@ -1,7 +1,9 @@
 "use client"
 
-import { QuizCard } from "./quiz-card"
+import { useId, type ReactNode } from "react"
+
 import { Icon, type IconName } from "@/components/ui/icon"
+import { cn } from "@/lib/utils"
 
 interface QuizOptionCardProps {
   icon: IconName
@@ -11,6 +13,23 @@ interface QuizOptionCardProps {
   disabled?: boolean
   onClick: () => void
   animationDelay?: number
+  trailing?: ReactNode
+}
+
+function SelectionCheck() {
+  return (
+    <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-plum)] text-primary-foreground">
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+        <path
+          d="M2.5 6L5 8.5L9.5 4"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  )
 }
 
 export function QuizOptionCard({
@@ -21,35 +40,63 @@ export function QuizOptionCard({
   disabled,
   onClick,
   animationDelay = 0,
+  trailing,
 }: QuizOptionCardProps) {
+  const labelId = useId()
+  const descriptionId = useId()
+
   return (
     <div className="animate-fade-in-up" style={{ animationDelay: `${animationDelay}ms` }}>
-      <QuizCard active={active} disabled={disabled} onClick={onClick}>
-        <div className="flex items-center gap-3">
+      <div
+        aria-disabled={disabled || undefined}
+        className={cn(
+          "quiz-card transition-all duration-200",
+          active && "quiz-card-active scale-[1.015]",
+          !disabled && "cursor-pointer",
+          disabled && "opacity-60",
+        )}
+      >
+        <button
+          type="button"
+          aria-labelledby={labelId}
+          aria-describedby={description ? descriptionId : undefined}
+          aria-pressed={active}
+          disabled={disabled}
+          onClick={onClick}
+          className="absolute inset-0 z-0 rounded-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[rgba(var(--brand-plum-rgb),0.35)] disabled:cursor-not-allowed"
+        />
+        <div className="pointer-events-none relative z-10 grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3">
           <div className="flex items-center justify-center w-10 h-10 rounded-full bg-[rgba(var(--brand-plum-rgb),0.1)] shrink-0">
             <Icon name={icon} size={32} className="text-primary" />
           </div>
           <div className="flex-1 min-w-0">
-            <p className="text-base font-semibold text-foreground">{label}</p>
+            <p
+              id={labelId}
+              className="break-words hyphens-auto text-base font-semibold leading-snug text-foreground"
+            >
+              {label}
+            </p>
             {description && (
-              <p className="text-sm text-muted-foreground mt-0.5 leading-relaxed">{description}</p>
+              <p
+                id={descriptionId}
+                className="text-sm text-muted-foreground mt-0.5 leading-relaxed"
+              >
+                {description}
+              </p>
             )}
           </div>
-          {active && (
-            <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--brand-plum)] text-primary-foreground">
-              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                <path
-                  d="M2.5 6L5 8.5L9.5 4"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+          {(trailing || active) && (
+            <div className="pointer-events-auto flex min-w-[4.25rem] shrink-0 items-center justify-end gap-2">
+              {trailing}
+              {active ? (
+                <SelectionCheck />
+              ) : trailing ? (
+                <span className="h-5 w-5 shrink-0" aria-hidden="true" />
+              ) : null}
             </div>
           )}
         </div>
-      </QuizCard>
+      </div>
     </div>
   )
 }

--- a/src/components/quiz/quiz-question.tsx
+++ b/src/components/quiz/quiz-question.tsx
@@ -9,6 +9,8 @@ import { Button } from "@/components/ui/button"
 import { ArrowLeft } from "lucide-react"
 import { toggleTreatmentSelection } from "@/lib/quiz/normalization"
 import { QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
+import { InfoTip } from "@/components/ui/info-tip"
+import { INFO_TIPS } from "@/lib/help/info-tips"
 
 const ANSWER_KEY_MAP: Record<number, keyof import("@/lib/quiz/types").QuizAnswers> = {
   2: "structure",
@@ -84,6 +86,7 @@ export function QuizQuestion({ question }: QuizQuestionProps) {
   }
 
   const multiHasSelection = Array.isArray(localSelection) && localSelection.length > 0
+  const infoTip = question.infoTipId ? INFO_TIPS[question.infoTipId] : null
 
   return (
     <div className="flex flex-col" key={question.step}>
@@ -105,7 +108,17 @@ export function QuizQuestion({ question }: QuizQuestionProps) {
       </div>
 
       {/* Title */}
-      <h2 className="font-header text-3xl leading-tight text-foreground mb-2">{question.title}</h2>
+      <div className="mb-2 flex items-baseline gap-2">
+        <h2 className="font-header text-3xl leading-tight text-foreground">{question.title}</h2>
+        {infoTip && (
+          <InfoTip
+            title={infoTip.title}
+            body={infoTip.body}
+            label={`Info zu ${question.title}`}
+            buttonClassName="h-7 w-7"
+          />
+        )}
+      </div>
 
       {/* Instruction */}
       <p className="text-sm text-muted-foreground leading-relaxed mb-5">{question.instruction}</p>

--- a/src/components/quiz/quiz-scalp-question.tsx
+++ b/src/components/quiz/quiz-scalp-question.tsx
@@ -5,7 +5,11 @@ import { useQuizStore } from "@/lib/quiz/store"
 import { QuizOptionCard } from "./quiz-option-card"
 import { QuizProgressBar } from "./quiz-progress-bar"
 import { ArrowLeft } from "lucide-react"
-import { QUIZ_TOTAL_QUESTIONS } from "@/lib/quiz/questions"
+import {
+  getQuizQuestionNumber,
+  getRemainingQuizQuestions,
+  QUIZ_TOTAL_QUESTIONS,
+} from "@/lib/quiz/questions"
 
 type Phase = "type" | "gate" | "condition"
 
@@ -166,6 +170,8 @@ export function QuizScalpQuestion() {
   }, [phase, goBack, setAnswer])
 
   const pastTypePhase = phase !== "type"
+  const questionNumber = getQuizQuestionNumber(6) ?? 8
+  const remainingQuestions = getRemainingQuizQuestions(6) ?? 0
 
   return (
     <div className="flex flex-col" key="scalp-question">
@@ -179,10 +185,10 @@ export function QuizScalpQuestion() {
           <ArrowLeft className="h-5 w-5" />
         </button>
         <div className="flex-1">
-          <QuizProgressBar current={8} total={QUIZ_TOTAL_QUESTIONS} />
+          <QuizProgressBar current={questionNumber} total={QUIZ_TOTAL_QUESTIONS} />
         </div>
         <span className="text-sm text-[var(--text-caption)] tabular-nums">
-          8/{QUIZ_TOTAL_QUESTIONS}
+          {questionNumber}/{QUIZ_TOTAL_QUESTIONS}
         </span>
       </div>
 
@@ -293,7 +299,9 @@ export function QuizScalpQuestion() {
       </div>
 
       {/* Motivation text — always anchored at bottom */}
-      <p className="mt-3 text-center text-sm text-[var(--text-caption)]">Gut — noch 2 Fragen.</p>
+      <p className="mt-3 text-center text-sm text-[var(--text-caption)]">
+        Gut — noch {remainingQuestions} Fragen.
+      </p>
     </div>
   )
 }

--- a/src/components/ui/info-tip.tsx
+++ b/src/components/ui/info-tip.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import { useCallback, useEffect, useId, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { cn } from "@/lib/utils"
+
+const VIEWPORT_MARGIN = 16
+const GAP = 8
+const MAX_WIDTH = 320
+
+interface PopupPosition {
+  left: number
+  top: number
+  width: number
+}
+
+interface InfoTipProps {
+  title: string
+  body: string
+  label?: string
+  className?: string
+  buttonClassName?: string
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function InfoTip({ title, body, label, className, buttonClassName }: InfoTipProps) {
+  const [open, setOpen] = useState(false)
+  const [position, setPosition] = useState<PopupPosition | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popupRef = useRef<HTMLDivElement>(null)
+  const generatedId = useId()
+  const popupId = `info-tip-${generatedId}`
+  const accessibleLabel = label ?? `Info zu ${title}`
+
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current
+
+    if (!trigger) return
+
+    const triggerRect = trigger.getBoundingClientRect()
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+    const width = Math.min(MAX_WIDTH, Math.max(0, viewportWidth - VIEWPORT_MARGIN * 2))
+    const left = clamp(
+      triggerRect.left + triggerRect.width / 2 - width / 2,
+      VIEWPORT_MARGIN,
+      viewportWidth - VIEWPORT_MARGIN - width,
+    )
+    const measuredHeight = popupRef.current?.offsetHeight ?? 0
+    const belowTop = triggerRect.bottom + GAP
+    const aboveTop = triggerRect.top - measuredHeight - GAP
+    const top =
+      measuredHeight > 0 && belowTop + measuredHeight > viewportHeight - VIEWPORT_MARGIN
+        ? clamp(aboveTop, VIEWPORT_MARGIN, viewportHeight - VIEWPORT_MARGIN - measuredHeight)
+        : belowTop
+
+    setPosition({ left, top, width })
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+
+    updatePosition()
+
+    const frame = window.requestAnimationFrame(updatePosition)
+
+    return () => window.cancelAnimationFrame(frame)
+  }, [open, updatePosition])
+
+  useEffect(() => {
+    if (!open) return
+
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target
+
+      if (!(target instanceof Node)) return
+      if (triggerRef.current?.contains(target) || popupRef.current?.contains(target)) return
+
+      setOpen(false)
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false)
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown, true)
+    document.addEventListener("keydown", handleKeyDown)
+    window.addEventListener("resize", updatePosition)
+    window.addEventListener("scroll", updatePosition, true)
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true)
+      document.removeEventListener("keydown", handleKeyDown)
+      window.removeEventListener("resize", updatePosition)
+      window.removeEventListener("scroll", updatePosition, true)
+    }
+  }, [open, updatePosition])
+
+  return (
+    <span className={cn("inline-flex items-center align-baseline", className)}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={accessibleLabel}
+        aria-expanded={open}
+        aria-controls={popupId}
+        aria-describedby={open ? popupId : undefined}
+        onClick={(event) => {
+          event.stopPropagation()
+          setOpen((current) => !current)
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            setOpen(false)
+          }
+          event.stopPropagation()
+        }}
+        className={cn(
+          "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-background text-xs font-semibold leading-none text-muted-foreground shadow-sm transition-colors hover:border-[rgba(var(--brand-plum-rgb),0.35)] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--brand-plum-rgb),0.35)]",
+          buttonClassName,
+        )}
+      >
+        i
+      </button>
+      {typeof document !== "undefined" &&
+        open &&
+        createPortal(
+          <div
+            ref={popupRef}
+            id={popupId}
+            role="tooltip"
+            style={
+              position
+                ? {
+                    left: position.left,
+                    top: position.top,
+                    width: position.width,
+                  }
+                : undefined
+            }
+            className={cn(
+              "fixed z-50 rounded-2xl border border-border bg-background px-4 py-3 text-left shadow-xl",
+              "max-w-[calc(100vw-2rem)]",
+              position ? "opacity-100" : "opacity-0",
+            )}
+          >
+            <p className="text-sm font-semibold leading-snug text-foreground">{title}</p>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{body}</p>
+          </div>,
+          document.body,
+        )}
+    </span>
+  )
+}

--- a/src/lib/help/info-tips.ts
+++ b/src/lib/help/info-tips.ts
@@ -1,0 +1,128 @@
+export type InfoTipSurface = "product" | "quiz" | "routine"
+
+export type InfoTipId =
+  | "product.shampoo"
+  | "product.conditioner"
+  | "product.leave_in"
+  | "product.hair_oil"
+  | "product.mask"
+  | "product.scalp_peeling"
+  | "product.dry_shampoo"
+  | "product.bond_builder"
+  | "product.deep_cleansing_shampoo"
+  | "quiz.hair_texture"
+  | "quiz.thickness"
+  | "quiz.density"
+  | "quiz.surface_test"
+  | "quiz.pull_test"
+  | "routine.towel_technique"
+  | "routine.diffuser"
+  | "routine.bonnet"
+  | "routine.pineapple"
+  | "routine.heat_protection"
+
+export interface InfoTipContent {
+  surface: InfoTipSurface
+  title: string
+  body: string
+}
+
+export const INFO_TIPS = {
+  "product.shampoo": {
+    surface: "product",
+    title: "Shampoo",
+    body: "Reinigt vor allem Kopfhaut und Ansatz. Die Längen bekommen beim Ausspülen meist genug Schaum ab.",
+  },
+  "product.conditioner": {
+    surface: "product",
+    title: "Conditioner / Spülung",
+    body: "Ausspülbare Pflege nach dem Shampoo. Meist in Längen und Spitzen, nicht als Kopfhautpflege.",
+  },
+  "product.leave_in": {
+    surface: "product",
+    title: "Leave-in",
+    body: "Pflege, die im Haar bleibt. Nach dem Waschen sparsam in Längen und Spitzen verwenden.",
+  },
+  "product.hair_oil": {
+    surface: "product",
+    title: "Haaröl",
+    body: "Meist Finish oder Pre-Wash-Schutz für Längen und Spitzen. Sehr sparsam dosieren.",
+  },
+  "product.mask": {
+    surface: "product",
+    title: "Haarmaske",
+    body: "Intensivere Zusatzpflege, meistens gelegentlich. Kein täglicher Pflichtschritt.",
+  },
+  "product.scalp_peeling": {
+    surface: "product",
+    title: "Kopfhautpeeling",
+    body: "Kopfhaut-Produkt, kein Längenprodukt. Eher selten und sanft einsetzen.",
+  },
+  "product.dry_shampoo": {
+    surface: "product",
+    title: "Trockenshampoo",
+    body: "Frischt den Ansatz auf und nimmt Talg auf, ersetzt aber keine Haarwäsche. Rückstände später auswaschen.",
+  },
+  "product.bond_builder": {
+    surface: "product",
+    title: "Bond Repair / Bondbuilder",
+    body: "Gezielte Zusatzpflege bei stark geschädigtem Haar, zum Beispiel durch Blondieren, Hitze oder chemische Behandlungen. Kein Conditioner und keine Feuchtigkeitsmaske.",
+  },
+  "product.deep_cleansing_shampoo": {
+    surface: "product",
+    title: "Tiefenreinigungsshampoo",
+    body: "Gelegentlicher Reset bei Rückständen und Build-up. Kein Alltags-Shampoo.",
+  },
+  "quiz.hair_texture": {
+    surface: "quiz",
+    title: "Haarstruktur",
+    body: "Textur meint das Muster deiner Haare, nicht Dicke oder Haarmenge: glatt, wellig, lockig oder kraus.",
+  },
+  "quiz.thickness": {
+    surface: "quiz",
+    title: "Haardicke",
+    body: "Haardicke meint den Durchmesser eines einzelnen Haares, nicht wie viele Haare du insgesamt hast.",
+  },
+  "quiz.density": {
+    surface: "quiz",
+    title: "Haardichte",
+    body: "Haardichte meint die Haarmenge auf dem Kopf. Du kannst feines Haar haben und trotzdem viel davon.",
+  },
+  "quiz.surface_test": {
+    surface: "quiz",
+    title: "Oberfläche / Finger-Test",
+    body: "Es geht nicht um Sauberkeit, sondern um die Oberfläche der Strähne: glatt, leicht uneben oder rau.",
+  },
+  "quiz.pull_test": {
+    surface: "quiz",
+    title: "Elastizität / Zug-Test",
+    body: "Elastizität zeigt, wie gut eine Strähne Zug aushält. Für uns reicht eine grobe Tendenz, kein perfekter Test.",
+  },
+  "routine.towel_technique": {
+    surface: "routine",
+    title: "Scrunchen",
+    body: "Scrunchen heißt: Wasser oder Pflege sanft von unten einkneten, statt das Haar trocken zu rubbeln.",
+  },
+  "routine.diffuser": {
+    surface: "routine",
+    title: "Diffusor",
+    body: "Ein Diffusor ist ein Föhnaufsatz, der Luft breiter verteilt. Das kann Wellen und Locken weniger auseinanderpusten.",
+  },
+  "routine.bonnet": {
+    surface: "routine",
+    title: "Bonnet / Schlafhaube",
+    body: "Ein Bonnet bzw. eine Schlafhaube aus Satin oder Seide reduziert Reibung beim Schlafen und hält Längen oder Locken besser zusammen.",
+  },
+  "routine.pineapple": {
+    surface: "routine",
+    title: "Pineapple",
+    body: "Ein hoher, lockerer Zopf oder Dutt, der Wellen und Locken nachts weniger plattdrückt.",
+  },
+  "routine.heat_protection": {
+    surface: "routine",
+    title: "Hitzeschutz",
+    body: "Produkt vor Föhn, Glätteisen oder Lockenstab. Es hilft gegen Hitzestress, ersetzt aber keine niedrigere Temperatur.",
+  },
+} satisfies Record<InfoTipId, InfoTipContent>
+
+export const INFO_TIP_IDS = Object.keys(INFO_TIPS) as InfoTipId[]

--- a/src/lib/onboarding/product-options.ts
+++ b/src/lib/onboarding/product-options.ts
@@ -1,21 +1,80 @@
 import type { IconName } from "@/components/ui/icon"
+import type { InfoTipId } from "@/lib/help/info-tips"
 
-export const BASIC_PRODUCT_OPTIONS: { value: string; label: string; icon: IconName }[] = [
-  { value: "shampoo", label: "Shampoo", icon: "product-shampoo" },
-  { value: "conditioner", label: "Conditioner", icon: "product-conditioner" },
-  { value: "leave_in", label: "Leave-in", icon: "product-leave-in" },
-  { value: "oil", label: "Öl", icon: "product-oil" },
-  { value: "mask", label: "Maske", icon: "product-mask" },
+export interface ProductCategoryOption {
+  value: string
+  label: string
+  icon: IconName
+  infoTipId: InfoTipId
+  drilldownTitle: string
+}
+
+export const BASIC_PRODUCT_OPTIONS: ProductCategoryOption[] = [
+  {
+    value: "shampoo",
+    label: "Shampoo",
+    icon: "product-shampoo",
+    infoTipId: "product.shampoo",
+    drilldownTitle: "Dein Shampoo",
+  },
+  {
+    value: "conditioner",
+    label: "Conditioner",
+    icon: "product-conditioner",
+    infoTipId: "product.conditioner",
+    drilldownTitle: "Dein Conditioner",
+  },
+  {
+    value: "leave_in",
+    label: "Leave-in",
+    icon: "product-leave-in",
+    infoTipId: "product.leave_in",
+    drilldownTitle: "Dein Leave-in",
+  },
+  {
+    value: "oil",
+    label: "Haaröl",
+    icon: "product-oil",
+    infoTipId: "product.hair_oil",
+    drilldownTitle: "Dein Haaröl",
+  },
+  {
+    value: "mask",
+    label: "Haarmaske",
+    icon: "product-mask",
+    infoTipId: "product.mask",
+    drilldownTitle: "Deine Haarmaske",
+  },
 ]
 
-export const EXTRA_PRODUCT_OPTIONS: { value: string; label: string; icon: IconName }[] = [
-  { value: "peeling", label: "Peeling (Serum/Scrub)", icon: "product-peeling" },
-  { value: "dry_shampoo", label: "Trockenshampoo", icon: "product-dry-shampoo" },
-  { value: "bondbuilder", label: "Bondbuilder", icon: "product-bond-builder" },
+export const EXTRA_PRODUCT_OPTIONS: ProductCategoryOption[] = [
+  {
+    value: "peeling",
+    label: "Kopfhautpeeling",
+    icon: "product-peeling",
+    infoTipId: "product.scalp_peeling",
+    drilldownTitle: "Dein Kopfhautpeeling",
+  },
+  {
+    value: "dry_shampoo",
+    label: "Trockenshampoo",
+    icon: "product-dry-shampoo",
+    infoTipId: "product.dry_shampoo",
+    drilldownTitle: "Dein Trockenshampoo",
+  },
+  {
+    value: "bondbuilder",
+    label: "Bondbuilder",
+    icon: "product-bond-builder",
+    infoTipId: "product.bond_builder",
+    drilldownTitle: "Dein Bondbuilder",
+  },
   {
     value: "deep_cleansing_shampoo",
     label: "Tiefenreinigungsshampoo",
     icon: "product-deep-cleansing",
+    infoTipId: "product.deep_cleansing_shampoo",
+    drilldownTitle: "Dein Tiefenreinigungsshampoo",
   },
 ]
 
@@ -27,5 +86,12 @@ export const PRODUCT_CATEGORY_LABELS: Record<string, string> = Object.fromEntrie
   [...BASIC_PRODUCT_OPTIONS, ...EXTRA_PRODUCT_OPTIONS].map((option) => [
     option.value,
     option.label,
+  ]),
+)
+
+export const PRODUCT_CATEGORY_DRILLDOWN_TITLES: Record<string, string> = Object.fromEntries(
+  [...BASIC_PRODUCT_OPTIONS, ...EXTRA_PRODUCT_OPTIONS].map((option) => [
+    option.value,
+    option.drilldownTitle,
   ]),
 )

--- a/src/lib/quiz/brand-panel-content.ts
+++ b/src/lib/quiz/brand-panel-content.ts
@@ -1,5 +1,5 @@
 import type { LeadCaptureSubStep, QuizStep } from "./types"
-import { QUIZ_TOTAL_QUESTIONS } from "./questions"
+import { getQuizQuestionNumber, QUIZ_TOTAL_QUESTIONS } from "./questions"
 
 export interface QuizBrandPanelContent {
   eyebrow: string | null
@@ -9,19 +9,17 @@ export interface QuizBrandPanelContent {
   variant: "landing" | "journey"
 }
 
-const QUESTION_PANEL_CONTENT: Partial<
-  Record<QuizStep, { questionNumber: number; description: string }>
-> = {
-  2: { questionNumber: 1, description: "Deine natürliche Haarstruktur." },
-  3: { questionNumber: 2, description: "Dicke einzelner Haare." },
-  13: { questionNumber: 3, description: "Wie voll dein Haar insgesamt ist." },
-  15: { questionNumber: 4, description: "Wie lang deine Haare aktuell sind." },
-  4: { questionNumber: 5, description: "Wie sich die Oberfläche anfühlt." },
-  5: { questionNumber: 6, description: "Wie belastbar die Längen sind." },
-  7: { questionNumber: 7, description: "Wie stark dein Haar behandelt ist." },
-  6: { questionNumber: 8, description: "Was an der Kopfhaut mitspielt." },
-  8: { questionNumber: 9, description: "Was dich gerade ausbremst." },
-  12: { questionNumber: 10, description: "Worauf wir hinarbeiten." },
+const QUESTION_PANEL_DESCRIPTIONS: Partial<Record<QuizStep, string>> = {
+  2: "Deine natürliche Haarstruktur.",
+  3: "Dicke einzelner Haare.",
+  13: "Wie voll dein Haar insgesamt ist.",
+  15: "Wie lang deine Haare aktuell sind.",
+  4: "Wie sich die Oberfläche anfühlt.",
+  5: "Wie belastbar die Längen sind.",
+  7: "Wie stark dein Haar behandelt ist.",
+  6: "Was an der Kopfhaut mitspielt.",
+  8: "Was dich gerade ausbremst.",
+  12: "Worauf wir hinarbeiten.",
 }
 
 export function getQuizBrandPanelContent(
@@ -30,12 +28,13 @@ export function getQuizBrandPanelContent(
 ): QuizBrandPanelContent {
   void leadCaptureSubStep
 
-  const questionContent = QUESTION_PANEL_CONTENT[step]
-  if (questionContent) {
+  const questionDescription = QUESTION_PANEL_DESCRIPTIONS[step]
+  const questionNumber = getQuizQuestionNumber(step)
+  if (questionDescription && questionNumber) {
     return {
-      eyebrow: `FRAGE ${questionContent.questionNumber} VON ${QUIZ_TOTAL_QUESTIONS}`,
-      description: questionContent.description,
-      progressCurrent: questionContent.questionNumber,
+      eyebrow: `FRAGE ${questionNumber} VON ${QUIZ_TOTAL_QUESTIONS}`,
+      description: questionDescription,
+      progressCurrent: questionNumber,
       progressComplete: false,
       variant: "journey",
     }

--- a/src/lib/quiz/questions.ts
+++ b/src/lib/quiz/questions.ts
@@ -1,15 +1,36 @@
-import type { QuizQuestion } from "./types"
+import type { QuizQuestion, QuizStep } from "./types"
 import { HAIR_LENGTH_OPTIONS } from "@/lib/vocabulary"
 
-export const QUIZ_TOTAL_QUESTIONS = 10
+export const QUIZ_QUESTION_STEPS = [
+  2, 3, 13, 15, 4, 5, 7, 6, 8, 12,
+] as const satisfies readonly QuizStep[]
+
+export const QUIZ_TOTAL_QUESTIONS = QUIZ_QUESTION_STEPS.length
+
+export function getQuizQuestionNumber(step: QuizStep): number | undefined {
+  const index = QUIZ_QUESTION_STEPS.indexOf(step as (typeof QUIZ_QUESTION_STEPS)[number])
+  return index === -1 ? undefined : index + 1
+}
+
+export function getRemainingQuizQuestions(step: QuizStep): number | undefined {
+  const questionNumber = getQuizQuestionNumber(step)
+  return questionNumber === undefined ? undefined : QUIZ_TOTAL_QUESTIONS - questionNumber
+}
+
+function remainingQuestionsText(step: QuizStep, prefix: string, suffix = "Fragen"): string {
+  const remaining = getRemainingQuizQuestions(step)
+  if (remaining === 1) return `${prefix} — eine Frage noch.`
+  return `${prefix} — noch ${remaining ?? 0} ${suffix}.`
+}
 
 export const quizQuestions: QuizQuestion[] = [
   {
     step: 2,
-    questionNumber: 1,
+    questionNumber: getQuizQuestionNumber(2) ?? 1,
     title: "Welche Haarstruktur haben die meisten deiner Haare?",
+    infoTipId: "quiz.hair_texture",
     instruction:
-      "Schau dir eine typische nasse Strähne an und wähle unten aus, welche Form sie annimmt.\n\nBei Dauerwelle oder chemischer Glättung: Wähle hier deine natürliche Struktur am Ansatz, nicht die chemisch umgeformten Längen.",
+      "Wähle die natürliche Form deiner Haare, so gut du sie erkennen kannst. Wenn deine Längen chemisch geglättet oder dauergewellt sind, hilft der unbehandelte Ansatz als Orientierung.",
     options: [
       {
         value: "straight",
@@ -37,12 +58,13 @@ export const quizQuestions: QuizQuestion[] = [
       },
     ],
     selectionMode: "single",
-    motivation: "Super — noch 9 kurze Fragen.",
+    motivation: remainingQuestionsText(2, "Super", "kurze Fragen"),
   },
   {
     step: 3,
-    questionNumber: 2,
+    questionNumber: getQuizQuestionNumber(3) ?? 2,
     title: "Wie dick fühlt sich ein einzelnes Haar bei dir meistens an?",
+    infoTipId: "quiz.thickness",
     instruction: "Vergleiche ein einzelnes Haar mit einem Nähfaden.",
     options: [
       {
@@ -69,10 +91,10 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 13,
-    questionNumber: 3,
+    questionNumber: getQuizQuestionNumber(13) ?? 3,
     title: "Wie dicht ist dein Haar insgesamt?",
-    instruction:
-      "Jetzt geht es nicht mehr um ein einzelnes Haar, sondern um die Haarmenge auf dem Kopf. Schau zum Beispiel auf Scheitel, Zopf-Umfang und wie viel Kopfhaut sichtbar ist.",
+    infoTipId: "quiz.density",
+    instruction: "Schau zum Beispiel auf Scheitel, Zopf-Umfang und wie viel Kopfhaut sichtbar ist.",
     options: [
       {
         value: "low",
@@ -98,7 +120,7 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 15,
-    questionNumber: 4,
+    questionNumber: getQuizQuestionNumber(15) ?? 4,
     title: "Wie lang sind deine Haare aktuell?",
     instruction:
       "Bei Locken oder Coils zählt die sanft gestreckte Länge einer Strähne.\n\nWenn du zwischen zwei Längen liegst, wähle die längere Option.",
@@ -114,10 +136,10 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 4,
-    questionNumber: 5,
-    title: "Wie fühlt sich dein Haar an?",
+    questionNumber: getQuizQuestionNumber(4) ?? 5,
+    title: "Wie fühlt sich deine Haaroberfläche an?",
     instruction:
-      "Nimm ein gewaschenes, trockenes Haar aus deiner Bürste \u2013 es darf kein Produkt mehr drauf sein. Schließ die Augen und fahre ganz langsam mit zwei Fingern von der Wurzel zur Spitze. Konzentrier dich darauf, was du fühlst:",
+      "Fahre langsam mit zwei Fingern über ein sauberes, trockenes Haar: glatt, leicht uneben oder rau?",
     options: [
       {
         value: "glatt",
@@ -143,10 +165,11 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 5,
-    questionNumber: 6,
+    questionNumber: getQuizQuestionNumber(5) ?? 6,
     title: "Wie elastisch ist dein Haar?",
+    infoTipId: "quiz.pull_test",
     instruction:
-      "Nimm dasselbe Haar. Klemm es zwischen Ringfinger und Zeigefinger auf der einen Seite und zwischen Ringfinger und Mittelfinger auf der anderen. Zieh jetzt vorsichtig \u2013 wirklich mit Gefühl, nicht reißen. Beobachte genau, was passiert:\n\nZiehe nur leicht. Uns geht es um die Tendenz, nicht um Perfektion.",
+      "Nimm dasselbe Haar. Klemm es zwischen Ringfinger und Zeigefinger auf der einen Seite und zwischen Ringfinger und Mittelfinger auf der anderen. Zieh jetzt vorsichtig \u2013 wirklich mit Gefühl, nicht reißen. Beobachte genau, was passiert.",
     options: [
       {
         value: "stretches_bounces",
@@ -168,11 +191,11 @@ export const quizQuestions: QuizQuestion[] = [
       },
     ],
     selectionMode: "single",
-    motivation: "Gut gemacht — noch 4 Fragen.",
+    motivation: remainingQuestionsText(5, "Gut gemacht"),
   },
   {
     step: 7,
-    questionNumber: 7,
+    questionNumber: getQuizQuestionNumber(7) ?? 7,
     title: "Sind deine Haare chemisch behandelt?",
     instruction:
       "Gemeint ist alles, was Farbe oder Form länger verändert hat: Färben/Tönen, Aufhellen, Dauerwelle oder Glättung. Deine natürliche Struktur hast du schon angegeben.",
@@ -213,7 +236,7 @@ export const quizQuestions: QuizQuestion[] = [
   },
   {
     step: 8,
-    questionNumber: 9,
+    questionNumber: getQuizQuestionNumber(8) ?? 9,
     title: "Welche Haarprobleme beschäftigen dich gerade am meisten?",
     instruction:
       "Wähle bis zu 3 Punkte aus, die aktuell am besten zu deinen Längen und Spitzen passen.",
@@ -257,7 +280,7 @@ export const quizQuestions: QuizQuestion[] = [
     ],
     selectionMode: "multi",
     maxSelections: 3,
-    motivation: "Fast geschafft — eine Frage noch.",
+    motivation: remainingQuestionsText(8, "Fast geschafft"),
   },
 ]
 

--- a/src/lib/quiz/store.ts
+++ b/src/lib/quiz/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 import { clearQuizDraft, loadQuizDraft, saveQuizDraft } from "./draft"
+import { QUIZ_QUESTION_STEPS } from "./questions"
 import type { QuizStep, LeadCaptureSubStep, QuizAnswers, LeadData } from "./types"
 
 interface QuizState {
@@ -21,7 +22,7 @@ interface QuizState {
   reset: () => void
 }
 
-const STEP_ORDER: QuizStep[] = [2, 3, 13, 15, 4, 5, 7, 6, 8, 12, 9, 10, 11, 14]
+const STEP_ORDER: QuizStep[] = [...QUIZ_QUESTION_STEPS, 9, 10, 11, 14]
 
 function nextStep(current: QuizStep): QuizStep {
   const idx = STEP_ORDER.indexOf(current)

--- a/src/lib/quiz/types.ts
+++ b/src/lib/quiz/types.ts
@@ -21,6 +21,7 @@ export type LeadCaptureSubStep = "name" | "email" | "consent"
 export type SelectionMode = "single" | "multi"
 
 import type { IconName } from "@/components/ui/icon"
+import type { InfoTipId } from "@/lib/help/info-tips"
 import type { HairLength, ProfileConcern } from "@/lib/vocabulary"
 
 export interface QuizOption {
@@ -35,6 +36,7 @@ export interface QuizQuestion {
   questionNumber: number
   title: string
   instruction: string
+  infoTipId?: InfoTipId
   options: QuizOption[]
   selectionMode: SelectionMode
   maxSelections?: number

--- a/src/lib/vocabulary/onboarding-care.ts
+++ b/src/lib/vocabulary/onboarding-care.ts
@@ -99,9 +99,9 @@ export type NightProtection = (typeof NIGHT_PROTECTIONS)[number]
 
 export const NIGHT_PROTECTION_LABELS = {
   silk_satin_pillow: "Seidenkissenbezug",
-  silk_satin_bonnet: "Seidenhaube / Bonnet",
+  silk_satin_bonnet: "Bonnet / Schlafhaube",
   loose_tied: "Locker zusammengebunden",
-  pineapple: "Pineapple (hoher lockerer Dutt)",
+  pineapple: "Pineapple",
   length_tip_accessory: "Längen-/Spitzenschutz (z. B. HairHOMIE)",
 } as const satisfies Record<NightProtection, string>
 

--- a/tests/e2e-deployed.spec.ts
+++ b/tests/e2e-deployed.spec.ts
@@ -89,35 +89,35 @@ test.describe("Deployed App E2E Tests", () => {
     await startButton.waitFor({ state: "visible" })
     await startButton.click()
 
-    // Step 1: Hair structure question (question 1/7)
+    // Step 1: Hair structure question (question 1/10)
     await expect(page.getByText(/Haarstruktur/i)).toBeVisible({ timeout: 15000 })
 
     // Click "Glatt" option — should auto-advance after 400ms
     await page.getByText("Glatt").first().click()
 
-    // Step 2: Hair thickness (question 2/7)
+    // Step 2: Hair thickness (question 2/10)
     await expect(page.getByText(/Wie dick fühlt sich ein einzelnes Haar/i)).toBeVisible({
       timeout: 10000,
     })
-    await expect(page.getByText("2/7")).toBeVisible()
+    await expect(page.getByText("2/10")).toBeVisible()
 
     // Click "Mittel"
     await page.getByText("Mittel").first().click()
 
-    // Step 3: Surface test (question 3/7)
-    await expect(page.getByText(/Wie fühlt sich dein Haar an/i)).toBeVisible({
+    // Step 3: Hair density (question 3/10)
+    await expect(page.getByText(/Wie dicht ist dein Haar insgesamt/i)).toBeVisible({
       timeout: 10000,
     })
-    await expect(page.getByText("3/7")).toBeVisible()
+    await expect(page.getByText("3/10")).toBeVisible()
 
-    // Click "Glatt wie Glas"
-    await page.getByText("Glatt wie Glas").click()
+    // Click "Mittlere Dichte"
+    await page.getByText("Mittlere Dichte").click()
 
-    // Step 4: Pull test (question 4/7)
-    await expect(page.getByText("WIE ELASTISCH IST DEIN HAAR?", { exact: false })).toBeVisible({
+    // Step 4: Hair length (question 4/10)
+    await expect(page.getByText(/Wie lang sind deine Haare aktuell/i)).toBeVisible({
       timeout: 10000,
     })
-    await expect(page.getByText("4/7")).toBeVisible()
+    await expect(page.getByText("4/10")).toBeVisible()
   })
 
   test("quiz flow: navigate through scalp question progressive disclosure", async ({ page }) => {
@@ -126,8 +126,9 @@ test.describe("Deployed App E2E Tests", () => {
       timeout: 15000,
     })
 
-    // Navigate to scalp question (step 6, question 6/7)
-    // Steps: start -> Q1(texture) -> Q2(thickness) -> Q3(surface) -> Q4(pull) -> Q5(chemical) -> Q6(scalp)
+    // Navigate to scalp question (step 6, question 8/10)
+    // Steps: start -> Q1(texture) -> Q2(thickness) -> Q3(density) -> Q4(length)
+    // -> Q5(surface) -> Q6(pull) -> Q7(chemical) -> Q8(scalp)
     const startBtn = page.getByRole("button", { name: /QUIZ STARTEN/i })
     await startBtn.waitFor({ state: "visible" })
     await startBtn.click()
@@ -135,26 +136,32 @@ test.describe("Deployed App E2E Tests", () => {
     await expect(page.getByText(/Haarstruktur/i)).toBeVisible({ timeout: 15000 })
 
     await page.getByText("Glatt").first().click()
-    await expect(page.getByText("2/7")).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("2/10")).toBeVisible({ timeout: 10000 })
 
     await page.getByText("Mittel").first().click()
-    await expect(page.getByText("3/7")).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("3/10")).toBeVisible({ timeout: 10000 })
+
+    await page.getByText("Mittlere Dichte").click()
+    await expect(page.getByText("4/10")).toBeVisible({ timeout: 10000 })
+
+    await page.getByText("Mittellang").click()
+    await expect(page.getByText("5/10")).toBeVisible({ timeout: 10000 })
 
     await page.getByText("Glatt wie Glas").click()
-    await expect(page.getByText("4/7")).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("6/10")).toBeVisible({ timeout: 10000 })
 
     await page.getByText("Dehnt sich und geht zurück").click()
-    await expect(page.getByText("5/7")).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("7/10")).toBeVisible({ timeout: 10000 })
 
-    // Chemical treatment (question 5/7)
-    await expect(
-      page.getByText("SIND DEINE HAARE CHEMISCH BEHANDELT?", { exact: false }),
-    ).toBeVisible({ timeout: 10000 })
+    // Chemical treatment (question 7/10)
+    await expect(page.getByText(/Sind deine Haare chemisch behandelt/i)).toBeVisible({
+      timeout: 10000,
+    })
     await page.locator(".quiz-card", { hasText: "Naturhaar" }).click()
     await page.getByRole("button", { name: /^Weiter$/i }).click()
 
-    // Should be on scalp type question (6/7)
-    await expect(page.getByText("6/7")).toBeVisible({ timeout: 10000 })
+    // Should be on scalp type question (8/10)
+    await expect(page.getByText("8/10")).toBeVisible({ timeout: 10000 })
     await expect(
       page.getByRole("heading", { name: /Wie schnell fetten deine Ansätze nach/i }),
     ).toBeVisible({ timeout: 10000 })
@@ -163,13 +170,13 @@ test.describe("Deployed App E2E Tests", () => {
     await page.getByText("Ausgeglichen").click()
 
     // Gate question should appear
-    await expect(page.getByText("BESCHWERDEN WIE SCHUPPEN", { exact: false })).toBeVisible({
+    await expect(page.getByText(/Beschwerden wie Schuppen/i)).toBeVisible({
       timeout: 5000,
     })
 
     // Click "NEIN" to skip condition and advance to the new concerns page
-    await page.getByRole("button", { name: "NEIN" }).click()
-    await expect(page.getByText("7/7")).toBeVisible({ timeout: 10000 })
+    await page.getByRole("button", { name: /^Nein$/i }).click()
+    await expect(page.getByText("9/10")).toBeVisible({ timeout: 10000 })
     await expect(page.getByText(/Welche Haarprobleme/i)).toBeVisible({ timeout: 10000 })
   })
 

--- a/tests/info-tips.test.ts
+++ b/tests/info-tips.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { INFO_TIP_IDS, INFO_TIPS, type InfoTipId } from "../src/lib/help/info-tips"
+
+const REQUIRED_INFO_TIP_IDS: InfoTipId[] = [
+  "product.shampoo",
+  "product.conditioner",
+  "product.leave_in",
+  "product.hair_oil",
+  "product.mask",
+  "product.scalp_peeling",
+  "product.dry_shampoo",
+  "product.bond_builder",
+  "product.deep_cleansing_shampoo",
+  "quiz.hair_texture",
+  "quiz.thickness",
+  "quiz.density",
+  "quiz.pull_test",
+  "routine.towel_technique",
+  "routine.diffuser",
+  "routine.bonnet",
+  "routine.pineapple",
+  "routine.heat_protection",
+]
+
+const GERMAN_COPY_MARKER =
+  /(der|die|das|und|nicht|kein|meist|pflege|produkt|haar|haare|kopfhaut|längen|strähne|föhn|glätteisen|schlafhaube)/i
+
+test("required info-tip IDs have German title and body copy", () => {
+  for (const id of REQUIRED_INFO_TIP_IDS) {
+    const tip = INFO_TIPS[id]
+
+    assert.ok(tip, `Missing info tip: ${id}`)
+    assert.equal(typeof tip.title, "string", `${id} title should be a string`)
+    assert.equal(typeof tip.body, "string", `${id} body should be a string`)
+    assert.ok(tip.title.trim().length > 0, `${id} title should not be empty`)
+    assert.ok(tip.body.trim().length > 0, `${id} body should not be empty`)
+    assert.match(tip.body, GERMAN_COPY_MARKER, `${id} body should be German copy`)
+  }
+})
+
+test("optional surface test copy is available for later wiring", () => {
+  assert.ok(INFO_TIP_IDS.includes("quiz.surface_test"))
+  assert.ok(INFO_TIPS["quiz.surface_test"].title.trim())
+  assert.ok(INFO_TIPS["quiz.surface_test"].body.trim())
+})

--- a/tests/onboarding-care-vocabulary.test.ts
+++ b/tests/onboarding-care-vocabulary.test.ts
@@ -57,6 +57,8 @@ test("night protection options include length tip accessory and remove tight hai
     NIGHT_PROTECTION_LABELS.length_tip_accessory,
     "Längen-/Spitzenschutz (z. B. HairHOMIE)",
   )
+  assert.equal(NIGHT_PROTECTION_LABELS.silk_satin_bonnet, "Bonnet / Schlafhaube")
+  assert.equal(NIGHT_PROTECTION_LABELS.pineapple, "Pineapple")
   assert.ok(!NIGHT_PROTECTIONS.includes("tight_hairstyles" as never))
 })
 

--- a/tests/quiz-motivation-copy.test.ts
+++ b/tests/quiz-motivation-copy.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
 import test from "node:test"
-import { quizQuestions, QUIZ_TOTAL_QUESTIONS } from "../src/lib/quiz/questions"
+import {
+  getQuizQuestionNumber,
+  getRemainingQuizQuestions,
+  quizQuestions,
+  QUIZ_TOTAL_QUESTIONS,
+} from "../src/lib/quiz/questions"
 
 test("quiz motivation copy matches the visible question count", () => {
   const firstQuestion = quizQuestions.find((question) => question.questionNumber === 1)
@@ -13,4 +19,20 @@ test("quiz motivation copy matches the visible question count", () => {
     `Gut gemacht — noch ${QUIZ_TOTAL_QUESTIONS - 6} Fragen.`,
   )
   assert.equal(problemsQuestion?.motivation, "Fast geschafft — eine Frage noch.")
+})
+
+test("quiz question sequence drives special step counters", () => {
+  assert.equal(QUIZ_TOTAL_QUESTIONS, 10)
+  assert.equal(getQuizQuestionNumber(6), 8)
+  assert.equal(getRemainingQuizQuestions(6), 2)
+  assert.equal(getQuizQuestionNumber(12), 10)
+  assert.equal(getRemainingQuizQuestions(12), 0)
+})
+
+test("goal cards expose selection state without repeated status pills", async () => {
+  const source = await readFile("src/components/quiz/quiz-goals.tsx", "utf8")
+
+  assert.match(source, /aria-pressed=\{isSelected\}/)
+  assert.doesNotMatch(source, />Ziel</)
+  assert.doesNotMatch(source, />Ausgewählt</)
 })

--- a/tests/quiz-option-card.test.tsx
+++ b/tests/quiz-option-card.test.tsx
@@ -10,7 +10,8 @@ test("quiz option card centers the icon row against single-line labels", () => {
     <QuizOptionCard icon="product-shampoo" label="Shampoo" active={false} onClick={() => {}} />,
   )
 
-  assert.match(html, /<div class="flex items-center gap-3">/)
+  assert.match(html, /grid-cols-\[auto_minmax\(0,1fr\)_auto\]/)
+  assert.match(html, /\bitems-center\b/)
   assert.doesNotMatch(html, /\bitems-start\b/)
 })
 
@@ -25,8 +26,58 @@ test("quiz option card centers descriptive rows against the full text block", ()
     />,
   )
 
-  assert.match(html, /<div class="flex items-center gap-3">/)
+  assert.match(html, /grid-cols-\[auto_minmax\(0,1fr\)_auto\]/)
+  assert.match(html, /\bitems-center\b/)
   assert.doesNotMatch(html, /\bitems-start\b/)
+})
+
+test("quiz option card reserves a fixed right action rail for trailing info", () => {
+  const html = renderToStaticMarkup(
+    <QuizOptionCard
+      icon="product-conditioner"
+      label="Conditioner"
+      active={false}
+      onClick={() => {}}
+      trailing={<button type="button">i</button>}
+    />,
+  )
+
+  assert.match(html, /grid-cols-\[auto_minmax\(0,1fr\)_auto\]/)
+  assert.match(html, /min-w-\[4\.25rem\]/)
+  assert.match(html, /\bjustify-end\b/)
+  assert.match(html, /<p id="[^"]+" class="break-words hyphens-auto/)
+})
+
+test("quiz option card keeps trailing info outside the selectable card button", async () => {
+  const html = renderToStaticMarkup(
+    <QuizOptionCard
+      icon="product-conditioner"
+      label="Conditioner"
+      description="Pflege nach dem Shampoo"
+      active={false}
+      onClick={() => {}}
+      trailing={<button type="button">i</button>}
+    />,
+  )
+  const source = await readFile("src/components/ui/info-tip.tsx", "utf8")
+  const accessibleButtonMatch = html.match(
+    /<button type="button" aria-labelledby="([^"]+)" aria-describedby="([^"]+)"/,
+  )
+
+  assert.ok(accessibleButtonMatch)
+  assert.match(html, new RegExp(`<p id="${accessibleButtonMatch[1]}"[^>]*>Conditioner</p>`))
+  assert.match(
+    html,
+    new RegExp(`<p id="${accessibleButtonMatch[2]}"[^>]*>Pflege nach dem Shampoo</p>`),
+  )
+  assert.match(html, /<button type="button">i<\/button>/)
+  assert.match(html, /<\/button><div class="pointer-events-none relative z-10 grid/)
+  assert.doesNotMatch(html, /role="button"/)
+  assert.match(source, /event\.stopPropagation\(\)/)
+  assert.match(source, /event\.key === "Escape"/)
+  assert.match(source, /aria-describedby=\{open \? popupId : undefined\}/)
+  assert.match(html, /\bfocus-visible:ring-inset\b/)
+  assert.match(html, /\baria-pressed="false"/)
 })
 
 test("single-select screen syncs prop changes and cancels delayed selection on back", async () => {


### PR DESCRIPTION
## Summary
- Add reusable optional info tips for onboarding product categories, product drilldowns, selected quiz/test concepts, and routine pages.
- Keep helper text focused on how to answer, while info tips carry optional definitions/why-it-matters copy.
- Clean up quiz numbering, shorten Haarstruktur/Oberflaeche copy, align option-card info buttons, and canonicalize product drilldown category URLs.

## Verification
- npx tsx --test tests/info-tips.test.ts tests/quiz-option-card.test.tsx tests/onboarding-care-vocabulary.test.ts tests/quiz-motivation-copy.test.ts tests/quiz-brand-panel-content.test.ts
- npm run typecheck
- npm run lint (0 errors; 3 existing warnings in header/avatar/model-client)
- git diff --check
- npx playwright test tests/e2e-deployed.spec.ts --list
- Browser/manual pass during development: quiz retake flow, onboarding product basics/extras, product drilldown, towel/drying, night protection, mobile popover clamp.
- Clawpatch: init/doctor/map/status/report completed; report shows findings: 0. Provider-backed local review was flaky: Codex provider blocked by local service_tier config, Claude provider doctor passed but review wrapper failed despite Claude returning success.

## Notes
- No video/tutorial asset work included.
- Profile quiz editor intentionally left out of this v1.
